### PR TITLE
Include version data for types

### DIFF
--- a/site/_data/chromeApiNamespaces.js
+++ b/site/_data/chromeApiNamespaces.js
@@ -29,7 +29,7 @@ const {build} = require('../../tools/types/build.js');
 /**
  * Bump this value if the parser changes, so folks' caches are invalidated.
  */
-const typesRevision = '2021-02-17';
+const typesRevision = '2021-02-25';
 
 /**
  * Building the JSON types is reasonably expensive. Don't do this often. When deploying to prod,

--- a/site/_data/chromeApiNamespaces.js
+++ b/site/_data/chromeApiNamespaces.js
@@ -29,7 +29,7 @@ const {build} = require('../../tools/types/build.js');
 /**
  * Bump this value if the parser changes, so folks' caches are invalidated.
  */
-const typesRevision = '2021-02-25';
+const typesRevision = '2021-02-26';
 
 /**
  * Building the JSON types is reasonably expensive. Don't do this often. When deploying to prod,

--- a/site/_data/chromeApiNamespaces.js
+++ b/site/_data/chromeApiNamespaces.js
@@ -29,7 +29,7 @@ const {build} = require('../../tools/types/build.js');
 /**
  * Bump this value if the parser changes, so folks' caches are invalidated.
  */
-const typesRevision = '2021-02-26';
+const typesRevision = '2021-02-26b';
 
 /**
  * Building the JSON types is reasonably expensive. Don't do this often. When deploying to prod,

--- a/site/_includes/layouts/namespace-reference.njk
+++ b/site/_includes/layouts/namespace-reference.njk
@@ -78,11 +78,11 @@
               </div>
             </li>
           {% endif %}
-          {% if namespace.channel !== 'stable' or namespace.version.low %}
+          {% if namespace.version.channel !== 'stable' or namespace.version.low %}
             <li>
               <div class="code-sections__label">Availability</div>
               <div>
-                {% if namespace.channel === 'dev' %}
+                {% if namespace.version.channel === 'dev' %}
                   Dev channel only.
                 {% elif namespace.version.channel === 'beta' %}
                   Beta and Dev channels only.

--- a/site/_includes/layouts/namespace-reference.njk
+++ b/site/_includes/layouts/namespace-reference.njk
@@ -78,14 +78,17 @@
               </div>
             </li>
           {% endif %}
-          {% if namespace.channel !== 'stable' %}
+          {% if namespace.channel !== 'stable' or namespace.version.low %}
             <li>
               <div class="code-sections__label">Availability</div>
               <div>
                 {% if namespace.channel === 'dev' %}
                   Dev channel only.
-                {% else %}
+                {% elif namespace.version.channel === 'beta' %}
                   Beta and Dev channels only.
+                {% else if namespace.version.low %}
+                  Since Chrome {{ namespace.version.low }}.
+                  {# No namespace is currently deprecated. #}
                 {% endif %}
               </div>
             </li>

--- a/site/_includes/layouts/namespace-reference.njk
+++ b/site/_includes/layouts/namespace-reference.njk
@@ -86,7 +86,7 @@
                   Dev channel only.
                 {% elif namespace.version.channel === 'beta' %}
                   Beta and Dev channels only.
-                {% else if namespace.version.low %}
+                {% elif namespace.version.low %}
                   Since Chrome {{ namespace.version.low }}.
                   {# No namespace is currently deprecated. #}
                 {% endif %}

--- a/site/_includes/layouts/reference-landing.njk
+++ b/site/_includes/layouts/reference-landing.njk
@@ -8,6 +8,9 @@
   {% import 'macros/reference.njk' as macros with context %}
 
   <h2 id="stable_apis">Stable APIs</h2>
+  <p>
+    Release information is not available for APIs before Chrome 39, which was released in November 2014.
+  </p>
   {{ macros.renderReferenceTable(collections.reference, 'stable', 'index.d.ts') }}
 
   <h2 id="beta_apis">Beta APIs</h2>

--- a/site/_includes/macros/reference.njk
+++ b/site/_includes/macros/reference.njk
@@ -16,13 +16,16 @@
   {% for page in all %}
     {% if page.data.namespace %}
       {% set namespace = page.data.namespace %}
-      {% if not channel or channel === namespace.channel %}
-        {% if not source or source === namespace.source %}
-          <tr>
-            <td><a class="link weight-medium" href="{{ namespace.name | namespaceToPath }}">{{ namespace.shortName }}</a></td>
-            <td class="reference-collapse type">{{ namespace.comment | safe }}</td>
-          </tr>
-        {% endif %}
+      {% if (not channel or channel === namespace.version.channel) and (not source or source === namespace.source) %}
+        <tr>
+          <td>
+            <a class="link weight-medium" href="{{ namespace.fullName | namespaceToPath }}">{{ namespace.name }}</a><br />
+            {% if not channel and namespace.version.low %}
+              Chrome {{ namespace.version.low }}
+            {% endif %}
+          </td>
+          <td class="reference-collapse type">{{ namespace.comment | safe }}</td>
+        </tr>
       {% endif %}
     {% endif %}
   {% endfor %}

--- a/site/_includes/macros/reference.njk
+++ b/site/_includes/macros/reference.njk
@@ -20,7 +20,11 @@
         <tr>
           <td>
             <a class="link weight-medium" href="{{ namespace.fullName | namespaceToPath }}">{{ namespace.name }}</a><br />
-            {% if not channel and namespace.version.low %}
+            {% if not channel and namespace.version.channel === 'dev' %}
+              Dev channel
+            {% elif not channel and namespace.version.channel === 'beta' %}
+              Beta and Dev channels
+            {% elif namespace.version.low %}
               Chrome {{ namespace.version.low }}
             {% endif %}
           </td>

--- a/site/_includes/macros/render-type.njk
+++ b/site/_includes/macros/render-type.njk
@@ -113,11 +113,25 @@
 {% endmacro %}
 
 {#
-  Renders a comment and its optional deprecation notice.
+  Renders a comment, its optional version information and deprecation notice.
 #}
 {% macro renderComment(spec) %}
-  {% if spec.deprecated !== undefined %}
-  <p class="code-sections__deprecated"><strong>Deprecated</strong>. {{ spec.deprecated | safe }}
+  {% if spec.version.unknown %}
+    <p class="code-sections__deprecated">This API is in active development.</p>
+  {% endif %}
+  {% if spec.version.low %}
+    <p class="code-sections__deprecated">Since Chrome {{ spec.version.low }}.</p>
+  {% endif %}
+  {% if spec.deprecatedComment !== undefined or spec.version.deprecated %}
+    <p class="code-sections__deprecated">
+      <strong>
+        Deprecated
+        {%- if spec.version.deprecated > 0 %}
+          since Chrome {{ spec.version.deprecated }}
+        {%- endif -%}
+      </strong>.
+      {{ spec.deprecatedComment | safe }}
+    </p>
   {% endif %}
   {{ spec.comment | safe }}
 {% endmacro %}

--- a/site/en/docs/extensions/reference/reference.11tydata.js
+++ b/site/en/docs/extensions/reference/reference.11tydata.js
@@ -83,7 +83,7 @@ module.exports = {
       const namespace = namespaceForData(data);
 
       // We can't use ?? here, as `data.title` is the empty string if missing.
-      return data.title || namespace?.name || '?';
+      return data.title || namespace?.fullName || '?';
     },
 
     /**

--- a/tests/tools/types/types.js
+++ b/tests/tools/types/types.js
@@ -93,8 +93,8 @@ test('parse demo Chrome types', async t => {
   t.is(namespaces.length, 2);
 
   const [chromeStuff, chromeTest] = namespaces;
-  t.is(chromeStuff.name, 'chrome.stuff');
-  t.is(chromeTest.name, 'chrome.test');
+  t.is(chromeStuff.fullName, 'chrome.stuff');
+  t.is(chromeTest.fullName, 'chrome.test');
 
   // Check that a variable that can only be one thing is not converted to an enum.
   const variableTestSingle = chromeTest.properties.find(

--- a/tools/types/build.js
+++ b/tools/types/build.js
@@ -25,6 +25,7 @@ const {
 } = require('./types');
 const fetch = require('node-fetch');
 const tmp = require('tmp');
+const {enumerateAllRenderNamespace} = require('./helpers');
 
 // We create render types for both the regular types and platform apps.
 const sourceFiles = ['index.d.ts', 'platform_app.d.ts'];
@@ -88,6 +89,64 @@ async function build() {
       // Store the output as "chrome.accessibilityFeatures", to match the source data.
       out[name] = rn;
     }
+  }
+
+  /**
+   * Builds a set of partial version data for this node (i.e., only the differences from the
+   * parent).
+   *
+   * @param {RenderBase} base
+   * @param {string} parentFullName
+   */
+  const buildPartialVersionData = (base, parentFullName = '') => {
+    if (!base.fullName) {
+      throw new Error('operates only on base with name');
+    }
+    const selfRawData = versionData.symbols[base.fullName];
+    if (!selfRawData) {
+      // TODO(samthor): The raw data is not including all subpaths properly. Properties of
+      // function arguments seem to be flattened.
+      // see e.g.: chrome.input.ime.setCandidateWindowProperties.parameters.properties
+      return; // skip
+    }
+
+    const parentRawData = versionData.symbols[parentFullName] ?? {};
+    base.version = {};
+
+    for (const key in selfRawData) {
+      if (parentRawData[key] === selfRawData[key]) {
+        continue;
+      }
+      if (key === 'release') {
+        // TODO(samthor): Source file has the wrong key.
+        base.version.channel = selfRawData['release'];
+      } else {
+        base.version[key] = selfRawData[key];
+      }
+    }
+
+    // if (Object.keys(base.version).length) {
+    //   console.warn(base.fullName, base.version);
+    // }
+  };
+
+  // Enumerate through all final namespaces and add version data.
+  for (const name in out) {
+    const rn = out[name];
+
+    // Build version data for both the namespace itself and all its children.
+    buildPartialVersionData(rn);
+    enumerateAllRenderNamespace(rn, (base, parent) => {
+      if (base.fullName) {
+        return;
+      }
+      if (!base.name || !parent.fullName) {
+        // This happens in e.g. options of unions or enums. Ignore.
+        return;
+      }
+      base.fullName = parent.fullName + '.' + base.name;
+      buildPartialVersionData(base, parent.fullName);
+    });
   }
 
   const count = Object.keys(out).length;

