### PR TITLE
don't swallow // links

### DIFF
--- a/server/redirect.js
+++ b/server/redirect.js
@@ -67,7 +67,7 @@ function buildRedirectHandler(filename, staticPaths = undefined, code = 301) {
   /** @type {express.RequestHandler} */
   return (req, res, next) => {
     const target = handler(req.url);
-    if (target !== null) {
+    if (target !== null && target !== req.url) {
       return res.redirect(code, target);
     }
 
@@ -80,7 +80,7 @@ function buildRedirectHandler(filename, staticPaths = undefined, code = 301) {
         update = update.slice(0, -5) + '.html';
       }
       const target = handler(update);
-      if (target !== null) {
+      if (target !== null && target !== req.url) {
         return res.redirect(code, target);
       }
     }

--- a/server/unique-redirect.js
+++ b/server/unique-redirect.js
@@ -282,7 +282,6 @@ function buildUniqueRedirectHandler() {
 
   // Build the handler async, and once it's ready, insert into the 404 handler path.
   buildMatcher()
-    .catch(err => console.error('failed to build uniqueRedirectHandler', err))
     .then(match => {
       /**
        * @type {express.RequestHandler}
@@ -309,7 +308,8 @@ function buildUniqueRedirectHandler() {
         }
         return res.redirect(301, redirectTo);
       };
-    });
+    })
+    .catch(err => console.error('failed to build uniqueRedirectHandler', err));
 
   return (req, res, next) => replacedHandler(req, res, next);
 }

--- a/site/_transforms/pretty-urls.js
+++ b/site/_transforms/pretty-urls.js
@@ -1,6 +1,8 @@
 const path = require('path');
 const {defaultLocale} = require('../_data/site.json');
 
+const fakeOrigin = `https://fake-does-not-exist-${Math.random()}.localhost`;
+
 /**
  * Converts /en/... urls to /...,
  * and /... urls to locale-specific ones.
@@ -22,14 +24,19 @@ const prettyUrls = ($, outputPath, locale) => {
       return;
     }
 
-    // Ignore external/internal/mailto, and relative links
-    if (
-      href.startsWith('http://') ||
-      href.startsWith('https://') ||
-      href.startsWith('#') ||
-      href.startsWith('mailto:') ||
-      !path.isAbsolute(href)
-    ) {
+    // Fix URLs targeting the same scheme.
+    if (href.startsWith('//')) {
+      href = `https:${href}`;
+    }
+
+    // If constructing a new URL puts us on a new origin, skip it.
+    const checkExternalOrigin = new URL(href, fakeOrigin);
+    if (checkExternalOrigin.origin !== fakeOrigin) {
+      return;
+    }
+
+    // Ignore internal and relative links.
+    if (href.startsWith('#') || !path.isAbsolute(href)) {
       return;
     }
 


### PR DESCRIPTION
Links written as e.g., //twitter.com/chromiumdev were being flattened to be a local pathname.