### PR TITLE
Add border to screenshot class

### DIFF
--- a/site/_scss/blocks/_screenshot.scss
+++ b/site/_scss/blocks/_screenshot.scss
@@ -1,5 +1,17 @@
 .screenshot {
-  background: var(--color-code-bg);
   border: 1px solid var(--color-hairline);
   padding: get-size(400);
+
+  // This ensures images are scaled to the exact size specified by the
+  // width attribute, preventing HiDPI screenshots from being blurry:
+  //  <img src="800x500.png" width="400" class="screenshot">
+  box-sizing: content-box;
+}
+
+.screenshot--filled {
+  background-color: var(--color-code-bg);
+
+  // This ensures image size fits to content width with padding(16 * 2)
+  // while specifying `box-sizing: content-box;` in .screenshot
+  max-width: calc(100% - 2 * #{get-size(400)});
 }

--- a/site/_scss/blocks/_screenshot.scss
+++ b/site/_scss/blocks/_screenshot.scss
@@ -1,16 +1,14 @@
 .screenshot {
   border: 1px solid var(--color-hairline);
-  padding: get-size(400);
-
   // This ensures images are scaled to the exact size specified by the
   // width attribute, preventing HiDPI screenshots from being blurry:
   //  <img src="800x500.png" width="400" class="screenshot">
   box-sizing: content-box;
+  padding: get-size(400);
 }
 
 .screenshot--filled {
   background-color: var(--color-code-bg);
-
   // This ensures image size fits to content width with padding(16 * 2)
   // while specifying `box-sizing: content-box;` in .screenshot
   max-width: calc(100% - 2 * #{get-size(400)});

--- a/site/_scss/blocks/_screenshot.scss
+++ b/site/_scss/blocks/_screenshot.scss
@@ -4,7 +4,7 @@
   // width attribute, preventing HiDPI screenshots from being blurry:
   //  <img src="800x500.png" width="400" class="screenshot">
   box-sizing: content-box;
-  padding: get-size(400);
+  padding: get-size(100);
 }
 
 .screenshot--filled {
@@ -12,4 +12,5 @@
   // This ensures image size fits to content width with padding(16 * 2)
   // while specifying `box-sizing: content-box;` in .screenshot
   max-width: calc(100% - 2 * #{get-size(400)});
+  padding: get-size(400);
 }

--- a/site/_scss/blocks/_screenshot.scss
+++ b/site/_scss/blocks/_screenshot.scss
@@ -1,0 +1,5 @@
+.screenshot {
+  background: var(--color-code-bg);
+  border: 1px solid var(--color-hairline);
+  padding: get-size(400);
+}

--- a/site/_scss/main.scss
+++ b/site/_scss/main.scss
@@ -62,6 +62,7 @@
 @import 'blocks/skip-link';
 @import 'blocks/compare';
 @import 'blocks/pagination';
+@import 'blocks/screenshot';
 
 // Utilities
 @import 'utilities/center-margin';

--- a/site/en/docs/extensions/mv3/devtools/index.md
+++ b/site/en/docs/extensions/mv3/devtools/index.md
@@ -91,8 +91,9 @@ DevTools extension can add UI elements to the DevTools window:
   appearance of sidebar panes may not match the image, depending on the version of Chrome you're
   using, and where the DevTools window is docked.)
 
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/TDNgfhI9byR4eeGQ0Xxv.png",
-       alt="DevTools window showing Elements panel and Styles sidebar pane.", height="302", width="770" %}
+{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/TDNgfhI9byR4eeGQ0Xxv.png"
+    className="screenshot",
+    alt="DevTools window showing Elements panel and Styles sidebar pane.", height="302", width="770" %}
 
 Each panel is its own HTML file, which can include other resources (JavaScript, CSS, images, and so
 on). Creating a basic panel looks like this:

--- a/site/en/docs/extensions/mv3/devtools/index.md
+++ b/site/en/docs/extensions/mv3/devtools/index.md
@@ -91,7 +91,7 @@ DevTools extension can add UI elements to the DevTools window:
   appearance of sidebar panes may not match the image, depending on the version of Chrome you're
   using, and where the DevTools window is docked.)
 
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/TDNgfhI9byR4eeGQ0Xxv.png"
+{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/TDNgfhI9byR4eeGQ0Xxv.png",
     className="screenshot",
     alt="DevTools window showing Elements panel and Styles sidebar pane.", height="302", width="770" %}
 

--- a/site/en/docs/handbook/components/index.md
+++ b/site/en/docs/handbook/components/index.md
@@ -474,7 +474,9 @@ Shortcode object fields allow for modifying how the embed is presented:
 
 ## Images
 
