### PR TITLE
Migration of Chromium Chronicle articles & Add float-(left|right) 

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -21,7 +21,7 @@ const {glitch} = require('./site/_shortcodes/glitch');
 const {img} = require('./site/_shortcodes/img');
 const {video} = require('./site/_shortcodes/video');
 const {youtube} = require('./site/_shortcodes/youtube');
-const {columns} = require('./site/_shortcodes/columns');
+const {columns, column} = require('./site/_shortcodes/columns');
 const {Compare, CompareCaption} = require('./site/_shortcodes/Compare');
 
 // Transforms
@@ -45,7 +45,7 @@ const extensionsReferenceCollection = require('./site/_collections/reference');
 
 // Create a helpful environment flags
 const isProduction = process.env.NODE_ENV === 'production';
-const isCI = true || process.env.CI;
+const isCI = process.env.CI;
 
 module.exports = eleventyConfig => {
   // Tell 11ty to use the .eleventyignore and ignore our .gitignore file
@@ -106,6 +106,7 @@ module.exports = eleventyConfig => {
   eleventyConfig.addShortcode('video', video);
   eleventyConfig.addShortcode('youtube', youtube);
   eleventyConfig.addPairedShortcode('columns', columns);
+  eleventyConfig.addPairedShortcode('column', column);
   eleventyConfig.addPairedShortcode('Compare', Compare);
   eleventyConfig.addPairedShortcode('CompareCaption', CompareCaption);
 

--- a/site/_data/i18n/tags.yml
+++ b/site/_data/i18n/tags.yml
@@ -11,6 +11,9 @@ accessibility:
 amp:
   en: AMP
 
+chromium-chronicle:
+  en: Chromium Chronicle
+
 devices:
   en: Devices
 

--- a/site/_data/supportedTags.json
+++ b/site/_data/supportedTags.json
@@ -11,6 +11,9 @@
   "amp": {
     "title": "i18n.tags.amp"
   },
+  "chromium-chronicle": {
+    "title": "i18n.tags.chromium-chronicle"
+  },
   "devices": {
     "title": "i18n.tags.devices"
   },

--- a/site/_includes/layouts/blog-post.njk
+++ b/site/_includes/layouts/blog-post.njk
@@ -31,7 +31,7 @@
 
     {% include 'partials/draft.njk' %}
 
-    <div class="stack type center-images">
+    <div class="stack stack--block type center-images">
       {{ content | safe }}
     </div>
   </article>

--- a/site/_includes/layouts/doc-post.njk
+++ b/site/_includes/layouts/doc-post.njk
@@ -26,7 +26,7 @@
       {% include 'partials/toc-inner.njk' %}
       {% include 'partials/draft.njk' %}
 
-      <div class="stack type center-images">
+      <div class="stack stack--block type center-images">
         {{ content | safe }}
       </div>
     </article>

--- a/site/_scss/blocks/_columns.scss
+++ b/site/_scss/blocks/_columns.scss
@@ -4,6 +4,14 @@
   grid-auto-flow: row;
   
   @include media-query('md') {
+    grid-auto-columns: 1fr;
     grid-auto-flow: column;
+  }
+}
+
+.columns__column {
+  @include media-query('md') {
+    display: flex;
+    flex-direction: column;
   }
 }

--- a/site/_scss/blocks/_stack.scss
+++ b/site/_scss/blocks/_stack.scss
@@ -29,6 +29,13 @@
 }
 /* purgecss end ignore */
 
+// The default .stack class uses flexbox, and flexbox ignores floats.
+// Authors like to use floats in blog posts and docs so this exception can be
+// used on those stacks to enable floats.
+.stack--block {
+  display: block;
+}
+
 // Use the stack-exception class to change the top AND bottom margin
 // around an individual element.
 // These exceptions follow the rest of our size scale.

--- a/site/_scss/main.scss
+++ b/site/_scss/main.scss
@@ -66,6 +66,7 @@
 // Utilities
 @import 'utilities/center-margin';
 @import 'utilities/center-images';
+@import 'utilities/floats';
 @import 'utilities/elevation';
 @import 'utilities/hairline';
 @import 'utilities/colors';

