### PR TITLE
debounce search

### DIFF
--- a/site/_js/utils/debounce.js
+++ b/site/_js/utils/debounce.js
@@ -1,0 +1,26 @@
+/**
+ * A simple debounce util for ensuring a function only gets called once during
+ * a particular interval.
+ * @param {!Function} func A function to debounce based on the wait time.
+ * @param {!number} wait Time in milliseconds to wait before invoking function.
+ * @return {() => void | Promise<void> | TODO} A debounced copy of the function.
+ */
+export const debounce = (func, wait) => {
+  if (!func) {
+    throw new TypeError('func is a required argument.');
+  }
+
+  if (!wait) {
+    throw new TypeError('wait is a required argument.');
+  }
+
+  let timeout;
+  return function (...args) {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    timeout = setTimeout(() => {
+      func(...args);
+    }, wait);
+  };
+};

--- a/site/_js/web-components/search-box.js
+++ b/site/_js/web-components/search-box.js
@@ -17,6 +17,7 @@ import algoliasearch from 'algoliasearch/dist/algoliasearch-lite.esm.browser';
 import {html} from 'lit-element';
 import {unsafeHTML} from 'lit-html/directives/unsafe-html';
 import {unsafeSVG} from 'lit-html/directives/unsafe-svg';
+import {debounce} from '../utils/debounce';
 
 import closeIcon from '../../_includes/icons/close.svg';
 import searchIcon from '../../_includes/icons/search.svg';
@@ -90,6 +91,7 @@ export class SearchBox extends BaseElement {
     this.searchIcon = unsafeSVG(searchIcon);
 
     this.renderResult = this.renderResult.bind(this);
+    this.search = debounce(this.search.bind(this), 500);
   }
 
   clearSearch() {


### PR DESCRIPTION
Algolia is currently searching on every keystroke, which appears to be seriously inflating our query costs. This debounces the search query to run after a 500ms delay. web.dev uses a 200ms delay so this is more aggressive, but I want to see how significant an impact it has on our unit costs. If it doesn't bring things down dramatically then we may have another issue on our hands.

Changes proposed in this pull request:

- Adds `debounce.js` util
- Debounces searches to 500ms