### PR TITLE
Fix search clear not working

### DIFF
--- a/site/_js/web-components/search-box.js
+++ b/site/_js/web-components/search-box.js
@@ -92,6 +92,12 @@ export class SearchBox extends BaseElement {
     this.renderResult = this.renderResult.bind(this);
   }
 
+  clearSearch() {
+    this.active = false;
+    this.input.value = '';
+    this.search('');
+  }
+
   connectedCallback() {
     super.connectedCallback();
     this.setAttribute('role', 'combobox');
@@ -145,7 +151,7 @@ export class SearchBox extends BaseElement {
     // If the user has deleted everything in the search box, clear all state
     // and hide the results modal.
     if (!this.input?.value) {
-      this.active = false;
+      this.clearSearch();
       return;
     }
 
@@ -184,8 +190,7 @@ export class SearchBox extends BaseElement {
         return;
 
       case 'Escape':
-        this.active = false;
-        this.input.value = '';
+        this.clearSearch();
         return;
     }
   }
@@ -265,6 +270,8 @@ export class SearchBox extends BaseElement {
       // and calling focus() on it would have no effect.
       await this.updateComplete;
       this.input?.focus();
+    } else {
+      this.clearSearch();
     }
   }
 

--- a/site/_js/web-components/search-box.js
+++ b/site/_js/web-components/search-box.js
@@ -279,6 +279,8 @@ export class SearchBox extends BaseElement {
     this.query = query.trim();
     if (this.query === '') {
       this.results = [];
+      this.docsResults = [];
+      this.blogResults = [];
       return;
     }
 


### PR DESCRIPTION
Fixes #125

Changes proposed in this pull request:

- Add a clearSearch() method to centralize clear search logic.
- Call clearSearch when a user deletes everything in the search box, clicks the (x) button or presses the ESC key.
- Clear categorized result arrays along with the combined one to prevent showing previous results.

## Before:

https://user-images.githubusercontent.com/1273138/102888822-cdc5c300-4459-11eb-91c7-1c25b802afe9.mov

## After:

https://user-images.githubusercontent.com/1273138/102888824-cef6f000-4459-11eb-857e-c004ed76d15d.mov

