### PR TITLE
Adds "What's new in extensions" page

### DIFF
--- a/site/_data/docs/extensions/toc.yml
+++ b/site/_data/docs/extensions/toc.yml
@@ -1,4 +1,5 @@
 - url: /docs/extensions/mv3
+- url: /docs/extensions/whatsnew
 - url: /docs/extensions/mv3/getstarted
 - title: i18n.docs.extensions.mv3
   sections:

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -32,11 +32,10 @@ its documentation, and related policy or other changes.
 
 ### 2021.01.19: Manifest V3 launched
 
-With the launch of Chrome 88, the extensions platform now supports extensions
+With the release of Chrome 88, the extensions platform now supports extensions
 built with Manifest v3, and you can upload them to the Chrome Web Store.
 Manifest v3 is a new extension platform that makes Chrome extensions more
 secure, performant, and privacy respecting, by default.
 
 Check out [Welcome to Manifest V3](/docs/extensions/mv3/intro/) for complete
 details about Manifest V3 and how to build or migrate extensions for it.
-

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -25,6 +25,7 @@ date: 2021-02-25
 
 ---
 <!--lint disable no-duplicate-headings-->
+<!--lint disable first-heading-level-->
 
 Check this page often to learn about changes to the Chrome extensions platform,
 its documentation, and related policy or other changes.

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -25,7 +25,9 @@ date: 2021-02-25
 Check this page often to learn about changes to the Chrome extensions platform,
 its documentation, and related policy or other changes.
 
-### 2020-01-19 Manifest V3 launched
+## 2021
+
+### Jan 19: Manifest V3 launched
 
 With the launch of Chrome 88, the extensions platform now supports extensions
 built with Manifest v3, and you can upload them to the Chrome Web Store.

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -20,14 +20,16 @@ date: 2021-02-25
 # A list of authors. These usernames correspond to the keys in the
 # _data/authorsData.json file.
 
+# Note: disabling the linter for duplicate headings because this isn't hierarchical and it needs
+# smaller font headings.
+
 ---
+<!--lint disable no-duplicate-headings-->
 
 Check this page often to learn about changes to the Chrome extensions platform,
 its documentation, and related policy or other changes.
 
-## 2021
-
-### Jan 19: Manifest V3 launched
+### 2021.01.19: Manifest V3 launched
 
 With the launch of Chrome 88, the extensions platform now supports extensions
 built with Manifest v3, and you can upload them to the Chrome Web Store.

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -25,13 +25,13 @@ date: 2021-02-25
 Check this page often to learn about changes to the Chrome extensions platform,
 its documentation, and related policy or other changes.
 
-## 2020-01-19 Manifest V3 is in Chrome stable.
+### 2020-01-19 Manifest V3 launched
 
 With the launch of Chrome 88, the extensions platform now supports extensions
 built with Manifest v3, and you can upload them to the Chrome Web Store.
 Manifest v3 is a new extension platform that makes Chrome extensions more
 secure, performant, and privacy respecting, by default.
 
-Check out [Welcome to Manifest V3][/docs/extensions/mv3/intro/] for complete
+Check out [Welcome to Manifest V3](/docs/extensions/mv3/intro/) for complete
 details about Manifest V3 and how to build or migrate extensions for it.
 

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -1,0 +1,37 @@
+---
+layout: 'layouts/doc-post.njk'
+
+title: What's new in Chrome extensions
+
+# This appears below the title and is an optional teaser
+# subhead: 
+
+# This appears in the ToC of the project landing page at
+# /docs/[project-name]/. It also appears in the <meta description> used in 
+# Google Search.
+description: 'Recent changes to the Chrome extensions platform, documentation, and policy'
+
+# The publish date
+date: 2021-02-25
+
+# An optional updated date
+# updated: 2020-10-16
+
+# A list of authors. These usernames correspond to the keys in the
+# _data/authorsData.json file.
+
+---
+
+Check this page often to learn about changes to the Chrome extensions platform,
+its documentation, and related policy or other changes.
+
+## 2020-01-19 Manifest V3 is in Chrome stable.
+
+With the launch of Chrome 88, the extensions platform now supports extensions
+built with Manifest v3, and you can upload them to the Chrome Web Store.
+Manifest v3 is a new extension platform that makes Chrome extensions more
+secure, performant, and privacy respecting, by default.
+
+Check out [Welcome to Manifest V3][/docs/extensions/mv3/intro/] for complete
+details about Manifest V3 and how to build or migrate extensions for it.
+


### PR DESCRIPTION
Added page at /docs/extensions/whatsnew

This is intended as a canonical reference for significant changes to the extensions platform, documentation, and policy.

Fixes #316 