### PR TITLE
warn when we can't find URL:s

### DIFF
--- a/site/_includes/macros/project-sections.njk
+++ b/site/_includes/macros/project-sections.njk
@@ -29,6 +29,13 @@ have been defined in the _data/docs/*.yml file for this project.
         {{ projectSections(item.sections, type) }}
       </li>
     {% elif item.url %}
+      {#
+        Reset postTitle and friends, in case we can't find the post below.
+        (Otherwise, the values from our previous iteration are used.)
+      #}
+      {% set postTitle = '' %}
+      {% set postDescription = '' %}
+      {% set postUrl = '' %}
 
       {#
         Check to see if the item is a regular post on the site or an external


### PR DESCRIPTION
Fixes #46.

Does two things:
- warns (usually once) when we can't find URLs—to be fair, this doesn't tell you the origin of the failure (since the _once_ behavior is helpful not to spam you), but it starts you off, and there's only a handful right now
- doesn't emit a duplicate entry in`project-sections.njk` when we can't find a post (this actually fixes the issue)