### PR TITLE
check for existing namespace was broken

### DIFF
--- a/site/_collections/reference.js
+++ b/site/_collections/reference.js
@@ -34,7 +34,7 @@ module.exports = collections => {
       // for it.
       if (api && !namespace) {
         console.warn(
-          `Reference page with 'api: ${api}' has missing namespace:`,
+          `Reference page with 'api: ${api}' does not have source data, check types flow:`,
           inputPath
         );
       }

--- a/site/_data/chromeApiNamespaces.js
+++ b/site/_data/chromeApiNamespaces.js
@@ -29,7 +29,7 @@ const {build} = require('../../tools/types/build.js');
 /**
  * Bump this value if the generated types change shape, so folks' caches are invalidated.
  */
-const typesRevision = '3';
+const typesRevision = '2021-02-07';
 
 /**
  * Building the JSON types is reasonably expensive. Don't do this often. When deploying to prod,

--- a/site/_filters/namespace.js
+++ b/site/_filters/namespace.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * Converts a namespace name like "chrome.foo.bar" into a path segment like
- * "foo_bar". Throws if namespace does not start with "chrome.".
+ * Converts a namespace name like "chrome.foo.bar" into a path segment like "foo_bar". Throws if
+ * namespace does not start with "chrome.", as this is all the site currently supports.
  *
  * @param {string} namespace
  * @return {string}

--- a/site/en/docs/extensions/reference/reference.11tydata.js
+++ b/site/en/docs/extensions/reference/reference.11tydata.js
@@ -26,8 +26,11 @@ function namespaceForData(data) {
   const {api, chromeApiNamespaces} = data;
   if (!api) {
     return undefined;
-  } else if (api in chromeApiNamespaces) {
-    return chromeApiNamespaces[api];
+  }
+
+  const canonicalApi = `chrome.${api}`;
+  if (canonicalApi in chromeApiNamespaces) {
+    return chromeApiNamespaces[canonicalApi];
   }
 
   // This can be called several times by Eleventy. The first time it's called it's unlikely that

--- a/tools/types/build.js
+++ b/tools/types/build.js
@@ -71,8 +71,8 @@ async function build() {
       const namespace = namespaces[name];
       const rn = renderNamespaceFromNamespace(sourceFile, name, namespace);
 
-      // Store the output as "accessibilityFeatures", not "chrome.accessibilityFeatures".
-      out[rn.shortName] = rn;
+      // Store the output as "chrome.accessibilityFeatures", to match the source data.
+      out[name] = rn;
     }
   }
 


### PR DESCRIPTION
Fixes #360.

The check to see if we already had a namespace in out database was using the name _without_ `chrome.`, so any namespace in platform_apps (regardless of whether it was also in extensions) was being marked as deprecated.

