### PR TITLE
bump chrome-types to fix beta/stable versions of APIs, availability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "async-transforms": "^1.0.6",
         "browser-media-mime-type": "^1.0.0",
         "chokidar-cli": "^2.1.0",
-        "chrome-types": "^0.0.10",
+        "chrome-types": "^0.0.14",
         "common-tags": "^1.8.0",
         "compression": "^1.7.4",
         "concurrently": "^5.2.0",
@@ -6167,9 +6167,9 @@
       }
     },
     "node_modules/chrome-types": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/chrome-types/-/chrome-types-0.0.10.tgz",
-      "integrity": "sha512-TNtDK3wbO7cB/2BrCA+V5ZFquswhpRW8TW1FpCuVjd7O+opdnsfhtO/hyvGdGwSIgRyJruX2JAXeaizYB0qzoQ=="
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/chrome-types/-/chrome-types-0.0.14.tgz",
+      "integrity": "sha512-uBoBIQRkPf2FihmYpvgpW4fDYlkkDJw3EcH+xoh0kerEFyCz0HOY/GxjYW1Ii2/kP83hXVESUG/JnKDb3ZyCLw=="
     },
     "node_modules/chunkd": {
       "version": "2.0.1",
@@ -32765,9 +32765,9 @@
       }
     },
     "chrome-types": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/chrome-types/-/chrome-types-0.0.10.tgz",
-      "integrity": "sha512-TNtDK3wbO7cB/2BrCA+V5ZFquswhpRW8TW1FpCuVjd7O+opdnsfhtO/hyvGdGwSIgRyJruX2JAXeaizYB0qzoQ=="
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/chrome-types/-/chrome-types-0.0.14.tgz",
+      "integrity": "sha512-uBoBIQRkPf2FihmYpvgpW4fDYlkkDJw3EcH+xoh0kerEFyCz0HOY/GxjYW1Ii2/kP83hXVESUG/JnKDb3ZyCLw=="
     },
     "chunkd": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "async-transforms": "^1.0.6",
     "browser-media-mime-type": "^1.0.0",
     "chokidar-cli": "^2.1.0",
-    "chrome-types": "^0.0.10",
+    "chrome-types": "^0.0.14",
     "common-tags": "^1.8.0",
     "compression": "^1.7.4",
     "concurrently": "^5.2.0",


### PR DESCRIPTION
Fixes #373.

We weren't parsing the feature files correctly; now we are. This correctly fixes where APIs are available.