### PR TITLE
awkwardly support extra permissions info

### DIFF
--- a/site/_includes/layouts/namespace-reference.njk
+++ b/site/_includes/layouts/namespace-reference.njk
@@ -13,54 +13,6 @@
 {# Update "content" with additional headings and so forth, so we can pass it
    through the toc filter. #}
 {% set content %}
-  {% if namespace.source === 'platform_app.d.ts' %}
-    <div class="aside aside--warning">
-      This API is part of the deprecated Chrome Apps platform.
-      Learn more about <a href="/docs/apps/migration">migrating your app</a>.
-    </div>
-  {% endif %}
-
-  {% if namespace.platforms.length === 1 and namespace.platforms[0] === 'chromeos' %}
-    {# There are some historic cases of multi-platform support in Platform Apps, but
-        the only restriction these days is CrOS vs everywhere. #}
-    <div class="aside aside--note">
-      <strong>Important:</strong> This API works <strong>only on Chrome OS</strong>
-    </div>
-  {% endif %}
-
-  <div class="code-sections code-sections--summary">
-    <ul class="stack flow-space-300">
-      <li>
-        <div class="code-sections__label">Description</div>
-        <div class="type">
-          {{ namespace.comment | safe }}
-        </div>
-      </li>
-      {% if namespace.permissions.length %}
-        <li>
-          <div class="code-sections__label">Permissions</div>
-          <div>
-            {% for permission in namespace.permissions %}
-              <code>{{ permission }}</code>{% if not loop.last %}, {% endif %}
-            {% endfor %}
-          </div>
-        </li>
-      {% endif %}
-      {% if namespace.channel !== 'stable' %}
-        <li>
-          <div class="code-sections__label">Availability</div>
-          <div>
-            {% if namespace.channel === 'dev' %}
-              Dev channel only.
-            {% else %}
-              Beta and Dev channels only.
-            {% endif %}
-          </div>
-        </li>
-      {% endif %}
-    </ul>
-  </div>
-
   <div class="type stack">
     {{ content | safe }}
   </div>
@@ -92,7 +44,57 @@
     <article class="stack measure-long center-margin pad-left-400 pad-right-400">
       <h1 class="type--h2">{{ title }}</h1>
 
+      {% if namespace.source === 'platform_app.d.ts' %}
+        <div class="aside aside--warning">
+          This API is part of the deprecated Chrome Apps platform.
+          Learn more about <a href="/docs/apps/migration">migrating your app</a>.
+        </div>
+      {% endif %}
+
+      {% if namespace.platforms.length === 1 and namespace.platforms[0] === 'chromeos' %}
+        {# There are some historic cases of multi-platform support in Platform Apps, but
+            the only restriction these days is CrOS vs everywhere. #}
+        <div class="aside aside--note">
+          <strong>Important:</strong> This API works <strong>only on Chrome OS</strong>
+        </div>
+      {% endif %}
+
+      <div class="code-sections code-sections--summary">
+        <ul class="stack flow-space-300">
+          <li>
+            <div class="code-sections__label">Description</div>
+            <div class="type">
+              {{ namespace.comment | safe }}
+            </div>
+          </li>
+          {% if namespace.permissions.length %}
+            <li>
+              <div class="code-sections__label">Permissions</div>
+              <div>
+                {% for permission in permissions %}
+                  <code>{{ permission }}</code><br />
+                {% endfor %}
+                {{ extra_permissions_html | safe }}
+              </div>
+            </li>
+          {% endif %}
+          {% if namespace.channel !== 'stable' %}
+            <li>
+              <div class="code-sections__label">Availability</div>
+              <div>
+                {% if namespace.channel === 'dev' %}
+                  Dev channel only.
+                {% else %}
+                  Beta and Dev channels only.
+                {% endif %}
+              </div>
+            </li>
+          {% endif %}
+        </ul>
+      </div>
+
       {% include 'partials/toc-inner.njk' %}
+
       {{ content | safe }}
     </article>
 

--- a/site/en/docs/extensions/reference/declarativeNetRequest/extra_permissions.md
+++ b/site/en/docs/extensions/reference/declarativeNetRequest/extra_permissions.md
@@ -1,0 +1,3 @@
+Hello, I'm an extra *permission*
+
+Am I [linked](https://google.com) to stuff?

--- a/site/en/docs/extensions/reference/declarativeNetRequest/extra_permissions.md
+++ b/site/en/docs/extensions/reference/declarativeNetRequest/extra_permissions.md
@@ -1,3 +1,0 @@
-Hello, I'm an extra *permission*
-
-Am I [linked](https://google.com) to stuff?

--- a/site/en/docs/extensions/reference/declarativeNetRequest/index.md
+++ b/site/en/docs/extensions/reference/declarativeNetRequest/index.md
@@ -1,5 +1,10 @@
 ---
 api: declarativeNetRequest
+extra_permissions:
+- declarativeNetRequestFeedback
+extra_permissions_html:
+  <a href="declare_permissions#host-permissions">host permissions</a><br />
+  Note that <code>declarativeNetRequestFeedback</code> and host permissions should only be specified when necessary.
 ---
 
 ## Manifest

--- a/site/en/docs/extensions/reference/reference.11tydata.js
+++ b/site/en/docs/extensions/reference/reference.11tydata.js
@@ -44,6 +44,25 @@ module.exports = {
       return namespaceForData(data);
     },
 
+    /**
+     * Finds all permissions, both specified in the .d.ts and any additional permissions
+     * specified here inside the front matter.
+     *
+     * @return {string[]}
+     */
+    permissions: data => {
+      const extraPermissions = data.extra_permissions ?? [];
+      const namespacePermissions = data.namespace?.permissions ?? [];
+
+      const all = new Set([...extraPermissions, ...namespacePermissions]);
+      const out = [...all];
+      out.sort();
+      return out;
+    },
+
+    /**
+     * @return {string}
+     */
     layout: data => {
       if (data.layout) {
         return data.layout; // don't clobber existing values
@@ -57,6 +76,9 @@ module.exports = {
       return data.layout;
     },
 
+    /**
+     * @return {string}
+     */
     title: data => {
       const namespace = namespaceForData(data);
 
@@ -64,6 +86,9 @@ module.exports = {
       return data.title || namespace?.name || '?';
     },
 
+    /**
+     * @return {string}
+     */
     description: data => {
       if (!data.api || data.description) {
         return data.description;

--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -1,5 +1,7 @@
 ---
 api: tabs
+extra_permissions_html:
+  The majority of the <code>chrome.tabs</code> API can be used without declaring any permission. However, the <code>"tabs"</code> permission is required in order to populate the <code>url</code>, <code>pendingUrl</code>, <code>title</code>, and <code>favIconUrl</code> properties of <code><a href="#type-Tab">Tab</a></code>.
 ---
 
 ## Manifest

--- a/site/en/docs/extensions/reference/windows/index.md
+++ b/site/en/docs/extensions/reference/windows/index.md
@@ -1,5 +1,7 @@
 ---
 api: windows
+extra_permissions_html:
+  The <code>chrome.windows</code> API can be used without declaring any permission. However, the <code>"tabs"</code> permission is required in order to populate the <code>url</code>, <code>pendingUrl</code>, <code>title</code>, and <code>favIconUrl</code> properties of <code><a href="../tabs/#type-Tab">Tab</a></code>.
 ---
 
 ## Manifest


### PR DESCRIPTION
Fixes #111. There's only three useful cases of this in the old codebase.

(There's a comment on [`socket`](https://3-72-0-dot-chrome-apps-doc.appspot.com/apps/socket), but that API is deprecated in two different ways, and the comment isn't repeated on its peers `sockets.udp` and etc).

This is so rare that it's not worth doing more here. As an aside, I'm very sad I can't set the content of blocks from within Markdown (which would have been much nicer than doing it the front-matter).