### PR TITLE
Fix broken masonry layout on Windows.

### DIFF
--- a/site/_includes/layouts/home.njk
+++ b/site/_includes/layouts/home.njk
@@ -10,14 +10,13 @@
 
     {{ heroCard() }}
     <div class="masonry-grid gap-top-500">
-      {% include 'partials/featured-cds-card.njk' %}
       {% set blog = 'blog-' + locale %}
       {{ featuredPostCard(collections[blog][0]) }}
       {{ featuredDocsCard(featured_projects) }}
+      {% include 'partials/report-a-bug.njk' %}
       {% if tweets and tweets.length %}
         {{ featuredTweetCard() }}
       {% endif %}
-      {% include 'partials/report-a-bug.njk' %}
     </div>
 
     {#

--- a/site/_scss/blocks/_masonry-grid.scss
+++ b/site/_scss/blocks/_masonry-grid.scss
@@ -16,7 +16,6 @@
     display: grid;
     gap: get-size(500);
     grid-template-columns: 1fr 1fr;
-    grid-template-columns: 1fr;
     justify-items: center;
   }
 


### PR DESCRIPTION
Fixes #356 (sorta).

This doesn't fix the underlying issue that our card measurement seems to be a bit off on Windows. You can "fix" the issue by resizing the page so it's smaller than 960px and then the card will snap into place and remain in place. So likely something is off with how the card is being measured during its initial layout.

Changes proposed in this pull request:

- Remove the CDS card as CDS has been over for a while now
- Remove an extra `1r` that should not have been in the CSS and was causing column widths to be slightly off on desktop.