### PR TITLE
Don't title case "Table of contents"

### DIFF
--- a/site/_data/i18n/common.yml
+++ b/site/_data/i18n/common.yml
@@ -85,8 +85,8 @@ follow:
   es: 'Seguir'
 
 toc:
-  en: 'Table of Contents'
-  es: 'Tabla de Contenido'
+  en: 'Table of contents'
+  es: 'Tabla de contenido'
 
 tags:
   en: 'Tags'


### PR DESCRIPTION
I noticed the ToC title cases "Table of Contents" which seems a bit odd.