### PR TITLE
fix misc docs typos

### DIFF
--- a/site/en/docs/apps/game_engines/index.md
+++ b/site/en/docs/apps/game_engines/index.md
@@ -31,20 +31,6 @@ based development tools support real-time collaboration.
 PlayCanvas exports content that requires a small amount of manual work to package into a Chrome App.
 See: [PlayCanvas Packaged App Publishing Documentation][8].
 
-## WiMi5 {: #WiMi5 }
-
-[http://wimi5.com][9]
-
-WiMi5 demo on Chrome Web Store: [Bakus Legend][10][][11]
-
-{% img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/VW3o5YeL4YdpPDH7pbl0.png", alt="WiMi5 editor screenshot", height="281", width="500" %}
-
-WiMi5 is a free cloud based webapp to create, publish and monetize web games. Games are quickly
-developed using a visual scripting editor. Programming is not required.
-
-WiMi5 can create a package for Chrome Web Store with 1-click. See: [How to publish your game on the
-Chrome Web][14].
-
 [1]: https://blog.chromium.org/2020/01/moving-forward-from-chrome-apps.html
 [2]: https://developer.chrome.com/apps/migration
 [3]: https://playcanvas.com
@@ -53,9 +39,3 @@ Chrome Web][14].
 [6]: /static/images/playcanvas_designer2.png
 [7]: /static/images/playcanvas_designer2.png
 [8]: http://developer.playcanvas.com/user-manual/publishing/chromewebstore/
-[9]: http://wimi5.com
-[10]: https://chrome.google.com/webstore/detail/bakus-legend/gopkooheadfmnimkccijjjckbkbjdmhi
-[11]: /static/images/wimi5_editor.jpg
-[12]: /static/images/wimi5_editor.jpg
-[13]: /static/images/wimi5_editor.jpg
-[14]: http://wimi5.com/howto-publish-chrome-web-store/

--- a/site/en/docs/apps/publish_app/index.md
+++ b/site/en/docs/apps/publish_app/index.md
@@ -22,7 +22,7 @@ and zip file in a way that reduces the size of the user download package. For de
 the size of the user download package][5].
 
 [1]: https://blog.chromium.org/2020/01/moving-forward-from-chrome-apps.html
-[2]: https://developer.chrome.com/apps/migration
-[3]: https://developers.google.com/chrome/web-store/docs/publish
-[4]: https://developers.google.com/native-client/
-[5]: https://developers.google.com/native-client/dev/devguide/distributing#multi-platform-zip
+[2]: https://developer.chrome.com/docs/apps/migration/
+[3]: https://developer.chrome.com/docs/webstore/publish/
+[4]: https://developer.chrome.com/docs/native-client/
+[5]: https://developer.chrome.com/docs/native-client/devguide/distributing/#chrome-apps

--- a/site/en/docs/extensions/mv2/declare_permissions/index.md
+++ b/site/en/docs/extensions/mv2/declare_permissions/index.md
@@ -31,7 +31,330 @@ Here's an example of the permissions part of a manifest file:
 
 The following table lists the currently available permissions:
 
