### PR TITLE
Add skip link

### DIFF
--- a/site/_includes/partials/top-nav.njk
+++ b/site/_includes/partials/top-nav.njk
@@ -1,6 +1,8 @@
 {% from 'macros/icon.njk' import icon with context %}
 
 <top-nav role="banner" class="display-block hairline-bottom" data-side-nav-inert>
+  <a href="#main-content" class="color-primary visually-hidden skip-link">Skip to content</a>
+
   <nav class="display-grid align-center" aria-label="{{ 'i18n.common.chrome_developers' | i18n(locale) }}">
     {# Hamburger button #}
     <button class="top-nav__hamburger button display-flex lg:display-none align-center justify-content-center width-700 height-700" aria-label="{{ 'i18n.common.menu' | i18n(locale) }}">

--- a/site/_scss/blocks/_skip-link.scss
+++ b/site/_scss/blocks/_skip-link.scss
@@ -1,0 +1,12 @@
+.skip-link {
+  @extend %material-button;
+
+  background-color: var(--color-bg);
+
+  &:focus {
+    clip: auto;
+    padding: inherit;
+    width: auto;
+    z-index: 1;
+  }
+}

--- a/site/_scss/main.scss
+++ b/site/_scss/main.scss
@@ -59,6 +59,7 @@
 @import 'blocks/announcement-banner';
 @import 'blocks/cookie-banner';
 @import 'blocks/columns';
+@import 'blocks/skip-link';
 
 // Utilities
 @import 'utilities/center-margin';


### PR DESCRIPTION
Fixes #93 

Changes proposed in this pull request:

- Add a link at the very top that points to the already existing `#main-content`.
- The link is visually hidden unless it's focused. When visible, it looks like a material button (see screenshot below).

<img width="1054" alt="Skip link on focus" src="https://user-images.githubusercontent.com/1273138/103300088-5adebe00-49fe-11eb-9eef-e8a54cdb9b59.png">
