### PR TITLE
Minor rewording on reference to samples

### DIFF
--- a/site/en/docs/extensions/mv2/tut_analytics/index.md
+++ b/site/en/docs/extensions/mv2/tut_analytics/index.md
@@ -152,8 +152,7 @@ documentation][8].
 
 ## Sample code {: #toc-samplecode }
 
-A sample extension that uses these techniques is available in the Chromium source tree:
-[.../examples/tutorials/analytics/][9]
+An example extension that uses these techniques is available in the [samples repository][9].
 
 [1]: /apps/analytics
 [2]: /docs/extensions/mv2/getstarted

--- a/site/en/docs/extensions/mv3/tut_analytics/index.md
+++ b/site/en/docs/extensions/mv3/tut_analytics/index.md
@@ -152,8 +152,7 @@ documentation][8].
 
 ## Sample code {: #toc-samplecode }
 
-A sample extension that uses these techniques is available in the Chromium source tree:
-[.../examples/tutorials/analytics/][9]
+An example extension that uses these techniques is available in the [samples repository][9].
 
 [1]: /apps/analytics
 [2]: /docs/extensions/mv3/getstarted


### PR DESCRIPTION
They are in a repo now, not a relative path. Just tweaked the intro wording.
fixes #190 