-<table><tbody><tr><th>Permission</th><th>Description</th></tr><tr id="activeTab"><td><code>"activeTab"</code></td><td>Requests that the extension be granted permissions according to the <a href="activeTab">activeTab</a> specification.</td></tr><tr id="alarms"><td><code>"alarms"</code></td><td>Gives your extension access to the <a href="alarms">chrome.alarms</a> API.</td></tr><tr id="background"><td><code>"background"</code></td><td><p id="bg">Makes Chrome start up early and and shut down late, so that apps and extensions can have a longer life.</p><p>When any installed hosted app, packaged app, or extension has "background" permission, Chrome runs (invisibly) as soon as the user logs into their computer—before the user launches Chrome. The "background" permission also makes Chrome continue running (even after its last window is closed) until the user explicitly quits Chrome.</p><div class="aside aside--note"><b>Note:</b> Disabled apps and extensions are treated as if they aren't installed.</div><p>You typically use the "background" permission with a <a href="background_pages">background page</a>, <a href="/docs/extensions/mv2/event_pages">event page</a> or (for hosted apps) a <a href="http://developers.google.com/chrome/apps/docs/background.html">background window</a>.</p></td></tr><tr id="bookmarks"><td><code>"bookmarks"</code></td><td>Gives your extension access to the <a href="bookmarks">chrome.bookmarks</a> API.</td></tr><tr id="browsingData"><td><code>"browsingData"</code></td><td>Gives your extension access to the <a href="browsingData">chrome.browsingData</a> API.</td></tr><tr id="certificateProvider"><td><code>"certificateProvider"</code></td><td>Gives your extension access to the <a href="certificateProvider">chrome.certificateProvider</a> API.</td></tr><tr id="clipboardRead"><td><code>"clipboardRead"</code></td><td>Required if the extension or app uses <code>document.execCommand('paste')</code>.</td></tr><tr id="clipboardWrite"><td><code>"clipboardWrite"</code></td><td>Indicates the extension or app uses <code>document.execCommand('copy')</code> or <code>document.execCommand('cut')</code>. This permission is <b>required for hosted apps</b>; it's recommended for extensions and packaged apps.</td></tr><tr id="contentSettings"><td><code>"contentSettings"</code></td><td>Gives your extension access to the <a href="contentSettings">chrome.contentSettings</a> API.</td></tr><tr id="contextMenus"><td><code>"contextMenus"</code></td><td>Gives your extension access to the <a href="contextMenus">chrome.contextMenus</a> API.</td></tr><tr id="cookies"><td><code>"cookies"</code></td><td>Gives your extension access to the <a href="cookies">chrome.cookies</a> API.</td></tr><tr id="debugger"><td><code>"debugger"</code></td><td>Gives your extension access to the <a href="debugger">chrome.debugger</a> API.</td></tr><tr id="declarativeContent"><td><code>"declarativeContent"</code></td><td>Gives your extension access to the <a href="declarativeContent">chrome.declarativeContent</a> API.</td></tr><tr id="declarativeNetRequest"><td><code>"declarativeNetRequest"</code></td><td>Gives your extension access to the <a href="declarativeNetRequest">chrome.declarativeNetRequest</a> API.</td></tr><tr id="declarativeNetRequestFeedback"><td><code>"declarativeNetRequestFeedback"</code></td><td>Grants the extension access to events and methods within the <a href="declarativeNetRequest">chrome.declarativeNetRequest</a> API which return information on declarative rules matched.</td></tr><tr id="declarativeWebRequest"><td><code>"declarativeWebRequest"</code></td><td>Gives your extension access to the <a href="declarativeWebRequest">chrome.declarativeWebRequest</a> API.</td></tr><tr id="desktopCapture"><td><code>"desktopCapture"</code></td><td>Gives your extension access to the <a href="desktopCapture">chrome.desktopCapture</a> API.</td></tr><tr id="displaySource"><td><code>"displaySource"</code></td><td>Gives your extension access to the <a href="displaySource">chrome.displaySource</a> API.</td></tr><tr id="dns"><td><code>"dns"</code></td><td>Gives your extension access to the <a href="dns">chrome.dns</a> API.</td></tr><tr id="documentScan"><td><code>"documentScan"</code></td><td>Gives your extension access to the <a href="documentScan">chrome.documentScan</a> API.</td></tr><tr id="downloads"><td><code>"downloads"</code></td><td>Gives your extension access to the <a href="downloads">chrome.downloads</a> API.</td></tr><tr id="enterprise.deviceAttributes"><td><code>"enterprise.deviceAttributes"</code></td><td>Gives your extension access to the <a href="enterprise.deviceAttributes">chrome.enterprise.deviceAttributes</a> API.</td></tr><tr id="enterprise.hardwarePlatform"><td><code>"enterprise.hardwarePlatform"</code></td><td>Gives your extension access to the <a href="enterprise.hardwarePlatform">chrome.enterprise.hardwarePlatform</a> API.</td></tr><tr id="enterprise.networkingAttributes"><td><code>"enterprise.networkingAttributes"</code></td><td>Gives your extension access to the <a href="enterprise.networkingAttributes">chrome.enterprise.networkingAttributes</a> API.</td></tr><tr id="enterprise.platformKeys"><td><code>"enterprise.platformKeys"</code></td><td>Gives your extension access to the <a href="enterprise.platformKeys">chrome.enterprise.platformKeys</a> API.</td></tr><tr id="experimental"><td><code>"experimental"</code></td><td>Required if the extension or app uses any <a href="experimental">chrome.experimental.* APIs</a>.</td></tr><tr id="fileBrowserHandler"><td><code>"fileBrowserHandler"</code></td><td>Gives your extension access to the <a href="fileBrowserHandler">chrome.fileBrowserHandler</a> API.</td></tr><tr id="fileSystemProvider"><td><code>"fileSystemProvider"</code></td><td>Gives your extension access to the <a href="fileSystemProvider">chrome.fileSystemProvider</a> API.</td></tr><tr id="fontSettings"><td><code>"fontSettings"</code></td><td>Gives your extension access to the <a href="fontSettings">chrome.fontSettings</a> API.</td></tr><tr id="gcm"><td><code>"gcm"</code></td><td>Gives your extension access to the <a href="gcm">chrome.gcm</a> API.</td></tr><tr id="geolocation"><td><code>"geolocation"</code></td><td>Allows the extension or app to use the proposed HTML5 <a href="http://dev.w3.org/geo/api/spec-source.html">geolocation API</a> without prompting the user for permission.</td></tr><tr id="history"><td><code>"history"</code></td><td>Gives your extension access to the <a href="history">chrome.history</a> API.</td></tr><tr id="identity"><td><code>"identity"</code></td><td>Gives your extension access to the <a href="identity">chrome.identity</a> API.</td></tr><tr id="idle"><td><code>"idle"</code></td><td>Gives your extension access to the <a href="idle">chrome.idle</a> API.</td></tr><tr id="idltest"><td><code>"idltest"</code></td><td>Gives your extension access to the <a href="idltest">chrome.idltest</a> API.</td></tr><tr id="login"><td><code>"login"</code></td><td>Gives your extension access to the <a href="login">chrome.login</a> API.</td></tr><tr id="loginScreenStorage"><td><code>"loginScreenStorage"</code></td><td>Gives your extension access to the <a href="loginScreenStorage">chrome.loginScreenStorage</a> API.</td></tr><tr id="loginState"><td><code>"loginState"</code></td><td>Gives your extension access to the <a href="loginState">chrome.loginState</a> API.</td></tr><tr id="management"><td><code>"management"</code></td><td>Gives your extension access to the <a href="management">chrome.management</a> API.</td></tr><tr id="nativeMessaging"><td><code>"nativeMessaging"</code></td><td>Gives your extension access to the <a href="messaging.html#native-messaging">native messaging API</a>.</td></tr><tr id="notifications"><td><code>"notifications"</code></td><td>Gives your extension access to the <a href="notifications">chrome.notifications</a> API.</td></tr><tr id="pageCapture"><td><code>"pageCapture"</code></td><td>Gives your extension access to the <a href="pageCapture">chrome.pageCapture</a> API.</td></tr><tr id="platformKeys"><td><code>"platformKeys"</code></td><td>Gives your extension access to the <a href="platformKeys">chrome.platformKeys</a> API.</td></tr><tr id="power"><td><code>"power"</code></td><td>Gives your extension access to the <a href="power">chrome.power</a> API.</td></tr><tr id="printerProvider"><td><code>"printerProvider"</code></td><td>Gives your extension access to the <a href="printerProvider">chrome.printerProvider</a> API.</td></tr><tr id="printing"><td><code>"printing"</code></td><td>Gives your extension access to the <a href="printing">chrome.printing</a> API.</td></tr><tr id="printingMetrics"><td><code>"printingMetrics"</code></td><td>Gives your extension access to the <a href="printingMetrics">chrome.printingMetrics</a> API.</td></tr><tr id="privacy"><td><code>"privacy"</code></td><td>Gives your extension access to the <a href="privacy">chrome.privacy</a> API.</td></tr><tr id="processes"><td><code>"processes"</code></td><td>Gives your extension access to the <a href="processes">chrome.processes</a> API.</td></tr><tr id="proxy"><td><code>"proxy"</code></td><td>Gives your extension access to the <a href="proxy">chrome.proxy</a> API.</td></tr><tr id="scripting"><td><code>"scripting"</code></td><td>Gives your extension access to the <a href="scripting">chrome.scripting</a> API.</td></tr><tr id="search"><td><code>"search"</code></td><td>Gives your extension access to the <a href="search">chrome.search</a> API.</td></tr><tr id="sessions"><td><code>"sessions"</code></td><td>Gives your extension access to the <a href="sessions">chrome.sessions</a> API.</td></tr><tr id="signedInDevices"><td><code>"signedInDevices"</code></td><td>Gives your extension access to the <a href="signedInDevices">chrome.signedInDevices</a> API.</td></tr><tr id="storage"><td><code>"storage"</code></td><td>Gives your extension access to the <a href="storage">chrome.storage</a> API.</td></tr><tr id="system.cpu"><td><code>"system.cpu"</code></td><td>Gives your extension access to the <a href="system.cpu">chrome.system.cpu</a> API.</td></tr><tr id="system.display"><td><code>"system.display"</code></td><td>Gives your extension access to the <a href="system.display">chrome.system.display</a> API.</td></tr><tr id="system.memory"><td><code>"system.memory"</code></td><td>Gives your extension access to the <a href="system.memory">chrome.system.memory</a> API.</td></tr><tr id="system.storage"><td><code>"system.storage"</code></td><td>Gives your extension access to the <a href="system.storage">chrome.system.storage</a> API.</td></tr><tr id="tabCapture"><td><code>"tabCapture"</code></td><td>Gives your extension access to the <a href="tabCapture">chrome.tabCapture</a> API.</td></tr><tr id="tabGroups"><td><code>"tabGroups"</code></td><td>Gives your extension access to the <a href="tabGroups">chrome.tabGroups</a> API.</td></tr><tr id="tabs"><td><code>"tabs"</code></td><td>Gives your extension access to privileged fields of the <a href="https://developer.chrome.com/extensions/tabs#type-Tab"><code>Tab</code></a> objects used by several APIs including <a href="/extensions/tabs">chrome.tabs</a> and <a href="/extensions/windows">chrome.windows</a>. In many circumstances your extension will not need to declare the <code>"tabs"</code> permission to make use of these APIs.</td></tr><tr id="topSites"><td><code>"topSites"</code></td><td>Gives your extension access to the <a href="topSites">chrome.topSites</a> API.</td></tr><tr id="tts"><td><code>"tts"</code></td><td>Gives your extension access to the <a href="tts">chrome.tts</a> API.</td></tr><tr id="ttsEngine"><td><code>"ttsEngine"</code></td><td>Gives your extension access to the <a href="ttsEngine">chrome.ttsEngine</a> API.</td></tr><tr id="unlimitedStorage"><td><code>"unlimitedStorage"</code></td><td>Provides an unlimited quota for storing HTML5 client-side data, such as databases and local storage files. Without this permission, the extension or app is limited to 5 MB of local storage.<div class="aside aside--note"><b>Note:</b> This permission applies only to Web SQL Database and application cache (see issue <a href="http://crbug.com/58985">58985</a>). Also, it doesn't currently work with wildcard subdomains such as <code>http://*.example.com</code>.</div></td></tr><tr id="vpnProvider"><td><code>"vpnProvider"</code></td><td>Gives your extension access to the <a href="vpnProvider">chrome.vpnProvider</a> API.</td></tr><tr id="wallpaper"><td><code>"wallpaper"</code></td><td>Gives your extension access to the <a href="wallpaper">chrome.wallpaper</a> API.</td></tr><tr id="webNavigation"><td><code>"webNavigation"</code></td><td>Gives your extension access to the <a href="webNavigation">chrome.webNavigation</a> API.</td></tr><tr id="webRequest"><td><code>"webRequest"</code></td><td>Gives your extension access to the <a href="webRequest">chrome.webRequest</a> API.</td></tr><tr id="webRequestBlocking"><td><code>"webRequestBlocking"</code></td><td>Required if the extension uses the <a href="webRequest">chrome.webRequest</a> API in a blocking fashion.</td></tr></tbody></table>
+<table>
+  <tbody>
+    <tr>
+      <th>Permission</th>
+      <th>Description</th>
+    </tr>
+    <tr id="activeTab">
+      <td><code>"activeTab"</code></td>
+      <td>Requests that the extension be granted permissions according to the <a href="activeTab">activeTab</a>
+        specification.</td>
+    </tr>
+    <tr id="alarms">
+      <td><code>"alarms"</code></td>
+      <td>Gives your extension access to the <a href="alarms">chrome.alarms</a> API.</td>
+    </tr>
+    <tr id="background">
+      <td><code>"background"</code></td>
+      <td>
+        <p id="bg">Makes Chrome start up early and and shut down late, so that apps and extensions can have a longer
+          life.</p>
+        <p>When any installed hosted app, packaged app, or extension has "background" permission, Chrome runs
+          (invisibly) as soon as the user logs into their computer—before the user launches Chrome. The "background"
+          permission also makes Chrome continue running (even after its last window is closed) until the user explicitly
+          quits Chrome.</p>
+        <div class="aside aside--note"><b>Note:</b> Disabled apps and extensions are treated as if they aren't
+          installed.</div>
+        <p>You typically use the "background" permission with a <a href="background_pages">background page</a>, <a
+            href="/docs/extensions/mv2/event_pages">event page</a> or (for hosted apps) a <a
+            href="http://developers.google.com/chrome/apps/docs/background.html">background window</a>.</p>
+      </td>
+    </tr>
+    <tr id="bookmarks">
+      <td><code>"bookmarks"</code></td>
+      <td>Gives your extension access to the <a href="../reference/bookmarks">chrome.bookmarks</a> API.</td>
+    </tr>
+    <tr id="browsingData">
+      <td><code>"browsingData"</code></td>
+      <td>Gives your extension access to the <a href="../reference/browsingData">chrome.browsingData</a> API.</td>
+    </tr>
+    <tr id="certificateProvider">
+      <td><code>"certificateProvider"</code></td>
+      <td>Gives your extension access to the <a href="../reference/certificateProvider">chrome.certificateProvider</a> API.</td>
+    </tr>
+    <tr id="clipboardRead">
+      <td><code>"clipboardRead"</code></td>
+      <td>Required if the extension or app uses <code>document.execCommand('paste')</code>.</td>
+    </tr>
+    <tr id="clipboardWrite">
+      <td><code>"clipboardWrite"</code></td>
+      <td>Indicates the extension or app uses <code>document.execCommand('copy')</code> or
+        <code>document.execCommand('cut')</code>. This permission is <b>required for hosted apps</b>; it's recommended
+        for extensions and packaged apps.</td>
+    </tr>
+    <tr id="contentSettings">
+      <td><code>"contentSettings"</code></td>
+      <td>Gives your extension access to the <a href="../reference/contentSettings">chrome.contentSettings</a> API.</td>
+    </tr>
+    <tr id="contextMenus">
+      <td><code>"contextMenus"</code></td>
+      <td>Gives your extension access to the <a href="../reference/contextMenus">chrome.contextMenus</a> API.</td>
+    </tr>
+    <tr id="cookies">
+      <td><code>"cookies"</code></td>
+      <td>Gives your extension access to the <a href="../reference/cookies">chrome.cookies</a> API.</td>
+    </tr>
+    <tr id="debugger">
+      <td><code>"debugger"</code></td>
+      <td>Gives your extension access to the <a href="../reference/debugger">chrome.debugger</a> API.</td>
+    </tr>
+    <tr id="declarativeContent">
+      <td><code>"declarativeContent"</code></td>
+      <td>Gives your extension access to the <a href="../reference/declarativeContent">chrome.declarativeContent</a> API.</td>
+    </tr>
+    <tr id="declarativeNetRequest">
+      <td><code>"declarativeNetRequest"</code></td>
+      <td>Gives your extension access to the <a href="../reference/declarativeNetRequest">chrome.declarativeNetRequest</a> API.</td>
+    </tr>
+    <tr id="declarativeNetRequestFeedback">
+      <td><code>"declarativeNetRequestFeedback"</code></td>
+      <td>Grants the extension access to events and methods within the <a
+          href="../reference/declarativeNetRequest">chrome.declarativeNetRequest</a> API which return information on declarative
+        rules matched.</td>
+    </tr>
+    <tr id="declarativeWebRequest">
+      <td><code>"declarativeWebRequest"</code></td>
+      <td>Gives your extension access to the <a href="../reference/declarativeWebRequest">chrome.declarativeWebRequest</a> API.</td>
+    </tr>
+    <tr id="desktopCapture">
+      <td><code>"desktopCapture"</code></td>
+      <td>Gives your extension access to the <a href="../reference/desktopCapture">chrome.desktopCapture</a> API.</td>
+    </tr>
+    <tr id="displaySource">
+      <td><code>"displaySource"</code></td>
+      <td>Gives your extension access to the <a href="../reference/displaySource">chrome.displaySource</a> API.</td>
+    </tr>
+    <tr id="dns">
+      <td><code>"dns"</code></td>
+      <td>Gives your extension access to the <a href="../reference/dns">chrome.dns</a> API.</td>
+    </tr>
+    <tr id="documentScan">
+      <td><code>"documentScan"</code></td>
+      <td>Gives your extension access to the <a href="../reference/documentScan">chrome.documentScan</a> API.</td>
+    </tr>
+    <tr id="downloads">
+      <td><code>"downloads"</code></td>
+      <td>Gives your extension access to the <a href="../reference/downloads">chrome.downloads</a> API.</td>
+    </tr>
+    <tr id="enterprise.deviceAttributes">
+      <td><code>"enterprise.deviceAttributes"</code></td>
+      <td>Gives your extension access to the <a
+          href="../reference/enterprise_deviceAttributes">chrome.enterprise.deviceAttributes</a> API.</td>
+    </tr>
+    <tr id="enterprise.hardwarePlatform">
+      <td><code>"enterprise.hardwarePlatform"</code></td>
+      <td>Gives your extension access to the <a
+          href="../reference/enterprise_hardwarePlatform">chrome.enterprise.hardwarePlatform</a> API.</td>
+    </tr>
+    <tr id="enterprise.networkingAttributes">
+      <td><code>"enterprise.networkingAttributes"</code></td>
+      <td>Gives your extension access to the <a
+          href="../reference/enterprise_networkingAttributes">chrome.enterprise.networkingAttributes</a> API.</td>
+    </tr>
+    <tr id="enterprise.platformKeys">
+      <td><code>"enterprise.platformKeys"</code></td>
+      <td>Gives your extension access to the <a href="../reference/enterprise_platformKeys">chrome.enterprise.platformKeys</a> API.
+      </td>
+    </tr>
+    <tr id="experimental">
+      <td><code>"experimental"</code></td>
+      <td>Required if the extension or app uses any <a href="../reference/#experimental_apis">chrome.experimental.* APIs</a>.</td>
+    </tr>
+    <tr id="fileBrowserHandler">
+      <td><code>"fileBrowserHandler"</code></td>
+      <td>Gives your extension access to the <a href="../reference/fileBrowserHandler">chrome.fileBrowserHandler</a> API.</td>
+    </tr>
+    <tr id="fileSystemProvider">
+      <td><code>"fileSystemProvider"</code></td>
+      <td>Gives your extension access to the <a href="../reference/fileSystemProvider">chrome.fileSystemProvider</a> API.</td>
+    </tr>
+    <tr id="fontSettings">
+      <td><code>"fontSettings"</code></td>
+      <td>Gives your extension access to the <a href="../reference/fontSettings">chrome.fontSettings</a> API.</td>
+    </tr>
+    <tr id="gcm">
+      <td><code>"gcm"</code></td>
+      <td>Gives your extension access to the <a href="../reference/gcm">chrome.gcm</a> API.</td>
+    </tr>
+    <tr id="geolocation">
+      <td><code>"geolocation"</code></td>
+      <td>Allows the extension or app to use the <a
+          href="https://dev.w3.org/geo/api/spec-source.html">geolocation API</a> without prompting the user for
+        permission.</td>
+    </tr>
+    <tr id="history">
+      <td><code>"history"</code></td>
+      <td>Gives your extension access to the <a href="../reference/history">chrome.history</a> API.</td>
+    </tr>
+    <tr id="identity">
+      <td><code>"identity"</code></td>
+      <td>Gives your extension access to the <a href="../reference/identity">chrome.identity</a> API.</td>
+    </tr>
+    <tr id="idle">
+      <td><code>"idle"</code></td>
+      <td>Gives your extension access to the <a href="../reference/idle">chrome.idle</a> API.</td>
+    </tr>
+    <tr id="idltest">
+      <td><code>"idltest"</code></td>
+      <td>Gives your extension access to the <a href="../reference/idltest">chrome.idltest</a> API.</td>
+    </tr>
+    <tr id="login">
+      <td><code>"login"</code></td>
+      <td>Gives your extension access to the <a href="../reference/login">chrome.login</a> API.</td>
+    </tr>
+    <tr id="loginScreenStorage">
+      <td><code>"loginScreenStorage"</code></td>
+      <td>Gives your extension access to the <a href="../reference/loginScreenStorage">chrome.loginScreenStorage</a> API.</td>
+    </tr>
+    <tr id="loginState">
+      <td><code>"loginState"</code></td>
+      <td>Gives your extension access to the <a href="../reference/loginState">chrome.loginState</a> API.</td>
+    </tr>
+    <tr id="management">
+      <td><code>"management"</code></td>
+      <td>Gives your extension access to the <a href="../reference/management">chrome.management</a> API.</td>
+    </tr>
+    <tr id="nativeMessaging">
+      <td><code>"nativeMessaging"</code></td>
+      <td>Gives your extension access to the <a href="/docs/apps/nativeMessaging/">native messaging API</a>.</td>
+    </tr>
+    <tr id="notifications">
+      <td><code>"notifications"</code></td>
+      <td>Gives your extension access to the <a href="../reference/notifications">chrome.notifications</a> API.</td>
+    </tr>
+    <tr id="pageCapture">
+      <td><code>"pageCapture"</code></td>
+      <td>Gives your extension access to the <a href="../reference/pageCapture">chrome.pageCapture</a> API.</td>
+    </tr>
+    <tr id="platformKeys">
+      <td><code>"platformKeys"</code></td>
+      <td>Gives your extension access to the <a href="../reference/platformKeys">chrome.platformKeys</a> API.</td>
+    </tr>
+    <tr id="power">
+      <td><code>"power"</code></td>
+      <td>Gives your extension access to the <a href="../reference/power">chrome.power</a> API.</td>
+    </tr>
+    <tr id="printerProvider">
+      <td><code>"printerProvider"</code></td>
+      <td>Gives your extension access to the <a href="../reference/printerProvider">chrome.printerProvider</a> API.</td>
+    </tr>
+    <tr id="printing">
+      <td><code>"printing"</code></td>
+      <td>Gives your extension access to the <a href="../reference/printing">chrome.printing</a> API.</td>
+    </tr>
+    <tr id="printingMetrics">
+      <td><code>"printingMetrics"</code></td>
+      <td>Gives your extension access to the <a href="../reference/printingMetrics">chrome.printingMetrics</a> API.</td>
+    </tr>
+    <tr id="privacy">
+      <td><code>"privacy"</code></td>
+      <td>Gives your extension access to the <a href="../reference/privacy">chrome.privacy</a> API.</td>
+    </tr>
+    <tr id="processes">
+      <td><code>"processes"</code></td>
+      <td>Gives your extension access to the <a href="../reference/processes">chrome.processes</a> API.</td>
+    </tr>
+    <tr id="proxy">
+      <td><code>"proxy"</code></td>
+      <td>Gives your extension access to the <a href="../reference/proxy">chrome.proxy</a> API.</td>
+    </tr>
+    <tr id="scripting">
+      <td><code>"scripting"</code></td>
+      <td>Gives your extension access to the <a href="../reference/scripting">chrome.scripting</a> API.</td>
+    </tr>
+    <tr id="search">
+      <td><code>"search"</code></td>
+      <td>Gives your extension access to the <a href="../reference/search">chrome.search</a> API.</td>
+    </tr>
+    <tr id="sessions">
+      <td><code>"sessions"</code></td>
+      <td>Gives your extension access to the <a href="../reference/sessions">chrome.sessions</a> API.</td>
+    </tr>
+    <tr id="signedInDevices">
+      <td><code>"signedInDevices"</code></td>
+      <td>Gives your extension access to the <a href="../reference/signedInDevices">chrome.signedInDevices</a> API.</td>
+    </tr>
+    <tr id="storage">
+      <td><code>"storage"</code></td>
+      <td>Gives your extension access to the <a href="../reference/storage">chrome.storage</a> API.</td>
+    </tr>
+    <tr id="system.cpu">
+      <td><code>"system.cpu"</code></td>
+      <td>Gives your extension access to the <a href="../reference/system_cpu">chrome.system.cpu</a> API.</td>
+    </tr>
+    <tr id="system.display">
+      <td><code>"system.display"</code></td>
+      <td>Gives your extension access to the <a href="../reference/system_display">chrome.system.display</a> API.</td>
+    </tr>
+    <tr id="system.memory">
+      <td><code>"system.memory"</code></td>
+      <td>Gives your extension access to the <a href="../reference/system_memory">chrome.system.memory</a> API.</td>
+    </tr>
+    <tr id="system.storage">
+      <td><code>"system.storage"</code></td>
+      <td>Gives your extension access to the <a href="../reference/system_storage">chrome.system.storage</a> API.</td>
+    </tr>
+    <tr id="tabCapture">
+      <td><code>"tabCapture"</code></td>
+      <td>Gives your extension access to the <a href="../reference/tabCapture">chrome.tabCapture</a> API.</td>
+    </tr>
+    <tr id="tabGroups">
+      <td><code>"tabGroups"</code></td>
+      <td>Gives your extension access to the <a href="../reference/tabGroups">chrome.tabGroups</a> API.</td>
+    </tr>
+    <tr id="tabs">
+      <td><code>"tabs"</code></td>
+      <td>Gives your extension access to privileged fields of the <a
+          href="https://developer.chrome.com/extensions/tabs#type-Tab"><code>Tab</code></a> objects used by several APIs
+        including <a href="/extensions/tabs">chrome.tabs</a> and <a href="/extensions/windows">chrome.windows</a>. In
+        many circumstances your extension will not need to declare the <code>"tabs"</code> permission to make use of
+        these APIs.</td>
+    </tr>
+    <tr id="topSites">
+      <td><code>"topSites"</code></td>
+      <td>Gives your extension access to the <a href="../reference/topSites">chrome.topSites</a> API.</td>
+    </tr>
+    <tr id="tts">
+      <td><code>"tts"</code></td>
+      <td>Gives your extension access to the <a href="../reference/tts">chrome.tts</a> API.</td>
+    </tr>
+    <tr id="ttsEngine">
+      <td><code>"ttsEngine"</code></td>
+      <td>Gives your extension access to the <a href="../reference/ttsEngine">chrome.ttsEngine</a> API.</td>
+    </tr>
+    <tr id="unlimitedStorage">
+      <td><code>"unlimitedStorage"</code></td>
+      <td>Provides an unlimited quota for storing client-side data, such as databases and local storage files.
+        Without this permission, the extension or app is limited to 5 MB of local storage.<div
+          class="aside aside--note"><b>Note:</b> This permission applies only to Web SQL Database and application cache
+          (see issue <a href="http://crbug.com/58985">58985</a>). Also, it doesn't currently work with wildcard
+          subdomains such as <code>http://*.example.com</code>.</div>
+      </td>
+    </tr>
+    <tr id="vpnProvider">
+      <td><code>"vpnProvider"</code></td>
+      <td>Gives your extension access to the <a href="../reference/vpnProvider">chrome.vpnProvider</a> API.</td>
+    </tr>
+    <tr id="wallpaper">
+      <td><code>"wallpaper"</code></td>
+      <td>Gives your extension access to the <a href="../reference/wallpaper">chrome.wallpaper</a> API.</td>
+    </tr>
+    <tr id="webNavigation">
+      <td><code>"webNavigation"</code></td>
+      <td>Gives your extension access to the <a href="../reference/webNavigation">chrome.webNavigation</a> API.</td>
+    </tr>
+    <tr id="webRequest">
+      <td><code>"webRequest"</code></td>
+      <td>Gives your extension access to the <a href="../reference/webRequest">chrome.webRequest</a> API.</td>
+    </tr>
+    <tr id="webRequestBlocking">
+      <td><code>"webRequestBlocking"</code></td>
+      <td>Required if the extension uses the <a href="../reference/webRequest">chrome.webRequest</a> API in a blocking fashion.</td>
+    </tr>
+  </tbody>
+</table>
 
 [1]: /docs/extensions/mv2/tabs
 [2]: /docs/extensions/mv2/match_patterns

