### PR TITLE
Publish MV3 remote code policy

### DIFF
--- a/site/en/docs/webstore/program_policies/index.md
+++ b/site/en/docs/webstore/program_policies/index.md
@@ -164,7 +164,7 @@ Code Readability Requirements:
 Additional Requirements for Manifest V3:
 
 : Extensions using Manifest V3 must meet additional requirements related to the
-  extension’s code. Specifically, the full functionality of an extension must be
+  extension's code. Specifically, the full functionality of an extension must be
   easily discernible from its submitted code. This means that the logic of how
   each extension operates should be self contained. The extension may reference
   and load data and other information sources that are external to the extension,

--- a/site/en/docs/webstore/program_policies/index.md
+++ b/site/en/docs/webstore/program_policies/index.md
@@ -161,6 +161,53 @@ Code Readability Requirements:
   - Shortening of variable and function names
   - Collapsing files together
 
+
+
+
+
+
+
+
+
+
+Additional Requirements for Manifest V3:
+
+: Extensions using Manifest V3 must meet additional requirements related to the
+  extension’s code. Specifically, the full functionality of an extension must be
+  easily discernible from its submitted code. This means that the logic of how
+  each extension operates should be self contained. The extension may reference
+  and load data and other information sources that are external to the extension,
+  but these external resources must not contain any logic.
+
+  Some common violations include:
+
+  * Including a &lt;script> tag that points to a resource that is not within the
+    extension's package
+
+  * Using JavaScript's
+    [eval()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval)
+    method or other mechanisms to execute a string fetched from a remote source
+
+  * Building an interpreter to run complex commands fetched from a remote source,
+    even if those commands are fetched as data
+
+  Communicating with remote servers for certain purposes is still allowed.  For instance,
+
+  * Syncing user account data with a remote server
+
+  * Fetching a remote configuration file for A/B testing or determining enabled
+    features, where all logic for the functionality is contained within the
+    extension package
+
+  * Fetching remote resources that are not used to evaluate logic, such as images
+
+  * Performing server-side operations with data (such as for the purposes of
+    encryption with a private key)
+
+  If our reviewers are unable to determine the full functionality of your
+  extension during the review process, we may reject your submission or remove it
+  from the store.
+
 Prohibited Products:
 
 : We don't allow products or services that:

--- a/site/en/docs/webstore/program_policies/index.md
+++ b/site/en/docs/webstore/program_policies/index.md
@@ -161,15 +161,6 @@ Code Readability Requirements:
   - Shortening of variable and function names
   - Collapsing files together
 
-
-
-
-
-
-
-
-
-
 Additional Requirements for Manifest V3:
 
 : Extensions using Manifest V3 must meet additional requirements related to the


### PR DESCRIPTION
Updates CWS program policies page to add the new MV3 restriction on remote code.