### PR TITLE
Update samples paths for MV2 sample reorg

### DIFF
--- a/site/en/docs/apps/nativeMessaging/index.md
+++ b/site/en/docs/apps/nativeMessaging/index.md
@@ -96,7 +96,7 @@ message sent to the native messaging host is 4 GB.
 The first argument to the native messaging host is the origin of the caller, usually
 `chrome-extension://[ID of allowed extension]`. This allows native messaging hosts to identify the
 source of the message when multiple extensions are specified in the `allowed_origins` key in the
-[native messaging host manifest][7].  
+[native messaging host manifest][7].
 **_Warning_**: In Windows, in Chrome 54 and earlier, the origin was passed as the second parameter
 instead of the first parameter.
 
@@ -117,7 +117,7 @@ messaging host create native UI windows that are correctly focused.
 Sending and receiving messages to and from a native application is very similar to cross-extension
 messaging. The main difference is that [runtime.connectNative][11] is used instead of
 [runtime.connect][12], and [runtime.sendNativeMessage][13] is used instead of
-[runtime.sendMessage][14].  
+[runtime.sendMessage][14].
 These methods can only be used if the "nativeMessaging" permission is [declared][15] in your app's
 manifest file.
 
@@ -227,7 +227,7 @@ host. Then [load the app][27] and interact with the app. Run `uninstall_host.bat
 [21]: #native-messaging-host-location
 [22]: #native-messaging-host-protocol
 [23]: https://msdn.microsoft.com/en-us/library/tw4k6df8.aspx
-[24]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/api/nativeMessaging
+[24]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/nativeMessaging
 [25]: /extensions/examples/api/nativeMessaging/app.zip
 [26]: /extensions/examples/api/nativeMessaging/host.zip
 [27]: getstarted#unpacked

--- a/site/en/docs/extensions/mv2/desktop_notifications/index.md
+++ b/site/en/docs/extensions/mv2/desktop_notifications/index.md
@@ -109,6 +109,6 @@ unnecessary if you declare the "notifications" permission.
 [5]: http://dev.chromium.org/developers/design-documents/desktop-notifications/api-specification
 [6]: /docs/extensions/extension#method-getBackgroundPage
 [7]: /docs/extensions/extension#method-getViews
-[8]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/api/notifications/
+[8]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/notifications/
 [9]: /docs/extensions/mv2/samples
 [10]: http://www.html5rocks.com/tutorials/notifications/quick/

--- a/site/en/docs/extensions/mv2/messaging/index.md
+++ b/site/en/docs/extensions/mv2/messaging/index.md
@@ -344,6 +344,6 @@ native app. For more examples and for help in viewing the source code, see [Samp
 [37]: /docs/extensions/mv2/security#content_scripts
 [38]: /docs/extensions/mv2/security#sanitize
 [39]: https://en.wikipedia.org/wiki/Cross-site_scripting
-[40]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/api/messaging
+[40]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/messaging
 [41]: /docs/apps/nativeMessaging#examples
 [42]: /docs/extensions/mv2/samples

--- a/site/en/docs/extensions/mv2/tut_analytics/index.md
+++ b/site/en/docs/extensions/mv2/tut_analytics/index.md
@@ -162,4 +162,4 @@ An example extension that uses these techniques is available in the [samples rep
 [6]: /docs/extensions/mv2/tabs
 [7]: /docs/extensions/mv2/tut_debugging
 [8]: https://developers.google.com/analytics/devguides/collection/gajs/eventTrackerGuide
-[9]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/tutorials/analytics/
+[9]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/tutorials/analytics/

--- a/site/en/docs/extensions/mv3/messaging/index.md
+++ b/site/en/docs/extensions/mv3/messaging/index.md
@@ -342,6 +342,6 @@ native app. For more examples and for help in viewing the source code, see [Samp
 [37]: /docs/extensions/mv3/security#content_scripts
 [38]: /docs/extensions/mv3/security#sanitize
 [39]: https://en.wikipedia.org/wiki/Cross-site_scripting
-[40]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/api/messaging
+[40]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/messaging
 [41]: /docs/apps/nativeMessaging/#examples
 [42]: /docs/extensions/mv3/samples

--- a/site/en/docs/extensions/mv3/tut_analytics/index.md
+++ b/site/en/docs/extensions/mv3/tut_analytics/index.md
@@ -162,4 +162,4 @@ An example extension that uses these techniques is available in the [samples rep
 [6]: /docs/extensions/mv3/tabs
 [7]: /docs/extensions/mv3/tut_debugging
 [8]: https://developers.google.com/analytics/devguides/collection/gajs/eventTrackerGuide
-[9]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/tutorials/analytics/
+[9]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/tutorials/analytics/

--- a/site/en/docs/extensions/reference/bookmarks/index.md
+++ b/site/en/docs/extensions/reference/bookmarks/index.md
@@ -72,5 +72,5 @@ help in viewing the source code, see [Samples][6].
 [2]: #type-BookmarkTreeNode
 [3]: #method-create
 [4]: #type-BookmarkTreeNode
-[5]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/api/bookmarks/basic/
+[5]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/bookmarks/basic/
 [6]: /docs/extensions/mv2/samples

--- a/site/en/docs/extensions/reference/browserAction/index.md
+++ b/site/en/docs/extensions/reference/browserAction/index.md
@@ -141,5 +141,5 @@ directory. For other examples and for help in viewing the source code, see [Samp
 [15]: #manifest
 [16]: #method-setPopup
 [17]: /extensions/pageAction
-[18]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/api/browserAction/
+[18]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/browserAction/
 [19]: /docs/extensions/mv2/samples

--- a/site/en/docs/extensions/reference/cookies/index.md
+++ b/site/en/docs/extensions/reference/cookies/index.md
@@ -27,5 +27,5 @@ You can find a simple example of using the cookies API in the
 the source code, see [Samples][3].
 
 [1]: /docs/extensions/mv2/declare_permissions
-[2]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/api/cookies/
+[2]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/cookies/
 [3]: /docs/extensions/mv2/samples

--- a/site/en/docs/extensions/reference/downloads/index.md
+++ b/site/en/docs/extensions/reference/downloads/index.md
@@ -23,5 +23,5 @@ You can find simple examples of using the `chrome.downloads` API in the [example
 directory. For other examples and for help in viewing the source code, see [Samples][3].
 
 [1]: /docs/extensions/mv2/tabs
-[2]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/api/downloads/
+[2]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/downloads/
 [3]: /docs/extensions/mv2/samples

--- a/site/en/docs/extensions/reference/fontSettings/index.md
+++ b/site/en/docs/extensions/reference/fontSettings/index.md
@@ -64,5 +64,5 @@ directory. For other examples and for help in viewing the source code, see [Samp
 
 [1]: /docs/extensions/mv2/tabs
 [2]: https://www.w3.org/TR/CSS21/fonts.html#generic-font-families
-[3]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/api/fontSettings/
+[3]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/fontSettings/
 [4]: /docs/extensions/mv2/samples

--- a/site/en/docs/extensions/reference/history/index.md
+++ b/site/en/docs/extensions/reference/history/index.md
@@ -40,6 +40,6 @@ directory][9]. For other examples and for help in viewing the source code, see [
 [5]: #tt_keyword
 [6]: #tt_keyword_generated
 [7]: #tt_keyword
-[8]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/api/history/
+[8]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/history/
 [9]: https://chromium.googlesource.com/chromium/src/+/master/chrome/test/data/extensions/api_test/history/
 [10]: /docs/extensions/mv2/samples

--- a/site/en/docs/extensions/reference/i18n/index.md
+++ b/site/en/docs/extensions/reference/i18n/index.md
@@ -352,8 +352,8 @@ For more details on calling `detectLanguage(inputText)`, see the [API reference]
 [11]: #testing-linux
 [12]: #testing-chromeos
 [13]: https://www.chromium.org/developers/creating-and-using-profiles
-[14]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/api/i18n/
-[15]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/extensions/news/
+[14]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/i18n/
+[15]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/extensions/news/
 [16]: /docs/extensions/mv2/samples
 [17]: /docs/extensions/mv2/i18n-messages
 [18]: #method-getMessage

--- a/site/en/docs/extensions/reference/input_ime/index.md
+++ b/site/en/docs/extensions/reference/input_ime/index.md
@@ -46,5 +46,5 @@ For an example of using this API, see the [basic input.ime sample][2]. For other
 help in viewing the source code, see [Samples][3].
 
 [1]: /docs/extensions/mv2/tabs
-[2]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/api/input.ime/basic/
+[2]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/input.ime/basic/
 [3]: /docs/extensions/mv2/samples

--- a/site/en/docs/extensions/reference/pageAction/index.md
+++ b/site/en/docs/extensions/reference/pageAction/index.md
@@ -93,5 +93,5 @@ For other examples and for help in viewing the source code, see [Samples][8].
 [4]: #method-show
 [5]: #method-hide
 [6]: /docs/extensions/browserAction
-[7]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/api/pageAction/
+[7]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/pageAction/
 [8]: /docs/extensions/mv2/samples

--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -34,5 +34,5 @@ You can find simple examples of manipulating tabs with the `chrome.tabs` API in 
 [4]: #property-Tab-title
 [5]: #property-Tab-favIconUrl
 [6]: #type-Tab
-[7]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/api/tabs/
+[7]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/tabs/
 [8]: /docs/extensions/mv2/samples

--- a/site/en/docs/extensions/reference/webNavigation/index.md
+++ b/site/en/docs/extensions/reference/webNavigation/index.md
@@ -103,7 +103,7 @@ The following transition qualifiers exist:
 <table><tbody><tr><th>Transition qualifier</th><th>Description</th></tr><tr><td>"client_redirect"</td><td>One or more redirects caused by JavaScript or meta refresh tags on the page happened during the navigation.</td></tr><tr><td>"server_redirect"</td><td>One or more redirects caused by HTTP headers sent from the server happened during the navigation.</td></tr><tr><td>"forward_back"</td><td>The user used the Forward or Back button to initiate the navigation.</td></tr><tr><td>"from_address_bar"</td><td>The user initiated the navigation from the address bar (aka Omnibox).</td></tr></tbody></table>
 
 [1]: /docs/extensions/mv2/tabs
-[2]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/api/webNavigation/
+[2]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/webNavigation/
 [3]: /docs/extensions/mv2/samples
 [4]: https://support.google.com/chrome/answer/177873
 [5]: https://support.google.com/chrome/answer/1385029

--- a/site/en/docs/extensions/reference/windows/index.md
+++ b/site/en/docs/extensions/reference/windows/index.md
@@ -50,7 +50,7 @@ other examples and for help in viewing the source code, see [Samples][14].
 [8]: /docs/extensions/tabs#type-Tab
 [9]: /docs/extensions/tabs#method-query
 [10]: /docs/extensions/mv2/event_pages
-[11]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/api/windows/
-[12]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/api/tabs/inspector/tabs_api.html
-[13]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/api/tabs/inspector/
+[11]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/windows/
+[12]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/tabs/inspector/tabs_api.html
+[13]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/tabs/inspector/
 [14]: /docs/extensions/mv2/samples


### PR DESCRIPTION
Updates code samples URLs to account for the MV2 reorganization occuring in GoogleChrome/chrome-extensions-samples#542. 