--- a/site/en/docs/extensions/mv2/declare_permissions/index.md
+++ b/site/en/docs/extensions/mv2/declare_permissions/index.md
@@ -64,15 +64,15 @@ The following table lists the currently available permissions:
     </tr>
     <tr id="bookmarks">
       <td><code>"bookmarks"</code></td>
-      <td>Gives your extension access to the <a href="../reference/bookmarks">chrome.bookmarks</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/bookmarks">chrome.bookmarks</a> API.</td>
     </tr>
     <tr id="browsingData">
       <td><code>"browsingData"</code></td>
-      <td>Gives your extension access to the <a href="../reference/browsingData">chrome.browsingData</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/browsingData/">chrome.browsingData</a> API.</td>
     </tr>
     <tr id="certificateProvider">
       <td><code>"certificateProvider"</code></td>
-      <td>Gives your extension access to the <a href="../reference/certificateProvider">chrome.certificateProvider</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/certificateProvider/">chrome.certificateProvider</a> API.</td>
     </tr>
     <tr id="clipboardRead">
       <td><code>"clipboardRead"</code></td>
@@ -86,97 +86,97 @@ The following table lists the currently available permissions:
     </tr>
     <tr id="contentSettings">
       <td><code>"contentSettings"</code></td>
-      <td>Gives your extension access to the <a href="../reference/contentSettings">chrome.contentSettings</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/contentSettings/">chrome.contentSettings</a> API.</td>
     </tr>
     <tr id="contextMenus">
       <td><code>"contextMenus"</code></td>
-      <td>Gives your extension access to the <a href="../reference/contextMenus">chrome.contextMenus</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/contextMenus/">chrome.contextMenus</a> API.</td>
     </tr>
     <tr id="cookies">
       <td><code>"cookies"</code></td>
-      <td>Gives your extension access to the <a href="../reference/cookies">chrome.cookies</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/cookies/">chrome.cookies</a> API.</td>
     </tr>
     <tr id="debugger">
       <td><code>"debugger"</code></td>
-      <td>Gives your extension access to the <a href="../reference/debugger">chrome.debugger</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/debugger/">chrome.debugger</a> API.</td>
     </tr>
     <tr id="declarativeContent">
       <td><code>"declarativeContent"</code></td>
-      <td>Gives your extension access to the <a href="../reference/declarativeContent">chrome.declarativeContent</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/declarativeContent/">chrome.declarativeContent</a> API.</td>
     </tr>
     <tr id="declarativeNetRequest">
       <td><code>"declarativeNetRequest"</code></td>
-      <td>Gives your extension access to the <a href="../reference/declarativeNetRequest">chrome.declarativeNetRequest</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/declarativeNetRequest/">chrome.declarativeNetRequest</a> API.</td>
     </tr>
     <tr id="declarativeNetRequestFeedback">
       <td><code>"declarativeNetRequestFeedback"</code></td>
       <td>Grants the extension access to events and methods within the <a
-          href="../reference/declarativeNetRequest">chrome.declarativeNetRequest</a> API which return information on declarative
+          href="/docs/extensions/reference/declarativeNetRequest/">chrome.declarativeNetRequest</a> API which return information on declarative
         rules matched.</td>
     </tr>
     <tr id="declarativeWebRequest">
       <td><code>"declarativeWebRequest"</code></td>
-      <td>Gives your extension access to the <a href="../reference/declarativeWebRequest">chrome.declarativeWebRequest</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/declarativeWebRequest/">chrome.declarativeWebRequest</a> API.</td>
     </tr>
     <tr id="desktopCapture">
       <td><code>"desktopCapture"</code></td>
-      <td>Gives your extension access to the <a href="../reference/desktopCapture">chrome.desktopCapture</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/desktopCapture/">chrome.desktopCapture</a> API.</td>
     </tr>
     <tr id="displaySource">
       <td><code>"displaySource"</code></td>
-      <td>Gives your extension access to the <a href="../reference/displaySource">chrome.displaySource</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/displaySource/">chrome.displaySource</a> API.</td>
     </tr>
     <tr id="dns">
       <td><code>"dns"</code></td>
-      <td>Gives your extension access to the <a href="../reference/dns">chrome.dns</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/dns/">chrome.dns</a> API.</td>
     </tr>
     <tr id="documentScan">
       <td><code>"documentScan"</code></td>
-      <td>Gives your extension access to the <a href="../reference/documentScan">chrome.documentScan</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/documentScan/">chrome.documentScan</a> API.</td>
     </tr>
     <tr id="downloads">
       <td><code>"downloads"</code></td>
-      <td>Gives your extension access to the <a href="../reference/downloads">chrome.downloads</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/downloads/">chrome.downloads</a> API.</td>
     </tr>
     <tr id="enterprise.deviceAttributes">
       <td><code>"enterprise.deviceAttributes"</code></td>
       <td>Gives your extension access to the <a