-Images should always use the {% raw %}`{% Img %}`{% endraw %} shortcode.
+Images should always use the {% raw %}`{% Img %}`{% endraw %} shortcode. This
+shortcode will be generated for you when you upload your image to our CDN.
+See the [Add an image or video guide](https://developer.chrome.com/docs/handbook/how-to/add-media/) for upload instructions.
 
 ```md
 {% raw %}{% Img src="image/foR0vJZKULb5AGJExlazy1xYDgI2/w9i7lEqGw5J5b3jx5fAu.jpg", alt="ALT_TEXT_HERE", width="800", height="450" %}{% endraw %}
@@ -482,7 +484,21 @@ Images should always use the {% raw %}`{% Img %}`{% endraw %} shortcode.
 
 {% Img src="image/foR0vJZKULb5AGJExlazy1xYDgI2/w9i7lEqGw5J5b3jx5fAu.jpg", alt="ALT_TEXT_HERE", width="800", height="450" %}
 
-See the [Add an image or video guide](https://developer.chrome.com/docs/handbook/how-to/add-media/).
+Images with a white background should use the `.screenshot` class to give
+them a border so they don't appear to "float" on the page.
+
+```md
+{% raw %}{% Img src='image/BrQidfK9jaQyIHwdw91aVpkPiib2/TDNgfhI9byR4eeGQ0Xxv.png', alt='Screenshot', height="302", width="770", className="screenshot" %}{% endraw %}
+
+<!-- Add the .screenshot--filled modifier to give the screenshot padding and a grey background. -->
+{% raw %}{% Img src='image/BrQidfK9jaQyIHwdw91aVpkPiib2/TDNgfhI9byR4eeGQ0Xxv.png', alt='Screenshot', height="302", width="770", className="screenshot screenshot--filled" %}{% endraw %}
+```
+
+{% Img src='image/BrQidfK9jaQyIHwdw91aVpkPiib2/TDNgfhI9byR4eeGQ0Xxv.png', alt='Screenshot', height="302", width="770", className="screenshot" %}
+
+<br>
+
+{% Img src='image/BrQidfK9jaQyIHwdw91aVpkPiib2/TDNgfhI9byR4eeGQ0Xxv.png', alt='Screenshot', height="302", width="770", className="screenshot screenshot--filled" %}
 
 ### Full bleed images
 
@@ -862,7 +878,9 @@ responsive. To prevent this from happening add the `fixed-table` class.
 
 ## Video
 
-Videos should always use the {% raw %}`{% Video %}`{% endraw %} shortcode.
+Videos should always use the {% raw %}`{% Video %}`{% endraw %} shortcode. This
+shortcode will be generated for you when you upload your video to our CDN.
+See the [Add an image or video guide](https://developer.chrome.com/docs/handbook/how-to/add-media/) for upload instructions.
 
 ```md
 {% raw %}{% Video src='video/tcFciHGuF3MxnTr1y5ue01OGLBn2/1601081394086.mp4' %}{% endraw %}

--- a/site/en/style-guide/index.njk
+++ b/site/en/style-guide/index.njk
@@ -84,11 +84,11 @@ title: Style guide
     <figcaption>Fig1. A picture stolen from web.dev's about page.</figcaption>
   </figure>
   <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Quasi, culpa quo totam alias maxime expedita porro ut perspiciatis nulla hic, sed obcaecati voluptates sunt dolores, distinctio illo cumque voluptate explicabo!</p>
-  
+
   <figure class="type--full-bleed">
     <img src="./a.jpg" alt="">
   </figure>
-  
+
   <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Quasi, culpa quo totam alias maxime expedita porro ut perspiciatis nulla hic, sed obcaecati voluptates sunt dolores, distinctio illo cumque voluptate explicabo!</p>
 
 
@@ -456,5 +456,10 @@ line-height: 160%;
     {% Img src='image/foR0vJZKULb5AGJExlazy1xYDgI2/1600132969326.jpg', alt='Smiling Dog', height='450', width='800' %}
     {% Video src='video/tcFciHGuF3MxnTr1y5ue01OGLBn2/1601081394086.mp4' %}
   </div>
+
+  <div>
+    {% img src='image/BrQidfK9jaQyIHwdw91aVpkPiib2/TDNgfhI9byR4eeGQ0Xxv.png', alt='Screenshot', height="302", width="770", className="screenshot" %}
+  </div>
+
 </article>
 {% endblock %}

--- a/site/en/style-guide/index.njk
+++ b/site/en/style-guide/index.njk
@@ -458,7 +458,7 @@ line-height: 160%;
   </div>
 
   <div>
-    {% img src='image/BrQidfK9jaQyIHwdw91aVpkPiib2/TDNgfhI9byR4eeGQ0Xxv.png', alt='Screenshot', height="302", width="770", className="screenshot" %}
+    {% img src='image/BrQidfK9jaQyIHwdw91aVpkPiib2/TDNgfhI9byR4eeGQ0Xxv.png', alt='Screenshot', height="302", width="770", className="screenshot screenshot--filled" %}
   </div>
 
 </article>

--- a/site/en/style-guide/index.njk
+++ b/site/en/style-guide/index.njk
@@ -24,54 +24,40 @@ title: Style guide
     <p class="type--xsmall">Small Text</p>
   </div>
 
-  <div class="aside">
-    <p>
-      Lorem ipsum dolor sit amet consectetur adipisicing elit. In, culpa quas
-      ratione <a href="#">quidem inventore</a> id.
-    </p>
-  </div>
+  {% Aside %}
+  Lorem ipsum dolor sit amet consectetur adipisicing elit. In, culpa quas
+  ratione quidem inventore id.
+  {% endAside %}
 
-  <div class="aside aside--caution">
-    <p>
-      Lorem ipsum dolor sit amet consectetur adipisicing elit. In, culpa quas
-      ratione <a href="#">quidem inventore</a> id.
-    </p>
-  </div>
+  {% Aside 'caution' %}
+  Lorem ipsum dolor sit amet consectetur adipisicing elit. In, culpa quas
+  ratione quidem inventore id.
+  {% endAside %}
 
-  <div class="aside aside--warning">
-    <p>
-      Lorem ipsum dolor sit amet consectetur adipisicing elit. In, culpa quas
-      ratione <a href="#">quidem inventore</a> id.
-    </p>
-  </div>
+  {% Aside 'warning' %}
+  Lorem ipsum dolor sit amet consectetur adipisicing elit. In, culpa quas
+  ratione quidem inventore id.
+  {% endAside %}
 
-  <div class="aside aside--success">
-    <p>
-      Lorem ipsum dolor sit amet consectetur adipisicing elit. In, culpa quas
-      ratione <a href="#">quidem inventore</a> id.
-    </p>
-  </div>
+  {% Aside 'success' %}
+  Lorem ipsum dolor sit amet consectetur adipisicing elit. In, culpa quas
+  ratione quidem inventore id.
+  {% endAside %}
 
-  <div class="aside aside--gotchas">
-    <p>
-      Lorem ipsum dolor sit amet consectetur adipisicing elit. In, culpa quas
-      ratione <a href="#">quidem inventore</a> id.
-    </p>
-  </div>
+  {% Aside 'gotchas' %}
+  Lorem ipsum dolor sit amet consectetur adipisicing elit. In, culpa quas
+  ratione quidem inventore id.
+  {% endAside %}
 
-  <div class="aside aside--key">
-    <p>
-      Lorem ipsum dolor sit amet consectetur adipisicing elit. In, culpa quas
-      ratione <a href="#">quidem inventore</a> id.
-    </p>
-  </div>
+  {% Aside 'key-term' %}
+  Lorem ipsum dolor sit amet consectetur adipisicing elit. In, culpa quas
+  ratione quidem inventore id.
+  {% endAside %}
 
-  <div class="aside aside--codelab">
-    <p>
-      Lorem ipsum dolor sit amet consectetur adipisicing elit. In, culpa quas
-      ratione <a href="#">quidem inventore</a> id.
-    </p>
-  </div>
+  {% Aside 'codelab' %}
+  Lorem ipsum dolor sit amet consectetur adipisicing elit. In, culpa quas
+  ratione quidem inventore id.
+  {% endAside %}
 
   <p>This paragraph is nested inside an article. It contains many different, sometimes useful, <a href="https://www.w3schools.com/tags/">HTML5 tags</a>. Of course there are classics like <em>emphasis</em>, <strong>strong</strong>, and <small>small</small> but there are many others as well. Hover the following text for abbreviation tag: <abbr title="abbreviation">abbr</abbr>. Similarly, you can use acronym tag like this: <acronym title="For The Win">ftw</acronym>. You can define <del>deleted text</del> which often gets replaced with <ins>inserted</ins> text.</p>
   <p>You can also use <kbd>keyboard text</kbd>, which sometimes is styled similarly to the <code>&lt;code&gt;</code> or <samp>samp</samp> tags. Even more specifically, there is a tag just for <var>variables</var>. Not to be mistaken with blockquotes
@@ -458,7 +444,8 @@ line-height: 160%;
   </div>
 
   <div>
-    {% img src='image/BrQidfK9jaQyIHwdw91aVpkPiib2/TDNgfhI9byR4eeGQ0Xxv.png', alt='Screenshot', height="302", width="770", className="screenshot screenshot--filled" %}
+    {% Img src='image/BrQidfK9jaQyIHwdw91aVpkPiib2/TDNgfhI9byR4eeGQ0Xxv.png', alt='Screenshot', height="302", width="770", className="screenshot" %}
+    {% Img src='image/BrQidfK9jaQyIHwdw91aVpkPiib2/TDNgfhI9byR4eeGQ0Xxv.png', alt='Screenshot', height="302", width="770", className="screenshot screenshot--filled" %}
   </div>
 
 </article>


### PR DESCRIPTION
Fixes #91

Adds a hairline border and a light grey background to screenshots.
<img width="736" alt="Screenshot 2021-02-04 at 17 10 35" src="https://user-images.githubusercontent.com/1914261/106921126-fbb24e80-670b-11eb-9e13-24ae06a1a60e.png">
