### PR TITLE
Change enterprise.platformKeys usage example

### DIFF
--- a/site/en/docs/extensions/reference/enterprise_platformKeys/index.md
+++ b/site/en/docs/extensions/reference/enterprise_platformKeys/index.md
@@ -50,7 +50,7 @@ function generateAndSign(userToken) {
     publicExponent:
         new Uint8Array([0x01, 0x00, 0x01]),  // Equivalent to 65537
     hash: {
-      name: "SHA-1",
+      name: "SHA-256",
     }
   };
   var cachedKeyPair;


### PR DESCRIPTION
Currently SHA-1, SHA-256, SHA-384 and SHA-512 are supported in enterprise.platformKeys API as hash algorithms that can be used for signing using RSA keys. Here's a [link](https://source.chromium.org/chromium/chromium/src/+/master:chrome/browser/extensions/api/platform_keys/platform_keys_api_ash.cc;l=308?q=platform.*keys%20sign%20f:ash&ss=chromium) to the related chromium code. Although all of them are supported, but SHA-1 is the weakest. This PR changes the API usage example to SHA-256 instead of SHA-1 as it is stronger and not cryptographically broken.