### PR TITLE
Next tranche of fixes in the 404-bash.

### DIFF
--- a/site/en/docs/extensions/mv2/declare_permissions/index.md
+++ b/site/en/docs/extensions/mv2/declare_permissions/index.md
@@ -39,12 +39,12 @@ The following table lists the currently available permissions:
     </tr>
     <tr id="activeTab">
       <td><code>"activeTab"</code></td>
-      <td>Requests that the extension be granted permissions according to the <a href="activeTab">activeTab</a>
+      <td>Requests that the extension be granted permissions according to the <a href="/docs/extensions/mv2/manifest/activeTab">activeTab</a>
         specification.</td>
     </tr>
     <tr id="alarms">
       <td><code>"alarms"</code></td>
-      <td>Gives your extension access to the <a href="alarms">chrome.alarms</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/alarms">chrome.alarms</a> API.</td>
     </tr>
     <tr id="background">
       <td><code>"background"</code></td>
@@ -57,8 +57,8 @@ The following table lists the currently available permissions:
           quits Chrome.</p>
         <div class="aside aside--note"><b>Note:</b> Disabled apps and extensions are treated as if they aren't
           installed.</div>
-        <p>You typically use the "background" permission with a <a href="background_pages">background page</a>, <a
-            href="/docs/extensions/mv2/event_pages">event page</a> or (for hosted apps) a <a
+        <p>You typically use the "background" permission with a <a href="/docs/extensions/mv2/background_pages">background page</a>, <a
+            href="/docs/apps/event_pages">event page</a> or (for hosted apps) a <a
             href="http://developers.google.com/chrome/apps/docs/background.html">background window</a>.</p>
       </td>
     </tr>
@@ -122,6 +122,8 @@ The following table lists the currently available permissions:
       <td><code>"desktopCapture"</code></td>
       <td>Gives your extension access to the <a href="/docs/extensions/reference/desktopCapture/">chrome.desktopCapture</a> API.</td>
     </tr>
+
+<!-- No corresponding reference entry
     <tr id="displaySource">
       <td><code>"displaySource"</code></td>
       <td>Gives your extension access to the <a href="/docs/extensions/reference/displaySource/">chrome.displaySource</a> API.</td>
@@ -130,6 +132,8 @@ The following table lists the currently available permissions:
       <td><code>"dns"</code></td>
       <td>Gives your extension access to the <a href="/docs/extensions/reference/dns/">chrome.dns</a> API.</td>
     </tr>
+-->
+
     <tr id="documentScan">
       <td><code>"documentScan"</code></td>
       <td>Gives your extension access to the <a href="/docs/extensions/reference/documentScan/">chrome.documentScan</a> API.</td>
@@ -196,6 +200,8 @@ The following table lists the currently available permissions:
       <td><code>"idle"</code></td>
       <td>Gives your extension access to the <a href="/docs/extensions/reference/idle/">chrome.idle</a> API.</td>
     </tr>
+
+<!-- No corresponding reference entry
     <tr id="idltest">
       <td><code>"idltest"</code></td>
       <td>Gives your extension access to the <a href="/docs/extensions/reference/idltest/">chrome.idltest</a> API.</td>
@@ -208,6 +214,8 @@ The following table lists the currently available permissions:
       <td><code>"loginScreenStorage"</code></td>
       <td>Gives your extension access to the <a href="/docs/extensions/reference/loginScreenStorage/">chrome.loginScreenStorage</a> API.</td>
     </tr>
+-->
+
     <tr id="loginState">
       <td><code>"loginState"</code></td>
       <td>Gives your extension access to the <a href="/docs/extensions/reference/loginState/">chrome.loginState</a> API.</td>
@@ -356,12 +364,12 @@ The following table lists the currently available permissions:
   </tbody>
 </table>
 
-[1]: /docs/extensions/mv2/tabs
+[1]: /docs/extensions/mv2/manifest
 [2]: /docs/extensions/mv2/match_patterns
 [3]: /docs/extensions/mv2/permission_warnings