--- a/tools/types/build.js
+++ b/tools/types/build.js
@@ -114,6 +114,7 @@ async function build() {
       // TODO(samthor): The raw data is not including all subpaths properly. Properties of
       // function arguments seem to be flattened.
       // see e.g.: chrome.input.ime.setCandidateWindowProperties.parameters.properties
+      // Once this is resolved, this should be listed as `{unknown: true}`.
       return; // skip
     }
 

--- a/tools/types/build.js
+++ b/tools/types/build.js
@@ -28,6 +28,7 @@ const tmp = require('tmp');
 const {enumerateAllRenderNamespace} = require('./helpers');
 
 // We create render types for both the regular types and platform apps.
+// The order here is important: the namespaces in earlier files win.
 const sourceFiles = ['index.d.ts', 'platform_app.d.ts'];
 
 /**
@@ -52,7 +53,13 @@ async function build() {
 
   const versionDataRequest = await safeFetch('version-data.json');
   const versionData = await versionDataRequest.json();
-  console.warn('got version data for Chrome', versionData.version);
+  console.warn(
+    'Got version data for Chrome',
+    versionData.version,
+    'with',
+    Object.keys(versionData.symbols).length,
+    'symbols'
+  );
 
   /** @type {{[name: string]: RenderNamespace}} */
   const out = {};

