### PR TITLE
Reduce code font size

### DIFF
--- a/site/_scss/_typography.scss
+++ b/site/_scss/_typography.scss
@@ -118,6 +118,11 @@
     @extend %type--dd;
   }
 
+  pre,
+  code {
+    @extend %type--code;
+  }
+
   &--full-bleed {
     @extend %type--full-bleed;
   }

--- a/site/_scss/blocks/_code.scss
+++ b/site/_scss/blocks/_code.scss
@@ -1,9 +1,4 @@
 pre,
-code {
-  @include apply-utility('font', 'mono');
-}
-
-pre,
 pre[class*='language-'] {
   background: var(--color-code-bg);
   border: 1px solid var(--color-hairline);

--- a/site/_scss/globals/extends/_type.scss
+++ b/site/_scss/globals/extends/_type.scss
@@ -248,6 +248,11 @@
     }
   }
 
+  &--code {
+    @include apply-utility('font', 'mono');
+    @include font-setup(15px, 26px);
+  }
+
   &--full-bleed {
     margin-left: -#{$article-padding};
     margin-right: -#{$article-padding};


### PR DESCRIPTION
Fixes #226

Changes proposed in this pull request:

- Reduces code font to 15px, down from 16px. Previously the code font was displaying too big because the mono font at 16px is visually larger than our body copy at 16px

Now it looks like this:
![image](https://user-images.githubusercontent.com/1066253/104525057-411fa800-55b4-11eb-913a-8215e5ae6ee9.png)