-[4]: /docs/extensions/storage
-[5]: /docs/extensions/activeTab
-[6]: /docs/extensions/alarms
+[4]: /docs/extensions/reference/storage
+[5]: /docs/extensions/mv2/manifest/activeTab
+[6]: /docs/extensions/reference/alarms
 [7]: /docs/extensions/mv2/background_pages
 [8]: /docs/extensions/mv2/event_pages
 [9]: http://developers.google.com/chrome/apps/docs/background.html

--- a/site/en/docs/extensions/mv2/migrating_to_service_workers/index.md
+++ b/site/en/docs/extensions/mv2/migrating_to_service_workers/index.md
@@ -231,10 +231,10 @@ function makeCanvas(width, height) {
 For additional guidance on working with OffscreenCanvas, see [OffscreenCanvas — Speed up Your Canvas
 Operations with a Web Worker][18].
 
-[1]: /migrating_to_manifest_v3
+[1]: /docs/extensions/mv3/intro/
 [2]: https://developers.google.com/web/fundamentals/primers/service-workers/
-[3]: /docs/extensions/events
-[4]: /docs/extensions/workers
+[3]: #events
+[4]: #workers
 [5]: https://developers.google.com/web/ilt/pwa/introduction-to-service-worker
 [6]: https://developer.mozilla.org/en-US/docs/Web/API/Worker
 [7]: https://developer.mozilla.org/en-US/docs/Web/API/Window

--- a/site/en/docs/extensions/mv2/sandboxingEval/index.md
+++ b/site/en/docs/extensions/mv2/sandboxingEval/index.md
@@ -160,9 +160,9 @@ time.
 [6]: /docs/extensions/mv2/samples#sandboxed-frame
 [7]: http://handlebarsjs.com
 [8]: /docs/extensions/examples/howto/sandbox/sandbox.html
-[9]: /docs/extensions/mv2/event_pages
+[9]: /docs/apps/event_pages
 [10]: /docs/extensions/examples/howto/sandbox/eventpage.html
 [11]: /docs/extensions/examples/howto/sandbox/eventpage.js
-[12]: https://developer.mozilla.org/en/DOM/window.postMessage
+[12]: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
 [13]: /docs/extensions/mv2/desktop_notifications
 [14]: http://www.youtube.com/watch?v=GBxv8SaX0gg

--- a/site/en/docs/extensions/mv2/tut_debugging/index.md
+++ b/site/en/docs/extensions/mv2/tut_debugging/index.md
@@ -197,15 +197,15 @@ about [Chrome Devtools][14] by reading the documentation.
 
 [1]: https://developers.google.com/web/tools/chrome-devtools/
 [2]: https://storage.googleapis.com/chrome-gcs-uploader.appspot.com/file/WlD8wC6g8khYWPJUsQceQkhXSlv1/KZdyzIighjOsDUPaibEn.zip "broken_background_color.zip"
-[3]: /docs/extensions/runtime#event-onInstalled
-[4]: /docs/extensions/tabs#method-query
+[3]: /docs/extensions/reference/runtime#event-onInstalled
+[4]: /docs/extensions/reference/tabs#method-query
 [5]: /docs/extensions/mv2/override
 [6]: /docs/extensions/mv2/options#full_page
-[7]: /docs/extensions/cookies
-[8]: /docs/extensions/storage
+[7]: /docs/extensions/reference/cookies
+[8]: /docs/extensions/reference/storage
 [9]: /docs/extensions/mv2/xhr
 [10]: /docs/extensions/mv2/permission_warnings
-[11]: /docs/extensions/api_index
-[12]: /docs/extensions/mv2/tabs
+[11]: /docs/extensions/reference
+[12]: /docs/extensions/reference/tabs
 [13]: http://www.youtube.com/watch?v=IP0nMv_NI1s&feature=PlayList&p=CA101D6A85FE9D4B&index=5
 [14]: https://developers.google.com/web/tools/chrome-devtools/

--- a/site/en/docs/extensions/mv3/declare_permissions/index.md
+++ b/site/en/docs/extensions/mv3/declare_permissions/index.md
@@ -54,12 +54,12 @@ The following table lists the currently available permissions:
     </tr>
     <tr id="activeTab">
       <td><code>"activeTab"</code></td>
-      <td>Requests that the extension be granted permissions according to the <a href="activeTab">activeTab</a>
+      <td>Requests that the extension be granted permissions according to the <a href="/docs/extensions/mv3/manifest/activeTab">activeTab</a>
         specification.</td>
     </tr>
     <tr id="alarms">
       <td><code>"alarms"</code></td>
-      <td>Gives your extension access to the <a href="alarms">chrome.alarms</a> API.</td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/alarms">chrome.alarms</a> API.</td>
     </tr>
     <tr id="background">
       <td><code>"background"</code></td>
@@ -72,8 +72,8 @@ The following table lists the currently available permissions:
           quits Chrome.</p>
         <div class="aside aside--note"><b>Note:</b> Disabled apps and extensions are treated as if they aren't
           installed.</div>
-        <p>You typically use the "background" permission with a <a href="background_pages">background page</a>, <a
-            href="/docs/extensions/mv2/event_pages">event page</a> or (for hosted apps) a <a
+        <p>You typically use the "background" permission with a <a href="/docs/extensions/mv3/background_pages">background page</a>, <a
+            href="/docs/apps/event_pages">event page</a> or (for hosted apps) a <a
             href="http://developers.google.com/chrome/apps/docs/background.html">background window</a>.</p>
       </td>
     </tr>
@@ -133,10 +133,8 @@ The following table lists the currently available permissions:
       <td><code>"declarativeWebRequest"</code></td>
       <td>Gives your extension access to the <a href="/docs/extensions/reference/declarativeWebRequest/">chrome.declarativeWebRequest</a> API.</td>
     </tr>
-    <tr id="desktopCapture">
-      <td><code>"desktopCapture"</code></td>
-      <td>Gives your extension access to the <a href="/docs/extensions/reference/desktopCapture/">chrome.desktopCapture</a> API.</td>
-    </tr>
+
+<!-- No corresponding reference entry
     <tr id="displaySource">
       <td><code>"displaySource"</code></td>
       <td>Gives your extension access to the <a href="/docs/extensions/reference/displaySource/">chrome.displaySource</a> API.</td>
@@ -144,6 +142,12 @@ The following table lists the currently available permissions:
     <tr id="dns">
       <td><code>"dns"</code></td>
       <td>Gives your extension access to the <a href="/docs/extensions/reference/dns/">chrome.dns</a> API.</td>
+    </tr>
+-->
+
+    <tr id="desktopCapture">
+      <td><code>"desktopCapture"</code></td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/desktopCapture/">chrome.desktopCapture</a> API.</td>
     </tr>
     <tr id="documentScan">
       <td><code>"documentScan"</code></td>
@@ -211,6 +215,8 @@ The following table lists the currently available permissions:
       <td><code>"idle"</code></td>
       <td>Gives your extension access to the <a href="/docs/extensions/reference/idle/">chrome.idle</a> API.</td>
     </tr>
+
+<!-- No corresponding reference entry
     <tr id="idltest">
       <td><code>"idltest"</code></td>
       <td>Gives your extension access to the <a href="/docs/extensions/reference/idltest/">chrome.idltest</a> API.</td>
@@ -223,6 +229,8 @@ The following table lists the currently available permissions:
       <td><code>"loginScreenStorage"</code></td>
       <td>Gives your extension access to the <a href="/docs/extensions/reference/loginScreenStorage/">chrome.loginScreenStorage</a> API.</td>
     </tr>
+-->
+
     <tr id="loginState">
       <td><code>"loginState"</code></td>
       <td>Gives your extension access to the <a href="/docs/extensions/reference/loginState/">chrome.loginState</a> API.</td>
@@ -371,10 +379,10 @@ The following table lists the currently available permissions:
   </tbody>
 </table>
 
-[1]: /docs/extensions/mv3/tabs
+[1]: /docs/extensions/mv3/manifest
 [2]: /docs/extensions/mv3/match_patterns
 [3]: /docs/extensions/mv3/permission_warnings
-[4]: /docs/extensions/storage
+[4]: /docs/extensions/reference/storage
 [5]: /docs/extensions/activeTab
 [6]: /docs/extensions/alarms
 [7]: /docs/extensions/mv3/background_pages


### PR DESCRIPTION
Fixes 404 references in a number of files.

Note that sandboxingEval/index.md still has some 404 links due to the target files being missing. This is tracked in #247 and #248.