### PR TITLE
Add missing apps types, complain in future

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "async-transforms": "^1.0.6",
         "browser-media-mime-type": "^1.0.0",
         "chokidar-cli": "^2.1.0",
-        "chrome-types": "0.0.8",
+        "chrome-types": "^0.0.10",
         "common-tags": "^1.8.0",
         "compression": "^1.7.4",
         "concurrently": "^5.2.0",
@@ -6167,9 +6167,9 @@
       }
     },
     "node_modules/chrome-types": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/chrome-types/-/chrome-types-0.0.8.tgz",
-      "integrity": "sha512-YY7Ex9/nqb9LzXs4sG8SYPCs3H3NebFHfciADMbU6BvzIBMhYkVfT6g8oXyDXB5WV5u6+5TgTydJ6J0bmDOVgQ=="
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/chrome-types/-/chrome-types-0.0.10.tgz",
+      "integrity": "sha512-TNtDK3wbO7cB/2BrCA+V5ZFquswhpRW8TW1FpCuVjd7O+opdnsfhtO/hyvGdGwSIgRyJruX2JAXeaizYB0qzoQ=="
     },
     "node_modules/chunkd": {
       "version": "2.0.1",
@@ -32765,9 +32765,9 @@
       }
     },
     "chrome-types": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/chrome-types/-/chrome-types-0.0.8.tgz",
-      "integrity": "sha512-YY7Ex9/nqb9LzXs4sG8SYPCs3H3NebFHfciADMbU6BvzIBMhYkVfT6g8oXyDXB5WV5u6+5TgTydJ6J0bmDOVgQ=="
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/chrome-types/-/chrome-types-0.0.10.tgz",
+      "integrity": "sha512-TNtDK3wbO7cB/2BrCA+V5ZFquswhpRW8TW1FpCuVjd7O+opdnsfhtO/hyvGdGwSIgRyJruX2JAXeaizYB0qzoQ=="
     },
     "chunkd": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "async-transforms": "^1.0.6",
     "browser-media-mime-type": "^1.0.0",
     "chokidar-cli": "^2.1.0",
-    "chrome-types": "0.0.8",
+    "chrome-types": "^0.0.10",
     "common-tags": "^1.8.0",
     "compression": "^1.7.4",
     "concurrently": "^5.2.0",

--- a/site/en/docs/extensions/reference/reference.11tydata.js
+++ b/site/en/docs/extensions/reference/reference.11tydata.js
@@ -37,7 +37,8 @@ function namespaceForData({api}) {
     return indexedTypes[api];
   }
   throw new Error(
-    `cannot build, reference "api: ${api}" is missing from types`
+    `cannot build, reference "api: ${api}" ` +
+      'is missing from types (run `npm run types`?)'
   );
 }
 

--- a/site/en/docs/extensions/reference/reference.11tydata.js
+++ b/site/en/docs/extensions/reference/reference.11tydata.js
@@ -27,7 +27,7 @@ function stripForMeta(raw) {
  * Finds the RenderNamespace for the specified API.
  *
  * @param {{api: string}} param
- * @return {RenderNamespace|void}
+ * @return {RenderNamespace|undefined}
  */
 function namespaceForData({api}) {
   if (!api) {

--- a/site/en/docs/extensions/reference/reference.11tydata.js
+++ b/site/en/docs/extensions/reference/reference.11tydata.js
@@ -27,10 +27,18 @@ function stripForMeta(raw) {
  * Finds the RenderNamespace for the specified API.
  *
  * @param {{api: string}} param
- * @return {RenderNamespace|undefined}
+ * @return {RenderNamespace|void}
  */
 function namespaceForData({api}) {
-  return indexedTypes[api];
+  if (!api) {
+    return undefined;
+  }
+  if (api in indexedTypes) {
+    return indexedTypes[api];
+  }
+  throw new Error(
+    `cannot build, reference "api: ${api}" is missing from types`
+  );
 }
 
 module.exports = {

--- a/site/en/docs/extensions/reference/system_powerSource/index.md
+++ b/site/en/docs/extensions/reference/system_powerSource/index.md
@@ -1,5 +1,0 @@
----
-api: system.powerSource
----
-
-<!-- TODO(samthor): Apps API only -->


### PR DESCRIPTION
Fixes #148 and #149.

For #148, this now complains loudly when we can't generate an API reference page because the API can't be found in the types file. It also helpfully suggests running `npm run types` to get out of any funk.