### PR TITLE
[API Documentation] Add basic documentation for chrome.action

### DIFF
--- a/site/en/docs/extensions/reference/action/index.md
+++ b/site/en/docs/extensions/reference/action/index.md
@@ -4,9 +4,9 @@ api: action
 
 You can use the `chrome.action` API to control the toolbar button for your
 extension in Chrome's UI.  The action icons are displayed in the browser
-toolbar, to the right of the omnibox (on LTR devices). After installation, by
-default, these will be in the extensions menu (the puzzle piece). Users can
-choose to pin your extension icon to the toolbar.
+toolbar, to the right of the omnibox (on left-to-right devices). After
+installation, by default, these appear in the extensions menu (the puzzle
+piece). Users can choose to pin your extension icon to the toolbar.
 
 Note that every extension will have an icon in the toolbar in Chrome, even if
 the `action` key is not specified.
@@ -84,12 +84,12 @@ images in the PNG format.
 
 ### Tooltip (title)
 
-The tooltip, or title, is displayed when the user hovers the mouse of the
+The tooltip, or title, appears when the user hovers the mouse of the
 extension's icon in the toolbar. It is also included in the accessible text
-spoken by screenreaders when the button is focused.
+spoken by screenreaders when the button gets focus.
 
 The default tooltip is set from the `default_title` field in the `action`
-`manifest.json` file. It can also be set programmatically with the
+`manifest.json` file. You can also set it programmatically with the
 `action.setTitle()` method.
 
 ### Badge
@@ -131,7 +131,7 @@ point to a different relative path using the `action.setPopup()` method.
 
 !!!.aside
 The `action.onClicked` event will not be dispatched if the extension action
-has a popup on the current tab.
+has specified a popup to show on click on the current tab.
 !!!
 
 ## Per-tab state
@@ -139,7 +139,7 @@ has a popup on the current tab.
 Extension actions can have different states for each tab. For instance, you
 could set the badge text to be different on each tab (to show tab-specific state).
 You can set the value for an individual tab using the `tabId` property in the
-different setting methods on the `action` API. For instance, to set the badge
+various setting methods on the `action` API. For instance, to set the badge
 text on a specific tab, you would do something like the following:
 
 ```js
@@ -151,13 +151,13 @@ chrome.action.setBadgeText(
 ```
 
 If the `tabId` property is omitted, the setting is treated as a global setting.
-Tab-specific settings will take priority over any global settings.
+Tab-specific settings take priority over any global settings.
 
 ## Enabled state
 
 By default, toolbar actions are enabled (clickable) on every tab. You can
-control this by using the `action.enable()` and `action.disable()` methods.
-This will only affect whether the popup (if any) or `action.onClicked` event
+control this using the `action.enable()` and `action.disable()` methods.
+This only affects whether the popup (if any) or `action.onClicked` event
 is dispatched to your extension; it does not affect the action's presence in the
 toolbar.
 

--- a/site/en/docs/extensions/reference/action/index.md
+++ b/site/en/docs/extensions/reference/action/index.md
@@ -2,9 +2,165 @@
 api: action
 ---
 
