### PR TITLE
Snapshot pages that change less frequently.

### DIFF
--- a/.percy.js
+++ b/.percy.js
@@ -16,11 +16,11 @@ module.exports = {
     'snapshot-files': [
       'index.html',
       'releases/index.html',
-      'blog/index.html',
-      'demo/index.html',
       'docs/index.html',
-      'docs/extensions/index.html',
+      'docs/native-client/index.html',
+      'blog/welcome/index.html',
       'docs/extensions/what-are-extensions/index.html',
+      'docs/handbook/components/index.html'
     ].join(',')
   },
   'agent': {


### PR DESCRIPTION
Helps a bit with our issue where Percy is snapshotting live data.

I removed the /blog/ snapshot because it changes too often and is confusing for folks.
I switched to snapshotting the nacl landing page instead of the extensions landing page, and two posts which we don't expect to change often.