### PR TITLE
re-add missing api pages

### DIFF
--- a/site/en/docs/extensions/reference/serial/index.md
+++ b/site/en/docs/extensions/reference/serial/index.md
@@ -1,0 +1,5 @@
+---
+api: serial
+---
+
+<!-- Intentionally blank -->

--- a/site/en/docs/extensions/reference/socket/index.md
+++ b/site/en/docs/extensions/reference/socket/index.md
@@ -1,0 +1,5 @@
+---
+api: socket
+---
+
+<!-- Intentionally blank -->

--- a/site/en/docs/extensions/reference/tabGroups/index.md
+++ b/site/en/docs/extensions/reference/tabGroups/index.md
@@ -1,0 +1,5 @@
+---
+api: tabGroups
+---
+
+<!-- Intentionally blank -->


### PR DESCRIPTION
Part of #149. Adds three missing pages, although `tabGroups` was never documented on the old site, it's part of the regular extensions API.