### PR TITLE
Add data practices field description to CWS privacy page

### DIFF
--- a/site/en/docs/webstore/cws-dashboard-privacy/index.md
+++ b/site/en/docs/webstore/cws-dashboard-privacy/index.md
@@ -68,7 +68,8 @@ policies that you provide to the Chrome Web Store.
 group of checkboxes to disclose which types of data your extension collects. Use the second group of
 checkboxes to certify that you comply with each of the disclosure statements.
 
-{% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/PwmNuP356TsVi80bxWAj.png", alt="ALT_TEXT_HERE", width="800", height="495" %}
+{% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/PwmNuP356TsVi80bxWAj.png", alt="Screenshot of data
+use certification fields", width="800", height="495" %}
 
 [1]: /docs/webstore/program_policies/#extensions
 [2]: /docs/extensions/mv2/security/#permissions

--- a/site/en/docs/webstore/cws-dashboard-privacy/index.md
+++ b/site/en/docs/webstore/cws-dashboard-privacy/index.md
@@ -17,7 +17,7 @@ The [Extension Quality Guidelines][1] state that an extension must have a single
 narrow and easy to understand. Make sure that this field clearly communicates this purpose for your
 extension.
 
-**Single purpose description** Fill out this field to help the reviewers understand the focus of
+**Single purpose description**&emsp;Fill out this field to help the reviewers understand the focus of
 your extension.
 
 {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/lQuFOcL3XgQseosEwxk1.png",
@@ -29,7 +29,7 @@ your extension.
 Your extension should request the [minimum permissions][2] consistent with the purpose of the
 extension. Requesting broader permissions than necessary may cause your extension to be rejected.
 
-**Permissions list** This section contains a list of permissions that your extension uses (as
+**Permissions list**&emsp;This section contains a list of permissions that your extension uses (as
 declared in your manifest), with a field for you to state the justification for each permission.
 Fill out these fields to tell the reviewers why your extension needs to use each permission. If
 there are permissions listed here that you don't require, remove them from your manifest before
@@ -45,7 +45,7 @@ Your extension should avoid using remote code except where absolutely necessary.
 remote code will need extra scrutiny, resulting in longer review times. Extensions that call remote
 code and do not declare and justify it using the field shown above will be rejected.
 
-**Remote Code** Use this field to tell reviewers whether your extension executes remote code and, if
+**Remote Code**&emsp;Use this field to tell reviewers whether your extension executes remote code and, if
 so, why this is necessary. If your extension doesn't need to execute remote code, make sure that it
 does not and select "No, I am not using remote code."
 
@@ -64,7 +64,7 @@ Your disclosures are displayed to Chrome users, and should be consistent with th
 policies that you provide to the Chrome Web Store.
 
 
-**Data usage** Use this field to disclose and certify your data collection practices. Use the first
+**Data usage**&emsp;Use this field to disclose and certify your data collection practices. Use the first
 group of checkboxes to disclose which types of data your extension collects. Use the second group of
 checkboxes to certify that you comply with each of the disclosure statements.
 

--- a/site/en/docs/webstore/cws-dashboard-privacy/index.md
+++ b/site/en/docs/webstore/cws-dashboard-privacy/index.md
@@ -53,5 +53,22 @@ does not and select "No, I am not using remote code."
        alt="Screenshot of the remote code declarations field of the privacy field set",
        height="170", width="800" %}
 
+## Certify your data use practices
+
+You must disclose how your extension collects and uses user data. These disclosures include:
+
+* The nature of the data that the extensions collects from users
+* Your certification that the extension complies with the policy on limited use.
+
+Your disclosures are displayed to Chrome users, and should be consistent with the existing privacy
+policies that developers you provide to the Chrome Web Store.
+
+
+**Data usage** Use this field to disclose and certify your data collection practices. Use the first
+group of checkboxes to disclose which types of data your extension collects. Use the second group of
+checkboxes to certify that you comply with each of the disclosure statements.
+
+{% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/PwmNuP356TsVi80bxWAj.png", alt="ALT_TEXT_HERE", width="800", height="495" %}
+
 [1]: /docs/webstore/program_policies/#extensions
 [2]: /docs/extensions/mv2/security/#permissions

--- a/site/en/docs/webstore/cws-dashboard-privacy/index.md
+++ b/site/en/docs/webstore/cws-dashboard-privacy/index.md
@@ -58,10 +58,10 @@ does not and select "No, I am not using remote code."
 You must disclose how your extension collects and uses user data. These disclosures include:
 
 * The nature of the data that the extensions collects from users
-* Your certification that the extension complies with the policy on limited use.
+* Your certification that the extension complies with the policy on limited use
 
 Your disclosures are displayed to Chrome users, and should be consistent with the existing privacy
-policies that developers you provide to the Chrome Web Store.
+policies that you provide to the Chrome Web Store.
 
 
 **Data usage** Use this field to disclose and certify your data collection practices. Use the first


### PR DESCRIPTION
This adds to https://developer.chrome.com/docs/webstore/cws-dashboard-privacy/ the recently-introduced privacy disclosure fields.