### PR TITLE
simplify linters to catch more errors

### DIFF
--- a/site/en/docs/apps/app_frameworks/index.md
+++ b/site/en/docs/apps/app_frameworks/index.md
@@ -26,8 +26,8 @@ before. Application development requires collaboration from multiple developers.
 rich client-side features, is no exception.
 
 Design patterns are important to write maintainable and reusable code. A pattern is a reusable
-solution that can be applied to commonly occurring problems in software design—in our case —
-writing Chrome Apps. We recommend that developers decouple the app into a series of independent
+solution that can be applied to commonly occurring problems in software design—in our
+case—writing Chrome Apps. We recommend that developers decouple the app into a series of independent
 components following the MVC pattern.
 
 In the last few years, a series of JavaScript MVC frameworks have been developed, such as

--- a/site/en/docs/extensions/mv2/i18n-messages/index.md
+++ b/site/en/docs/extensions/mv2/i18n-messages/index.md
@@ -74,8 +74,8 @@ Here's a `messages.json` file that defines three messages named "prompt_for_name
 ## Field details {: #field_details }
 
 This section describes each field that can appear in a `messages.json` file. For details on how the
-messages file is used—for example, what happens when a locale doesn't define all the messages —
-see [Internationalization][6].
+messages file is used—for example, what happens when a locale doesn't define all the messages—see
+[Internationalization][6].
 
 ### name {: #name }
 

--- a/site/en/docs/extensions/mv3/i18n-messages/index.md
+++ b/site/en/docs/extensions/mv3/i18n-messages/index.md
@@ -72,8 +72,8 @@ Here's a `messages.json` file that defines three messages named "prompt_for_name
 ## Field details {: #field_details }
 
 This section describes each field that can appear in a `messages.json` file. For details on how the
-messages file is used—for example, what happens when a locale doesn't define all the messages —
-see [Internationalization][1].
+messages file is used—for example, what happens when a locale doesn't define all the messages—see
+[Internationalization][1].
 
 ### name {: #name }
 

--- a/site/en/docs/handbook/how-to/add-a-project/index.md
+++ b/site/en/docs/handbook/how-to/add-a-project/index.md
@@ -60,7 +60,7 @@ as well as in the side navigation when viewing an individual doc.
 
 The `toc.yml` supports these fields:
 
-- `url` — an absolute url path to your doc
+- `url`—an absolute url path to your doc
 - `title`—the title for a subsection in `i18n` path notation (explained below.)
 - `sections`—a collection of more urls, nested under a `title`.
 

--- a/tools/linting/no-dash-spaces.js
+++ b/tools/linting/no-dash-spaces.js
@@ -32,14 +32,8 @@ function noDashSpaces(tree, file) {
 
   /* eslint-disable require-jsdoc */
   function visitor(node) {
-    const lines = node.value.split('\n');
-    let line;
-
-    for (let index = 0; index < lines.length; index++) {
-      line = lines[index].trim();
-      if (line.match(/\s—\s|\s–\s/g)) {
-        return file.message(reason, node);
-      }
+    if (node.value.match(/\s—\s|\s–\s/g)) {
+      return file.message(reason, node);
     }
   }
 }

--- a/tools/linting/no-smart-quotes.js
+++ b/tools/linting/no-smart-quotes.js
@@ -32,14 +32,8 @@ function noSmartQuotes(tree, file) {
 
   /* eslint-disable require-jsdoc */
   function visitor(node) {
-    const lines = node.value.split('\n');
-    let line;
-
-    for (let index = 0; index < lines.length; index++) {
-      line = lines[index].trim();
-      if (line.match(/[‘’“”]/g)) {
-        return file.message(reason, node);
-      }
+    if (node.value.match(/[‘’“”]/g)) {
+      return file.message(reason, node);
     }
   }
 }


### PR DESCRIPTION
Don't check every line, check nodes (paragraphs) as a whole. Same as [the fix for web.dev](https://github.com/GoogleChrome/web.dev/pull/4806).