### PR TITLE
details fixes

### DIFF
--- a/site/_includes/partials/toc-inner.njk
+++ b/site/_includes/partials/toc-inner.njk
@@ -4,9 +4,12 @@
 
   <div class="toc-container display-block xl:display-none">
     <details class="toc" role="navigation" aria-label="{{ 'i18n.common.toc' | i18n(locale) }}">
-      <summary class="surface display-inline-flex align-center color-secondary-text user-select-none">
-        <div class="type--h6">{{ 'i18n.common.toc' | i18n(locale) }}</div>
-        <span class="toc__icon">{{ icon('arrow-right') }}</span>
+      <summary class="surface color-secondary-text user-select-none">
+        {# This is nested as Safari fails to render `display: inline-flex` on <summary>. #}
+        <div class="display-inline-flex align-center">
+          <div class="type--h6">{{ 'i18n.common.toc' | i18n(locale) }}</div>
+          <span class="toc__icon">{{ icon('arrow-right') }}</span>
+        </div>
       </summary>
       <div class="toc__wrapper">{{ tocContents | safe }}</div>
     </details>

--- a/site/_scss/blocks/_details.scss
+++ b/site/_scss/blocks/_details.scss
@@ -1,11 +1,9 @@
 .details {
-  position: relative;
-
   border: 1px solid var(--color-hairline);
   border-width: 1px 0;
-
   margin: calc(var(--flow-space)) 0;
   padding: calc(var(--flow-space) / 2) 0;
+  position: relative;
 }
 
 .details__summary {

--- a/site/_scss/blocks/_details.scss
+++ b/site/_scss/blocks/_details.scss
@@ -1,5 +1,11 @@
 .details {
   position: relative;
+
+  border: 1px solid var(--color-hairline);
+  border-width: 1px 0;
+
+  margin: calc(var(--flow-space)) 0;
+  padding: calc(var(--flow-space) / 2) 0;
 }
 
 .details__summary {
@@ -25,7 +31,6 @@
 .details__header {
   --chevron-size: 2rem;
 
-  margin-bottom: calc(var(--flow-space) / 2);
   padding-right: var(--chevron-size);
   position: relative;
 

--- a/site/_scss/blocks/_details.scss
+++ b/site/_scss/blocks/_details.scss
@@ -6,9 +6,10 @@
   position: relative;
 }
 
-.details__summary {
+.details > summary {
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
+  list-style: none;
 
   &::-webkit-details-marker {
     display: none;
@@ -23,10 +24,9 @@
     background-color: var(--color-blue-lighter);
     border: 1px solid  var(--color-blue-medium);
   }
-
 }
 
-.details__header {
+.details > summary > .details__header {
   --chevron-size: 2rem;
 
   padding-right: var(--chevron-size);
@@ -56,6 +56,6 @@
   }
 }
 
-.details[open] .details__header > :first-child::after {
+.details[open] > summary > .details__header > :first-child::after {
   transform: rotate(0deg) translateY(-50%);
 }

--- a/site/_scss/blocks/_details.scss
+++ b/site/_scss/blocks/_details.scss
@@ -1,3 +1,5 @@
+// stylelint-disable selector-max-compound-selectors
+
 .details {
   border: 1px solid var(--color-hairline);
   border-width: 1px 0;
@@ -8,8 +10,8 @@
 
 .details > summary {
   cursor: pointer;
-  -webkit-tap-highlight-color: transparent;
   list-style: none;
+  -webkit-tap-highlight-color: transparent;
 
   &::-webkit-details-marker {
     display: none;

--- a/site/_scss/blocks/_toc.scss
+++ b/site/_scss/blocks/_toc.scss
@@ -16,6 +16,8 @@
 }
 
 .toc__icon {
+  // We need this for Safari, otherwise it makes the toc__icon too large.
+  display: inline-flex;
   margin-left: get-size(200);
 
   > svg {

--- a/site/_shortcodes/Details.js
+++ b/site/_shortcodes/Details.js
@@ -6,7 +6,7 @@
 function Details(content, state) {
   const stateOverride = state === 'open' ? 'open' : '';
   // Whitespace is needed for the markdown parser to process the ${content}.
-  return `<details class="details" ${stateOverride}>
+  return `<details class="details stack" ${stateOverride}>
 
 ${content}</details>`;
 }

--- a/site/_shortcodes/DetailsSummary.js
+++ b/site/_shortcodes/DetailsSummary.js
@@ -4,7 +4,7 @@
  */
 function DetailsSummary(content) {
   // Whitespace is needed for the markdown parser to process the ${content}.
-  return `<summary class="details__summary"> <div class="details__header">
+  return `<summary class="details__summary"> <div class="details__header stack">
 
 ${content}</div></summary>`;
 }

--- a/site/en/docs/handbook/components/index.md
+++ b/site/en/docs/handbook/components/index.md
@@ -7,45 +7,63 @@ updated: 2021-01-27
 
 ## Details
 
-Lorem ipsum dolor sit amet consectetur adipisicing elit. Beatae ab aspernatur
-praesentium, dolores deleniti, nemo eos, saepe laudantium id maiores corporis
-qui? Culpa eligendi nobis, dolores rem expedita similique quas.
+Use a details section to hide extra information from the user until it's needed. It can have an optional preview.
 
-{% Details %}
+<!-- Example 1 -->
 
+````md
+{% raw %}{% Details %}
 {% DetailsSummary %}
-Details component _summary_
+### A normal heading goes here
 {% endDetailsSummary %}
 
-  This is the body of the Details component.
-  It **can contain** markdown
-  ```js
-  const bar = 'foo';
-  console.log(bar);
-  ```
-{% endDetails %}
+The body of the Details component goes here, and **can** contain markdown.
 
+{% endDetails %}{% endraw %}
+````
 
 {% Details %}
-
 {% DetailsSummary %}
-### Details component _summary_
-
-This is an optional preview.
+### A normal heading goes here
 {% endDetailsSummary %}
 
-  This is the body of the Details component.
-  It **can contain** markdown
-  ```js
-  const bar = 'foo';
-  console.log(bar);
-  ```
+The body of the Details component goes here, and **can** contain markdown.
+
 {% endDetails %}
 
+<!-- Example 2 -->
 
-Lorem ipsum dolor sit amet consectetur adipisicing elit. Iusto, dolorum? Vitae
-necessitatibus omnis rem recusandae laudantium, nostrum deleniti maxime
-corporis? Id deserunt quam dicta dolore tempore in omnis iure ex!
+````md
+{% raw %}{% Details %}
+{% DetailsSummary %}
+### Details component summary
+This is an optional preview. 
+{% endDetailsSummary %}
+
+This is the body of the Details component.
+It **can** contain markdown.
+
+```js
+const bar = 'foo';
+console.log(bar);
+```
+{% endDetails %}{% endraw %}
+````
+
+{% Details %}
+{% DetailsSummary %}
+### Details component summary
+This is an optional preview. 
+{% endDetailsSummary %}
+
+This is the body of the Details component.
+It **can** contain markdown.
+
+```js
+const bar = 'foo';
+console.log(bar);
+```
+{% endDetails %}
 
 ## Asides
 Use asides to provide information that's related to but distinct from the


### PR DESCRIPTION
Fixes #448.

This also makes two style changes:

- we put a hairline at top/bottom of details so you can see the boundaries
- we make details stacks so correct spacing appears in their content.