### PR TITLE
Fast cheerio

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -24,7 +24,7 @@ const {youtube} = require('./site/_shortcodes/youtube');
 const {columns} = require('./site/_shortcodes/columns');
 
 // Transforms
-const {domTransformer} = require('./site/_transforms/dom-transformer');
+const {domTransformer} = require('./site/_transforms/dom-transformer-pool');
 const {purifyCss} = require('./site/_transforms/purify-css');
 const {minifyHtml} = require('./site/_transforms/minify-html');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3252,9 +3252,9 @@
       }
     },
     "async-transforms": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/async-transforms/-/async-transforms-1.0.4.tgz",
-      "integrity": "sha512-ARh5TbJm3e5AAyVSaSVVS2M5f1MG+sMl2Z4WmlvtyPmgVv/VqcJE50NlYd5FnFXlsY7svYBqJ+bGGUqLCbntyg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/async-transforms/-/async-transforms-1.0.6.tgz",
+      "integrity": "sha512-bvILqKILVEOTyIuhaM9fChWV6qBTrpU6WLWjfvRkUcY3l6F2U8ubPlGZDyV06na2mrdIc7XA33NdSeK0IVg1QQ==",
       "requires": {
         "@types/node": "^14.14.20"
       },
@@ -3262,7 +3262,8 @@
         "@types/node": {
           "version": "14.14.20",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.20.tgz",
-          "integrity": "sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A=="
+          "integrity": "sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A==",
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3252,9 +3252,19 @@
       }
     },
     "async-transforms": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/async-transforms/-/async-transforms-1.0.3.tgz",
-      "integrity": "sha512-knq7FXuYfQdInEWWysBLOn35p5YbXxdZ+D8a2sY6tiaYoN1TyljBNCqqNh9sFotyYRI2TRIGVQZPslOTiRwOLg=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/async-transforms/-/async-transforms-1.0.4.tgz",
+      "integrity": "sha512-ARh5TbJm3e5AAyVSaSVVS2M5f1MG+sMl2Z4WmlvtyPmgVv/VqcJE50NlYd5FnFXlsY7svYBqJ+bGGUqLCbntyg==",
+      "requires": {
+        "@types/node": "^14.14.20"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.14.20",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.20.tgz",
+          "integrity": "sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A=="
+        }
+      }
     },
     "asynckit": {
       "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3251,6 +3251,11 @@
         "async-done": "^1.2.2"
       }
     },
+    "async-transforms": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/async-transforms/-/async-transforms-1.0.3.tgz",
+      "integrity": "sha512-knq7FXuYfQdInEWWysBLOn35p5YbXxdZ+D8a2sY6tiaYoN1TyljBNCqqNh9sFotyYRI2TRIGVQZPslOTiRwOLg=="
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@lhci/cli": "^0.5.0",
     "@rollup/plugin-node-resolve": "^8.4.0",
     "algoliasearch": "^4.6.0",
-    "async-transforms": "^1.0.4",
+    "async-transforms": "^1.0.6",
     "browser-media-mime-type": "^1.0.0",
     "chokidar-cli": "^2.1.0",
     "chrome-types": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@lhci/cli": "^0.5.0",
     "@rollup/plugin-node-resolve": "^8.4.0",
     "algoliasearch": "^4.6.0",
-    "async-transforms": "^1.0.3",
+    "async-transforms": "^1.0.4",
     "browser-media-mime-type": "^1.0.0",
     "chokidar-cli": "^2.1.0",
     "chrome-types": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@lhci/cli": "^0.5.0",
     "@rollup/plugin-node-resolve": "^8.4.0",
     "algoliasearch": "^4.6.0",
+    "async-transforms": "^1.0.3",
     "browser-media-mime-type": "^1.0.0",
     "chokidar-cli": "^2.1.0",
     "chrome-types": "0.0.7",