-          href="../reference/enterprise_deviceAttributes">chrome.enterprise.deviceAttributes</a> API.</td>
+          href="/docs/extensions/reference/enterprise_deviceAttributes/">chrome.enterprise.deviceAttributes</a> API.</td>
     </tr>
     <tr id="enterprise.hardwarePlatform">
       <td><code>"enterprise.hardwarePlatform"</code></td>
       <td>Gives your extension access to the <a
-          href="../reference/enterprise_hardwarePlatform">chrome.enterprise.hardwarePlatform</a> API.</td>
+          href="/docs/extensions/reference/enterprise_hardwarePlatform/">chrome.enterprise.hardwarePlatform</a> API.</td>
     </tr>
     <tr id="enterprise.networkingAttributes">
       <td><code>"enterprise.networkingAttributes"</code></td>
       <td>Gives your extension access to the <a
-          href="../reference/enterprise_networkingAttributes">chrome.enterprise.networkingAttributes</a> API.</td>
+          href="/docs/extensions/reference/enterprise_networkingAttributes/">chrome.enterprise.networkingAttributes</a> API.</td>
     </tr>
     <tr id="enterprise.platformKeys">
       <td><code>"enterprise.platformKeys"</code></td>
-      <td>Gives your extension access to the <a href="../reference/enterprise_platformKeys">chrome.enterprise.platformKeys</a> API.
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/enterprise_platformKeys/">chrome.enterprise.platformKeys</a> API.
       </td>
     </tr>
     <tr id="experimental">
       <td><code>"experimental"</code></td>
-      <td>Required if the extension or app uses any <a href="../reference/#experimental_apis">chrome.experimental.* APIs</a>.</td>
+      <td>Required if the extension or app uses any <a href="/docs/extensions/reference/#experimental_apis/">chrome.experimental.* APIs</a>.</td>
     </tr>
     <tr id="fileBrowserHandler">
       <td><code>"fileBrowserHandler"</code></td>
-      <td>Gives your extension access to the <a href="../reference/fileBrowserHandler">chrome.fileBrowserHandler</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/fileBrowserHandler/">chrome.fileBrowserHandler</a> API.</td>
     </tr>
     <tr id="fileSystemProvider">
       <td><code>"fileSystemProvider"</code></td>
-      <td>Gives your extension access to the <a href="../reference/fileSystemProvider">chrome.fileSystemProvider</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/fileSystemProvider/">chrome.fileSystemProvider</a> API.</td>
     </tr>
     <tr id="fontSettings">
       <td><code>"fontSettings"</code></td>
-      <td>Gives your extension access to the <a href="../reference/fontSettings">chrome.fontSettings</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/fontSettings/">chrome.fontSettings</a> API.</td>
     </tr>
     <tr id="gcm">
       <td><code>"gcm"</code></td>
-      <td>Gives your extension access to the <a href="../reference/gcm">chrome.gcm</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/gcm/">chrome.gcm</a> API.</td>
     </tr>
     <tr id="geolocation">
       <td><code>"geolocation"</code></td>
@@ -186,35 +186,35 @@ The following table lists the currently available permissions:
     </tr>
     <tr id="history">
       <td><code>"history"</code></td>
-      <td>Gives your extension access to the <a href="../reference/history">chrome.history</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/history/">chrome.history</a> API.</td>
     </tr>
     <tr id="identity">
       <td><code>"identity"</code></td>
-      <td>Gives your extension access to the <a href="../reference/identity">chrome.identity</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/identity/">chrome.identity</a> API.</td>
     </tr>
     <tr id="idle">
       <td><code>"idle"</code></td>
-      <td>Gives your extension access to the <a href="../reference/idle">chrome.idle</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/idle/">chrome.idle</a> API.</td>
     </tr>
     <tr id="idltest">
       <td><code>"idltest"</code></td>
-      <td>Gives your extension access to the <a href="../reference/idltest">chrome.idltest</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/idltest/">chrome.idltest</a> API.</td>
     </tr>
     <tr id="login">
       <td><code>"login"</code></td>
-      <td>Gives your extension access to the <a href="../reference/login">chrome.login</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/login/">chrome.login</a> API.</td>
     </tr>
     <tr id="loginScreenStorage">
       <td><code>"loginScreenStorage"</code></td>
-      <td>Gives your extension access to the <a href="../reference/loginScreenStorage">chrome.loginScreenStorage</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/loginScreenStorage/">chrome.loginScreenStorage</a> API.</td>
     </tr>
     <tr id="loginState">
       <td><code>"loginState"</code></td>
-      <td>Gives your extension access to the <a href="../reference/loginState">chrome.loginState</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/loginState/">chrome.loginState</a> API.</td>
     </tr>
     <tr id="management">
       <td><code>"management"</code></td>
-      <td>Gives your extension access to the <a href="../reference/management">chrome.management</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/management/">chrome.management</a> API.</td>
     </tr>
     <tr id="nativeMessaging">
       <td><code>"nativeMessaging"</code></td>
@@ -222,87 +222,87 @@ The following table lists the currently available permissions:
     </tr>
     <tr id="notifications">
       <td><code>"notifications"</code></td>
-      <td>Gives your extension access to the <a href="../reference/notifications">chrome.notifications</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/notifications/">chrome.notifications</a> API.</td>
     </tr>
     <tr id="pageCapture">
       <td><code>"pageCapture"</code></td>
-      <td>Gives your extension access to the <a href="../reference/pageCapture">chrome.pageCapture</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/pageCapture/">chrome.pageCapture</a> API.</td>
     </tr>
     <tr id="platformKeys">
       <td><code>"platformKeys"</code></td>
-      <td>Gives your extension access to the <a href="../reference/platformKeys">chrome.platformKeys</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/platformKeys/">chrome.platformKeys</a> API.</td>
     </tr>
     <tr id="power">
       <td><code>"power"</code></td>
-      <td>Gives your extension access to the <a href="../reference/power">chrome.power</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/power/">chrome.power</a> API.</td>
     </tr>
     <tr id="printerProvider">
       <td><code>"printerProvider"</code></td>
-      <td>Gives your extension access to the <a href="../reference/printerProvider">chrome.printerProvider</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/printerProvider/">chrome.printerProvider</a> API.</td>
     </tr>
     <tr id="printing">
       <td><code>"printing"</code></td>
-      <td>Gives your extension access to the <a href="../reference/printing">chrome.printing</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/printing/">chrome.printing</a> API.</td>
     </tr>
     <tr id="printingMetrics">
       <td><code>"printingMetrics"</code></td>
-      <td>Gives your extension access to the <a href="../reference/printingMetrics">chrome.printingMetrics</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/printingMetrics/">chrome.printingMetrics</a> API.</td>
     </tr>
     <tr id="privacy">
       <td><code>"privacy"</code></td>
-      <td>Gives your extension access to the <a href="../reference/privacy">chrome.privacy</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/privacy/">chrome.privacy</a> API.</td>
     </tr>
     <tr id="processes">
       <td><code>"processes"</code></td>
-      <td>Gives your extension access to the <a href="../reference/processes">chrome.processes</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/processes/">chrome.processes</a> API.</td>
     </tr>
     <tr id="proxy">
       <td><code>"proxy"</code></td>
-      <td>Gives your extension access to the <a href="../reference/proxy">chrome.proxy</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/proxy/">chrome.proxy</a> API.</td>
     </tr>
     <tr id="scripting">
       <td><code>"scripting"</code></td>
-      <td>Gives your extension access to the <a href="../reference/scripting">chrome.scripting</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/scripting/">chrome.scripting</a> API.</td>
     </tr>
     <tr id="search">
       <td><code>"search"</code></td>
-      <td>Gives your extension access to the <a href="../reference/search">chrome.search</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/search/">chrome.search</a> API.</td>
     </tr>
     <tr id="sessions">
       <td><code>"sessions"</code></td>
-      <td>Gives your extension access to the <a href="../reference/sessions">chrome.sessions</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/sessions/">chrome.sessions</a> API.</td>
     </tr>
     <tr id="signedInDevices">
       <td><code>"signedInDevices"</code></td>
-      <td>Gives your extension access to the <a href="../reference/signedInDevices">chrome.signedInDevices</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/signedInDevices/">chrome.signedInDevices</a> API.</td>
     </tr>
     <tr id="storage">
       <td><code>"storage"</code></td>
-      <td>Gives your extension access to the <a href="../reference/storage">chrome.storage</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/storage/">chrome.storage</a> API.</td>
     </tr>
     <tr id="system.cpu">
       <td><code>"system.cpu"</code></td>
-      <td>Gives your extension access to the <a href="../reference/system_cpu">chrome.system.cpu</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/system_cpu/">chrome.system.cpu</a> API.</td>
     </tr>
     <tr id="system.display">
       <td><code>"system.display"</code></td>
-      <td>Gives your extension access to the <a href="../reference/system_display">chrome.system.display</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/system_display/">chrome.system.display</a> API.</td>
     </tr>
     <tr id="system.memory">
       <td><code>"system.memory"</code></td>
-      <td>Gives your extension access to the <a href="../reference/system_memory">chrome.system.memory</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/system_memory/">chrome.system.memory</a> API.</td>
     </tr>
     <tr id="system.storage">
       <td><code>"system.storage"</code></td>
-      <td>Gives your extension access to the <a href="../reference/system_storage">chrome.system.storage</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/system_storage/">chrome.system.storage</a> API.</td>
     </tr>
     <tr id="tabCapture">
       <td><code>"tabCapture"</code></td>
-      <td>Gives your extension access to the <a href="../reference/tabCapture">chrome.tabCapture</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/tabCapture/">chrome.tabCapture</a> API.</td>
     </tr>
     <tr id="tabGroups">
       <td><code>"tabGroups"</code></td>
-      <td>Gives your extension access to the <a href="../reference/tabGroups">chrome.tabGroups</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/tabGroups/">chrome.tabGroups</a> API.</td>
     </tr>
     <tr id="tabs">
       <td><code>"tabs"</code></td>
@@ -314,15 +314,15 @@ The following table lists the currently available permissions:
     </tr>
     <tr id="topSites">
       <td><code>"topSites"</code></td>
-      <td>Gives your extension access to the <a href="../reference/topSites">chrome.topSites</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/topSites/">chrome.topSites</a> API.</td>
     </tr>
     <tr id="tts">
       <td><code>"tts"</code></td>
-      <td>Gives your extension access to the <a href="../reference/tts">chrome.tts</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/tts/">chrome.tts</a> API.</td>
     </tr>
     <tr id="ttsEngine">
       <td><code>"ttsEngine"</code></td>
-      <td>Gives your extension access to the <a href="../reference/ttsEngine">chrome.ttsEngine</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/ttsEngine/">chrome.ttsEngine</a> API.</td>
     </tr>
     <tr id="unlimitedStorage">
       <td><code>"unlimitedStorage"</code></td>
@@ -335,23 +335,23 @@ The following table lists the currently available permissions:
     </tr>
     <tr id="vpnProvider">
       <td><code>"vpnProvider"</code></td>
-      <td>Gives your extension access to the <a href="../reference/vpnProvider">chrome.vpnProvider</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/vpnProvider/">chrome.vpnProvider</a> API.</td>
     </tr>
     <tr id="wallpaper">
       <td><code>"wallpaper"</code></td>
-      <td>Gives your extension access to the <a href="../reference/wallpaper">chrome.wallpaper</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/wallpaper/">chrome.wallpaper</a> API.</td>
     </tr>
     <tr id="webNavigation">
       <td><code>"webNavigation"</code></td>
-      <td>Gives your extension access to the <a href="../reference/webNavigation">chrome.webNavigation</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/webNavigation/">chrome.webNavigation</a> API.</td>
     </tr>
     <tr id="webRequest">
       <td><code>"webRequest"</code></td>
-      <td>Gives your extension access to the <a href="../reference/webRequest">chrome.webRequest</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/webRequest/">chrome.webRequest</a> API.</td>
     </tr>
     <tr id="webRequestBlocking">
       <td><code>"webRequestBlocking"</code></td>
-      <td>Required if the extension uses the <a href="../reference/webRequest">chrome.webRequest</a> API in a blocking fashion.</td>
+      <td>Required if the extension uses the <a href="/docs/extensions/reference/webRequest/">chrome.webRequest</a> API in a blocking fashion.</td>
     </tr>
   </tbody>
 </table>