--- a/site/_scss/utilities/_floats.scss
+++ b/site/_scss/utilities/_floats.scss
@@ -1,0 +1,20 @@
+.float-left {
+  @include media-query('lg') {
+    float: left;
+    margin-right: get-size(600) !important;
+  }
+}
+
+.float-right {
+  @include media-query('lg') {
+    float: right;
+    margin-left: get-size(600) !important;
+  }
+}
+
+.float-left,
+.float-right {
+  @include media-query('lg') {
+    max-width: calc((100% - #{get-size(600)}) / 2);
+  }
+}

--- a/site/_shortcodes/columns.js
+++ b/site/_shortcodes/columns.js
@@ -33,4 +33,8 @@ ${content}
 </div>`;
 };
 
-module.exports = {columns};
+const column = content => {
+  return `<div class="columns__column">${content}</div>`;
+};
+
+module.exports = {columns, column};

--- a/site/en/blog/chromium-chronicle-1/index.md
+++ b/site/en/blog/chromium-chronicle-1/index.md
@@ -14,8 +14,6 @@ tags:
   - chromium-chronicle
 ---
 
-<!-- Needs compare widget -->
-
 The Chrome team is proud to introduce the Chromium Chronicle, a monthly
 series geared specifically to Chromium developers, developers who build the
 browser.
@@ -39,16 +37,20 @@ to sequences. Sequences are chrome-managed “virtual threads” and are
 [preferred to creating your own thread][prefer-sequences]. How does an object
 know which sequence to post to?
 
+{% Compare 'worse' %}
+
 The old paradigm is to receive a SequencedTaskRunner from the creator:
-{: .compare-worse }
 
 ```cpp/0
 Foo::Foo(scoped_refptr<base::SequencedTaskRunner> backend_task_runner)
     : backend_task_runner_(std::move(backend_task_runner)) {}
 ```
 
+{% endCompare %}
+
+{% Compare 'better' %}
+
 The preferred paradigm is to create an independent SequencedTaskRunner:
-{: .compare-better }
 
 ```cpp/2-3
 Foo::Foo()
@@ -56,6 +58,8 @@ Foo::Foo()
           base::CreateSequencedTaskRunnerWithTraits({
               base::MayBlock(), base::TaskPriority::BEST_EFFORT})) {}
 ```
+
+{% endCompare %}
 
 This is easier to read and write as all the information is local and there’s
 no risk of inter-dependency with unrelated tasks.
@@ -79,8 +83,8 @@ manages the task environment throughout Foo’s lifetime. The TaskEnvironment
 will capture Foo’s request-on-construction to create a SequencedTaskRunner and
 will manage its tasks under each FooTest.
 
-To test the result of asynchronous execution, **use the RunLoop::Run()+QuitClosure()
-paradigm**:
+To test the result of asynchronous execution, **use the
+`RunLoop::Run()+QuitClosure()` paradigm**:
 
 ```cpp
 TEST_F(FooTest, TestAsyncWork) {
@@ -93,7 +97,7 @@ TEST_F(FooTest, TestAsyncWork) {
 
 This is preferred to RunUntilIdle(), which can be flaky if the asynchronous
 workload involves a task outside of the TaskEnvironment’s purview,
-e.g. a system event, so use [RunUntilIdle() with care][run-until-idle-w-care].
+e.g. a system event, so use [`RunUntilIdle()` with care][run-until-idle-w-care].
 
 !!!.aside.aside
 Pro-tip: Use TaskEnvironment’s `MOCK_TIME` mode to reliably test delayed

--- a/site/en/blog/chromium-chronicle-1/index.md
+++ b/site/en/blog/chromium-chronicle-1/index.md
@@ -96,7 +96,7 @@ workload involves a task outside of the TaskEnvironment’s purview,
 e.g. a system event, so use [RunUntilIdle() with care][run-until-idle-w-care].
 
 !!!.aside.aside
-Pro-tip: Use TaskEnvironment’s MOCK_TIME mode to reliably test delayed
+Pro-tip: Use TaskEnvironment’s `MOCK_TIME` mode to reliably test delayed
 tasks.
 !!!
 

--- a/site/en/blog/chromium-chronicle-1/index.md
+++ b/site/en/blog/chromium-chronicle-1/index.md
@@ -1,5 +1,5 @@
 ---
-title: "The Chromium Chronicle: Task Scheduling Best Practices"
+title: "The Chromium Chronicle #1: Task Scheduling Best Practices"
 description: >
   The Chrome team is proud to introduce the Chromium Chronicle, a monthly
   series geared specifically to Chromium developers - the developers who
@@ -10,7 +10,11 @@ date: 2019-04-16
 hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/hgu6uTktp2ipmuODZZhP.jpg'
 alt: >
   Chromium Chronicle image
+tags:
+  - chromium-chronicle
 ---
+
+<!-- Needs compare widget -->
 
 The Chrome team is proud to introduce the Chromium Chronicle, a monthly
 series geared specifically to Chromium developers, developers who build the
@@ -28,7 +32,7 @@ Take a look at our first episode below!
 ## Task Scheduling Best Practices
 
 **Episode 1:** by Gabriel Charette in Montréal, PQ (April, 2019)<br>
-[Previous episodes](/tags/chromium-chronicle)
+[Previous episodes](/tags/chromium-chronicle/)
 
 Chrome code that needs in-process asynchronous execution typically posts tasks
 to sequences. Sequences are chrome-managed “virtual threads” and are
@@ -91,10 +95,10 @@ This is preferred to RunUntilIdle(), which can be flaky if the asynchronous
 workload involves a task outside of the TaskEnvironment’s purview,
 e.g. a system event, so use [RunUntilIdle() with care][run-until-idle-w-care].
 
-<aside class="success">
+!!!.aside.aside
 Pro-tip: Use TaskEnvironment’s MOCK_TIME mode to reliably test delayed
 tasks.
-</aside>
+!!!
 
 **Want to learn more?** Read our documentation on [threading and tasks][threading-and-tasks]
 or get involved in the [migration to TaskEnvironment][task-env]!

--- a/site/en/blog/chromium-chronicle-1/index.md
+++ b/site/en/blog/chromium-chronicle-1/index.md
@@ -1,0 +1,105 @@
+---
+title: "The Chromium Chronicle: Task Scheduling Best Practices"
+description: >
+  The Chrome team is proud to introduce the Chromium Chronicle, a monthly
+  series geared specifically to Chromium developers - the developers who
+  build the browser. This month, we take a look at task scheduling best
+  practices.
+layout: 'layouts/blog-post.njk'
+date: 2019-04-16
+hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/hgu6uTktp2ipmuODZZhP.jpg'
+alt: >
+  Chromium Chronicle image
+---
+
+The Chrome team is proud to introduce the Chromium Chronicle, a monthly
+series geared specifically to Chromium developers, developers who build the
+browser.
+
+The Chromium Chronicle will primarily focus on spreading technical knowledge
+and best practices to write, build, and test Chrome. Our plan is to feature
+topics that are relevant and useful to Chromium developers, such as code
+health, helpful tools, unit testing, accessibility and much more! Each article
+will be written and edited by Chrome engineers.
+
+We are excited about this new series, and hope you are too! Ready to dive in?
+Take a look at our first episode below!
+
+## Task Scheduling Best Practices
+
+**Episode 1:** by Gabriel Charette in Montréal, PQ (April, 2019)<br>
+[Previous episodes](/tags/chromium-chronicle)
+
+Chrome code that needs in-process asynchronous execution typically posts tasks
+to sequences. Sequences are chrome-managed “virtual threads” and are
+[preferred to creating your own thread][prefer-sequences]. How does an object
+know which sequence to post to?
+
+The old paradigm is to receive a SequencedTaskRunner from the creator:
+{: .compare-worse }
+
+```cpp/0
+Foo::Foo(scoped_refptr<base::SequencedTaskRunner> backend_task_runner)
+    : backend_task_runner_(std::move(backend_task_runner)) {}
+```
+
+The preferred paradigm is to create an independent SequencedTaskRunner:
+{: .compare-better }
+
+```cpp/2-3
+Foo::Foo()
+    : backend_task_runner_(
+          base::CreateSequencedTaskRunnerWithTraits({
+              base::MayBlock(), base::TaskPriority::BEST_EFFORT})) {}
+```
+
+This is easier to read and write as all the information is local and there’s
+no risk of inter-dependency with unrelated tasks.
+
+This paradigm is also better when it comes to testing. Instead of injecting
+task runners manually, tests can **instantiate a controlled task environment**
+to manage Foo’s tasks:
+
+```cpp/4
+class FooTest : public testing::Test {
+ public
+  (...)
+ protected:
+  base::test::TaskEnvironment task_environment_;
+  Foo foo_;
+};
+```
+
+Having **TaskEnvironment first in the fixture** naturally ensures it
+manages the task environment throughout Foo’s lifetime. The TaskEnvironment
+will capture Foo’s request-on-construction to create a SequencedTaskRunner and
+will manage its tasks under each FooTest.
+
+To test the result of asynchronous execution, **use the RunLoop::Run()+QuitClosure()
+paradigm**:
+
+```cpp
+TEST_F(FooTest, TestAsyncWork) {
+  RunLoop run_loop;
+  foo_.BeginAsyncWork(run_loop.QuitClosure());
+  run_loop.Run();
+  EXPECT_TRUE(foo_.work_done());
+}
+```
+
+This is preferred to RunUntilIdle(), which can be flaky if the asynchronous
+workload involves a task outside of the TaskEnvironment’s purview,
+e.g. a system event, so use [RunUntilIdle() with care][run-until-idle-w-care].
+
+<aside class="success">
+Pro-tip: Use TaskEnvironment’s MOCK_TIME mode to reliably test delayed
+tasks.
+</aside>
+
+**Want to learn more?** Read our documentation on [threading and tasks][threading-and-tasks]
+or get involved in the [migration to TaskEnvironment][task-env]!
+
+[prefer-sequences]: https://chromium.googlesource.com/chromium/src/+/lkgr/docs/threading_and_tasks.md#Prefer-Sequences-to-Threads
+[threading-and-tasks]: https://chromium.googlesource.com/chromium/src/+/master/docs/threading_and_tasks.md
+[task-env]: https://docs.google.com/document/d/1QabRo8c7D9LsYY3cEcaPQbOCLo8Tu-6VLykYXyl3Pkk/edit
+[run-until-idle-w-care]: https://cs.chromium.org/chromium/src/base/test/task_environment.h?type=cs&q="void+RunUntilIdle()"+WARNING+case:yes&sq=package:chromium&g=0

--- a/site/en/blog/chromium-chronicle-10/index.md
+++ b/site/en/blog/chromium-chronicle-10/index.md
@@ -1,0 +1,59 @@
+---
+title: "The Chromium Chronicle: Catching UI Regressions with Pixel Tests"
+description: >
+  Chrome’s testing strategy relies heavily on automated functional correctness
+  tests and manual testing, but neither of these reliably catch minor UI
+  regressions. Use pixel tests to automate testing your desktop browser UI.
+layout: 'layouts/blog-post.njk'
+date: 2020-02-05
+hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/hgu6uTktp2ipmuODZZhP.jpg'
+alt: >
+  Chromium Chronicle image
+---
+
+**Episode 10:** by Sven Zheng in Bellevue, WA (January, 2020)<br>
+[Previous episodes](/tags/chromium-chronicle)
+
+Chrome’s testing strategy relies heavily on automated functional correctness
+tests and manual testing, but neither of these reliably catch minor UI
+regressions. **Use pixel tests to automate testing your desktop browser UI.**
+
+When writing a pixel test, avoid flakiness by: (1) disabling animation,
+(2) using mock data, and (3) testing the minimum possible surface area.
+
+Here is a sample image used to verify pixel correctness for the omnibox:
+
+{% img src="image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/WdIk74i8zUDGYrHX44FP.png", alt="Omnibox image used for pixel comparison." %}
+
+And the code to verify the browser matches this image:
+
+```cpp
+IN_PROC_BROWSER_TEST_F(SkiaGoldDemoPixelTest, TestOmnibox) {
+  // Always disable animation for stability.
+  ui::ScopedAnimationDurationScaleMode disable_animation(
+      ui::ScopedAnimationDurationScaleMode::ZERO_DURATION);
+  GURL url("chrome://bookmarks");
+  AddTabAtIndex(0, url, ui::PageTransition::PAGE_TRANSITION_FIRST);
+  auto* const browser_view = BrowserView::GetBrowserViewForBrowser(browser());
+  // CompareScreenshot() takes a screenshot and compares it with the golden image,
+  // which was previously human-approved, is stored server-side, and is managed
+  // by Skia Gold. If any pixels differ, the test will fail and output a link
+  // for the author to triage the new image.
+  bool ret = GetPixelDiff().CompareScreenshot("omnibox",
+      browser_view->GetLocationBarView());
+  EXPECT_TRUE(ret);
+}
+```
+
+This code lives at [chrome/test/pixel/demo/skia_gold_demo_pixeltest.cc][1].
+The relevant headers are `skia_gold_pixel_diff.h` for unit tests and
+`browser_skia_gold_pixel_diff.h` for browser tests.
+
+The pixel diff and approval process is powered by Skia Gold. **Skia Gold pixel
+tests provide a visual approval workflow, and allow developers to accept
+small flakes by approving multiple gold images.**
+
+Currently the test suite is running on the Windows FYI bot. Browser tests
+and Views unit tests are supported.
+
+[1]: https://chromium.googlesource.com/chromium/src.git/+/refs/heads/master/chrome/test/pixel/demo/

--- a/site/en/blog/chromium-chronicle-10/index.md
+++ b/site/en/blog/chromium-chronicle-10/index.md
@@ -1,5 +1,5 @@
 ---
-title: "The Chromium Chronicle: Catching UI Regressions with Pixel Tests"
+title: "The Chromium Chronicle #10: Catching UI Regressions with Pixel Tests"
 description: >
   Chrome’s testing strategy relies heavily on automated functional correctness
   tests and manual testing, but neither of these reliably catch minor UI
@@ -9,10 +9,14 @@ date: 2020-02-05
 hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/hgu6uTktp2ipmuODZZhP.jpg'
 alt: >
   Chromium Chronicle image
+tags:
+  - chromium-chronicle
 ---
 
+<!-- Ready -->
+
 **Episode 10:** by Sven Zheng in Bellevue, WA (January, 2020)<br>
-[Previous episodes](/tags/chromium-chronicle)
+[Previous episodes](/tags/chromium-chronicle/)
 
 Chrome’s testing strategy relies heavily on automated functional correctness
 tests and manual testing, but neither of these reliably catch minor UI
@@ -35,10 +39,11 @@ IN_PROC_BROWSER_TEST_F(SkiaGoldDemoPixelTest, TestOmnibox) {
   GURL url("chrome://bookmarks");
   AddTabAtIndex(0, url, ui::PageTransition::PAGE_TRANSITION_FIRST);
   auto* const browser_view = BrowserView::GetBrowserViewForBrowser(browser());
-  // CompareScreenshot() takes a screenshot and compares it with the golden image,
-  // which was previously human-approved, is stored server-side, and is managed
-  // by Skia Gold. If any pixels differ, the test will fail and output a link
-  // for the author to triage the new image.
+  // CompareScreenshot() takes a screenshot and compares it with the
+  // golden image, which was previously human-approved, is stored
+  // server-side, and is managed by Skia Gold. If any pixels differ, the
+  // test will fail and output a link for the author to triage the
+  // new image.
   bool ret = GetPixelDiff().CompareScreenshot("omnibox",
       browser_view->GetLocationBarView());
   EXPECT_TRUE(ret);

--- a/site/en/blog/chromium-chronicle-10/index.md
+++ b/site/en/blog/chromium-chronicle-10/index.md
@@ -13,8 +13,6 @@ tags:
   - chromium-chronicle
 ---
 
-<!-- Ready -->
-
 **Episode 10:** by Sven Zheng in Bellevue, WA (January, 2020)<br>
 [Previous episodes](/tags/chromium-chronicle/)
 

--- a/site/en/blog/chromium-chronicle-13/index.md
+++ b/site/en/blog/chromium-chronicle-13/index.md
@@ -1,0 +1,76 @@
+---
+title: "The Chromium Chronicle: Time-Travel Debugging with RR"
+description: >
+  Do you find yourself running the same test over and over in the debugger,
+  trying to figure out how the code got in a bad state? We have a tool for
+  you! RR will record an execution trace, making it easy to step backwards,
+  run backwards, see where variables changed their value or when a function
+  was last called on an object.
+layout: 'layouts/blog-post.njk'
+date: 2020-03-18
+hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/hgu6uTktp2ipmuODZZhP.jpg'
+alt: >
+  Chromium Chronicle image
+---
+
+**Episode 13:** by Christian Biesinger in Madison, WI (March, 2020)<br>
+[Previous episodes](/tags/chromium-chronicle)
+
+Do you find yourself **running the same test over and over** in the debugger,
+trying to figure out how the code got in a bad state? **We have a tool for you!**
+Easy to install and setup, it will record an execution trace, and that gives
+magical new powers to `gdb`. **Step backwards, run backwards**, see where
+variables changed their value or when a function was last called on an object
+(using conditional breakpoints).
+
+On Linux, you can **use rr**. Install using `sudo apt-get install rr` or
+from <https://rr-project.org/>.
+
+This is not officially supported, but very useful. The way `rr` works is that
+you **first record a trace**, then **replay it**.
+
+```bash
+rr record .../content_shell --no-sandbox  --disable-hang-monitor --single-process
+# record the trace. --single-process is optional, see below. The other flags are required.
+rr replay # This will replay the last trace
+(gdb)       # rr uses GDB to let you replay traces
+```
+
+Conveniently, timing and pointer addresses stay the same every time you replay
+the same trace. **Traces can be made portable** using `rr pack` so that you
+can copy them to another machine and replay there, or replay even after
+recompiling. Run your program using `continue`. You can use all regular
+GDB commands `-b`, `next`, `watch`, etc. However, you can also use
+**reverse-next** (`rn`), **reverse-cont** (`rc`), **reverse-step** (`rs`),
+**reverse-fin**.
+
+These still respect any breakpoints you’ve set. For example:
+
+```
+(gdb) c  # Execute to the end
+(gdb) break blink::LayoutFlexibleBox::UpdateLayout
+(gdb) rc # Run back to the last layout call
+Thread 5 hit Breakpoint 1, blink::LayoutBlock::UpdateLayout (
+    this=0x121672224010)
+(gdb) # Inspect anything you want here. To find the previous Layout call on this object:
+(gdb) cond 1 this == 0x121672224010
+(gdb) rc
+Thread 5 hit Breakpoint 1, blink::LayoutBlock::UpdateLayout (
+    this=0x121672224010)
+(gdb) watch -l style_.ptr_ # Or find the last time the style_ was changed
+(gdb) rc
+Thread 5 hit Hardware watchpoint 2: -location style_.ptr_
+
+Old value = (const blink::ComputedStyle *) 0x1631ad3dbb0
+New value = (const blink::ComputedStyle *) 0x0
+0x00007f68cabcf78e in std::__Cr::swap&lt;blink::ComputedStyle const*&gt; (
+```
+
+In this example, I have used `--single-process` for simplicity, but that’s
+not necessary. **RR can trace multiple processes**; after recording, you can
+see a list using `rr ps` and pick one to replay with `rr replay -f PID`.
+
+There are lots of ways RR can be useful. There are **other commands you can use**,
+such as when to find out at which event number you are at, or `rr replay -M`
+to annotate `stdout` with a process ID and event number for each line. See
+the [RR website and documentation](https://rr-project.org/) for more details.

--- a/site/en/blog/chromium-chronicle-13/index.md
+++ b/site/en/blog/chromium-chronicle-13/index.md
@@ -1,5 +1,5 @@
 ---
-title: "The Chromium Chronicle: Time-Travel Debugging with RR"
+title: "The Chromium Chronicle #13: Time-Travel Debugging with RR"
 description: >
   Do you find yourself running the same test over and over in the debugger,
   trying to figure out how the code got in a bad state? We have a tool for
@@ -11,10 +11,14 @@ date: 2020-03-18
 hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/hgu6uTktp2ipmuODZZhP.jpg'
 alt: >
   Chromium Chronicle image
+tags:
+  - chromium-chronicle
 ---
 
+<!-- Ready -->
+
 **Episode 13:** by Christian Biesinger in Madison, WI (March, 2020)<br>
-[Previous episodes](/tags/chromium-chronicle)
+[Previous episodes](/tags/chromium-chronicle/)
 
 Do you find yourself **running the same test over and over** in the debugger,
 trying to figure out how the code got in a bad state? **We have a tool for you!**
@@ -46,7 +50,7 @@ GDB commands `-b`, `next`, `watch`, etc. However, you can also use
 
 These still respect any breakpoints you’ve set. For example:
 
-```
+```text
 (gdb) c  # Execute to the end
 (gdb) break blink::LayoutFlexibleBox::UpdateLayout
 (gdb) rc # Run back to the last layout call

--- a/site/en/blog/chromium-chronicle-13/index.md
+++ b/site/en/blog/chromium-chronicle-13/index.md
@@ -15,8 +15,6 @@ tags:
   - chromium-chronicle
 ---
 
-<!-- Ready -->
-
 **Episode 13:** by Christian Biesinger in Madison, WI (March, 2020)<br>
 [Previous episodes](/tags/chromium-chronicle/)
 

--- a/site/en/blog/chromium-chronicle-14/index.md
+++ b/site/en/blog/chromium-chronicle-14/index.md
@@ -67,10 +67,10 @@ in [`//src/testing/buildbot/`][src-test-bbot]:
 3. More fine tunings.
      * [`mixins.pyl`][mixins-pyl] contains **arguments** that
        can be applied to a group of tests at various group levels.
-     * [variants.pyl][variants-pyl] helps run a suite **in multiple instances
+     * [`variants.pyl`][variants-pyl] helps run a suite **in multiple instances
        with different arguments**.
 4. **Regenerate configuration files** by running
-   [generate_buildbot_json.py][gen-bbot-py].
+   [`generate_buildbot_json.py`][gen-bbot-py].
 
 After these, it is a simple matter of **checking in** your config changes;
 the builders running this suite will pick up the new tests automatically, and

--- a/site/en/blog/chromium-chronicle-14/index.md
+++ b/site/en/blog/chromium-chronicle-14/index.md
@@ -1,0 +1,85 @@
+---
+title: "The Chromium Chronicle: Adding Tests to the Waterfall"
+description: >
+  Want to detect regressions for your new feature in Chrome? Add your tests to
+  the waterfall, Chrome’s continuous build and test infrastructure!
+layout: 'layouts/blog-post.njk'
+date: 2020-10-30
+hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/hgu6uTktp2ipmuODZZhP.jpg'
+alt: >
+  Chromium Chronicle image
+---
+
+**Episode 14:** by Zhaoyang Li in MTV, and Eric Aleshire in TOK (October 2020)<br>
+[Previous episodes](/tags/chromium-chronicle)
+
+Want to detect regressions for your new feature in Chrome? Add your
+tests to **the waterfall** (Chrome’s continuous build and test infrastructure)!
+
+There are many builders on Chrome's waterfall that run tests on a variety of
+platforms. This article describes how to add a test suite to an existing
+builder. Before proceeding, consider these questions:
+
+*Should the new tests live in a brand new suite, or just be added to an existing one?*
+
+* Tests are organized in test suites by **proximity of source location and theme.**
+  If your new tests can’t logically fit into any existing suite, you probably
+  need a new suite.
+
+*Should the tests run on a public builder or an internal builder?*
+
+* Use an **internal builder** if the code lives in an **internal repo**, or the
+  tests involve **confidential data**.
+
+*Should the tests run in FYI CI, main CI or commit queue(CQ)?*
+
+* FYI CI needs your self-monitoring and is used for test refinement or
+  experimentation.
+* **Main CI tests are regularly monitored** by sheriffs.
+* **CQ blocks CL submission** at failure but **takes more infra resources**.
+  A new suite should always **start from CI before being promoted to CQ**.
+* If you’re not sure, your platform’s **EngProd team** can help you decide.
+
+*I already have a test suite running in CI, how do I add it to CQ? / What if I
+need a new builder?*
+
+* [File a bug in Infra>Client>Chrome component][inf-cli-bug] so
+  `chrome-browser-infra@` team can start evaluations and help you set up.
+
+## How to add a test suite to an existing builder
+
+To **add a test suite to an existing builder**, you need to config some files
+in [`//src/testing/buildbot/`][src-test-bbot]:
+
+1. **Create a key** in [`gn_isolate_map.pyl`][gn-iso-map] for the new test suite
+   with test target label and type info.
+2. **Add that key to a test group** in [`test_suites.pyl`][test-suites-pyl].
+   (You can find the mapping from builder name to the test groups on builder in
+   [`waterfalls.pyl`][waterfalls-pyl].)
+
+        'all_simulator_tests': {
+          'previously_existing_test_suite': {},
+          'exciting_new_feature_test_suite': {},
+        },
+
+3. More fine tunings.
+     * [`mixins.pyl`][mixins-pyl] contains **arguments** that
+       can be applied to a group of tests at various group levels.
+     * [variants.pyl][variants-pyl] helps run a suite **in multiple instances
+       with different arguments**.
+4. **Regenerate configuration files** by running
+   [generate_buildbot_json.py][gen-bbot-py].
+
+After these, it is a simple matter of **checking in** your config changes;
+the builders running this suite will pick up the new tests automatically, and
+the **results will begin to flow in on the web interface** for the builder on
+the waterfall - complete with plenty of debug info in the case of failures!
+
+[inf-cli-bug]: https://bugs.chromium.org/p/chromium/issues/entry?components=Infra%3EClient%3EChrome
+[src-test-bbot]: https://source.chromium.org/chromium/chromium/src/+/master:testing/buildbot/
+[gn-iso-map]: https://source.chromium.org/chromium/chromium/src/+/master:testing/buildbot/gn_isolate_map.pyl
+[test-suites-pyl]: https://source.chromium.org/chromium/chromium/src/+/master:testing/buildbot/test_suites.pyl
+[waterfalls-pyl]: https://source.chromium.org/chromium/chromium/src/+/master:testing/buildbot/waterfalls.pyl
+[mixins-pyl]: https://source.chromium.org/chromium/chromium/src/+/master:testing/buildbot/mixins.pyl
+[variants-pyl]: https://source.chromium.org/chromium/chromium/src/+/master:testing/buildbot/variants.pyl
+[gen-bbot-py]: https://source.chromium.org/chromium/chromium/src/+/master:testing/buildbot/generate_buildbot_json.py

--- a/site/en/blog/chromium-chronicle-14/index.md
+++ b/site/en/blog/chromium-chronicle-14/index.md
@@ -59,10 +59,12 @@ in [`//src/testing/buildbot/`][src-test-bbot]:
    (You can find the mapping from builder name to the test groups on builder in
    [`waterfalls.pyl`][waterfalls-pyl].)
 
-        'all_simulator_tests': {
-          'previously_existing_test_suite': {},
-          'exciting_new_feature_test_suite': {},
-        },
+    ```json
+    'all_simulator_tests': {
+      'previously_existing_test_suite': {},
+      'exciting_new_feature_test_suite': {},
+    },
+    ```
 
 3. More fine tunings.
      * [`mixins.pyl`][mixins-pyl] contains **arguments** that

--- a/site/en/blog/chromium-chronicle-14/index.md
+++ b/site/en/blog/chromium-chronicle-14/index.md
@@ -1,5 +1,5 @@
 ---
-title: "The Chromium Chronicle: Adding Tests to the Waterfall"
+title: "The Chromium Chronicle #14: Adding Tests to the Waterfall"
 description: >
   Want to detect regressions for your new feature in Chrome? Add your tests to
   the waterfall, Chrome’s continuous build and test infrastructure!
@@ -8,10 +8,12 @@ date: 2020-10-30
 hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/hgu6uTktp2ipmuODZZhP.jpg'
 alt: >
   Chromium Chronicle image
+tags:
+  - chromium-chronicle
 ---
 
-**Episode 14:** by Zhaoyang Li in MTV, and Eric Aleshire in TOK (October 2020)<br>
-[Previous episodes](/tags/chromium-chronicle)
+**Episode 14:** by Zhaoyang Li in MTV, and Eric Aleshire in TOK (October, 2020)<br>
+[Previous episodes](/tags/chromium-chronicle/)
 
 Want to detect regressions for your new feature in Chrome? Add your
 tests to **the waterfall** (Chrome’s continuous build and test infrastructure)!

--- a/site/en/blog/chromium-chronicle-15/index.md
+++ b/site/en/blog/chromium-chronicle-15/index.md
@@ -1,5 +1,5 @@
 ---
-title: "The Chromium Chronicle: Restricting Target Visibility"
+title: "The Chromium Chronicle #15: Restricting Target Visibility"
 description: >
   In Chromium, it's common to find code written for one component that would
   be useful elsewhere, but might have hidden restrictions. For safety, limit
@@ -9,17 +9,21 @@ date: 2020-11-30
 hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/hgu6uTktp2ipmuODZZhP.jpg'
 alt: >
   Chromium Chronicle image
+tags:
+  - chromium-chronicle
 ---
 
-**Episode 15:** by Joe Mason in Montreal (November 2020)<br>
-[Previous episodes](/tags/chromium-chronicle)
+<!-- Ready -->
+
+**Episode 15:** by Joe Mason in Montreal, PQ (November, 2020)<br>
+[Previous episodes](/tags/chromium-chronicle/)
 
 Chrome is a big project with many sub-systems. It’s common to find code
 written for one component that would be useful elsewhere, but might have hidden
 restrictions. For safety, **limit external access to dangerous functionality**.
 For instance, a custom function tuned for specific performance needs:
 
-```
+```cpp
 // Blazing fast for 2-char strings, O(n^3) otherwise.
 std::string ConcatShortStringsFast(const std::string& a, const std::string& b);
 ```
@@ -28,10 +32,11 @@ There are several ways to restrict access. **GN visibility rules stop code
 outside your component from depending on a target**. By default targets are
 visible to all, but you can modify that:
 
-```
+```text
 # In components/restricted_component/BUILD.gn
 visibility = [
-  # Applies to all targets in this file. Only the given targets can depend on them.
+  # Applies to all targets in this file.
+  # Only the given targets can depend on them.
   "//components/restricted_component:*",
   "//components/authorized_other_component:a_single_target",
 ]
@@ -49,11 +54,12 @@ Every directory inherits `include_rules` from its parent, and can modify those
 rules in its own `DEPS` file. All header files included from outside
 directories must be allowed by the `include_rules`.
 
-```
+```text
 # In //components/authorized_other_component/DEPS
 include_rules = [
-  # Common directories like //base are inherited from //components/DEPS or //DEPS.
-  # Also allow includes from restricted_component, but not restricted_component/internal.
+  # Common directories like //base are inherited from
+  # //components/DEPS or //DEPS. Also allow includes from
+  # restricted_component, but not restricted_component/internal.
   "+components/restricted_component",
   "-components/restricted_component/internal",
   # But do allow a single header from internal, for testing.

--- a/site/en/blog/chromium-chronicle-15/index.md
+++ b/site/en/blog/chromium-chronicle-15/index.md
@@ -1,0 +1,80 @@
+---
+title: "The Chromium Chronicle: Restricting Target Visibility"
+description: >
+  In Chromium, it's common to find code written for one component that would
+  be useful elsewhere, but might have hidden restrictions. For safety, limit
+  external access to dangerous functionality by restricting target visibility.
+layout: 'layouts/blog-post.njk'
+date: 2020-11-30
+hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/hgu6uTktp2ipmuODZZhP.jpg'
+alt: >
+  Chromium Chronicle image
+---
+
+**Episode 15:** by Joe Mason in Montreal (November 2020)<br>
+[Previous episodes](/tags/chromium-chronicle)
+
+Chrome is a big project with many sub-systems. It’s common to find code
+written for one component that would be useful elsewhere, but might have hidden
+restrictions. For safety, **limit external access to dangerous functionality**.
+For instance, a custom function tuned for specific performance needs:
+
+```
+// Blazing fast for 2-char strings, O(n^3) otherwise.
+std::string ConcatShortStringsFast(const std::string& a, const std::string& b);
+```
+
+There are several ways to restrict access. **GN visibility rules stop code
+outside your component from depending on a target**. By default targets are
+visible to all, but you can modify that:
+
+```
+# In components/restricted_component/BUILD.gn
+visibility = [
+  # Applies to all targets in this file. Only the given targets can depend on them.
+  "//components/restricted_component:*",
+  "//components/authorized_other_component:a_single_target",
+]
+source_set("internal") {
+  # This dangerous target should be locked down even more.
+  visibility = [ "//components/restricted_component:privileged_target" ]
+}
+```
+
+Visibility declarations are validated with **`gn check`**, which runs as part
+of every GN build.
+
+**Another mechanism is DEPS `include_rules`, which limits access to header files**.
+Every directory inherits `include_rules` from its parent, and can modify those
+rules in its own `DEPS` file. All header files included from outside
+directories must be allowed by the `include_rules`.
+
+```
+# In //components/authorized_other_component/DEPS
+include_rules = [
+  # Common directories like //base are inherited from //components/DEPS or //DEPS.
+  # Also allow includes from restricted_component, but not restricted_component/internal.
+  "+components/restricted_component",
+  "-components/restricted_component/internal",
+  # But do allow a single header from internal, for testing.
+  "+components/restricted_component/internal/test_support.h",
+]
+```
+
+To ensure these dependencies are appropriate, **changes that add a directory
+to `include_rules` must be approved by that directory's `OWNERS`**. No
+approval is needed to restrict a directory using `include_rules`! You can
+ensure that everyone changing your component remembers not to use certain
+headers by adding an `include_rule` forbidding them.
+
+**`include_rules` are checked by the presubmit**, so you won’t see any
+errors until you try to upload a change. To test `include_rules` without
+uploading, run `buildtools/checkdeps/checkdeps.py <directory>`.
+
+## Resources
+
+* [Patterns you can use to restrict visibility in GN][gn-ref]
+* [Documentation of `DEPS` files and the `checkdeps` tool][deps-docs]
+
+[gn-ref]: https://gn.googlesource.com/gn/+/master/docs/reference.md#var_visibility
+[deps-docs]: https://chromium.googlesource.com/chromium/src/+/master/buildtools/checkdeps/README.md

--- a/site/en/blog/chromium-chronicle-15/index.md
+++ b/site/en/blog/chromium-chronicle-15/index.md
@@ -13,8 +13,6 @@ tags:
   - chromium-chronicle
 ---
 
-<!-- Ready -->
-
 **Episode 15:** by Joe Mason in Montreal, PQ (November, 2020)<br>
 [Previous episodes](/tags/chromium-chronicle/)
 

--- a/site/en/blog/chromium-chronicle-16/index.md
+++ b/site/en/blog/chromium-chronicle-16/index.md
@@ -12,8 +12,6 @@ tags:
   - chromium-chronicle
 ---
 
-<!-- Ready -->
-
 **Episode 16:** by Anjali Doneria in Bellevue, WA (January 2020)<br>
 [Previous episodes](/tags/chromium-chronicle/)
 

--- a/site/en/blog/chromium-chronicle-16/index.md
+++ b/site/en/blog/chromium-chronicle-16/index.md
@@ -1,5 +1,5 @@
 ---
-title: "The Chromium Chronicle: Updating Google Apps on Desktop"
+title: "The Chromium Chronicle #16: Updating Google Apps on Desktop"
 description: >
   Ever wondered how Chrome keeps itself up-to-date on your desktop? Or how
   updates are served to Chromebooks, Chromecast, or Android?
@@ -8,10 +8,14 @@ date: 2021-01-11
 hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/hgu6uTktp2ipmuODZZhP.jpg'
 alt: >
   Chromium Chronicle image
+tags:
+  - chromium-chronicle
 ---
 
+<!-- Ready -->
+
 **Episode 16:** by Anjali Doneria in Bellevue, WA (January 2020)<br>
-[Previous episodes](/tags/chromium-chronicle)
+[Previous episodes](/tags/chromium-chronicle/)
 
 Ever wondered how Chrome keeps itself up-to-date on your desktop? Or how
 updates are served to Chromebooks, Chromecast, or Android? Wait no more! Read
@@ -32,7 +36,7 @@ or first launch.
 The update process is controlled by rules in Omaha Configuration Language. The
 following example shows an update for Chrome extensions update checks:
 
-```
+```protobuf
 Update {
   # UpdatedVersion and subsequent Pair MUST be provided for chrome responses
   UpdatedVersion: "1.8.3.0"

--- a/site/en/blog/chromium-chronicle-16/index.md
+++ b/site/en/blog/chromium-chronicle-16/index.md
@@ -1,0 +1,47 @@
+---
+title: "The Chromium Chronicle: Updating Google Apps on Desktop"
+description: >
+  Ever wondered how Chrome keeps itself up-to-date on your desktop? Or how
+  updates are served to Chromebooks, Chromecast, or Android?
+layout: 'layouts/blog-post.njk'
+date: 2021-01-11
+hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/hgu6uTktp2ipmuODZZhP.jpg'
+alt: >
+  Chromium Chronicle image
+---
+
+**Episode 16:** by Anjali Doneria in Bellevue, WA (January 2020)<br>
+[Previous episodes](/tags/chromium-chronicle)
+
+Ever wondered how Chrome keeps itself up-to-date on your desktop? Or how
+updates are served to Chromebooks, Chromecast, or Android? Wait no more! Read
+on to understand how Google Update works to serve regular updates to your
+devices.
+
+**Google Update is the tool for managing desktop (Mac and Windows) client
+install and update processes. It’s not just for Chrome!** This tool serves
+updates via Auto-Update Server (also known as Omaha Server).
+
+On Windows, Google Update works both as an installer and updater for Google
+apps, while on Mac, Keystone is designed to centrally update all Mac software
+that Google ships; it is installed by the software it updates during install
+or first launch.
+
+{% img src="image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/XPiCoUveSMYp24BbOT50.jpg", alt="Overview of how Omaha works"%}
+
+The update process is controlled by rules in Omaha Configuration Language. The
+following example shows an update for Chrome extensions update checks:
+
+```
+Update {
+  # UpdatedVersion and subsequent Pair MUST be provided for chrome responses
+  UpdatedVersion: "1.8.3.0"
+  Pair: {Tag: "version" Value: "{updated_version}" }
+  Codebase: "http://dl.google.com/foo/{updated_version}/item.crx"
+}
+```
+
+Once you are done creating/changing your config, it can be deployed on Omaha
+Server. Alternatively, you can use Release Manager to automatically upload
+binaries to dl.google.com, generate and deploy the Omaha config. And voila,
+your desktop app is now ready to serve updates through Google Update!

--- a/site/en/blog/chromium-chronicle-2/index.md
+++ b/site/en/blog/chromium-chronicle-2/index.md
@@ -1,0 +1,100 @@
+---
+title: "The Chromium Chronicle: Fighting Test Flakiness"
+description: >
+  Flaky tests are a common problem in Chrome. They impact the productivity of
+  other developers, and get disabled over time. This month, we take a look
+  at how to fight test flakiness.
+layout: 'layouts/blog-post.njk'
+date: 2019-05-21
+hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/hgu6uTktp2ipmuODZZhP.jpg'
+alt: >
+  Chromium Chronicle image
+---
+
+**Episode 2:** by Vasilii in Munich (May, 2019)<br>
+[Previous episodes](/tags/chromium-chronicle)
+
+[Flaky tests][flaky-tests-context] are a common problem in Chrome. They
+impact the productivity of other developers, and get disabled over time.
+Disabled tests mean diminishing test coverage.
+
+## Triaging Stage
+
+**The OWNERS of directories are responsible for fixing their flaky tests.**
+If you received a bug about a flaky test, spend a few minutes and
+**comment what went wrong** on the bug. If you have an old flaky test and
+it's unclear what went wrong, **try to simply re-enable** the test.
+**Reassign the bug ASAP** if it's clearly a problem in another component.
+The owners of that component should have better judgement about the failure,
+
+## Debugging Stage
+
+A number of [command-line flags][useful-command-lines] are useful for
+fixing flaky tests. For example, **`--enable-pixel-output-in-tests`**
+will render the actual browser UI.
+
+**Have fallback tools** if the debugger makes flakiness disappear. It's
+possible that, under debugger, the test is never flaky. In that case, log
+statements or `base::debug::StackTrace` can be handy.
+
+Keep in mind common reasons for EXPECT__* failures besides bugs in production
+code:
+{: .compare-worse }
+
+* **Incorrect expectations** (e.g. secure page means HTTPS; it can be a localhost instead).
+* Race conditions due to tests not **waiting for the proper event.**
+
+[Don't test the implementation][not-implementation] but the behavior.
+
+```cpp
+// It takes 2 round trips between the UI and the background thread to complete.
+SyncWithTheStore();
+SyncWithTheStore();
+CheckTheStore();
+```
+
+The two round trips may change into three in the future, making the test flaky.
+However, only the store state is relevant. Instead, use an observer for the
+store.
+
+Beware of common patterns such as the following:
+{: .compare-worse }
+
+```cpp
+Submit TestPasswordForm();
+// Wait until things settle down.
+RunLoop().RunUntilIdle();
+CheckCredentialPromptVisible();
+```
+{: .compare-worse }
+
+A snippet like the above from a browser test is almost surely incorrect.
+There are **many events that should happen in different processes and
+threads before some UI appears.**
+
+The following is a correct fix:
+{: .compare-better }
+
+```cpp
+SubmitTestPasswordForm();
+WaitUntilCredentialPromptVisible();
+```
+{: .compare-better }
+
+The fix above is correct under the assumption that
+`WaitUntilCredentialPromptVisible()` doesn’t actually check the UI.
+**The browser tests should not depend on external UI events** like "focus lost"
+or “window became foreground”. Imagine an implementation where the prompt
+appears only when the browser window is active. Such an implementation
+would be correct; however, checking for the actual window makes the test flaky.
+
+## Post-fix Stage
+
+Once the test is fixed, run it hundreds of times locally. Keep an eye on the
+[Flakiness Portal][flakiness-portal].
+
+
+[flaky-tests-context]: https://www.chromium.org/developers/tree-sheriffs/sheriff-details-chromium/handling-a-failing-test
+[useful-command-lines]: https://www.chromium.org/developers/testing/browser-tests
+[not-implementation]: https://testing.googleblog.com/2013/08/testing-on-toilet-test-behavior-not.html
+[flakiness-portal]: https://analysis.chromium.org/p/chromium/flake-portal

--- a/site/en/blog/chromium-chronicle-2/index.md
+++ b/site/en/blog/chromium-chronicle-2/index.md
@@ -13,8 +13,6 @@ tags:
   - chromium-chronicle
 ---
 
-<!-- Needs compare widget -->
-
 **Episode 2:** by Vasilii in Munich (May, 2019)<br>
 [Previous episodes](/tags/chromium-chronicle/)
 
@@ -41,14 +39,17 @@ will render the actual browser UI.
 possible that, under debugger, the test is never flaky. In that case, log
 statements or `base::debug::StackTrace` can be handy.
 
-Keep in mind common reasons for EXPECT__* failures besides bugs in production
+{% Compare 'worse' %}
+
+Keep in mind common reasons for `EXPECT__*` failures besides bugs in production
 code:
-{: .compare-worse }
 
 * **Incorrect expectations** (e.g. secure page means HTTPS; it can be a localhost instead).
 * Race conditions due to tests not **waiting for the proper event.**
 
 [Don't test the implementation][not-implementation] but the behavior.
+
+{% endCompare %}
 
 ```cpp
 // It takes 2 round trips between the UI and the background thread to complete.
@@ -61,8 +62,8 @@ The two round trips may change into three in the future, making the test flaky.
 However, only the store state is relevant. Instead, use an observer for the
 store.
 
+{% Compare 'worse' %}
 Beware of common patterns such as the following:
-{: .compare-worse }
 
 ```cpp
 Submit TestPasswordForm();
@@ -70,20 +71,22 @@ Submit TestPasswordForm();
 RunLoop().RunUntilIdle();
 CheckCredentialPromptVisible();
 ```
-{: .compare-worse }
+
+{% endCompare %}
 
 A snippet like the above from a browser test is almost surely incorrect.
 There are **many events that should happen in different processes and
 threads before some UI appears.**
 
+{% Compare 'better' %}
 The following is a correct fix:
-{: .compare-better }
 
 ```cpp
 SubmitTestPasswordForm();
 WaitUntilCredentialPromptVisible();
 ```
-{: .compare-better }
+
+{% endCompare %}
 
 The fix above is correct under the assumption that
 `WaitUntilCredentialPromptVisible()` doesn’t actually check the UI.

--- a/site/en/blog/chromium-chronicle-2/index.md
+++ b/site/en/blog/chromium-chronicle-2/index.md
@@ -1,5 +1,5 @@
 ---
-title: "The Chromium Chronicle: Fighting Test Flakiness"
+title: "The Chromium Chronicle #2: Fighting Test Flakiness"
 description: >
   Flaky tests are a common problem in Chrome. They impact the productivity of
   other developers, and get disabled over time. This month, we take a look
@@ -9,10 +9,14 @@ date: 2019-05-21
 hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/hgu6uTktp2ipmuODZZhP.jpg'
 alt: >
   Chromium Chronicle image
+tags:
+  - chromium-chronicle
 ---
 
+<!-- Needs compare widget -->
+
 **Episode 2:** by Vasilii in Munich (May, 2019)<br>
-[Previous episodes](/tags/chromium-chronicle)
+[Previous episodes](/tags/chromium-chronicle/)
 
 [Flaky tests][flaky-tests-context] are a common problem in Chrome. They
 impact the productivity of other developers, and get disabled over time.
@@ -92,7 +96,6 @@ would be correct; however, checking for the actual window makes the test flaky.
 
 Once the test is fixed, run it hundreds of times locally. Keep an eye on the
 [Flakiness Portal][flakiness-portal].
-
 
 [flaky-tests-context]: https://www.chromium.org/developers/tree-sheriffs/sheriff-details-chromium/handling-a-failing-test
 [useful-command-lines]: https://www.chromium.org/developers/testing/browser-tests

--- a/site/en/blog/chromium-chronicle-3/index.md
+++ b/site/en/blog/chromium-chronicle-3/index.md
@@ -28,8 +28,10 @@ use the code coverage trybot to ensure you only submit well-tested code.
 To see code coverage for a Chromium CL, trigger the code coverage trybot
 *linux-coverage-rel*:
 
-{% img src="image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/Z9UKBlA67VrGcR1sxNpn.png", alt="", className="attempt-left" %}
-{% img src="image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/p4L6k3hEN6j4kvMgsbAs.png", alt="", className="attempt-right" %}
+{% columns %}
+  {% img src="image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/Z9UKBlA67VrGcR1sxNpn.png", alt="" %}
+  {% img src="image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/p4L6k3hEN6j4kvMgsbAs.png", alt="" %}
+{% endcolumns %}
 
 Once the build finishes and code coverage data is processed successfully,
 look at the right column of the side by side diff view to see coverage

--- a/site/en/blog/chromium-chronicle-3/index.md
+++ b/site/en/blog/chromium-chronicle-3/index.md
@@ -13,8 +13,6 @@ tags:
   - chromium-chronicle
 ---
 
-<!-- Needs float left/right -->
-
 **Episode 3:** by Yuke, Roberto and Sajjad in Mountain View, CA (June, 2019)<br>
 [Previous episodes](/tags/chromium-chronicle/)
 

--- a/site/en/blog/chromium-chronicle-3/index.md
+++ b/site/en/blog/chromium-chronicle-3/index.md
@@ -1,5 +1,5 @@
 ---
-title: "The Chromium Chronicle: Code Coverage in Gerrit"
+title: "The Chromium Chronicle #3: Code Coverage in Gerrit"
 description: >
   Tests are critical because they find bugs and regressions, enforce better
   designs and make code easier to maintain. This month, we take a look at
@@ -9,10 +9,14 @@ date: 2019-06-24
 hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/hgu6uTktp2ipmuODZZhP.jpg'
 alt: >
   Chromium Chronicle image
+tags:
+  - chromium-chronicle
 ---
 
+<!-- Needs float left/right -->
+
 **Episode 3:** by Yuke, Roberto and Sajjad in Mountain View, CA (June, 2019)<br>
-[Previous episodes](/tags/chromium-chronicle)
+[Previous episodes](/tags/chromium-chronicle/)
 
 Tests are critical because they find bugs and regressions, enforce better
 designs and make code easier to maintain. Code coverage helps you ensure

--- a/site/en/blog/chromium-chronicle-3/index.md
+++ b/site/en/blog/chromium-chronicle-3/index.md
@@ -1,0 +1,55 @@
+---
+title: "The Chromium Chronicle: Code Coverage in Gerrit"
+description: >
+  Tests are critical because they find bugs and regressions, enforce better
+  designs and make code easier to maintain. This month, we take a look at
+  how to conduct thorough tests with Gerrit.
+layout: 'layouts/blog-post.njk'
+date: 2019-06-24
+hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/hgu6uTktp2ipmuODZZhP.jpg'
+alt: >
+  Chromium Chronicle image
+---
+
+**Episode 3:** by Yuke, Roberto and Sajjad in Mountain View, CA (June, 2019)<br>
+[Previous episodes](/tags/chromium-chronicle)
+
+Tests are critical because they find bugs and regressions, enforce better
+designs and make code easier to maintain. Code coverage helps you ensure
+your tests are thorough.
+
+Chromium CLs can show a line-by-line breakdown of test coverage. You can
+use the code coverage trybot to ensure you only submit well-tested code.
+
+To see code coverage for a Chromium CL, trigger the code coverage trybot
+*linux-coverage-rel*:
+
+{% img src="image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/Z9UKBlA67VrGcR1sxNpn.png", alt="", className="attempt-left" %}
+{% img src="image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/p4L6k3hEN6j4kvMgsbAs.png", alt="", className="attempt-right" %}
+
+Once the build finishes and code coverage data is processed successfully,
+look at the right column of the side by side diff view to see coverage
+information:
+
+{% img src="image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/wUaY6ZViX5BWxUBIOPz7.jpg", alt="" %}
+
+The code coverage tool currently supports C/C++ code for Chrome on Linux;
+support for more platforms and more languages is in progress.
+
+The code coverage trybot has been rolled out to a 10% experiment, and once
+we’re more comfortable in its stability, we plan to enable it by default and
+expand it to more platforms.
+
+## Learn More
+
+Want to learn more? Check out the coverage in Gerrit [demo CL][demo-cl]
+and play around with code coverage in Gerrit, or see the full
+[codebase coverage dashboard][dashboard], broken down by directories and components.
+
+## Share your feedback
+
+Have any feedback? Contact code-coverage@chromium.org or [file a bug][file-bug].
+
+[demo-cl]: https://chromium-review.googlesource.com/c/chromium/src/+/1455344
+[dashboard]: https://analysis.chromium.org/p/chromium/coverage
+[file-bug]: https://bugs.chromium.org/p/chromium/issues/entry?labels=Pri-3&status=Unconfirmed&components=Tools%3ECodeCoverage&comment=what%27s%20the%20bug%20or%20feature?

--- a/site/en/blog/chromium-chronicle-4/index.md
+++ b/site/en/blog/chromium-chronicle-4/index.md
@@ -1,5 +1,5 @@
 ---
-title: "The Chromium Chronicle: Test your Web Platform Features with WPT"
+title: "The Chromium Chronicle #4: Test your Web Platform Features with WPT"
 description: >
   Web Platform tests (WPT) are the preferred way to test web-exposed features,
   as they are shared with other browsers via Github. This month, we take a
@@ -10,10 +10,14 @@ updated: 2019-08-21
 hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/hgu6uTktp2ipmuODZZhP.jpg'
 alt: >
   Chromium Chronicle image
+tags:
+  - chromium-chronicle
 ---
 
+<!-- Needs compare widget -->
+
 **Episode 4:** by Robert in Waterloo, ON (July, 2019)<br>
-[Previous episodes](/tags/chromium-chronicle)
+[Previous episodes](/tags/chromium-chronicle/)
 
 If you work on Blink, you might know of web_tests (formerly LayoutTests).
 web-platform-tests (WPT) lives inside `web_test/external/wpt`. **WPT is the
@@ -84,7 +88,7 @@ comments from a bot in your CL. **GitHub changes from other vendors are also
 continuously imported.** To receive automatically filed bugs when new failures
 are imported, create an `OWNERS` file in a subdirectory in WPT:
 
-```
+```text
 # TEAM: your-team@chromium.org
 # COMPONENT: Blink>YourComponent
 # WPT-NOTIFY: true

--- a/site/en/blog/chromium-chronicle-4/index.md
+++ b/site/en/blog/chromium-chronicle-4/index.md
@@ -1,0 +1,103 @@
+---
+title: "The Chromium Chronicle: Test your Web Platform Features with WPT"
+description: >
+  Web Platform tests (WPT) are the preferred way to test web-exposed features,
+  as they are shared with other browsers via Github. This month, we take a
+  look at WPT best practices.
+layout: 'layouts/blog-post.njk'
+date: 2019-07-30
+updated: 2019-08-21
+hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/hgu6uTktp2ipmuODZZhP.jpg'
+alt: >
+  Chromium Chronicle image
+---
+
+**Episode 4:** by Robert in Waterloo, ON (July, 2019)<br>
+[Previous episodes](/tags/chromium-chronicle)
+
+If you work on Blink, you might know of web_tests (formerly LayoutTests).
+web-platform-tests (WPT) lives inside `web_test/external/wpt`. **WPT is the
+preferred way to test web-exposed features** as it is shared with other
+browsers via GitHub. It has two main types of tests: *reftests* and
+*testharness.js* tests.
+
+*reftests* take and compare screenshots of two pages. By default, screenshots
+are taken after the `load` event is fired; if you add a `reftest-wait` class
+to the `<html>` element, the screenshot will be taken when the class is removed.
+Disabled tests mean diminishing test coverage. **Be aware of font-related
+flakiness; use the `Ahem` font when possible.**
+
+[*testharness.js*][test-harness] is a JavaScript framework for testing anything
+except rendering. When writing testharness.js tests, **pay attention to timing,
+and remember to clean up global state.**
+
+Flaky timeout & potential leaked states:
+{: .compare-worse }
+
+```html
+<script>
+promise_test(async t => {
+  assert_equals(await slowLocalStorageTest(), "expected", "message");
+  localStorage.clear();
+});
+</script>
+```
+{: .compare-worse }
+
+A better test with long timeout & cleanup:
+{: .compare-better }
+
+```html/0,3
+<meta name="timeout" content="long">
+<script>
+promise_test(async t => {
+  t.add_cleanup(() => localStorage.clear());
+  assert_equals(await slowLocalStorageTest(), "expected", "message");
+});
+</script>
+```
+
+**Use testdriver.js if you need automation otherwise unavailable on the web.**
+You can get a user gesture from `test_driver.bless`, generate complex,
+trusted inputs with `test_driver.action_sequence`, etc.
+
+**WPT also provides some useful server-side features through file names.**
+Multi-global tests (`.any.js` and its friends) run the same tests in different
+scopes (`window`, `worker`, etc.); `.https.sub.html` asks the test to be loaded
+over HTTPS with server-side substitution support like below:
+
+```js
+var anotherOrigin = "https://&#123;&#123;hosts[][www1]}}:&#123;&#123;ports[https][0]}}/path/to/page.html";
+```
+
+**Some features can also be enabled in query strings.**
+`baz.html?pipe=sub|header(X-Key,val)|trickle(d1)` enables substitution, adds `X-Key: val`
+to the headers of the response, and delays 1 second before responding. Search for "pipes"
+on [web-platform-tests.org][web-platform-tests] for more.
+
+**WPT can also test behaviors that are not included in specs yet;** just
+name the test as `.tentative`. If you need Blink internal APIs (e.g.
+`testRunner`, `internals`), put your tests in `web_tests/wpt_internal`.
+
+**Changes made to WPT are automatically exported to GitHub.** You will see
+comments from a bot in your CL. **GitHub changes from other vendors are also
+continuously imported.** To receive automatically filed bugs when new failures
+are imported, create an `OWNERS` file in a subdirectory in WPT:
+
+```
+# TEAM: your-team@chromium.org
+# COMPONENT: Blink>YourComponent
+# WPT-NOTIFY: true
+emails-here-will-be-cc@chromium.org
+```
+
+## Additional Resources
+
+* Want to find out how your tests run on other browsers, and how interoperable
+  your feature is? Use [wpt.fyi][wpt-fyi].
+* Looking for more documentation on APIs, guidelines, examples, tips and more?
+  Visit [web-platform-tests.org][web-platform-tests].
+
+[web-platform-tests]: https://web-platform-tests.org
+[wpt-fyi]: https://wpt.fyi
+[test-harness]: https://github.com/w3c/testharness.js/

--- a/site/en/blog/chromium-chronicle-4/index.md
+++ b/site/en/blog/chromium-chronicle-4/index.md
@@ -14,8 +14,6 @@ tags:
   - chromium-chronicle
 ---
 
-<!-- Needs compare widget -->
-
 **Episode 4:** by Robert in Waterloo, ON (July, 2019)<br>
 [Previous episodes](/tags/chromium-chronicle/)
 
@@ -36,7 +34,8 @@ except rendering. When writing testharness.js tests, **pay attention to timing,
 and remember to clean up global state.**
 
 Flaky timeout & potential leaked states:
-{: .compare-worse }
+
+{% Compare 'worse' %}
 
 ```html
 <script>
@@ -46,10 +45,12 @@ promise_test(async t => {
 });
 </script>
 ```
-{: .compare-worse }
+
+{% endCompare %}
 
 A better test with long timeout & cleanup:
-{: .compare-better }
+
+{% Compare 'better' %}
 
 ```html/0,3
 <meta name="timeout" content="long">
@@ -60,6 +61,8 @@ promise_test(async t => {
 });
 </script>
 ```
+
+{% endCompare %}
 
 **Use testdriver.js if you need automation otherwise unavailable on the web.**
 You can get a user gesture from `test_driver.bless`, generate complex,

--- a/site/en/blog/chromium-chronicle-5/index.md
+++ b/site/en/blog/chromium-chronicle-5/index.md
@@ -1,5 +1,5 @@
 ---
-title: "The Chromium Chronicle: Coding Outside the Sandbox"
+title: "The Chromium Chronicle #5: Coding Outside the Sandbox"
 description: >
   All code has bugs. The Chrome Browser process has no sandbox, meaning those
   bugs could give malcious code full access to the whole device. This episode
@@ -10,10 +10,14 @@ updated: 2019-09-17
 hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/hgu6uTktp2ipmuODZZhP.jpg'
 alt: >
   Chromium Chronicle image
+tags:
+  - chromium-chronicle
 ---
 
+<!-- Needs compare widget -->
+
 **Episode 5:** by Ade in Mountain View, CA (August, 2019)<br>
-[Previous episodes](/tags/chromium-chronicle)
+[Previous episodes](/tags/chromium-chronicle/)
 
 Chrome is split into processes. Some of them are sandboxed, which means that
 they have reduced access to the system and to users' accounts. In a sandboxed

--- a/site/en/blog/chromium-chronicle-5/index.md
+++ b/site/en/blog/chromium-chronicle-5/index.md
@@ -14,8 +14,6 @@ tags:
   - chromium-chronicle
 ---
 
-<!-- Needs compare widget -->
-
 **Episode 5:** by Ade in Mountain View, CA (August, 2019)<br>
 [Previous episodes](/tags/chromium-chronicle/)
 
@@ -37,7 +35,6 @@ of all browser tabs, login data, etc.
 For more information, see Chrome's [sandbox implementation guide][sandbox-implementation].
 
 Make sure to avoid the following common mistakes:
-{: .compare-worse }
 
 {% img src="image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/H5cmSK3JieUkRBdPw9oj.jpg", alt="rule of two", className="float-left" %}
 
@@ -48,8 +45,9 @@ Make sure to avoid the following common mistakes:
 
 <br style="clear: both;" />
 
+{% Compare 'better' %}
+
 Instead, use the following best practices:
-{: .compare-better }
 
 * Be extra paranoid if your code is in the browser process.
 * Validate all IPC from other processes. Assume all other processes are already
@@ -57,6 +55,8 @@ Instead, use the following best practices:
 * Do your processing in a renderer or utility process or some other sandboxed
   process. Ideally, also use a memory safe language such as JavaScript
   (solves >50% security bugs).
+
+{% endCompare %}
 
 For years, we ran network stacks (e.g. HTTP, DNS, QUIC) in the browser process,
 which led to some [critical vulnerabilities][critical-vulnerabilities]. On

--- a/site/en/blog/chromium-chronicle-5/index.md
+++ b/site/en/blog/chromium-chronicle-5/index.md
@@ -39,12 +39,14 @@ For more information, see Chrome's [sandbox implementation guide][sandbox-implem
 Make sure to avoid the following common mistakes:
 {: .compare-worse }
 
-{% img src="image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/H5cmSK3JieUkRBdPw9oj.jpg", alt="rule of two", className="attempt-left" %}
+{% img src="image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/H5cmSK3JieUkRBdPw9oj.jpg", alt="rule of two", className="float-left" %}
 
 * **Don’t parse or interpret untrustworthy data using C++ in the
   browser process.**
 * Don’t trust the origin a renderer claims to represent. The browser’s
   [RenderFrameHost][render-frame-host] can be used to get the current origin securely.
+
+<br style="clear: both;" />
 
 Instead, use the following best practices:
 {: .compare-better }

--- a/site/en/blog/chromium-chronicle-5/index.md
+++ b/site/en/blog/chromium-chronicle-5/index.md
@@ -1,0 +1,70 @@
+---
+title: "The Chromium Chronicle: Coding Outside the Sandbox"
+description: >
+  All code has bugs. The Chrome Browser process has no sandbox, meaning those
+  bugs could give malcious code full access to the whole device. This episode
+  explains the dos and don'ts of coding without a sandbox.
+layout: 'layouts/blog-post.njk'
+date: 2019-08-27
+updated: 2019-09-17
+hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/hgu6uTktp2ipmuODZZhP.jpg'
+alt: >
+  Chromium Chronicle image
+---
+
+**Episode 5:** by Ade in Mountain View, CA (August, 2019)<br>
+[Previous episodes](/tags/chromium-chronicle)
+
+Chrome is split into processes. Some of them are sandboxed, which means that
+they have reduced access to the system and to users' accounts. In a sandboxed
+process, bugs that allow malicious code to run are much less severe.
+
+**The browser process has no sandbox**, so a bug could give malicious code full
+access to the whole device. What should you do differently? And what's the
+situation with other processes?
+
+{% img src="image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/FFBrFUv5NMb2xhG4Zukw.png", alt="Sandbox diagram" %}
+
+**All code has bugs.** In the browser process, those bugs allow malicious code
+to install a program, steal user data, adjust computer settings, access content
+of all browser tabs, login data, etc.
+
+**In other processes, OS access is limited** via platform-specific restrictions.
+For more information, see Chrome's [sandbox implementation guide][sandbox-implementation].
+
+Make sure to avoid the following common mistakes:
+{: .compare-worse }
+
+{% img src="image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/H5cmSK3JieUkRBdPw9oj.jpg", alt="rule of two", className="attempt-left" %}
+
+* **Don’t parse or interpret untrustworthy data using C++ in the
+  browser process.**
+* Don’t trust the origin a renderer claims to represent. The browser’s
+  [RenderFrameHost][render-frame-host] can be used to get the current origin securely.
+
+Instead, use the following best practices:
+{: .compare-better }
+
+* Be extra paranoid if your code is in the browser process.
+* Validate all IPC from other processes. Assume all other processes are already
+  compromised and out to trick you.
+* Do your processing in a renderer or utility process or some other sandboxed
+  process. Ideally, also use a memory safe language such as JavaScript
+  (solves >50% security bugs).
+
+For years, we ran network stacks (e.g. HTTP, DNS, QUIC) in the browser process,
+which led to some [critical vulnerabilities][critical-vulnerabilities]. On
+some platforms, networking now has its own process, with a sandbox coming.
+
+## Additional Resources
+
+* [Chromium's Rule of Two][rule-of-two]: no more than two of unsafe data,
+unsafe code, and unsafe process.
+* [Validating IPC Data][validating-ipc]: a guide on how to ensure that IPCs
+from the renderer process are not full of fibs and misrepresentations.
+
+[sandbox-implementation]: https://chromium.googlesource.com/chromium/src/+/master/docs/design/sandbox.md
+[render-frame-host]: https://cs.chromium.org/search/?q=RenderFrameHost&sq=package:chromium&type=cs
+[critical-vulnerabilities]: https://bugs.chromium.org/p/chromium/issues/list?q=type%3Dbug-security%20component%3AInternals%3ENetwork%20status%3Afixed%2Cverified%20security_severity%3Dcritical&can=1
+[rule-of-two]: https://chromium.googlesource.com/chromium/src/+/master/docs/security/rule-of-2.md
+[validating-ipc]: https://chromium.googlesource.com/chromium/src/+/HEAD/docs/security/mojo.md#Validate-privilege_presuming-data-received-over-IPC

--- a/site/en/blog/chromium-chronicle-6/index.md
+++ b/site/en/blog/chromium-chronicle-6/index.md
@@ -13,8 +13,6 @@ tags:
   - chromium-chronicle
 ---
 
-<!-- All Good -->
-
 **Episode 6:** by Tiffany in San Francisco, CA (September, 2019)<br>
 [Previous episodes](/tags/chromium-chronicle/)
 

--- a/site/en/blog/chromium-chronicle-6/index.md
+++ b/site/en/blog/chromium-chronicle-6/index.md
@@ -1,0 +1,59 @@
+---
+title: "The Chromium Chronicle: Monorail’s Grid View"
+description: >
+  Chrome’s issue tracker, Monorail, offers a grid view that allows you to
+  visualize your issues in a Kanban style board. This episode explains how
+  to use the grid mode.
+layout: 'layouts/blog-post.njk'
+date: 2019-09-24
+hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/hgu6uTktp2ipmuODZZhP.jpg'
+alt: >
+  Chromium Chronicle image
+---
+
+**Episode 6:** by Tiffany in San Francisco, CA (September, 2019)<br>
+[Previous episodes](/tags/chromium-chronicle)
+
+Chrome’s issue tracker, [Monorail][monorail-homepage], offers a grid view
+that allows you to **visualize your issues in a Kanban style board**.
+When you’re viewing a list of issues, you can click the “Grid” button to
+activate grid mode!
+
+{% img src="image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/hcqAX7n6MD5nYfDbWkLP.png", alt="" %}
+
+While on the grid page, you can customize your view to **sort issues by
+almost any field you want**! Status, Priority, NextAction, Milestone,
+Owner, you name it!
+
+The flexibility of the grid view allows you to **customize it to fit your
+team’s needs**. For example, below we’ve set up the grid view to show all
+pending Q3 Monorail work, sorted by owner and sprint date.
+
+{% img src="image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/SLPm26hRL1ic74nbnDlY.png", alt="" %}
+
+If you need more information on each issue, you can view the grid view with
+“Tile” cells instead. And if you want a bird’s eye view of many, many issues,
+you can **view issues in the grid view as counts**. In fact, the grid view even
+supports loading up to 6,000 issues at once.
+
+{% img src="image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/qus5UiIZeYWxeIig0Kd0.png", alt="" %}
+
+All setting changes in the grid view are reflected in the page URL. So once
+you’ve configured your grid to your needs, you can **share a link to your new
+view with your team**. If you want, you could even use the grid view for your
+weekly team status meetings.
+
+As you use Monorail’s grid view, please [file feedback][file-feedback]! We’d
+love to hear your suggestions on how we can make the grid view better.
+
+## Additional Resources
+
+* Want to learn more about Chrome’s issue tracker? You can read more about
+[how to use Monorail on chromium.org][monorail-chromium].
+* Monorail is open source! If you need an issue tracker, you can set up your
+own instance of Monorail. Checkout [Monorail’s README][monorail-readme] here.
+
+[monorail-homepage]: https://bugs.chromium.org/hosting
+[file-feedback]: https://bugs.chromium.org/p/monorail/issues/entry?labels=UI-Refresh-Feedback,Feature-Grids,Via-Chrome-Chronicle&cc=zhangtiff@chromium.org,jrobbins@chromium.org&summary=Feedback+on+the+new+Monorail+Grid+View&components=UI
+[monorail-chromium]: https://www.chromium.org/issue-tracking
+[monorail-readme]: https://cs.chromium.org/chromium/infra/appengine/monorail/README.md

--- a/site/en/blog/chromium-chronicle-6/index.md
+++ b/site/en/blog/chromium-chronicle-6/index.md
@@ -1,5 +1,5 @@
 ---
-title: "The Chromium Chronicle: Monorail’s Grid View"
+title: "The Chromium Chronicle #6: Monorail’s Grid View"
 description: >
   Chrome’s issue tracker, Monorail, offers a grid view that allows you to
   visualize your issues in a Kanban style board. This episode explains how
@@ -9,10 +9,14 @@ date: 2019-09-24
 hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/hgu6uTktp2ipmuODZZhP.jpg'
 alt: >
   Chromium Chronicle image
+tags:
+  - chromium-chronicle
 ---
 
+<!-- All Good -->
+
 **Episode 6:** by Tiffany in San Francisco, CA (September, 2019)<br>
-[Previous episodes](/tags/chromium-chronicle)
+[Previous episodes](/tags/chromium-chronicle/)
 
 Chrome’s issue tracker, [Monorail][monorail-homepage], offers a grid view
 that allows you to **visualize your issues in a Kanban style board**.

--- a/site/en/blog/chromium-chronicle-7/index.md
+++ b/site/en/blog/chromium-chronicle-7/index.md
@@ -1,0 +1,92 @@
+---
+title: "The Chromium Chronicle: Preprocessing Source"
+description: >
+  Compiling a single Chromium source file by hand can help developers
+  experiment with compiler optimization options, understand subtle macro
+  details, or minimize a compiler bug. This month, we take a look at how to
+  preprocess source.
+layout: 'layouts/blog-post.njk'
+date: 2019-10-24
+hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/hgu6uTktp2ipmuODZZhP.jpg'
+alt: >
+  Chromium Chronicle image
+---
+
+**Episode 7:** by Bruce Dawson in Seattle, WA (October, 2019)<br>
+[Previous episodes](/tags/chromium-chronicle)
+
+Sometimes it is helpful **to compile a single Chromium source file by hand**,
+perhaps to experiment with compiler optimization options, to preprocess it
+to a single file to understand some subtle macro details, or to minimize a
+compiler bug.
+
+A few tricks will let a Chromium developer find and execute the command that
+compiles a particular source file, with modifications as needed.
+
+Start by going to your output directory and using autoninja (or ninja) to
+**compile the file of interest** (and any dependencies) **using the `^` suffix**.
+This suffix tells ninja to build the output of the specified `file—version.o`
+in this case. Then, touch the file, and **compile it (and only it) again with
+the `-v` (verbose) flag** to ninja:
+
+On Linux or OSX:
+{: .compare-better }
+
+```bash
+autoninja ../../base/version.cc^
+touch ../../base/version.cc
+autoninja -v ../../base/version.cc^
+```
+
+In the Windows cmd shell `^` is a special character and must be escaped:
+{: .compare-better }
+
+<pre class="">
+<span class="no-select">C:\></span> autoninja ../../base/version.cc^^
+<span class="no-select">C:\></span> touch ../../base/version.cc
+<span class="no-select">C:\></span> autoninja -v ../../base/version.cc^^
+</pre>
+
+Typical output of the `autoninja -v` command looks like this (significantly
+trimmed):
+
+```bash
+..\..\third_party\llvm-build\Release+Asserts\bin\clang-cl.exe /nologo /showIncludes -imsvc ...
+```
+
+This command allows you to compile the file of interest. To get the preprocessed
+output, use the following steps:
+
+**On Linux or OSX, remove the `-o obj/base/base/version.o` block from the end,
+and add `-E`**. This tells the compiler to print the preprocessed file to
+stdout.
+
+Redirect the output to a file, like this:
+{: .compare-better }
+
+```bash
+../../third_party/llvm-build/Release+Asserts/bin/clang++ -MMD ... -E >version.i
+```
+
+**On Windows, remove the `/showIncludes` option** from the beginning (it prints
+a line of output for each `#include`) **and then add `/P`** in order to
+preprocess the file instead of compiling it. The results will be saved in the
+current directory in `version.i`:
+
+<pre class="">
+..\..\third_party\llvm-build\Release+Asserts\bin\clang-cl.exe /nologo -imsvc ... /P
+</pre>
+
+Now you can examine the preprocessed file to see what the macros are actually doing,
+or make experimental compiler-switch changes and recompile to see what happens.
+
+## Additional Resources
+
+* [Fast Chrome Builds][fast-chrome-builds]: For more build-optimization tips
+  (focused on Windows).
+* [ETW][etw]: Find out how to find Windows performance problems—in Chrome
+  or in the build—by reading the ETW (also known as Xperf) docs.
+
+
+[fast-chrome-builds]: https://chromium.googlesource.com/chromium/src/+/master/docs/windows_build_instructions.md#Faster-builds
+[etw]: https://randomascii.wordpress.com/category/xperf/

--- a/site/en/blog/chromium-chronicle-7/index.md
+++ b/site/en/blog/chromium-chronicle-7/index.md
@@ -1,5 +1,5 @@
 ---
-title: "The Chromium Chronicle: Preprocessing Source"
+title: "The Chromium Chronicle #7: Preprocessing Source"
 description: >
   Compiling a single Chromium source file by hand can help developers
   experiment with compiler optimization options, understand subtle macro
@@ -10,10 +10,14 @@ date: 2019-10-24
 hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/hgu6uTktp2ipmuODZZhP.jpg'
 alt: >
   Chromium Chronicle image
+tags:
+  - chromium-chronicle
 ---
 
+<!-- Needs compare widget -->
+
 **Episode 7:** by Bruce Dawson in Seattle, WA (October, 2019)<br>
-[Previous episodes](/tags/chromium-chronicle)
+[Previous episodes](/tags/chromium-chronicle/)
 
 Sometimes it is helpful **to compile a single Chromium source file by hand**,
 perhaps to experiment with compiler optimization options, to preprocess it
@@ -41,11 +45,11 @@ autoninja -v ../../base/version.cc^
 In the Windows cmd shell `^` is a special character and must be escaped:
 {: .compare-better }
 
-<pre class="">
-<span class="no-select">C:\></span> autoninja ../../base/version.cc^^
-<span class="no-select">C:\></span> touch ../../base/version.cc
-<span class="no-select">C:\></span> autoninja -v ../../base/version.cc^^
-</pre>
+```bash
+C:\> autoninja ../../base/version.cc^^
+C:\> touch ../../base/version.cc
+C:\> autoninja -v ../../base/version.cc^^
+```
 
 Typical output of the `autoninja -v` command looks like this (significantly
 trimmed):
@@ -73,9 +77,9 @@ a line of output for each `#include`) **and then add `/P`** in order to
 preprocess the file instead of compiling it. The results will be saved in the
 current directory in `version.i`:
 
-<pre class="">
+```bash
 ..\..\third_party\llvm-build\Release+Asserts\bin\clang-cl.exe /nologo -imsvc ... /P
-</pre>
+```
 
 Now you can examine the preprocessed file to see what the macros are actually doing,
 or make experimental compiler-switch changes and recompile to see what happens.
@@ -86,7 +90,6 @@ or make experimental compiler-switch changes and recompile to see what happens.
   (focused on Windows).
 * [ETW][etw]: Find out how to find Windows performance problems—in Chrome
   or in the build—by reading the ETW (also known as Xperf) docs.
-
 
 [fast-chrome-builds]: https://chromium.googlesource.com/chromium/src/+/master/docs/windows_build_instructions.md#Faster-builds
 [etw]: https://randomascii.wordpress.com/category/xperf/

--- a/site/en/blog/chromium-chronicle-7/index.md
+++ b/site/en/blog/chromium-chronicle-7/index.md
@@ -14,8 +14,6 @@ tags:
   - chromium-chronicle
 ---
 
-<!-- Needs compare widget -->
-
 **Episode 7:** by Bruce Dawson in Seattle, WA (October, 2019)<br>
 [Previous episodes](/tags/chromium-chronicle/)
 
@@ -34,7 +32,6 @@ in this case. Then, touch the file, and **compile it (and only it) again with
 the `-v` (verbose) flag** to ninja:
 
 On Linux or OSX:
-{: .compare-better }
 
 ```bash
 autoninja ../../base/version.cc^
@@ -43,7 +40,6 @@ autoninja -v ../../base/version.cc^
 ```
 
 In the Windows cmd shell `^` is a special character and must be escaped:
-{: .compare-better }
 
 ```bash
 C:\> autoninja ../../base/version.cc^^
@@ -66,7 +62,6 @@ and add `-E`**. This tells the compiler to print the preprocessed file to
 stdout.
 
 Redirect the output to a file, like this:
-{: .compare-better }
 
 ```bash
 ../../third_party/llvm-build/Release+Asserts/bin/clang++ -MMD ... -E >version.i

--- a/site/en/blog/chromium-chronicle-8/index.md
+++ b/site/en/blog/chromium-chronicle-8/index.md
@@ -13,8 +13,6 @@ tags:
   - chromium-chronicle
 ---
 
-<!-- Ready -->
-
 **Episode 8:** by Vlad Tsyrklevich in Seattle, WA (November, 2019)<br>
 [Previous episodes](/tags/chromium-chronicle/)
 

--- a/site/en/blog/chromium-chronicle-8/index.md
+++ b/site/en/blog/chromium-chronicle-8/index.md
@@ -1,0 +1,54 @@
+---
+title: "The Chromium Chronicle: GWP-ASan: Detect bugs in the wild"
+description: >
+  GWP-ASan is a heap-only memory error detector designed to be used in the
+  wild. It detects use-after-frees, buffer overflows/underflows, and double
+  frees. Unlike ASan, it does not detect errors on the stack or in globals.
+layout: 'layouts/blog-post.njk'
+date: 2019-11-26
+hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/hgu6uTktp2ipmuODZZhP.jpg'
+alt: >
+  Chromium Chronicle image
+---
+
+**Episode 8:** by Vlad Tsyrklevich in Seattle, WA (November, 2019)<br>
+[Previous episodes](/tags/chromium-chronicle)
+
+Debugging memory safety errors, such as use-after-frees or buffer overflows,
+can be difficult. Tools like AddressSanitizer (ASan) are helpful to pinpoint
+memory errors in unit tests and fuzzers, but many bugs only manifest after
+deployment to users where ASan’s overhead is prohibitively high.
+
+**[GWP-ASan][gwp-asan] is a heap-only memory error detector designed to be
+used in the wild.** It detects use-after-frees, buffer overflows/underflows,
+and double frees. Unlike ASan, it does not detect errors on the stack or in
+globals.
+
+By sampling a tiny percentage of allocations, GWP-ASan is able to provide
+probabilistic error detection with negligible memory and performance overhead.
+**GWP-ASan will cause the process to crash immediately when a memory error
+occurs** with a sampled allocation. This makes it easier to spot the bug as
+the crash happens right where the error is made instead of at some later point
+when corrupt memory is used.
+
+Like ASan, **GWP-ASan crash reports include allocation and deallocation stack
+traces** to help debug memory issues. Let's take a look at an example
+([crbug/956230](https://crbug.com/956230)) of some of the additional data
+presented in the crash UI:
+
+{% img src="image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/7YXBJMmqzpQo9zTwm2vI.png", alt="" %}
+
+{% img src="image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/PVJMCXodiEt6PrCHIqOc.png", alt="" %}
+
+The use and deallocation both originate in `PDFiumEngine::ExtendSelection()`.
+The source quickly shows the bug is a use of an invalidated `std::vector`
+iterator.
+
+**GWP-ASan is enabled on the stable channel for allocations made using
+`malloc`/`new` and `PartitionAlloc`** on Windows and macOS. Android support is
+in progress. Over 60 GWP-ASan bugs have been reported so far and about 70%
+have been fixed. GWP-ASan crashes are all candidate security issues that
+may be exploitable so please triage them quickly and request backports
+where necessary.
+
+[gwp-asan]: https://chromium.googlesource.com/chromium/src/+/lkgr/docs/gwp_asan.md

--- a/site/en/blog/chromium-chronicle-8/index.md
+++ b/site/en/blog/chromium-chronicle-8/index.md
@@ -1,5 +1,5 @@
 ---
-title: "The Chromium Chronicle: GWP-ASan: Detect bugs in the wild"
+title: "The Chromium Chronicle #8: GWP-ASan: Detect bugs in the wild"
 description: >
   GWP-ASan is a heap-only memory error detector designed to be used in the
   wild. It detects use-after-frees, buffer overflows/underflows, and double
@@ -9,10 +9,14 @@ date: 2019-11-26
 hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/hgu6uTktp2ipmuODZZhP.jpg'
 alt: >
   Chromium Chronicle image
+tags:
+  - chromium-chronicle
 ---
 
+<!-- Ready -->
+
 **Episode 8:** by Vlad Tsyrklevich in Seattle, WA (November, 2019)<br>
-[Previous episodes](/tags/chromium-chronicle)
+[Previous episodes](/tags/chromium-chronicle/)
 
 Debugging memory safety errors, such as use-after-frees or buffer overflows,
 can be difficult. Tools like AddressSanitizer (ASan) are helpful to pinpoint

--- a/site/en/blog/chromium-chronicle-9/index.md
+++ b/site/en/blog/chromium-chronicle-9/index.md
@@ -54,7 +54,7 @@ converted into `protobufs`. Once ClusterFuzz finds a crash, it will try to
 **minimize the input test case and even bisect to find the offending commit**.
 It finds a lot...
 
-{% img src="image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/7KdI3HXVypDiK7GJZ3Gf.png", alt="", class="attempt-left" %}
+{% img src="image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/7KdI3HXVypDiK7GJZ3Gf.png", alt="", className="float-left" %}
 
 You can help:
 

--- a/site/en/blog/chromium-chronicle-9/index.md
+++ b/site/en/blog/chromium-chronicle-9/index.md
@@ -1,5 +1,5 @@
 ---
-title: "The Chromium Chronicle: ClusterFuzz"
+title: "The Chromium Chronicle #9: ClusterFuzz"
 description: >
   You may find you are asked to fix high-priority security bugs discovered by
   ClusterFuzz. What is it? Should you take those bugs seriously? How can you
@@ -9,16 +9,20 @@ date: 2019-12-13
 hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/hgu6uTktp2ipmuODZZhP.jpg'
 alt: >
   Chromium Chronicle image
+tags:
+  - chromium-chronicle
 ---
 
+<!-- Needs image float left/right -->
+
 **Episode 9:** by Adrian Taylor in Mountain View (December, 2019)<br>
-[Previous episodes](/tags/chromium-chronicle)
+[Previous episodes](/tags/chromium-chronicle/)
 
 You may find you are asked to fix high-priority security bugs discovered by
 ClusterFuzz. What is it? Should you take those bugs seriously? How can you
 help?
 
-![Fuzzing flow chart](/web/updates/images/2019/12/cr-chron-1.png)
+{% img src="image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/YAtzVlCiCpI5kX6IfgJ3.png", alt="Fuzzing flow chart" %}
 
 **ClusterFuzz feeds input to Chrome and watches for crashes.** Some of those
 Chrome builds have extra checks turned on, for example [AddressSanitizer][go-asan],
@@ -38,8 +42,9 @@ class Foo {
 void Foo::Bar() {
   delete widget;
   ...
-  widget->Activate();  // Bad in the renderer process, worse in the browser process.
-}                      // Obviously, real bugs are more subtle. Usually.
+  widget->Activate();  // Bad in the renderer process, worse in the
+                       // browser process. Obviously, real bugs are
+                       // more subtle. Usually.
 ```
 
 ClusterFuzz generates input from fuzzers or from bugs submitted externally.
@@ -49,7 +54,7 @@ converted into `protobufs`. Once ClusterFuzz finds a crash, it will try to
 **minimize the input test case and even bisect to find the offending commit**.
 It finds a lot...
 
-{% img src="image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/7KdI3HXVypDiK7GJZ3Gf.png", alt="ALT TEXT HERE", width="800", height="430", class="attempt-left" %}
+{% img src="image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/7KdI3HXVypDiK7GJZ3Gf.png", alt="", class="attempt-left" %}
 
 You can help:
 

--- a/site/en/blog/chromium-chronicle-9/index.md
+++ b/site/en/blog/chromium-chronicle-9/index.md
@@ -13,8 +13,6 @@ tags:
   - chromium-chronicle
 ---
 
-<!-- Needs image float left/right -->
-
 **Episode 9:** by Adrian Taylor in Mountain View (December, 2019)<br>
 [Previous episodes](/tags/chromium-chronicle/)
 

--- a/site/en/blog/chromium-chronicle-9/index.md
+++ b/site/en/blog/chromium-chronicle-9/index.md
@@ -1,0 +1,77 @@
+---
+title: "The Chromium Chronicle: ClusterFuzz"
+description: >
+  You may find you are asked to fix high-priority security bugs discovered by
+  ClusterFuzz. What is it? Should you take those bugs seriously? How can you
+  help?
+layout: 'layouts/blog-post.njk'
+date: 2019-12-13
+hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/hgu6uTktp2ipmuODZZhP.jpg'
+alt: >
+  Chromium Chronicle image
+---
+
+**Episode 9:** by Adrian Taylor in Mountain View (December, 2019)<br>
+[Previous episodes](/tags/chromium-chronicle)
+
+You may find you are asked to fix high-priority security bugs discovered by
+ClusterFuzz. What is it? Should you take those bugs seriously? How can you
+help?
+
+![Fuzzing flow chart](/web/updates/images/2019/12/cr-chron-1.png)
+
+**ClusterFuzz feeds input to Chrome and watches for crashes.** Some of those
+Chrome builds have extra checks turned on, for example [AddressSanitizer][go-asan],
+which looks for memory safety errors.
+
+ClusterFuzz assigns components based on the crash location, and **assigns
+severity based on the type of crash and whether it happened in a sandboxed
+process**. For example, a heap use-after-free will be high severity, unless
+it’s in the browser process, in which case it’s critical (no sandbox to limit
+impact!):
+
+```cpp
+class Foo {
+  Widget* widget;
+};
+
+void Foo::Bar() {
+  delete widget;
+  ...
+  widget->Activate();  // Bad in the renderer process, worse in the browser process.
+}                      // Obviously, real bugs are more subtle. Usually.
+```
+
+ClusterFuzz generates input from fuzzers or from bugs submitted externally.
+Some fuzzers are powered by [libFuzzer][go-libfuzzer], which evolves input to
+increase code coverage. Some understand the grammar of the input language
+converted into `protobufs`. Once ClusterFuzz finds a crash, it will try to
+**minimize the input test case and even bisect to find the offending commit**.
+It finds a lot...
+
+{% img src="image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/7KdI3HXVypDiK7GJZ3Gf.png", alt="ALT TEXT HERE", width="800", height="430", class="attempt-left" %}
+
+You can help:
+
+* Be paranoid about object lifetimes & integer overflows.
+* Add new fuzzers, especially when you process untrustworthy data or IPC (see
+  links below, often < 20 lines of code).
+* Fix ClusterFuzz-reported bugs: its **severity heuristics can be trusted because
+  they’re based on real-world exploitability**: Even a
+  [single byte overflow][go-onebyte] has led to arbitrary code execution by an
+  attacker.
+
+## Resources
+
+* [Fuzz testing in Chromium][go-fuzz-in-cr]: How to add new fuzzers to
+  ClusterFuzz for new data formats, or just because you want the credit of
+  finding awesome vulns.
+* [Chrome Fuzzer Program Update and How-To][go-cr-fuzz-pgm]: Fuzzers are also
+  written by external contributors. Hear about their experience and how easy
+  it can be to get started.
+
+[go-asan]: https://github.com/google/sanitizers/wiki/AddressSanitizer
+[go-libfuzzer]: https://llvm.org/docs/LibFuzzer.html
+[go-onebyte]: https://googleprojectzero.blogspot.com/2016/12/chrome-os-exploit-one-byte-overflow-and.html
+[go-fuzz-in-cr]: https://chromium.googlesource.com/chromium/src/+/master/testing/libfuzzer/README.md
+[go-cr-fuzz-pgm]: https://security.googleblog.com/2019/07/chrome-fuzzer-program-update-and-how-to.html

--- a/site/en/style-guide/index.njk
+++ b/site/en/style-guide/index.njk
@@ -7,7 +7,6 @@ title: Style guide
 {% block content %}
 <article class="stack wrapper type">
   <div class="stack flow-space-300">
-    
     <h1 class="type--var-large">Variable Headline Large</h1>
     <h1 class="type--var-small">Variable Headline Small</h1>
     <h1 class="type--h1">Headline 1</h1>


### PR DESCRIPTION
Changes proposed in this pull request:
- Migrates the [Chromium Chronicle posts](https://developers.google.com/web/updates/tags/chromium-chronicle) from d.g.c

Need the compare widget implemented (#213), and the image float left/right style (#212)