### PR TITLE
Add payments deprecation banner

### DIFF
--- a/site/en/docs/webstore/money/index.md
+++ b/site/en/docs/webstore/money/index.md
@@ -6,10 +6,8 @@ description: An overview of how you can monetize Chrome Web Store items.
 ---
 
 {% Aside 'warning' %}
-**Important:** Chrome will be removing support for Chrome Apps on Windows, Mac, and Linux. Chrome OS
-will continue to support Chrome Apps. Additionally, Chrome and the Web Store will continue to
-support extensions on all platforms. [Read the announcement][1] and learn more about [migrating your
-app][2].
+The Chrome Web Store payments system [is now deprecated](/docs/webstore/cws-payments-deprecation/).
+You are free to monetize your extensions using other payment platforms.
 {% endAside %}
 
 You can publish Hosted Apps, Chrome Apps, Chrome Extensions, and Themes in the Chrome Web Store.

--- a/site/en/docs/webstore/money/index.md
+++ b/site/en/docs/webstore/money/index.md
@@ -10,6 +10,13 @@ The Chrome Web Store payments system [is now deprecated](/docs/webstore/cws-paym
 You are free to monetize your extensions using other payment platforms.
 {% endAside %}
 
+{% Aside 'caution' %}
+Chrome no longer supports Chrome Apps on Windows, Mac, and Linux. Chrome OS
+will continue to support Chrome Apps. Additionally, Chrome and the Web Store will continue to
+support extensions on all platforms. [Read the announcement][1] and learn more about [migrating your	
+app][2].
+{% endAside %}
+
 You can publish Hosted Apps, Chrome Apps, Chrome Extensions, and Themes in the Chrome Web Store.
 Collectively these are called simply "Items". You have many choices when it comes to making money
 from items that you publish in the Chrome Web Store. This page covers just a few ways to monetize


### PR DESCRIPTION
Orphaned page http://localhost:8080/docs/webstore/money/ needed an updated deprecation banner.

Replaced content of page warning banner. The gist was: Chrome apps are going away. Now: CWS payments is deprecated.