### PR TITLE
Fix group names in .pullapprove.yml

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -5,7 +5,7 @@ groups:
   # Handles any changes related to extensions, web store, and chrome apps.
   # By default Simeon and Andy will be tagged in as reviewers, but anyone
   # on the dcc-extensions, dcc-content, or dcc-approvers team can approve PRs.
-  content:
+  extensions:
     reviewers:
       users:
       - awfuchs


### PR DESCRIPTION
@robdodson I saw a strange error and tracked it down to this repo... You had the same group name multiple times so I assume you meant something like this instead?

I'll have to see why the pullapprove error message wasn't more helpful in this situation.

Let me know if you have any questions.