-!!!.aside.warning
-This documentation is in active development.
-We're planning to expand the introduction section to provide more context and
-guidance on how to use this API.  This work is tracked in issue
-[#193](https://github.com/GoogleChrome/developer.chrome.com/issues/193).
+You can use the `chrome.action` API to control the toolbar button for your
+extension in Chrome's UI.  The action icons are displayed in the browser
+toolbar, to the right of the omnibox (on LTR devices). After installation, by
+default, these will be in the extensions menu (the puzzle piece). Users can
+choose to pin your extension icon to the toolbar.
+
+Note that every extension will have an icon in the toolbar in Chrome, even if
+the `action` key is not specified.
+
+## Manifest
+
+In order to use the `chrome.action` API, you need to specify the `action` key
+in your [manifest file][manifest].
+
+```json
+{
+  "name": "Action Extension",
+  "manifest_version": 3,
+  "action": {
+    "default_icon": {
+      "16": "images/icon16.png",
+      "24": "images/icon24.png",
+      "32": "images/icon32.png"
+    },
+    "default_title": "Click Me",
+    "default_popup": "popup.html"
+  },
+  ...
+}
+```
+
+Each of these values is optional; an empty dictionary is technically allowed.
+
+These properties are described more below.
+
+## Parts of the UI
+
+### Icon
+
+The icon is the main image used in the toolbar button. Icons are 16 DIPs
+(device-independent pixels) wide and tall. The icon is initially set by the
+`default_icon` key in the `action` entry in the `manifest.json` file. This
+key is a dictionary of sizes to image paths. Chrome will use these icons to
+choose which image scale to use. If an exact match is not found, Chrome will
+select the closest available and scale it to fit the image. However, this
+scaling can cause the icon to lose detail or look fuzzy.
+
+Since devices with less-common scale factors like 1.5x or 1.2x are becoming
+more common, you are encouraged to provide multiple sizes for your icons. This
+also ensures that if the icon display size is ever changed, you don't need to
+do any more work to provide different icons.
+
+The icon can also be set programmatically using the `action.setIcon()` method.
+This can be used to specify a different image path or to provide a
+dynamically-generated icon using the [HTML canvas element][canvas], or, if
+setting from an extension service worker, the
+[offscreen canvas][offscreenCanvas] API.
+
+```js
+const canvas = new OffscreenCanvas(16, 16);
+const context = canvas.getContext('2d');
+context.clearRect(0, 0, 16, 16);
+context.fillStyle = '#00FF00';  // Green
+context.fillRect(0, 0, 16, 16);
+const imageData = context.getImageData(0, 0, 16, 16);
+chrome.action.setIcon({imageData: imageData}, () => { ... });
+```
+
+!!!.aside
+The `action.setIcon()` API is intended to set a static image. It should not
+be used to simulate animation.
 !!!
+
+#### Formats
+
+For packed extensions (installed from a .crx file), images can be in most
+formats that the Blink rendering engine can display, including PNG, JPEG,
+BMP, ICO, and others (SVG is not supported). Unpacked extensions must use
+images in the PNG format.
+
+### Tooltip (title)
+
+The tooltip, or title, is displayed when the user hovers the mouse of the
+extension's icon in the toolbar. It is also included in the accessible text
+spoken by screenreaders when the button is focused.
+
+The default tooltip is set from the `default_title` field in the `action`
+`manifest.json` file. It can also be set programmatically with the
+`action.setTitle()` method.
+
+### Badge
+
+Actions can optionally display a "badge" &mdash; a bit of text layered over the
+icon. This makes it easy to update the action to display a small amount of
+information about the state of the extension, such as a counter. The badge has a
+text component and a background color.
+
+Note that the badge has limited space, and should typically use four characters
+or fewer.
+
+The badge does not have a default taken from the manifest; you can set it
+programmatically with `action.setBadgeBackgroundColor()` and
+`action.setBadgeText()`. When setting the color, the values can be either
+an array of four integers in the range of 0 - 255 that make up the RGBA
+color of the badge or a string with a CSS hex color value.
+
+```js
+chrome.action.setBadgeBackgroundColor(
+    {color: [0, 255, 0, 0]},  // Green
+    () => { ... });
+
+chrome.action.setBadgeBackgroundColor(
+    {color: '#00FF00'}  // Also green
+    () => { ... });
+```
+
+### Popup
+
+An action's popup will be shown when the user clicks on the extension's button
+in the toolbar. The popup can contain any HTML contents you like, and will be
+sized to fit its contents (though it has a maximum size).
+
+The popup is initially set from the `default_popup` property in the `action`
+key in the `manifest.json` file. If present, this should point to a relative
+path within the extension directory. It can also be updated dynamically to
+point to a different relative path using the `action.setPopup()` method.
+
+!!!.aside
+The `action.onClicked` event will not be dispatched if the extension action
+has a popup on the current tab.
+!!!
+
+## Per-tab state
+
+Extension actions can have different states for each tab. For instance, you
+could set the badge text to be different on each tab (to show tab-specific state).
+You can set the value for an individual tab using the `tabId` property in the
+different setting methods on the `action` API. For instance, to set the badge
+text on a specific tab, you would do something like the following:
+
+```js
+const tabId = getTabId();
+const tabMessage = getTabMessage(tabId);
+chrome.action.setBadgeText(
+    {text: tabMessage, tabId: tabId},
+    () => { ... });
+```
+
+If the `tabId` property is omitted, the setting is treated as a global setting.
+Tab-specific settings will take priority over any global settings.
+
+## Enabled state
+
+By default, toolbar actions are enabled (clickable) on every tab. You can
+control this by using the `action.enable()` and `action.disable()` methods.
+This will only affect whether the popup (if any) or `action.onClicked` event
+is dispatched to your extension; it does not affect the action's presence in the
+toolbar.
+
+[manifest]: /docs/extensions/mv3/manifest
+[canvas]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement
+[offscreenCanvas]: https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas


### PR DESCRIPTION
Add basic documentation for the MV3 chrome.action API, including
descriptions of the different components of the UI and a handful
of (very) small examples.

Fixes #193 