### PR TITLE
fix: docs mv2 options event listener example

### DIFF
--- a/site/en/docs/extensions/mv2/options/index.md
+++ b/site/en/docs/extensions/mv2/options/index.md
@@ -149,7 +149,7 @@ An extension can link directly to the options page by calling
 ```
 
 ```js
-document.querySelector('#go-to-options').addEventListener(function() {
+document.querySelector('#go-to-options').addEventListener('click', function() {
   if (chrome.runtime.openOptionsPage) {
     chrome.runtime.openOptionsPage();
   } else {


### PR DESCRIPTION
fix code example in docs

https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener