### PR TITLE
Fix code in headings

### DIFF
--- a/site/_scss/_typography.scss
+++ b/site/_scss/_typography.scss
@@ -123,6 +123,16 @@
     @extend %type--code;
   }
 
+  // Both pre and code have their font-size set in ems, this is because we want
+  // their size to be relative in case someone uses them inside of an h1-h6.
+  // But for fenced code blocks, markdown will render a code element inside of
+  // a pre. This causes the code element's font-size to be too small because
+  // we have an em inside of an em. So in this scenario we tell the code element
+  // to just inherit the font-size from its parent pre.
+  pre code {
+    font-size: inherit;
+  }
+
   &--full-bleed {
     @extend %type--full-bleed;
   }

--- a/site/_scss/globals/extends/_type.scss
+++ b/site/_scss/globals/extends/_type.scss
@@ -251,7 +251,7 @@
 
   &--code {
     @include apply-utility('font', 'mono');
-    @include font-setup(15px, 26px);
+    @include font-setup(15px, 26px, false, false);
   }
 
   &--full-bleed {


### PR DESCRIPTION
Fixes #326

Changes proposed in this pull request:

- Sets `pre` and `code` to use `em`s
- Sets `code` elements inside of `pre` elements to inherit their font-size