### PR TITLE
Fixed typo [#159] : replaed with replaced

### DIFF
--- a/site/en/docs/extensions/mv3/user_interface/index.md
+++ b/site/en/docs/extensions/mv3/user_interface/index.md
@@ -512,7 +512,7 @@ Register an override page in the manifest under the `"chrome_url_overrides"` fie
 }
 ```
 
-The `"newtab"` field should be replaed with `"bookmarks"` or `"history"` when overriding those
+The `"newtab"` field should be replaced with `"bookmarks"` or `"history"` when overriding those
 pages.
 
 ```html


### PR DESCRIPTION
Fixes typo in the docs, under the section
- developer.chrome.com/docs/extensions/mv3/user_interface/
Typo:  replaed was corrected to "replaced"
 
