### PR TITLE
Improve purge css

### DIFF
--- a/site/_scss/_reset.scss
+++ b/site/_scss/_reset.scss
@@ -32,12 +32,10 @@ body {
 // Remove list styles on ul, ol elements with a list role, which suggests
 // default styling will be removed.
 // https://github.com/hankchizljaw/modern-css-reset/issues/30
-/* purgecss start ignore */
 ul[role='list'],
 ol[role='list'] {
   list-style: none;
 }
-/* purgecss end ignore */
 
 // Don't let lists spill outside of their containing box.
 ul,

--- a/site/_scss/blocks/_announcement-banner.scss
+++ b/site/_scss/blocks/_announcement-banner.scss
@@ -1,4 +1,3 @@
-/* purgecss start ignore */
 .banner--hide announcement-banner,
 announcement-banner[hidden] {
   display: none;
@@ -17,4 +16,3 @@ announcement-banner {
     }
   }
 }
-/* purgecss end ignore */

--- a/site/_scss/blocks/_button.scss
+++ b/site/_scss/blocks/_button.scss
@@ -1,4 +1,3 @@
-/* purgecss start ignore */
 %button,
 .button {
   background: transparent;
@@ -6,7 +5,6 @@
   cursor: pointer;
   text-decoration: none;
 }
-/* purgecss end ignore */
 
 %material-button,
 .material-button {

--- a/site/_scss/blocks/_code-sections.scss
+++ b/site/_scss/blocks/_code-sections.scss
@@ -72,12 +72,10 @@
 // Ensure that .code-sections has a margin-top, except in cases where it's
 // already in a stack (as this will bring its margin).
 // purgecss tries to remove this bit.
-/* purgecss start ignore */
 /* stylelint-disable-next-line selector-max-compound-selectors */
 :not(.stack) > * + .code-sections {
   margin-top: get-size(300);
 }
-/* purgecss end ignore */
 
 // This is used for method signatures. We need to:
 //  - use opacity to make them less pronounced

--- a/site/_scss/blocks/_navigation-rail.scss
+++ b/site/_scss/blocks/_navigation-rail.scss
@@ -1,4 +1,3 @@
-/* purgecss start ignore */
 navigation-rail {
   display: none;
   outline: 0;
@@ -76,4 +75,3 @@ navigation-rail {
 
   width: 4rem;
 }
-/* purgecss end ignore */

--- a/site/_scss/blocks/_navigation-tree.scss
+++ b/site/_scss/blocks/_navigation-tree.scss
@@ -1,4 +1,3 @@
-/* purgecss start ignore */
 navigation-tree {
   display: none;
   width: px-to-rem(250px);
@@ -57,4 +56,3 @@ navigation-tree {
 .navigation-tree__nested > .navigation-tree__nested > .navigation-tree__link {
   padding-left: 3rem;
 }
-/* purgecss end ignore */

--- a/site/_scss/blocks/_search-box.scss
+++ b/site/_scss/blocks/_search-box.scss
@@ -1,4 +1,3 @@
-/* purgecss start ignore */
 search-box {
   min-height: $search-box-height;
   position: relative;
@@ -113,4 +112,3 @@ search-box[active] {
     margin-left: get-size(300);
   }
 }
-/* purgecss end ignore */

--- a/site/_scss/blocks/_side-nav.scss
+++ b/site/_scss/blocks/_side-nav.scss
@@ -1,4 +1,3 @@
-/* purgecss start ignore */
 $side-nav-transition-speed: 0.2s;
 $side-nav-transition-ease: cubic-bezier(0.4, 0, 0.2, 1);
 
@@ -122,4 +121,3 @@ side-nav[view='site'] {
     visibility: hidden;
   }
 }
-/* purgecss end ignore */

--- a/site/_scss/blocks/_stack.scss
+++ b/site/_scss/blocks/_stack.scss
@@ -9,7 +9,6 @@
 
 // https://every-layout.dev/layouts/stack/
 
-/* purgecss start ignore */
 %stack,
 .stack {
   display: flex;
@@ -27,7 +26,6 @@
     margin-top: var(--flow-space);
   }
 }
-/* purgecss end ignore */
 
 // The default .stack class uses flexbox, and flexbox ignores floats.
 // Authors like to use floats in blog posts and docs so this exception can be

--- a/site/_scss/blocks/_top-nav.scss
+++ b/site/_scss/blocks/_top-nav.scss
@@ -1,4 +1,3 @@
-/* purgecss start ignore */
 top-nav {
   padding: map-get($top-nav-padding, 'sm');
 
@@ -62,4 +61,3 @@ top-nav[data-search-active] {
     top: 0;
   }
 }
-/* purgecss end ignore */

--- a/site/_scss/globals/extends/_navigation.scss
+++ b/site/_scss/globals/extends/_navigation.scss
@@ -52,9 +52,7 @@
   }
 }
 
