### PR TITLE
Fix chrome.idle API reference pointing to history

### DIFF
--- a/site/en/docs/extensions/reference/idle/index.md
+++ b/site/en/docs/extensions/reference/idle/index.md
@@ -1,5 +1,5 @@
 ---
-api: history
+api: idle
 ---
 
 ## Manifest


### PR DESCRIPTION
Fixes #51 and part of #149.