### PR TITLE
Fix broken compare widget

### DIFF
--- a/site/_scss/blocks/_compare.scss
+++ b/site/_scss/blocks/_compare.scss
@@ -4,11 +4,11 @@
 .compare {
   position: relative;
 
-  .compare__label {
+  &__label {
     font-size: 1.125em;    
   }
 
-  .compare__caption {
+  &__caption {
     color: var(--color-secondary-text);
     font-size: 1em;
     line-height: 1.5em;

--- a/site/_scss/main.scss
+++ b/site/_scss/main.scss
@@ -62,7 +62,6 @@
 @import 'blocks/skip-link';
 @import 'blocks/compare';
 
-
 // Utilities
 @import 'utilities/center-margin';
 @import 'utilities/center-images';

--- a/site/_transforms/purify-css.js
+++ b/site/_transforms/purify-css.js
@@ -51,9 +51,7 @@ const purifyCss = async (content, outputPath) => {
       // these type classes are used by search-box.
       whitelist: ['type--h6', 'type--small', 'type--label', 'overflow-hidden'],
       defaultExtractor: content => {
-        // Capture as liberally as possible, including things like `lg\:display-none`
-        // https://tailwindcss.com/docs/controlling-file-size#understanding-the-regex
-        return content.match(/[^<>"'`\s]*[^<>"'`\s:]/g) || [];
+        return content.match(/[A-Za-z0-9\\:_-]+/g) || [];
       },
     });
 


### PR DESCRIPTION
Fixes #237

Because of the cryptic regex we were using for the purgeCSS extractor (which I copied from tailwind) it was purging selectors like `.compare[data-type=better]`. I noticed that the default extractor that ships with purgeCSS was working fine with these attributes, but it didn't support the `lg:\foo` media query style classes that we use so I added support for `\` and `:` to the default extractor and now it all seems fixed.

Changes proposed in this pull request:

- Simplify purgecss regex so it handles data attributes better while still working with selectors like `lg\:whatever`
- Removes the comment about the tailwind extractor because we don't use it anymore.