--- a/site/en/docs/extensions/mv2/getstarted/index.md
+++ b/site/en/docs/extensions/mv2/getstarted/index.md
@@ -307,7 +307,7 @@ changeColor.onclick = function(element) {
 };
 ```
 
-The updated code adds an onclick event the button, which triggers a [programatically injected
+The updated code adds an `onclick` event on the button, which triggers a [programatically injected
 content script][24]. This turns the background color of the page the same color as the button. Using
 programmatic injection allows for user-invoked content scripts, instead of auto inserting unwanted
 code into web pages.

--- a/site/en/docs/extensions/mv2/hosting/index.md
+++ b/site/en/docs/extensions/mv2/hosting/index.md
@@ -53,7 +53,7 @@ To release an update to an extension, increase the number in the `“version”`
 ```
 
 Convert the updated extension directory into a ZIP file and locate the old version in the [Developer
-Dashboard][10]. Select **Edit**, upload the new package, and hit **Publish**. The browser will will
+Dashboard][10]. Select **Edit**, upload the new package, and hit **Publish**. The browser will
 automatically update the extension for users after the new version is published.
 
 [1]: https://chrome.google.com/webstore/category/extensions

--- a/site/en/docs/extensions/mv2/publish_app/index.md
+++ b/site/en/docs/extensions/mv2/publish_app/index.md
@@ -20,7 +20,8 @@ and zip file in a way that reduces the size of the user download package. For de
 the size of the user download package][5].
 
 [1]: https://blog.chromium.org/2020/01/moving-forward-from-chrome-apps.html
-[2]: https://developer.chrome.com/apps/migration
-[3]: https://developers.google.com/chrome/web-store/docs/publish
-[4]: https://developers.google.com/native-client/
-[5]: https://developers.google.com/native-client/dev/devguide/distributing#multi-platform-zip
+[2]: https://developer.chrome.com/docs/apps/migration/
+[3]: https://developer.chrome.com/docs/webstore/publish/
+[4]: https://developer.chrome.com/docs/native-client/
+[5]: https://developer.chrome.com/docs/native-client/devguide/distributing/#chrome-apps
+

--- a/site/en/docs/extensions/mv3/declare_permissions/index.md
+++ b/site/en/docs/extensions/mv3/declare_permissions/index.md
@@ -79,15 +79,15 @@ The following table lists the currently available permissions:
     </tr>
     <tr id="bookmarks">
       <td><code>"bookmarks"</code></td>
-      <td>Gives your extension access to the <a href="../reference/bookmarks">chrome.bookmarks</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/bookmarks/">chrome.bookmarks</a> API.</td>
     </tr>
     <tr id="browsingData">
       <td><code>"browsingData"</code></td>
-      <td>Gives your extension access to the <a href="../reference/browsingData">chrome.browsingData</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/browsingData/">chrome.browsingData</a> API.</td>
     </tr>
     <tr id="certificateProvider">
       <td><code>"certificateProvider"</code></td>
-      <td>Gives your extension access to the <a href="../reference/certificateProvider">chrome.certificateProvider</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/certificateProvider/">chrome.certificateProvider</a> API.</td>
     </tr>
     <tr id="clipboardRead">
       <td><code>"clipboardRead"</code></td>
@@ -101,97 +101,97 @@ The following table lists the currently available permissions:
     </tr>
     <tr id="contentSettings">
       <td><code>"contentSettings"</code></td>
-      <td>Gives your extension access to the <a href="../reference/contentSettings">chrome.contentSettings</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/contentSettings/">chrome.contentSettings</a> API.</td>
     </tr>
     <tr id="contextMenus">
       <td><code>"contextMenus"</code></td>
-      <td>Gives your extension access to the <a href="../reference/contextMenus">chrome.contextMenus</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/contextMenus/">chrome.contextMenus</a> API.</td>
     </tr>
     <tr id="cookies">
       <td><code>"cookies"</code></td>
-      <td>Gives your extension access to the <a href="../reference/cookies">chrome.cookies</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/cookies/">chrome.cookies</a> API.</td>
     </tr>
     <tr id="debugger">
       <td><code>"debugger"</code></td>
-      <td>Gives your extension access to the <a href="../reference/debugger">chrome.debugger</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/debugger/">chrome.debugger</a> API.</td>
     </tr>
     <tr id="declarativeContent">
       <td><code>"declarativeContent"</code></td>
-      <td>Gives your extension access to the <a href="../reference/declarativeContent">chrome.declarativeContent</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/declarativeContent/">chrome.declarativeContent</a> API.</td>
     </tr>
     <tr id="declarativeNetRequest">
       <td><code>"declarativeNetRequest"</code></td>
-      <td>Gives your extension access to the <a href="../reference/declarativeNetRequest">chrome.declarativeNetRequest</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/declarativeNetRequest/">chrome.declarativeNetRequest</a> API.</td>
     </tr>
     <tr id="declarativeNetRequestFeedback">
       <td><code>"declarativeNetRequestFeedback"</code></td>
       <td>Grants the extension access to events and methods within the <a
-          href="../reference/declarativeNetRequest">chrome.declarativeNetRequest</a> API which return information on declarative
+          href="/docs/extensions/reference/declarativeNetRequest/">chrome.declarativeNetRequest</a> API which return information on declarative
         rules matched.</td>
     </tr>
     <tr id="declarativeWebRequest">
       <td><code>"declarativeWebRequest"</code></td>
-      <td>Gives your extension access to the <a href="../reference/declarativeWebRequest">chrome.declarativeWebRequest</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/declarativeWebRequest/">chrome.declarativeWebRequest</a> API.</td>
     </tr>
     <tr id="desktopCapture">
       <td><code>"desktopCapture"</code></td>
-      <td>Gives your extension access to the <a href="../reference/desktopCapture">chrome.desktopCapture</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/desktopCapture/">chrome.desktopCapture</a> API.</td>
     </tr>
     <tr id="displaySource">
       <td><code>"displaySource"</code></td>
-      <td>Gives your extension access to the <a href="../reference/displaySource">chrome.displaySource</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/displaySource/">chrome.displaySource</a> API.</td>
     </tr>
     <tr id="dns">
       <td><code>"dns"</code></td>
-      <td>Gives your extension access to the <a href="../reference/dns">chrome.dns</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/dns/">chrome.dns</a> API.</td>
     </tr>
     <tr id="documentScan">
       <td><code>"documentScan"</code></td>
-      <td>Gives your extension access to the <a href="../reference/documentScan">chrome.documentScan</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/documentScan/">chrome.documentScan</a> API.</td>
     </tr>
     <tr id="downloads">
       <td><code>"downloads"</code></td>
-      <td>Gives your extension access to the <a href="../reference/downloads">chrome.downloads</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/downloads/">chrome.downloads</a> API.</td>
     </tr>
     <tr id="enterprise.deviceAttributes">
       <td><code>"enterprise.deviceAttributes"</code></td>
       <td>Gives your extension access to the <a
-          href="../reference/enterprise_deviceAttributes">chrome.enterprise.deviceAttributes</a> API.</td>
+          href="/docs/extensions/reference/enterprise_deviceAttributes/">chrome.enterprise.deviceAttributes</a> API.</td>
     </tr>
     <tr id="enterprise.hardwarePlatform">
       <td><code>"enterprise.hardwarePlatform"</code></td>
       <td>Gives your extension access to the <a
-          href="../reference/enterprise_hardwarePlatform">chrome.enterprise.hardwarePlatform</a> API.</td>
+          href="/docs/extensions/reference/enterprise_hardwarePlatform/">chrome.enterprise.hardwarePlatform</a> API.</td>
     </tr>
     <tr id="enterprise.networkingAttributes">
       <td><code>"enterprise.networkingAttributes"</code></td>
       <td>Gives your extension access to the <a
-          href="../reference/enterprise_networkingAttributes">chrome.enterprise.networkingAttributes</a> API.</td>
+          href="/docs/extensions/reference/enterprise_networkingAttributes/">chrome.enterprise.networkingAttributes</a> API.</td>
     </tr>
     <tr id="enterprise.platformKeys">
       <td><code>"enterprise.platformKeys"</code></td>
-      <td>Gives your extension access to the <a href="../reference/enterprise_platformKeys">chrome.enterprise.platformKeys</a> API.
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/enterprise_platformKeys/">chrome.enterprise.platformKeys</a> API.
       </td>
     </tr>
     <tr id="experimental">
       <td><code>"experimental"</code></td>
-      <td>Required if the extension or app uses any <a href="../reference/#experimental_apis">chrome.experimental.* APIs</a>.</td>
+      <td>Required if the extension or app uses any <a href="/docs/extensions/reference/#experimental_apis/">chrome.experimental.* APIs</a>.</td>
     </tr>
     <tr id="fileBrowserHandler">
       <td><code>"fileBrowserHandler"</code></td>
-      <td>Gives your extension access to the <a href="../reference/fileBrowserHandler">chrome.fileBrowserHandler</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/fileBrowserHandler/">chrome.fileBrowserHandler</a> API.</td>
     </tr>
     <tr id="fileSystemProvider">
       <td><code>"fileSystemProvider"</code></td>
-      <td>Gives your extension access to the <a href="../reference/fileSystemProvider">chrome.fileSystemProvider</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/fileSystemProvider/">chrome.fileSystemProvider</a> API.</td>
     </tr>
     <tr id="fontSettings">
       <td><code>"fontSettings"</code></td>
-      <td>Gives your extension access to the <a href="../reference/fontSettings">chrome.fontSettings</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/fontSettings/">chrome.fontSettings</a> API.</td>
     </tr>
     <tr id="gcm">
       <td><code>"gcm"</code></td>
-      <td>Gives your extension access to the <a href="../reference/gcm">chrome.gcm</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/gcm/">chrome.gcm</a> API.</td>
     </tr>
     <tr id="geolocation">
       <td><code>"geolocation"</code></td>
@@ -201,35 +201,35 @@ The following table lists the currently available permissions:
     </tr>
     <tr id="history">
       <td><code>"history"</code></td>
-      <td>Gives your extension access to the <a href="../reference/history">chrome.history</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/history/">chrome.history</a> API.</td>
     </tr>
     <tr id="identity">
       <td><code>"identity"</code></td>
-      <td>Gives your extension access to the <a href="../reference/identity">chrome.identity</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/identity/">chrome.identity</a> API.</td>
     </tr>
     <tr id="idle">
       <td><code>"idle"</code></td>
-      <td>Gives your extension access to the <a href="../reference/idle">chrome.idle</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/idle/">chrome.idle</a> API.</td>
     </tr>
     <tr id="idltest">
       <td><code>"idltest"</code></td>
-      <td>Gives your extension access to the <a href="../reference/idltest">chrome.idltest</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/idltest/">chrome.idltest</a> API.</td>
     </tr>
     <tr id="login">
       <td><code>"login"</code></td>
-      <td>Gives your extension access to the <a href="../reference/login">chrome.login</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/login/">chrome.login</a> API.</td>
     </tr>
     <tr id="loginScreenStorage">
       <td><code>"loginScreenStorage"</code></td>
-      <td>Gives your extension access to the <a href="../reference/loginScreenStorage">chrome.loginScreenStorage</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/loginScreenStorage/">chrome.loginScreenStorage</a> API.</td>
     </tr>
     <tr id="loginState">
       <td><code>"loginState"</code></td>
-      <td>Gives your extension access to the <a href="../reference/loginState">chrome.loginState</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/loginState/">chrome.loginState</a> API.</td>
     </tr>
     <tr id="management">
       <td><code>"management"</code></td>
-      <td>Gives your extension access to the <a href="../reference/management">chrome.management</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/management/">chrome.management</a> API.</td>
     </tr>
     <tr id="nativeMessaging">
       <td><code>"nativeMessaging"</code></td>
@@ -237,87 +237,87 @@ The following table lists the currently available permissions:
     </tr>
     <tr id="notifications">
       <td><code>"notifications"</code></td>
-      <td>Gives your extension access to the <a href="../reference/notifications">chrome.notifications</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/notifications/">chrome.notifications</a> API.</td>
     </tr>
     <tr id="pageCapture">
       <td><code>"pageCapture"</code></td>
-      <td>Gives your extension access to the <a href="../reference/pageCapture">chrome.pageCapture</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/pageCapture/">chrome.pageCapture</a> API.</td>
     </tr>
     <tr id="platformKeys">
       <td><code>"platformKeys"</code></td>
-      <td>Gives your extension access to the <a href="../reference/platformKeys">chrome.platformKeys</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/platformKeys/">chrome.platformKeys</a> API.</td>
     </tr>
     <tr id="power">
       <td><code>"power"</code></td>
-      <td>Gives your extension access to the <a href="../reference/power">chrome.power</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/power/">chrome.power</a> API.</td>
     </tr>
     <tr id="printerProvider">
       <td><code>"printerProvider"</code></td>
-      <td>Gives your extension access to the <a href="../reference/printerProvider">chrome.printerProvider</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/printerProvider/">chrome.printerProvider</a> API.</td>
     </tr>
     <tr id="printing">
       <td><code>"printing"</code></td>
-      <td>Gives your extension access to the <a href="../reference/printing">chrome.printing</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/printing/">chrome.printing</a> API.</td>
     </tr>
     <tr id="printingMetrics">
       <td><code>"printingMetrics"</code></td>