--- a/site/_transforms/dom-transformer-pool.js
+++ b/site/_transforms/dom-transformer-pool.js
@@ -14,7 +14,7 @@ let runWithPool;
 const domTransformer = (content, outputPath) => {
   if (runWithPool === undefined) {
     // Lazily create the worker pool if needed.
-    const script = path.join(__dirname, './dom-transformer-thread.js');
+    const script = path.join(__dirname, './dom-transformer.js');
     runWithPool = buildWorkerPool(script);
   }
   return runWithPool({content, outputPath});

--- a/site/_transforms/dom-transformer-pool.js
+++ b/site/_transforms/dom-transformer-pool.js
@@ -1,0 +1,23 @@
+const path = require('path');
+
+// This works around: https://github.com/mysticatea/eslint-plugin-node/issues/244
+// @ts-ignore
+// eslint-disable-next-line node/no-missing-require
+const {pool: buildWorkerPool} = require('async-transforms/worker');
+
+let runWithPool;
+
+/**
+ * This wraps "dom-transformer.js", which uses Cheerio to modify the DOM for all pages. This work
+ * is CPU-bound, so use a worker pool for a speed improvement.
+ */
+const domTransformer = (content, outputPath) => {
+  if (runWithPool === undefined) {
+    // Lazily create the worker pool if needed.
+    const script = path.join(__dirname, './dom-transformer-thread.js');
+    runWithPool = buildWorkerPool(script);
+  }
+  return runWithPool({content, outputPath});
+};
+
+module.exports = {domTransformer};

--- a/site/_transforms/dom-transformer-pool.js
+++ b/site/_transforms/dom-transformer-pool.js
@@ -1,23 +1,23 @@
 const path = require('path');
 
 // This works around: https://github.com/mysticatea/eslint-plugin-node/issues/244
-// @ts-ignore
 // eslint-disable-next-line node/no-missing-require
 const {pool: buildWorkerPool} = require('async-transforms/worker');
 
-let runWithPool;
+/** @type {(content: string, outputPath: string) => Promise<string>} */
+let domTransformerPool;
 
 /**
  * This wraps "dom-transformer.js", which uses Cheerio to modify the DOM for all pages. This work
  * is CPU-bound, so use a worker pool for a speed improvement.
  */
 const domTransformer = (content, outputPath) => {
-  if (runWithPool === undefined) {
+  if (domTransformerPool === undefined) {
     // Lazily create the worker pool if needed.
     const script = path.join(__dirname, './dom-transformer.js');
-    runWithPool = buildWorkerPool(script);
+    domTransformerPool = buildWorkerPool(script);
   }
-  return runWithPool({content, outputPath});
+  return domTransformerPool(content, outputPath);
 };
 
 module.exports = {domTransformer};

--- a/site/_transforms/dom-transformer.js
+++ b/site/_transforms/dom-transformer.js
@@ -4,6 +4,11 @@ const {asides} = require('./asides');
 const {prettyUrls} = require('./pretty-urls');
 const {tables} = require('./tables');
 
+/**
+ * @param {string} content
+ * @param {string} outputPath
+ * @return {string}
+ */
 const domTransformer = (content, outputPath) => {
   // Make sure we're not interacting with something weird that has
   // permalink set to false or undefined.
@@ -35,4 +40,6 @@ const domTransformer = (content, outputPath) => {
   return $.html();
 };
 
-module.exports = {domTransformer};
+// Include a default export which runs the transformer, for async-transforms pool code.
+module.exports = ({content, outputPath}) => domTransformer(content, outputPath);
+module.exports.domTransformer = domTransformer;

--- a/site/_transforms/dom-transformer.js
+++ b/site/_transforms/dom-transformer.js
@@ -12,7 +12,8 @@ const domTransformer = (content, outputPath) => {
   }
 
   // Turn the page into a cheerio object to make it queryable.
-  const $ = cheerio.load(content);
+  // This uses https://github.com/fb55/htmlparser2 instead of the default parse5.
+  const $ = cheerio.load(content, {_useHtmlParser2: true});
 
   // Grab the locale for the page. This is used by various transforms.
   const locale = $('html').attr('lang');

--- a/site/_transforms/dom-transformer.js
+++ b/site/_transforms/dom-transformer.js
@@ -40,6 +40,5 @@ const domTransformer = (content, outputPath) => {
   return $.html();
 };
 
-// Include a default export which runs the transformer, for async-transforms pool code.
-module.exports = ({content, outputPath}) => domTransformer(content, outputPath);
-module.exports.domTransformer = domTransformer;
+// async-transforms can only operate on the default export.
+module.exports = domTransformer;

--- a/tests/site/_transforms/dom-transformer.js
+++ b/tests/site/_transforms/dom-transformer.js
@@ -1,5 +1,5 @@
 const test = require('ava');
-const {domTransformer} = require('../../../site/_transforms/dom-transformer');
+const domTransformer = require('../../../site/_transforms/dom-transformer');
 
 test("ignores content if there's no outputPath", t => {
   const content = '<a href="/en/foo"></a>';


### PR DESCRIPTION
This extends on @slightlyoff's change in the internal repo. It:

- sets`_useHtmlParser2` for cheerio, which makes Eleventy about 1/3 faster (thanks Alex)
- puts cheerio into worker threads, which on my [iMac Pro](https://en.wikichip.org/wiki/intel/xeon_w/w-2140b) uses 12 cores (of 16, `async-transforms` is set to 75% by default), and makes it 1/4 faster again
  - This works because our transforms don't depend on each other and are entirely CPU-bound.

For me, Eleventy goes from taking 16s to about 6s.