### PR TITLE
Add deprecation notice for nacl

### DIFF
--- a/site/en/docs/native-client/index.md
+++ b/site/en/docs/native-client/index.md
@@ -1,7 +1,7 @@
 ---
 title: Native Client
-description: "Native Client is a sandbox for running compiled C and C++ code
+description: "Native Client was a sandbox for running compiled C and C++ code
 in the browser efficiently and securely, independent of the user's
-operating system."
+operating system. It was deprecated in 2020 and support will end in June 2021."
 layout: 'layouts/project-landing.njk'
 ---


### PR DESCRIPTION
This is similar to the deprecation notice used for Chrome Apps and uses the dates from this blog post https://blog.chromium.org/2020/01/moving-forward-from-chrome-apps.html

This was a request from the folks handling the NaCl deprecation.