### PR TITLE
Remove "signature" and "spellcheck" manifest keys.

### DIFF
--- a/site/en/docs/apps/manifest/index.md
+++ b/site/en/docs/apps/manifest/index.md
@@ -81,7 +81,6 @@ discusses each field.
   "requirements": {...},
   "sandbox": [...],
   "short_name": "Short Name",
-  "signature": ...,
   "sockets": {
     "tcp": {
       "connect": "*"

--- a/site/en/docs/extensions/mv2/manifest/index.md
+++ b/site/en/docs/extensions/mv2/manifest/index.md
@@ -88,8 +88,6 @@ discusses each field.
   <span class="token property">"<a href="/docs/extensions/mv2/manifest/requirements">requirements</a>"</span><span class="token operator">:</span> <span class="token punctuation">{</span>...<span class="token punctuation">}</span><span class="token punctuation">,</span>
   <span class="token property">"<a href="/docs/extensions/mv2/manifest/sandbox">sandbox</a>"</span><span class="token operator">:</span> <span class="token punctuation">[</span>...<span class="token punctuation">]</span><span class="token punctuation">,</span>
   <span class="token property">"<a href="/docs/extensions/mv2/manifest/name">short_name</a>"</span><span class="token operator">:</span> <span class="token string">"Short Name"</span><span class="token punctuation">,</span>
-  <span class="token property">"signature"</span><span class="token operator">:</span> ...<span class="token punctuation">,</span>
-  <span class="token property">"spellcheck"</span><span class="token operator">:</span> ...<span class="token punctuation">,</span>
   <span class="token property">"<a href="/docs/extensions/mv2/manifest/storage">storage</a>"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
     <span class="token property">"managed_schema"</span><span class="token operator">:</span> <span class="token string">"schema.json"</span>
   <span class="token punctuation">}</span><span class="token punctuation">,</span>

--- a/site/en/docs/extensions/mv3/manifest/index.md
+++ b/site/en/docs/extensions/mv3/manifest/index.md
@@ -83,8 +83,6 @@ discusses each field.
   <span class="token property">"<a href="/docs/extensions/mv3/manifest/requirements">requirements</a>"</span><span class="token operator">:</span> <span class="token punctuation">{</span>...<span class="token punctuation">}</span><span class="token punctuation">,</span>
   <span class="token property">"<a href="/docs/extensions/mv3/manifest/sandbox">sandbox</a>"</span><span class="token operator">:</span> <span class="token punctuation">[</span>...<span class="token punctuation">]</span><span class="token punctuation">,</span>
   <span class="token property">"<a href="/docs/extensions/mv3/manifest/name#short_name">short_name</a>"</span><span class="token operator">:</span> <span class="token string">"Short Name"</span><span class="token punctuation">,</span>
-  <span class="token property">"signature"</span><span class="token operator">:</span> ...<span class="token punctuation">,</span>
-  <span class="token property">"spellcheck"</span><span class="token operator">:</span> ...<span class="token punctuation">,</span>
   <span class="token property">"<a href="/docs/extensions/mv3/manifest/storage">storage</a>"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
     <span class="token property">"managed_schema"</span><span class="token operator">:</span> <span class="token string">"schema.json"</span>
   <span class="token punctuation">}</span><span class="token punctuation">,</span>


### PR DESCRIPTION
Removed in the chromium repo in https://chromium-review.googlesource.com/c/chromium/src/+/2621972 and https://chromium-review.googlesource.com/c/chromium/src/+/2622572.

