### PR TITLE
types update, provide const values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5083,9 +5083,9 @@
       }
     },
     "chrome-types": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/chrome-types/-/chrome-types-0.0.7.tgz",
-      "integrity": "sha512-tY2zjlTkhD+9h2GXKVbuDgvwbgeHAmmRRW8JOqsDVY9aL/nUOFVXZTsCfzhqPRyESevqCoxnYL2qcFkvZle1KQ=="
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/chrome-types/-/chrome-types-0.0.8.tgz",
+      "integrity": "sha512-YY7Ex9/nqb9LzXs4sG8SYPCs3H3NebFHfciADMbU6BvzIBMhYkVfT6g8oXyDXB5WV5u6+5TgTydJ6J0bmDOVgQ=="
     },
     "chunkd": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "async-transforms": "^1.0.6",
     "browser-media-mime-type": "^1.0.0",
     "chokidar-cli": "^2.1.0",
-    "chrome-types": "0.0.7",
+    "chrome-types": "0.0.8",
     "common-tags": "^1.8.0",
     "compression": "^1.7.4",
     "concurrently": "^5.2.0",

--- a/site/_includes/macros/render-type.njk
+++ b/site/_includes/macros/render-type.njk
@@ -44,7 +44,7 @@
       <p>
         {% for option in spec.options %}
           {% if loop.last and not loop.first %}or{% endif %}
-          <code>{{ renderSingleType(option) | trim }}</code>{% if not loop.last %},{% endif %}
+          <code>{{ option.literalValue }}</code>{% if not loop.last %},{% endif %}
         {% endfor %}
       </p>
     </div>
@@ -84,6 +84,16 @@
     <ul class="stack flow-space-300">
       {{ internalRenderNamedType(spec.referenceTemplates[0], namespaceName, spec) }}
     </ul>
