### PR TITLE
remove extra top margin from project-sections

### DIFF
--- a/site/_includes/macros/project-sections.njk
+++ b/site/_includes/macros/project-sections.njk
@@ -16,7 +16,7 @@ have been defined in the _data/docs/*.yml file for this project.
   {% set type = 'nested-column' %}
 {% endif %}
 
-<ul class="project-sections__{{type}} stack flow-space-300 pad-left-0" role="list">
+<ul class="project-sections__{{type}} stack flow-space-300 pad-left-0 gap-top-0" role="list">
   {% for item in sections %}
     {% if item.sections %}
       <li>


### PR DESCRIPTION
Fixes a small bug where project sections had a bit of extra top margin.

Before:

![image](https://user-images.githubusercontent.com/1066253/105524220-30e28980-5c94-11eb-8a57-260e90221dbf.png)


After:

![image](https://user-images.githubusercontent.com/1066253/105524231-34761080-5c94-11eb-9346-53b587a5c955.png)
