### PR TITLE
Increase deploy timeout to 45mins

### DIFF
--- a/.cloudbuild/deploy.yaml
+++ b/.cloudbuild/deploy.yaml
@@ -1,4 +1,4 @@
-timeout: 1200s # support 20 minutes as we are timing out at default 10 minutes
+timeout: 2700s # set build timeout to 45 mins
 steps:
 - name: node
   entrypoint: npm


### PR DESCRIPTION
I noticed our cloud builds are failing because they exceed 20 mins. This just bumps the timeout to 45mins (I read that the max is 24hr).

Obviously we should explore if we can get these deploy times down, so this is a quick fix for now. If the deploy time ever starts approaching 1hr we'll have issues with our cloud scheduler.