+  </div>
+
+{# OPTION: literal #}
+{% elif spec.literalValue !== "" %}
+  <div class="code-sections">
+    <h4 class="type--label case-upper">Value</h4>
+
+    <div class="code-sections__overline code-sections__label">
+      {{ renderSingleType(spec, true) }}
+    </div>
   </div>
 
 {% else %}
@@ -209,7 +219,10 @@
     {% endif %}
 
     {# Primitive value ("number") or literal ("abc") #}
-    {{ rt.literalValue }}{{ rt.primitiveType }}
+    {{ rt.primitiveType }}
+    {% if rt.literalValue %}
+      <span class="code-sections__value">{{ rt.literalValue }}</span>
+    {% endif %}
   {% elif rt.type === 'reference' %}
     {# Reference to another type #}
     {% if rt.referenceLink  %}

--- a/site/_includes/macros/render-type.njk
+++ b/site/_includes/macros/render-type.njk
@@ -20,23 +20,9 @@
   {{ spec.comment | safe }}
 </div>
 
-{# OPTION: type (class) or object (property) #}
-{% if spec.type === 'type' or spec.type === 'object' %}
-  {% if spec.properties.length %}
-    <div class="code-sections">
-      <h4 class="type--label case-upper">Properties</h4>
-
-      <ul class="stack flow-space-300">
-        {% for prop in spec.properties %}
-          {{ internalRenderNamedType(prop, namespaceName, spec) }}
-        {% endfor %}
-      </ul>
-    </div>
-  {% endif %}
-
 {# OPTION: enum #}
 {# This is just a union but we render it specially. #}
-{% elif spec.type === 'union' and spec.isEnum %}
+{% if spec.type === 'union' and spec.isEnum %}
   <div class="code-sections">
     <h4 class="type--label case-upper">Enum</h4>
 
@@ -87,7 +73,7 @@
   </div>
 
 {# OPTION: literal #}
-{% elif spec.literalValue !== "" %}
+{% elif spec.literalValue !== undefined %}
   <div class="code-sections">
     <h4 class="type--label case-upper">Value</h4>
 
@@ -95,6 +81,10 @@
       {{ renderSingleType(spec, true) }}
     </div>
   </div>
+
+{# OPTION: type or object #}
+{% elif spec.type === 'object' or spec.type === 'type' %}
+  {# Ignore, we render properties below #}
 
 {% else %}
   {# nb. This technically includes array, and perhaps we're an array of an interesting type. #}
@@ -106,6 +96,19 @@
     </div>
   </div>
 
+{% endif %}
+
+{# Render properties, as they show up on different types. #}
+{% if spec.properties.length %}
+  <div class="code-sections">
+    <h4 class="type--label case-upper">Properties</h4>
+
+    <ul class="stack flow-space-300">
+      {% for prop in spec.properties %}
+        {{ internalRenderNamedType(prop, namespaceName, spec) }}
+      {% endfor %}
+    </ul>
+  </div>
 {% endif %}
 
 {% endmacro %}

--- a/site/_scss/blocks/_code-sections.scss
+++ b/site/_scss/blocks/_code-sections.scss
@@ -99,6 +99,10 @@
   color: var(--color-pink-medium);
 }
 
+.code-sections__value {
+  color: var(--color-code-number);
+}
+
 .code-sections__callback {
   background: get-color('grey-50');
   border: 1px solid var(--color-hairline);

--- a/tools/types/converter.js
+++ b/tools/types/converter.js
@@ -279,39 +279,14 @@ function buildRenderType(type, parentType, owner) {
     }
 
     case 'intersection': {
-      const intersectionType = /** @type {typedocModels.IntersectionType} */ (type);
-      const [a, b, ...rest] = intersectionType.types;
-      if (rest.length) {
-        break;
+      const out = parseIntersectionType(
+        /** @type {typedocModels.IntersectionType} */ (type),
+        owner
+      );
+      if (out) {
+        return out;
       }
-
-      const typeA = buildRenderType(a, undefined, owner);
-      const typeB = buildRenderType(b, undefined, owner);
-      if (
-        typeA?.type !== 'array' ||
-        typeB?.type !== 'array' ||
-        !deepStrictEqual(typeA.elementType, typeB.elementType)
-      ) {
-        break;
-      }
-
-      /** @type {RenderType} */
-      const out = {
-        type: 'array',
-        elementType: typeA.elementType,
-      };
-
-      const minLength = Math.max(typeA.minLength ?? 0, typeB.minLength ?? 0);
-      if (minLength) {
-        out.minLength = minLength;
-      }
-
-      const maxLength = Math.min(typeA.maxLength ?? 0, typeB.maxLength ?? 0);
-      if (maxLength) {
-        out.maxLength = maxLength;
-      }
-
-      return out;
+      break;
     }
 
     case 'reference': {
@@ -356,6 +331,18 @@ function buildRenderType(type, parentType, owner) {
       // This can be a bunch of things, including an enum.
       const unionType = /** @type {typedocModels.UnionType} */ (type);
       const options = unionType.types.map(c => buildRenderType(c, type, owner));
+
+      // Look for optional options (union of something and undefined).
+      if (options.length === 2) {
+        const filtered = options.filter(
+          ({primitiveType}) => primitiveType !== 'undefined'
+        );
+        if (filtered.length === 1) {
+          const t = filtered[0];
+          t.optional = true;
+          return t;
+        }
+      }
 
       // We only present enums if they contain primitive values (e.g., a choice of strings).
       const isEnum = !options.some(({type}) => type !== 'primitive');
@@ -422,4 +409,103 @@ function buildRenderType(type, parentType, owner) {
   return {type: '?'};
 }
 
-module.exports = {declarationToType};
+/**
+ * Attempts to tease out a sensible RenderType from typedoc's intersection type. There is only a
+ * few of these in Chrome's types and we match them all.
+ *
+ * @param {typedocModels.IntersectionType} intersectionType
+ * @param {typedocModels.Reflection} owner
+ * @return {RenderType|null}
+ */
+function parseIntersectionType(intersectionType, owner) {
+  const checkArray = internalParseArray(intersectionType, owner);
+  if (checkArray) {
+    // This is an array (probably with min/max).
+    return checkArray;
+  }
+
+  const checkRefProperties = internalParseRefProperties(
+    intersectionType,
+    owner
+  );
+  if (checkRefProperties) {
+    // This is a reference but which also has static properties (chrome.storage).
+    return checkRefProperties;
+  }
+
+  return null;
+}
+
+/**
+ * @param {typedocModels.IntersectionType} intersectionType
+ * @param {typedocModels.Reflection} owner
+ * @return {RenderType|null}
+ */
+function internalParseArray(intersectionType, owner) {
+  const [a, b, ...rest] = intersectionType.types;
+  if (rest.length) {
+    return null;
+  }
+
+  const typeA = buildRenderType(a, undefined, owner);
+  const typeB = buildRenderType(b, undefined, owner);
+  if (
+    typeA?.type !== 'array' ||
+    typeB?.type !== 'array' ||
+    !deepStrictEqual(typeA.elementType, typeB.elementType)
+  ) {
+    return null;
+  }
+
+  /** @type {RenderType} */
+  const out = {
+    type: 'array',
+    elementType: typeA.elementType,
+  };
+
+  const minLength = Math.max(typeA.minLength ?? 0, typeB.minLength ?? 0);
+  if (minLength) {
+    out.minLength = minLength;
+  }
+
+  const maxLength = Math.min(typeA.maxLength ?? 0, typeB.maxLength ?? 0);
+  if (maxLength) {
+    out.maxLength = maxLength;
+  }
+
+  return out;
+}
+
+/**
+ * @param {typedocModels.IntersectionType} intersectionType
+ * @param {typedocModels.Reflection} owner
+ * @return {RenderType|null}
+ */
+function internalParseRefProperties(intersectionType, owner) {
+  const [a, b, ...rest] = intersectionType.types;
+  if (rest.length) {
+    return null;
+  }
+
+  if (
+    !(
+      a instanceof typedocModels.ReferenceType &&
+      b instanceof typedocModels.ReflectionType
+    )
+  ) {
+    return null;
+  }
+  const referenceType = a;
+  const reflectionType = b;
+
+  const properties = buildRenderType(reflectionType, undefined, owner);
+  if (properties.type !== 'object') {
+    return null;
+  }
+
+  const t = buildRenderType(referenceType, undefined, owner);
+  t.properties = properties.properties;
+  return t;
+}
+
+module.exports = {declarationToType, buildRenderType};


### PR DESCRIPTION
Fixes #147 and fixes #61: updates chrome-types to respect `nodoc`.

Fixes #110: chrome-types includes constant values now, both as 'properties of references' (not really a subclass, but close) and top-level properties.