--- a/tools/types/converter.js
+++ b/tools/types/converter.js
@@ -56,9 +56,12 @@ function updateWithComment(renderType, commentModel, owner) {
   }
   const deprecatedTag = commentModel.getTag('deprecated');
   if (deprecatedTag) {
-    renderType.deprecated = extractComment(deprecatedTag.text, owner, false);
+    renderType.deprecatedComment = extractComment(
+      deprecatedTag.text,
+      owner,
+      false
+    );
   }
-  // TODO(samthor): When "@since Chrome xx" is available, parse this here.
 }
 
 /**

--- a/tools/types/index.js
+++ b/tools/types/index.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview This is a helper to test parsing published types for Chrome extensions.
+ *
+ * It is not used to build the site, just for development.
+ */
+
+const {build} = require('./build.js');
+
+run();
+
+async function run() {
+  const out = await build();
+  console.info('got', out);
+}

--- a/tools/types/index.js
+++ b/tools/types/index.js
@@ -17,7 +17,7 @@
 /**
  * @fileoverview This is a helper to test parsing published types for Chrome extensions.
  *
- * It is not used to build the site, just for development.
+ * It is not used to build the site, and is just provided for development and testing.
  */
 
 const {build} = require('./build.js');

--- a/tools/types/types.js
+++ b/tools/types/types.js
@@ -144,8 +144,12 @@ function renderNamespaceFromNamespace(source, fullName, reflection) {
     properties: [],
     methods: [],
     events: [],
-    // channel,
     source,
+
+    // Channel information is probably replaced by the top-level versionData.
+    version: {
+      channel,
+    },
   };
 
   if (permissions.length) {

--- a/tools/types/types.js
+++ b/tools/types/types.js
@@ -103,18 +103,18 @@ function extractPublicChromeNamespaces(typesData) {
 
 /**
  * @param {string} source
- * @param {string} name
+ * @param {string} fullName
  * @param {typedoc.DeclarationReflection} reflection
  * @return {RenderNamespace}
  */
-function renderNamespaceFromNamespace(source, name, reflection) {
-  const [, ...rest] = name.split('.');
+function renderNamespaceFromNamespace(source, fullName, reflection) {
+  const [, ...rest] = fullName.split('.');
   const shortName = rest.join('.');
 
   const permissions = [];
   const platforms = [];
 
-  /** @type {RenderNamespace["channel"]} */
+  /** @type {VersionData["channel"]} */
   let channel = 'stable';
 
   const tags = reflection?.comment?.tags ?? [];
@@ -137,14 +137,14 @@ function renderNamespaceFromNamespace(source, name, reflection) {
 
   /** @type {RenderNamespace} */
   const renderNamespace = {
-    name,
-    shortName,
+    name: shortName,
+    fullName,
     comment: extractComment(reflection.comment, reflection),
     types: [],
     properties: [],
     methods: [],
     events: [],
-    channel,
+    // channel,
     source,
   };
 

--- a/types/types/render-type.d.ts
+++ b/types/types/render-type.d.ts
@@ -24,12 +24,25 @@ declare global {
       "union" |
       "function";
 
-  export interface RenderType {
+  export interface VersionData {
+    low?: number;
+    high?: number;
+    deprecated?: number;
+    channel?: "stable" | "beta" | "dev";
+    unknown?: true;
+  }
+
+  export interface RenderBase {
     name?: string;
-    type: RenderTypeType;
+    fullName?: string;
+    version?: VersionData;
+    comment?: string;            // HTML, will always be wrapped by <p></p>
+    deprecatedComment?: string;  // HTML, not a pargraph
     optional?: boolean;
-    comment?: string;     // HTML, will always be wrapped by <p></p>
-    deprecated?: string;  // HTML but not wrapped in <p></p>
+  }
+
+  export interface RenderType extends RenderBase {
+    type: RenderTypeType;
 
     // primitive
     primitiveType?: string;
@@ -58,11 +71,7 @@ declare global {
     returnType?: RenderType;
   }
 
-  export interface RenderNamespace {
-    name: string;
-    shortName: string;  // name without "chrome." prefix
-    comment?: string;
-    channel: "stable" | "beta" | "dev";
+  export interface RenderNamespace extends RenderBase {
     permissions?: string[];
     platforms?: string[];
     source?: string;


### PR DESCRIPTION
Fixes #362
Fixes #360
Fixes #39

This supersedes #364 and only focuses on types, not comment rewriting code. There's really a few big parts to this PR:

- a helper which enumerates through all types so we can update them with version data
- code which only includes the difference from the parent (if the parent was released at 75, don't say it again)
- rendering code to display the types.

It also adds "tools/types/index.js" but just for convenience to test running the types.

This does _not_ add tests, but I'm thinking about that separately. The concern is that we are depending on live data, and I actually _want_ to test that.