### PR TITLE
Add warning about reusing email from deleted CWS account

### DIFF
--- a/site/en/docs/webstore/money/index.md
+++ b/site/en/docs/webstore/money/index.md
@@ -6,8 +6,10 @@ description: An overview of how you can monetize Chrome Web Store items.
 ---
 
 {% Aside 'warning' %}
-The Chrome Web Store payments system [is now deprecated](/docs/webstore/cws-payments-deprecation/).
-You are free to monetize your extensions using other payment platforms.
+**Important:** Chrome will be removing support for Chrome Apps on Windows, Mac, and Linux. Chrome OS
+will continue to support Chrome Apps. Additionally, Chrome and the Web Store will continue to
+support extensions on all platforms. [Read the announcement][1] and learn more about [migrating your
+app][2].
 {% endAside %}
 
 You can publish Hosted Apps, Chrome Apps, Chrome Extensions, and Themes in the Chrome Web Store.

--- a/site/en/docs/webstore/money/index.md
+++ b/site/en/docs/webstore/money/index.md
@@ -6,10 +6,8 @@ description: An overview of how you can monetize Chrome Web Store items.
 ---
 
 {% Aside 'warning' %}
-**Important:** Chrome will be removing support for Chrome Apps on Windows, Mac, and Linux. Chrome OS
-will continue to support Chrome Apps. Additionally, Chrome and the Web Store will continue to
-support extensions on all platforms. [Read the announcement][1] and learn more about [migrating your
-app][2].
+The Chrome Web Store payments system [is now deprecated](/docs/webstore/cws-payments-deprecation/).
+You are free to monetize your extensions using other payment platforms.
 {% endAside %}
 
 You can publish Hosted Apps, Chrome Apps, Chrome Extensions, and Themes in the Chrome Web Store.

--- a/site/en/docs/webstore/register/index.md
+++ b/site/en/docs/webstore/register/index.md
@@ -13,13 +13,13 @@ account; here are some tips about which email to use:
   That's why we suggest using a new email account just for publishing your Chrome Web Store items.
 * If you recently deleted your Chrome Web Store developer account, you can't reuse its associated
   email identity to create a new one. 
+  {% Aside 'warning' %}
+  If you requested the deletion of your account by mistake, please contact developer support
+  immediately.
+  {% endAside %}
 * Make sure to check this address frequently so that you're aware of any important alerts or
   announcements.
 
-{% Aside 'warning' %}
-If you requested the deletion of your account by mistake, please contact developer support
-immediately.
-{% endAside %}
 
 
 To register, just access the [developer console][1]. The first time you do this, a registration

--- a/site/en/docs/webstore/register/index.md
+++ b/site/en/docs/webstore/register/index.md
@@ -6,9 +6,19 @@ description: How to register as a Chrome Web Store developer.
 ---
 
 Before you can publish items on the Chrome Web Store, you must register as a CWS developer and pay a
-one-time registration fee.
+one-time registration fee. You must provide a developer email when you create your developer
+account; here are some tips about which email to use:
 
-<div class="aside aside--note">We suggest using a new account just for your app instead of your personal account.</div>
+* It's a good idea to decouple your personal account and your Chrome Web Store publishing account.
+  That's why we suggest using a new email account just for publishing your Chrome Web Store items.
+* If you recently deleted your Chrome Web Store developer account, you can't reuse its associated
+  email identity to create a new one. 
+
+{% Aside 'warning' %}
+If you requested the deletion of your account by mistake, please contact developer support
+immediately.
+{% endAside %}
+
 
 To register, just access the [developer console][1]. The first time you do this, a registration
 screen appears as shown here:

--- a/site/en/docs/webstore/register/index.md
+++ b/site/en/docs/webstore/register/index.md
@@ -13,6 +13,8 @@ account; here are some tips about which email to use:
   That's why we suggest using a new email account just for publishing your Chrome Web Store items.
 * If you recently deleted your Chrome Web Store developer account, you can't reuse its associated
   email identity to create a new one. 
+* Make sure to check this address frequently so that you're aware of any important alerts or
+  announcements.
 
 {% Aside 'warning' %}
 If you requested the deletion of your account by mistake, please contact developer support


### PR DESCRIPTION
After you delete your CWS publisher account, you can't reuse the associated email to create a new account (for a while). Added a note about this. Ref: b/173543004