### PR TITLE
docs: fix broken TCP and UDP links

### DIFF
--- a/site/en/docs/native-client/sdk/examples.html
+++ b/site/en/docs/native-client/sdk/examples.html
@@ -166,7 +166,7 @@ contains all of the application parts: A Chrome Web Store manifest file
 (<code>manifest.json</code>), an icon, and all of the regular Native Client application
 files. Refer to <a class="reference external" href="/apps">What are Chrome Apps</a> for more information about
 creating a Chrome app.</p>
-<p>Some Pepper features, such as <a class="reference external" href="/docs/native-client/sdk/pepper_stable/cpp/classpp_1_1_t_c_p_socket/">TCP</a> or <a class="reference external" href="/docs/native-client/sdk/pepper_stable/cpp/classpp_1_1_u_d_p_socket/">UDP</a> socket access, are only allowed
+<p>Some Pepper features, such as <a class="reference external" href="/docs/native-client/pepper_stable/cpp/classpp_1_1_t_c_p_socket/">TCP</a> or <a class="reference external" href="/docs/native-client/pepper_stable/cpp/classpp_1_1_u_d_p_socket/">UDP</a> socket access, are only allowed
 in <a class="reference external" href="/apps">Chrome apps</a>. The examples that use these features must be run as
 <a class="reference external" href="/apps">Chrome apps</a>, by using the following command:</p>
 <pre class="prettyprint">$ make run_package


### PR DESCRIPTION
Fixes #419

The TCP and UDP links were leading to broken links in [_Native Client > SDK > Examples doc_](https://developer.chrome.com/docs/native-client/sdk/examples/):
- https://developer.chrome.com/docs/native-client/sdk/pepper_stable/cpp/classpp_1_1_t_c_p_socket/ `HTTP 404` 
- https://developer.chrome.com/docs/native-client/sdk/pepper_stable/cpp/classpp_1_1_u_d_p_socket/ `HTTP 404` 

Replaced them to the correct URLs (omitting `/sdk` from the path):
- https://developer.chrome.com/docs/native-client/pepper_stable/cpp/classpp_1_1_t_c_p_socket/ ✔️ `HTTP 200` 
- https://developer.chrome.com/docs/native-client/pepper_stable/cpp/classpp_1_1_u_d_p_socket/ ✔️ `HTTP 200`