-      <td>Gives your extension access to the <a href="../reference/printingMetrics">chrome.printingMetrics</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/printingMetrics/">chrome.printingMetrics</a> API.</td>
     </tr>
     <tr id="privacy">
       <td><code>"privacy"</code></td>
-      <td>Gives your extension access to the <a href="../reference/privacy">chrome.privacy</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/privacy/">chrome.privacy</a> API.</td>
     </tr>
     <tr id="processes">
       <td><code>"processes"</code></td>
-      <td>Gives your extension access to the <a href="../reference/processes">chrome.processes</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/processes/">chrome.processes</a> API.</td>
     </tr>
     <tr id="proxy">
       <td><code>"proxy"</code></td>
-      <td>Gives your extension access to the <a href="../reference/proxy">chrome.proxy</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/proxy/">chrome.proxy</a> API.</td>
     </tr>
     <tr id="scripting">
       <td><code>"scripting"</code></td>
-      <td>Gives your extension access to the <a href="../reference/scripting">chrome.scripting</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/scripting/">chrome.scripting</a> API.</td>
     </tr>
     <tr id="search">
       <td><code>"search"</code></td>
-      <td>Gives your extension access to the <a href="../reference/search">chrome.search</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/search/">chrome.search</a> API.</td>
     </tr>
     <tr id="sessions">
       <td><code>"sessions"</code></td>
-      <td>Gives your extension access to the <a href="../reference/sessions">chrome.sessions</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/sessions/">chrome.sessions</a> API.</td>
     </tr>
     <tr id="signedInDevices">
       <td><code>"signedInDevices"</code></td>
-      <td>Gives your extension access to the <a href="../reference/signedInDevices">chrome.signedInDevices</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/signedInDevices/">chrome.signedInDevices</a> API.</td>
     </tr>
     <tr id="storage">
       <td><code>"storage"</code></td>
-      <td>Gives your extension access to the <a href="../reference/storage">chrome.storage</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/storage/">chrome.storage</a> API.</td>
     </tr>
     <tr id="system.cpu">
       <td><code>"system.cpu"</code></td>
-      <td>Gives your extension access to the <a href="../reference/system_cpu">chrome.system.cpu</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/system_cpu/">chrome.system.cpu</a> API.</td>
     </tr>
     <tr id="system.display">
       <td><code>"system.display"</code></td>
-      <td>Gives your extension access to the <a href="../reference/system_display">chrome.system.display</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/system_display/">chrome.system.display</a> API.</td>
     </tr>
     <tr id="system.memory">
       <td><code>"system.memory"</code></td>
-      <td>Gives your extension access to the <a href="../reference/system_memory">chrome.system.memory</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/system_memory/">chrome.system.memory</a> API.</td>
     </tr>
     <tr id="system.storage">
       <td><code>"system.storage"</code></td>
-      <td>Gives your extension access to the <a href="../reference/system_storage">chrome.system.storage</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/system_storage/">chrome.system.storage</a> API.</td>
     </tr>
     <tr id="tabCapture">
       <td><code>"tabCapture"</code></td>
-      <td>Gives your extension access to the <a href="../reference/tabCapture">chrome.tabCapture</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/tabCapture/">chrome.tabCapture</a> API.</td>
     </tr>
     <tr id="tabGroups">
       <td><code>"tabGroups"</code></td>
-      <td>Gives your extension access to the <a href="../reference/tabGroups">chrome.tabGroups</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/tabGroups/">chrome.tabGroups</a> API.</td>
     </tr>
     <tr id="tabs">
       <td><code>"tabs"</code></td>
@@ -329,15 +329,15 @@ The following table lists the currently available permissions:
     </tr>
     <tr id="topSites">
       <td><code>"topSites"</code></td>
-      <td>Gives your extension access to the <a href="../reference/topSites">chrome.topSites</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/topSites/">chrome.topSites</a> API.</td>
     </tr>
     <tr id="tts">
       <td><code>"tts"</code></td>
-      <td>Gives your extension access to the <a href="../reference/tts">chrome.tts</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/tts/">chrome.tts</a> API.</td>
     </tr>
     <tr id="ttsEngine">
       <td><code>"ttsEngine"</code></td>
-      <td>Gives your extension access to the <a href="../reference/ttsEngine">chrome.ttsEngine</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/ttsEngine/">chrome.ttsEngine</a> API.</td>
     </tr>
     <tr id="unlimitedStorage">
       <td><code>"unlimitedStorage"</code></td>
@@ -350,23 +350,23 @@ The following table lists the currently available permissions:
     </tr>
     <tr id="vpnProvider">
       <td><code>"vpnProvider"</code></td>
-      <td>Gives your extension access to the <a href="../reference/vpnProvider">chrome.vpnProvider</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/vpnProvider/">chrome.vpnProvider</a> API.</td>
     </tr>
     <tr id="wallpaper">
       <td><code>"wallpaper"</code></td>
-      <td>Gives your extension access to the <a href="../reference/wallpaper">chrome.wallpaper</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/wallpaper/">chrome.wallpaper</a> API.</td>
     </tr>
     <tr id="webNavigation">
       <td><code>"webNavigation"</code></td>
-      <td>Gives your extension access to the <a href="../reference/webNavigation">chrome.webNavigation</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/webNavigation/">chrome.webNavigation</a> API.</td>
     </tr>
     <tr id="webRequest">
       <td><code>"webRequest"</code></td>
-      <td>Gives your extension access to the <a href="../reference/webRequest">chrome.webRequest</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/webRequest/">chrome.webRequest</a> API.</td>
     </tr>
     <tr id="webRequestBlocking">
       <td><code>"webRequestBlocking"</code></td>
-      <td>Required if the extension uses the <a href="../reference/webRequest">chrome.webRequest</a> API in a blocking fashion.</td>
+      <td>Required if the extension uses the <a href="/docs/extensions/reference/webRequest/">chrome.webRequest</a> API in a blocking fashion.</td>
     </tr>
   </tbody>
 </table>

--- a/site/en/docs/extensions/mv3/declare_permissions/index.md
+++ b/site/en/docs/extensions/mv3/declare_permissions/index.md
@@ -38,7 +38,6 @@ Here's an example of the permissions part of a manifest file:
 "optional_permissions": [
   "unlimitedStorage"
 ],