-/* purgecss start ignore */
 %navigation__link[aria-current='page'] {
   background: var(--color-secondary);
   color: var(--color-side-nav-active);
 }
-/* purgecss end ignore */

--- a/site/_scss/globals/extends/_overlay.scss
+++ b/site/_scss/globals/extends/_overlay.scss
@@ -7,7 +7,6 @@
 // two lines, the hover state will break.
 // https://twitter.com/rob_dodson/status/1335077889641832449
 
-/* purgecss start ignore */
 %overlay {
   overflow: hidden;
   position: relative;
@@ -37,4 +36,3 @@
     opacity: 0.16;
   }  
 }
-/* purgecss end ignore */

--- a/site/_transforms/purify-css.js
+++ b/site/_transforms/purify-css.js
@@ -35,6 +35,15 @@ const purifyCss = async (content, outputPath) => {
     });
 
     const purged = await new PurgeCSS().purge({
+      // Here we take the actual text of the current page and give it to
+      // PurgeCss to grep and look for any strings that match the regex listed
+      // in the `defaultExtractor`.
+      // In addition, we tell it to look at all of our js files.
+      // Really all it's doing is looking for strings like ".some-class" and if
+      // it appears in either the js bundle or the page html, it preserves that
+      // class in the CSS. All other classes/selectors/etc will get purged.
+      // The Tailwind docs have a nice explainer:
+      // https://tailwindcss.com/docs/optimizing-for-production#writing-purgeable-html
       content: [
         {
           raw: content,

--- a/site/_transforms/purify-css.js
+++ b/site/_transforms/purify-css.js
@@ -40,6 +40,7 @@ const purifyCss = async (content, outputPath) => {
           raw: content,
           extension: 'html',
         },
+        './site/_js/**/*.js',
       ],
       css: [
         {
@@ -49,7 +50,7 @@ const purifyCss = async (content, outputPath) => {
       fontFace: true,
       // whitelist utility classes used by custom elements.
       // these type classes are used by search-box.
-      whitelist: ['type--h6', 'type--small', 'type--label', 'overflow-hidden'],
+      // whitelist: ['type--h6', 'type--small', 'type--label', 'overflow-hidden'],
       defaultExtractor: content => {
         return content.match(/[A-Za-z0-9\\:_-]+/g) || [];
       },

--- a/site/_transforms/purify-css.js
+++ b/site/_transforms/purify-css.js
@@ -48,9 +48,6 @@ const purifyCss = async (content, outputPath) => {
         },
       ],
       fontFace: true,
-      // whitelist utility classes used by custom elements.
-      // these type classes are used by search-box.
-      // whitelist: ['type--h6', 'type--small', 'type--label', 'overflow-hidden'],
       defaultExtractor: content => {
         return content.match(/[A-Za-z0-9\\:_-]+/g) || [];
       },

--- a/tools/eleventyignore/index.js
+++ b/tools/eleventyignore/index.js
@@ -38,7 +38,7 @@ const isProduction = process.env.NODE_ENV === 'production';
 const isCI = process.env.CI;
 
 // Only use ignore environment variables during dev and CI builds.
-if (!isProduction || isCI) {
+if (true) {
   // Ignore /docs/
   if (process.env.ELEVENTY_IGNORE_DOCS) {
     console.log(warning('Ignoring ALL docs.'));

--- a/tools/eleventyignore/index.js
+++ b/tools/eleventyignore/index.js
@@ -38,7 +38,7 @@ const isProduction = process.env.NODE_ENV === 'production';
 const isCI = process.env.CI;
 
 // Only use ignore environment variables during dev and CI builds.
-if (true) {
+if (!isProduction || isCI) {
   // Ignore /docs/
   if (process.env.ELEVENTY_IGNORE_DOCS) {
     console.log(warning('Ignoring ALL docs.'));


### PR DESCRIPTION
I was having [a conversation on twitter about this](https://twitter.com/tailwindcss/status/1355570032479244292) and got really excited to give it a shot. It turns out you can point purgeCss at your JS files as well and it'll include classes that it sees. This is *much* nicer than having to manually tell it to include all of the classes used by our custom elements. We can ditch all of the `purgecss start ignore` comments as well as the weird `whitelist` property in the config file.

It would be good for folks to double check any files that this touches. I did a quick pass and it looked good but Sam may want to do a production build and confirm that the code sections look correct.