-],
 "host_permissions": [
   "http://www.blogger.com/",
   "http://*.google.com/"
@@ -47,7 +46,330 @@ Here's an example of the permissions part of a manifest file:
 
 The following table lists the currently available permissions:
 
-<table><tbody><tr><th>Permission</th><th>Description</th></tr><tr id="activeTab"><td><code>"activeTab"</code></td><td>Requests that the extension be granted permissions according to the <a href="activeTab">activeTab</a> specification.</td></tr><tr id="alarms"><td><code>"alarms"</code></td><td>Gives your extension access to the <a href="alarms">chrome.alarms</a> API.</td></tr><tr id="background"><td><code>"background"</code></td><td><p id="bg">Makes Chrome start up early and and shut down late, so that apps and extensions can have a longer life.</p><p>When any installed hosted app, packaged app, or extension has "background" permission, Chrome runs (invisibly) as soon as the user logs into their computer—before the user launches Chrome. The "background" permission also makes Chrome continue running (even after its last window is closed) until the user explicitly quits Chrome.</p><div class="aside aside--note"><b>Note:</b> Disabled apps and extensions are treated as if they aren't installed.</div><p>You typically use the "background" permission with a <a href="background_pages">background page</a>, <a href="/docs/extensions/mv3/event_pages">event page</a> or (for hosted apps) a <a href="http://developers.google.com/chrome/apps/docs/background.html">background window</a>.</p></td></tr><tr id="bookmarks"><td><code>"bookmarks"</code></td><td>Gives your extension access to the <a href="bookmarks">chrome.bookmarks</a> API.</td></tr><tr id="browsingData"><td><code>"browsingData"</code></td><td>Gives your extension access to the <a href="browsingData">chrome.browsingData</a> API.</td></tr><tr id="certificateProvider"><td><code>"certificateProvider"</code></td><td>Gives your extension access to the <a href="certificateProvider">chrome.certificateProvider</a> API.</td></tr><tr id="clipboardRead"><td><code>"clipboardRead"</code></td><td>Required if the extension or app uses <code>document.execCommand('paste')</code>.</td></tr><tr id="clipboardWrite"><td><code>"clipboardWrite"</code></td><td>Indicates the extension or app uses <code>document.execCommand('copy')</code> or <code>document.execCommand('cut')</code>. This permission is <b>required for hosted apps</b>; it's recommended for extensions and packaged apps.</td></tr><tr id="contentSettings"><td><code>"contentSettings"</code></td><td>Gives your extension access to the <a href="contentSettings">chrome.contentSettings</a> API.</td></tr><tr id="contextMenus"><td><code>"contextMenus"</code></td><td>Gives your extension access to the <a href="contextMenus">chrome.contextMenus</a> API.</td></tr><tr id="cookies"><td><code>"cookies"</code></td><td>Gives your extension access to the <a href="cookies">chrome.cookies</a> API.</td></tr><tr id="debugger"><td><code>"debugger"</code></td><td>Gives your extension access to the <a href="debugger">chrome.debugger</a> API.</td></tr><tr id="declarativeContent"><td><code>"declarativeContent"</code></td><td>Gives your extension access to the <a href="declarativeContent">chrome.declarativeContent</a> API.</td></tr><tr id="declarativeNetRequest"><td><code>"declarativeNetRequest"</code></td><td>Gives your extension access to the <a href="declarativeNetRequest">chrome.declarativeNetRequest</a> API.</td></tr><tr id="declarativeNetRequestFeedback"><td><code>"declarativeNetRequestFeedback"</code></td><td>Grants the extension access to events and methods within the <a href="declarativeNetRequest">chrome.declarativeNetRequest</a> API which return information on declarative rules matched.</td></tr><tr id="declarativeWebRequest"><td><code>"declarativeWebRequest"</code></td><td>Gives your extension access to the <a href="declarativeWebRequest">chrome.declarativeWebRequest</a> API.</td></tr><tr id="desktopCapture"><td><code>"desktopCapture"</code></td><td>Gives your extension access to the <a href="desktopCapture">chrome.desktopCapture</a> API.</td></tr><tr id="displaySource"><td><code>"displaySource"</code></td><td>Gives your extension access to the <a href="displaySource">chrome.displaySource</a> API.</td></tr><tr id="dns"><td><code>"dns"</code></td><td>Gives your extension access to the <a href="dns">chrome.dns</a> API.</td></tr><tr id="documentScan"><td><code>"documentScan"</code></td><td>Gives your extension access to the <a href="documentScan">chrome.documentScan</a> API.</td></tr><tr id="downloads"><td><code>"downloads"</code></td><td>Gives your extension access to the <a href="downloads">chrome.downloads</a> API.</td></tr><tr id="enterprise.deviceAttributes"><td><code>"enterprise.deviceAttributes"</code></td><td>Gives your extension access to the <a href="enterprise.deviceAttributes">chrome.enterprise.deviceAttributes</a> API.</td></tr><tr id="enterprise.hardwarePlatform"><td><code>"enterprise.hardwarePlatform"</code></td><td>Gives your extension access to the <a href="enterprise.hardwarePlatform">chrome.enterprise.hardwarePlatform</a> API.</td></tr><tr id="enterprise.networkingAttributes"><td><code>"enterprise.networkingAttributes"</code></td><td>Gives your extension access to the <a href="enterprise.networkingAttributes">chrome.enterprise.networkingAttributes</a> API.</td></tr><tr id="enterprise.platformKeys"><td><code>"enterprise.platformKeys"</code></td><td>Gives your extension access to the <a href="enterprise.platformKeys">chrome.enterprise.platformKeys</a> API.</td></tr><tr id="experimental"><td><code>"experimental"</code></td><td>Required if the extension or app uses any <a href="experimental">chrome.experimental.* APIs</a>.</td></tr><tr id="fileBrowserHandler"><td><code>"fileBrowserHandler"</code></td><td>Gives your extension access to the <a href="fileBrowserHandler">chrome.fileBrowserHandler</a> API.</td></tr><tr id="fileSystemProvider"><td><code>"fileSystemProvider"</code></td><td>Gives your extension access to the <a href="fileSystemProvider">chrome.fileSystemProvider</a> API.</td></tr><tr id="fontSettings"><td><code>"fontSettings"</code></td><td>Gives your extension access to the <a href="fontSettings">chrome.fontSettings</a> API.</td></tr><tr id="gcm"><td><code>"gcm"</code></td><td>Gives your extension access to the <a href="gcm">chrome.gcm</a> API.</td></tr><tr id="geolocation"><td><code>"geolocation"</code></td><td>Allows the extension or app to use the proposed HTML5 <a href="http://dev.w3.org/geo/api/spec-source.html">geolocation API</a> without prompting the user for permission.</td></tr><tr id="history"><td><code>"history"</code></td><td>Gives your extension access to the <a href="history">chrome.history</a> API.</td></tr><tr id="identity"><td><code>"identity"</code></td><td>Gives your extension access to the <a href="identity">chrome.identity</a> API.</td></tr><tr id="idle"><td><code>"idle"</code></td><td>Gives your extension access to the <a href="idle">chrome.idle</a> API.</td></tr><tr id="idltest"><td><code>"idltest"</code></td><td>Gives your extension access to the <a href="idltest">chrome.idltest</a> API.</td></tr><tr id="login"><td><code>"login"</code></td><td>Gives your extension access to the <a href="login">chrome.login</a> API.</td></tr><tr id="loginScreenStorage"><td><code>"loginScreenStorage"</code></td><td>Gives your extension access to the <a href="loginScreenStorage">chrome.loginScreenStorage</a> API.</td></tr><tr id="loginState"><td><code>"loginState"</code></td><td>Gives your extension access to the <a href="loginState">chrome.loginState</a> API.</td></tr><tr id="management"><td><code>"management"</code></td><td>Gives your extension access to the <a href="management">chrome.management</a> API.</td></tr><tr id="nativeMessaging"><td><code>"nativeMessaging"</code></td><td>Gives your extension access to the <a href="messaging.html#native-messaging">native messaging API</a>.</td></tr><tr id="notifications"><td><code>"notifications"</code></td><td>Gives your extension access to the <a href="notifications">chrome.notifications</a> API.</td></tr><tr id="pageCapture"><td><code>"pageCapture"</code></td><td>Gives your extension access to the <a href="pageCapture">chrome.pageCapture</a> API.</td></tr><tr id="platformKeys"><td><code>"platformKeys"</code></td><td>Gives your extension access to the <a href="platformKeys">chrome.platformKeys</a> API.</td></tr><tr id="power"><td><code>"power"</code></td><td>Gives your extension access to the <a href="power">chrome.power</a> API.</td></tr><tr id="printerProvider"><td><code>"printerProvider"</code></td><td>Gives your extension access to the <a href="printerProvider">chrome.printerProvider</a> API.</td></tr><tr id="printing"><td><code>"printing"</code></td><td>Gives your extension access to the <a href="printing">chrome.printing</a> API.</td></tr><tr id="printingMetrics"><td><code>"printingMetrics"</code></td><td>Gives your extension access to the <a href="printingMetrics">chrome.printingMetrics</a> API.</td></tr><tr id="privacy"><td><code>"privacy"</code></td><td>Gives your extension access to the <a href="privacy">chrome.privacy</a> API.</td></tr><tr id="processes"><td><code>"processes"</code></td><td>Gives your extension access to the <a href="processes">chrome.processes</a> API.</td></tr><tr id="proxy"><td><code>"proxy"</code></td><td>Gives your extension access to the <a href="proxy">chrome.proxy</a> API.</td></tr><tr id="scripting"><td><code>"scripting"</code></td><td>Gives your extension access to the <a href="scripting">chrome.scripting</a> API.</td></tr><tr id="search"><td><code>"search"</code></td><td>Gives your extension access to the <a href="search">chrome.search</a> API.</td></tr><tr id="sessions"><td><code>"sessions"</code></td><td>Gives your extension access to the <a href="sessions">chrome.sessions</a> API.</td></tr><tr id="signedInDevices"><td><code>"signedInDevices"</code></td><td>Gives your extension access to the <a href="signedInDevices">chrome.signedInDevices</a> API.</td></tr><tr id="storage"><td><code>"storage"</code></td><td>Gives your extension access to the <a href="storage">chrome.storage</a> API.</td></tr><tr id="system.cpu"><td><code>"system.cpu"</code></td><td>Gives your extension access to the <a href="system.cpu">chrome.system.cpu</a> API.</td></tr><tr id="system.display"><td><code>"system.display"</code></td><td>Gives your extension access to the <a href="system.display">chrome.system.display</a> API.</td></tr><tr id="system.memory"><td><code>"system.memory"</code></td><td>Gives your extension access to the <a href="system.memory">chrome.system.memory</a> API.</td></tr><tr id="system.storage"><td><code>"system.storage"</code></td><td>Gives your extension access to the <a href="system.storage">chrome.system.storage</a> API.</td></tr><tr id="tabCapture"><td><code>"tabCapture"</code></td><td>Gives your extension access to the <a href="tabCapture">chrome.tabCapture</a> API.</td></tr><tr id="tabGroups"><td><code>"tabGroups"</code></td><td>Gives your extension access to the <a href="tabGroups">chrome.tabGroups</a> API.</td></tr><tr id="tabs"><td><code>"tabs"</code></td><td>Gives your extension access to privileged fields of the <a href="https://developer.chrome.com/extensions/tabs#type-Tab"><code>Tab</code></a> objects used by several APIs including <a href="/extensions/tabs">chrome.tabs</a> and <a href="/extensions/windows">chrome.windows</a>. In many circumstances your extension will not need to declare the <code>"tabs"</code> permission to make use of these APIs.</td></tr><tr id="topSites"><td><code>"topSites"</code></td><td>Gives your extension access to the <a href="topSites">chrome.topSites</a> API.</td></tr><tr id="tts"><td><code>"tts"</code></td><td>Gives your extension access to the <a href="tts">chrome.tts</a> API.</td></tr><tr id="ttsEngine"><td><code>"ttsEngine"</code></td><td>Gives your extension access to the <a href="ttsEngine">chrome.ttsEngine</a> API.</td></tr><tr id="unlimitedStorage"><td><code>"unlimitedStorage"</code></td><td>Provides an unlimited quota for storing HTML5 client-side data, such as databases and local storage files. Without this permission, the extension or app is limited to 5 MB of local storage.<div class="aside aside--note"><b>Note:</b> This permission applies only to Web SQL Database and application cache (see issue <a href="http://crbug.com/58985">58985</a>). Also, it doesn't currently work with wildcard subdomains such as <code>http://*.example.com</code>.</div></td></tr><tr id="vpnProvider"><td><code>"vpnProvider"</code></td><td>Gives your extension access to the <a href="vpnProvider">chrome.vpnProvider</a> API.</td></tr><tr id="wallpaper"><td><code>"wallpaper"</code></td><td>Gives your extension access to the <a href="wallpaper">chrome.wallpaper</a> API.</td></tr><tr id="webNavigation"><td><code>"webNavigation"</code></td><td>Gives your extension access to the <a href="webNavigation">chrome.webNavigation</a> API.</td></tr><tr id="webRequest"><td><code>"webRequest"</code></td><td>Gives your extension access to the <a href="webRequest">chrome.webRequest</a> API.</td></tr><tr id="webRequestBlocking"><td><code>"webRequestBlocking"</code></td><td>Required if the extension uses the <a href="webRequest">chrome.webRequest</a> API in a blocking fashion.</td></tr></tbody></table>
+<table>
+  <tbody>
+    <tr>
+      <th>Permission</th>
+      <th>Description</th>
+    </tr>
+    <tr id="activeTab">
+      <td><code>"activeTab"</code></td>
+      <td>Requests that the extension be granted permissions according to the <a href="activeTab">activeTab</a>
+        specification.</td>
+    </tr>
+    <tr id="alarms">
+      <td><code>"alarms"</code></td>
+      <td>Gives your extension access to the <a href="alarms">chrome.alarms</a> API.</td>
+    </tr>
+    <tr id="background">
+      <td><code>"background"</code></td>
+      <td>
+        <p id="bg">Makes Chrome start up early and and shut down late, so that apps and extensions can have a longer
+          life.</p>
+        <p>When any installed hosted app, packaged app, or extension has "background" permission, Chrome runs
+          (invisibly) as soon as the user logs into their computer—before the user launches Chrome. The "background"
+          permission also makes Chrome continue running (even after its last window is closed) until the user explicitly
+          quits Chrome.</p>
+        <div class="aside aside--note"><b>Note:</b> Disabled apps and extensions are treated as if they aren't
+          installed.</div>
+        <p>You typically use the "background" permission with a <a href="background_pages">background page</a>, <a
+            href="/docs/extensions/mv2/event_pages">event page</a> or (for hosted apps) a <a
+            href="http://developers.google.com/chrome/apps/docs/background.html">background window</a>.</p>
+      </td>
+    </tr>
+    <tr id="bookmarks">
+      <td><code>"bookmarks"</code></td>
+      <td>Gives your extension access to the <a href="../reference/bookmarks">chrome.bookmarks</a> API.</td>
+    </tr>
+    <tr id="browsingData">
+      <td><code>"browsingData"</code></td>
+      <td>Gives your extension access to the <a href="../reference/browsingData">chrome.browsingData</a> API.</td>
+    </tr>
+    <tr id="certificateProvider">
+      <td><code>"certificateProvider"</code></td>
+      <td>Gives your extension access to the <a href="../reference/certificateProvider">chrome.certificateProvider</a> API.</td>
+    </tr>
+    <tr id="clipboardRead">
+      <td><code>"clipboardRead"</code></td>
+      <td>Required if the extension or app uses <code>document.execCommand('paste')</code>.</td>
+    </tr>
+    <tr id="clipboardWrite">
+      <td><code>"clipboardWrite"</code></td>
+      <td>Indicates the extension or app uses <code>document.execCommand('copy')</code> or
+        <code>document.execCommand('cut')</code>. This permission is <b>required for hosted apps</b>; it's recommended
+        for extensions and packaged apps.</td>
+    </tr>
+    <tr id="contentSettings">
+      <td><code>"contentSettings"</code></td>
+      <td>Gives your extension access to the <a href="../reference/contentSettings">chrome.contentSettings</a> API.</td>
+    </tr>
+    <tr id="contextMenus">
+      <td><code>"contextMenus"</code></td>
+      <td>Gives your extension access to the <a href="../reference/contextMenus">chrome.contextMenus</a> API.</td>
+    </tr>
+    <tr id="cookies">
+      <td><code>"cookies"</code></td>
+      <td>Gives your extension access to the <a href="../reference/cookies">chrome.cookies</a> API.</td>
+    </tr>
+    <tr id="debugger">
+      <td><code>"debugger"</code></td>
+      <td>Gives your extension access to the <a href="../reference/debugger">chrome.debugger</a> API.</td>
+    </tr>
+    <tr id="declarativeContent">
+      <td><code>"declarativeContent"</code></td>
+      <td>Gives your extension access to the <a href="../reference/declarativeContent">chrome.declarativeContent</a> API.</td>
+    </tr>
+    <tr id="declarativeNetRequest">
+      <td><code>"declarativeNetRequest"</code></td>
+      <td>Gives your extension access to the <a href="../reference/declarativeNetRequest">chrome.declarativeNetRequest</a> API.</td>
+    </tr>
+    <tr id="declarativeNetRequestFeedback">
+      <td><code>"declarativeNetRequestFeedback"</code></td>
+      <td>Grants the extension access to events and methods within the <a
+          href="../reference/declarativeNetRequest">chrome.declarativeNetRequest</a> API which return information on declarative
+        rules matched.</td>
+    </tr>
+    <tr id="declarativeWebRequest">
+      <td><code>"declarativeWebRequest"</code></td>
+      <td>Gives your extension access to the <a href="../reference/declarativeWebRequest">chrome.declarativeWebRequest</a> API.</td>
+    </tr>
+    <tr id="desktopCapture">
+      <td><code>"desktopCapture"</code></td>
+      <td>Gives your extension access to the <a href="../reference/desktopCapture">chrome.desktopCapture</a> API.</td>
+    </tr>
+    <tr id="displaySource">
+      <td><code>"displaySource"</code></td>
+      <td>Gives your extension access to the <a href="../reference/displaySource">chrome.displaySource</a> API.</td>
+    </tr>
+    <tr id="dns">
+      <td><code>"dns"</code></td>
+      <td>Gives your extension access to the <a href="../reference/dns">chrome.dns</a> API.</td>
+    </tr>
+    <tr id="documentScan">
+      <td><code>"documentScan"</code></td>
+      <td>Gives your extension access to the <a href="../reference/documentScan">chrome.documentScan</a> API.</td>
+    </tr>
+    <tr id="downloads">
+      <td><code>"downloads"</code></td>
+      <td>Gives your extension access to the <a href="../reference/downloads">chrome.downloads</a> API.</td>
+    </tr>
+    <tr id="enterprise.deviceAttributes">
+      <td><code>"enterprise.deviceAttributes"</code></td>
+      <td>Gives your extension access to the <a
+          href="../reference/enterprise_deviceAttributes">chrome.enterprise.deviceAttributes</a> API.</td>
+    </tr>
+    <tr id="enterprise.hardwarePlatform">
+      <td><code>"enterprise.hardwarePlatform"</code></td>
+      <td>Gives your extension access to the <a
+          href="../reference/enterprise_hardwarePlatform">chrome.enterprise.hardwarePlatform</a> API.</td>
+    </tr>
+    <tr id="enterprise.networkingAttributes">
+      <td><code>"enterprise.networkingAttributes"</code></td>
+      <td>Gives your extension access to the <a
+          href="../reference/enterprise_networkingAttributes">chrome.enterprise.networkingAttributes</a> API.</td>
+    </tr>
+    <tr id="enterprise.platformKeys">
+      <td><code>"enterprise.platformKeys"</code></td>
+      <td>Gives your extension access to the <a href="../reference/enterprise_platformKeys">chrome.enterprise.platformKeys</a> API.
+      </td>
+    </tr>
+    <tr id="experimental">
+      <td><code>"experimental"</code></td>
+      <td>Required if the extension or app uses any <a href="../reference/#experimental_apis">chrome.experimental.* APIs</a>.</td>
+    </tr>
+    <tr id="fileBrowserHandler">
+      <td><code>"fileBrowserHandler"</code></td>
+      <td>Gives your extension access to the <a href="../reference/fileBrowserHandler">chrome.fileBrowserHandler</a> API.</td>
+    </tr>
+    <tr id="fileSystemProvider">
+      <td><code>"fileSystemProvider"</code></td>
+      <td>Gives your extension access to the <a href="../reference/fileSystemProvider">chrome.fileSystemProvider</a> API.</td>
+    </tr>
+    <tr id="fontSettings">
+      <td><code>"fontSettings"</code></td>
+      <td>Gives your extension access to the <a href="../reference/fontSettings">chrome.fontSettings</a> API.</td>
+    </tr>
+    <tr id="gcm">
+      <td><code>"gcm"</code></td>
+      <td>Gives your extension access to the <a href="../reference/gcm">chrome.gcm</a> API.</td>
+    </tr>
+    <tr id="geolocation">
+      <td><code>"geolocation"</code></td>
+      <td>Allows the extension or app to use the <a
+          href="https://dev.w3.org/geo/api/spec-source.html">geolocation API</a> without prompting the user for
+        permission.</td>
+    </tr>
+    <tr id="history">
+      <td><code>"history"</code></td>
+      <td>Gives your extension access to the <a href="../reference/history">chrome.history</a> API.</td>
+    </tr>
+    <tr id="identity">
+      <td><code>"identity"</code></td>
+      <td>Gives your extension access to the <a href="../reference/identity">chrome.identity</a> API.</td>
+    </tr>
+    <tr id="idle">
+      <td><code>"idle"</code></td>
+      <td>Gives your extension access to the <a href="../reference/idle">chrome.idle</a> API.</td>
+    </tr>
+    <tr id="idltest">
+      <td><code>"idltest"</code></td>
+      <td>Gives your extension access to the <a href="../reference/idltest">chrome.idltest</a> API.</td>
+    </tr>
+    <tr id="login">
+      <td><code>"login"</code></td>
+      <td>Gives your extension access to the <a href="../reference/login">chrome.login</a> API.</td>
+    </tr>
+    <tr id="loginScreenStorage">
+      <td><code>"loginScreenStorage"</code></td>
+      <td>Gives your extension access to the <a href="../reference/loginScreenStorage">chrome.loginScreenStorage</a> API.</td>
+    </tr>
+    <tr id="loginState">
+      <td><code>"loginState"</code></td>
+      <td>Gives your extension access to the <a href="../reference/loginState">chrome.loginState</a> API.</td>
+    </tr>
+    <tr id="management">
+      <td><code>"management"</code></td>
+      <td>Gives your extension access to the <a href="../reference/management">chrome.management</a> API.</td>
+    </tr>
+    <tr id="nativeMessaging">
+      <td><code>"nativeMessaging"</code></td>
+      <td>Gives your extension access to the <a href="/docs/apps/nativeMessaging/">native messaging API</a>.</td>
+    </tr>
+    <tr id="notifications">
+      <td><code>"notifications"</code></td>
+      <td>Gives your extension access to the <a href="../reference/notifications">chrome.notifications</a> API.</td>
+    </tr>
+    <tr id="pageCapture">
+      <td><code>"pageCapture"</code></td>
+      <td>Gives your extension access to the <a href="../reference/pageCapture">chrome.pageCapture</a> API.</td>
+    </tr>
+    <tr id="platformKeys">
+      <td><code>"platformKeys"</code></td>
+      <td>Gives your extension access to the <a href="../reference/platformKeys">chrome.platformKeys</a> API.</td>
+    </tr>
+    <tr id="power">
+      <td><code>"power"</code></td>
+      <td>Gives your extension access to the <a href="../reference/power">chrome.power</a> API.</td>
+    </tr>
+    <tr id="printerProvider">
+      <td><code>"printerProvider"</code></td>
+      <td>Gives your extension access to the <a href="../reference/printerProvider">chrome.printerProvider</a> API.</td>
+    </tr>
+    <tr id="printing">
+      <td><code>"printing"</code></td>
+      <td>Gives your extension access to the <a href="../reference/printing">chrome.printing</a> API.</td>
+    </tr>
+    <tr id="printingMetrics">
+      <td><code>"printingMetrics"</code></td>
+      <td>Gives your extension access to the <a href="../reference/printingMetrics">chrome.printingMetrics</a> API.</td>
+    </tr>
+    <tr id="privacy">
+      <td><code>"privacy"</code></td>
+      <td>Gives your extension access to the <a href="../reference/privacy">chrome.privacy</a> API.</td>
+    </tr>
+    <tr id="processes">
+      <td><code>"processes"</code></td>
+      <td>Gives your extension access to the <a href="../reference/processes">chrome.processes</a> API.</td>
+    </tr>
+    <tr id="proxy">
+      <td><code>"proxy"</code></td>
+      <td>Gives your extension access to the <a href="../reference/proxy">chrome.proxy</a> API.</td>
+    </tr>
+    <tr id="scripting">
+      <td><code>"scripting"</code></td>
+      <td>Gives your extension access to the <a href="../reference/scripting">chrome.scripting</a> API.</td>
+    </tr>
+    <tr id="search">
+      <td><code>"search"</code></td>
+      <td>Gives your extension access to the <a href="../reference/search">chrome.search</a> API.</td>
+    </tr>
+    <tr id="sessions">
+      <td><code>"sessions"</code></td>
+      <td>Gives your extension access to the <a href="../reference/sessions">chrome.sessions</a> API.</td>
+    </tr>
+    <tr id="signedInDevices">
+      <td><code>"signedInDevices"</code></td>
+      <td>Gives your extension access to the <a href="../reference/signedInDevices">chrome.signedInDevices</a> API.</td>
+    </tr>
+    <tr id="storage">
+      <td><code>"storage"</code></td>
+      <td>Gives your extension access to the <a href="../reference/storage">chrome.storage</a> API.</td>
+    </tr>
+    <tr id="system.cpu">
+      <td><code>"system.cpu"</code></td>
+      <td>Gives your extension access to the <a href="../reference/system_cpu">chrome.system.cpu</a> API.</td>
+    </tr>
+    <tr id="system.display">
+      <td><code>"system.display"</code></td>
+      <td>Gives your extension access to the <a href="../reference/system_display">chrome.system.display</a> API.</td>
+    </tr>
+    <tr id="system.memory">
+      <td><code>"system.memory"</code></td>
+      <td>Gives your extension access to the <a href="../reference/system_memory">chrome.system.memory</a> API.</td>
+    </tr>
+    <tr id="system.storage">
+      <td><code>"system.storage"</code></td>
+      <td>Gives your extension access to the <a href="../reference/system_storage">chrome.system.storage</a> API.</td>
+    </tr>
+    <tr id="tabCapture">
+      <td><code>"tabCapture"</code></td>
+      <td>Gives your extension access to the <a href="../reference/tabCapture">chrome.tabCapture</a> API.</td>
+    </tr>
+    <tr id="tabGroups">
+      <td><code>"tabGroups"</code></td>
+      <td>Gives your extension access to the <a href="../reference/tabGroups">chrome.tabGroups</a> API.</td>
+    </tr>
+    <tr id="tabs">
+      <td><code>"tabs"</code></td>
+      <td>Gives your extension access to privileged fields of the <a
+          href="https://developer.chrome.com/extensions/tabs#type-Tab"><code>Tab</code></a> objects used by several APIs
+        including <a href="/extensions/tabs">chrome.tabs</a> and <a href="/extensions/windows">chrome.windows</a>. In
+        many circumstances your extension will not need to declare the <code>"tabs"</code> permission to make use of
+        these APIs.</td>
+    </tr>
+    <tr id="topSites">
+      <td><code>"topSites"</code></td>
+      <td>Gives your extension access to the <a href="../reference/topSites">chrome.topSites</a> API.</td>
+    </tr>
+    <tr id="tts">
+      <td><code>"tts"</code></td>
+      <td>Gives your extension access to the <a href="../reference/tts">chrome.tts</a> API.</td>
+    </tr>
+    <tr id="ttsEngine">
+      <td><code>"ttsEngine"</code></td>
+      <td>Gives your extension access to the <a href="../reference/ttsEngine">chrome.ttsEngine</a> API.</td>
+    </tr>
+    <tr id="unlimitedStorage">
+      <td><code>"unlimitedStorage"</code></td>
+      <td>Provides an unlimited quota for storing client-side data, such as databases and local storage files.
+        Without this permission, the extension or app is limited to 5 MB of local storage.<div
+          class="aside aside--note"><b>Note:</b> This permission applies only to Web SQL Database and application cache
+          (see issue <a href="http://crbug.com/58985">58985</a>). Also, it doesn't currently work with wildcard
+          subdomains such as <code>http://*.example.com</code>.</div>
+      </td>
+    </tr>
+    <tr id="vpnProvider">
+      <td><code>"vpnProvider"</code></td>
+      <td>Gives your extension access to the <a href="../reference/vpnProvider">chrome.vpnProvider</a> API.</td>
+    </tr>
+    <tr id="wallpaper">
+      <td><code>"wallpaper"</code></td>
+      <td>Gives your extension access to the <a href="../reference/wallpaper">chrome.wallpaper</a> API.</td>
+    </tr>
+    <tr id="webNavigation">
+      <td><code>"webNavigation"</code></td>
+      <td>Gives your extension access to the <a href="../reference/webNavigation">chrome.webNavigation</a> API.</td>
+    </tr>
+    <tr id="webRequest">
+      <td><code>"webRequest"</code></td>
+      <td>Gives your extension access to the <a href="../reference/webRequest">chrome.webRequest</a> API.</td>
+    </tr>
+    <tr id="webRequestBlocking">
+      <td><code>"webRequestBlocking"</code></td>
+      <td>Required if the extension uses the <a href="../reference/webRequest">chrome.webRequest</a> API in a blocking fashion.</td>
+    </tr>
+  </tbody>
+</table>
 
 [1]: /docs/extensions/mv3/tabs
 [2]: /docs/extensions/mv3/match_patterns

--- a/site/en/docs/extensions/mv3/getstarted/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/index.md
@@ -311,7 +311,7 @@ function setTheColor() {
 
 ```
 
-The updated code adds an onclick event the button, which triggers a [programatically injected
+The updated code adds an `onclick` event on the button, which triggers a [programatically injected
 content script][24]. This turns the background color of the page the same color as the button. Using
 programmatic injection allows for user-invoked content scripts, instead of auto inserting unwanted
 code into web pages.

--- a/site/en/docs/extensions/mv3/hosting/index.md
+++ b/site/en/docs/extensions/mv3/hosting/index.md
@@ -53,7 +53,7 @@ To release an update to an extension, increase the number in the `“version”`
 ```
 
 Convert the updated extension directory into a ZIP file and locate the old version in the [Developer
-Dashboard][10]. Select **Edit**, upload the new package, and hit **Publish**. The browser will will
+Dashboard][10]. Select **Edit**, upload the new package, and hit **Publish**. The browser will
 automatically update the extension for users after the new version is published.
 
 [1]: https://chrome.google.com/webstore/category/extensions


### PR DESCRIPTION
- Fixes the permissions tables in declare_permissions not linking to the correct APIs
- Removes link to now-squatted domain from Apps docs
- a couple of other incorrect words

These were found by going down the historical issues [here](https://bugs.chromium.org/p/chromium/issues/list?q=component:Platform%3EExtensions%3EDocumentation).

Fixes #47