### PR TITLE
Linter behaviour test

### DIFF
--- a/site/en/docs/webstore/group-publishers/dummy.md
+++ b/site/en/docs/webstore/group-publishers/dummy.md
@@ -1,0 +1,35 @@
+---
+layout: "layouts/doc-post.njk"
+title: Set up a group publisher
+date: 2020-06-20
+description: How to share ownership of your Chrome Web Store items with other developers.
+---
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+1. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+
+    {% Aside "caution" %}
+    Pellentesque pretium mauris at nulla suscipit, sed euismod enim scelerisque. Cras sodales scelerisque ante, a ultricies dui viverra euismod -- phasellus pulvinar elit eu ultrices varius.
+    {% endAside %}
+
+1. Cras bibendum nunc id nisl ultrices, eget vulputate mi rhoncus:
+
+    {% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/ozixwtnU0bikOAzhBaPM.png", alt="Screenshot of the
+    Google group publishing field", width="800", height="291" %}
+
+1. Curabitur sodales malesuada risus in rhoncus.
+
+1. Suspendisse efficitur a tellus eu posuere:
+
+    {% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/TU0AD2DYks5nPZGNWGLb.png", alt="Screenshot of Allow
+    posting by email option", width="800", height="104" %}
+
+1. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+est laborum:
+
+    {% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/LV2itIZXoZTLdgetsUwz.png", alt="Screenshot of
+    selecting the only-invited-users option", width="800", height="211" %}
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+

--- a/site/en/docs/webstore/group-publishers/index.md
+++ b/site/en/docs/webstore/group-publishers/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: Set up Group Publishing
+title: Set up group publishing
 date: 2020-06-20
 description: How to share ownership of your Chrome Web Store items with other developers.
 ---
@@ -9,6 +9,19 @@ You can share ownership of your items in Google Chrome Web Store with other deve
 group publishing. With group publishing, you can add developers to a Google Group, who can then act
 on your behalf. They'll have access to all the items you own and can make any changes to them that
 you can make.
+
+{% Aside 'warning' %}
+
+It's important that the Google Group you use for group publishing is private and that you carefully
+control the group membership. For this reason, we recommend:
+
+* Use a Google Group that is dedicated just to group publishing on the Chrome Web Store. Don't use
+  an existing group that has other purposes.
+
+* Keep this group private. This is the default; make sure not to change it to public.
+
+Remember that anyone who is a  member of the group can make changes to your published items!
+{% endAside %}
 
 ## Before you set up group publishing
 

--- a/site/en/docs/webstore/group-publishers/index.md
+++ b/site/en/docs/webstore/group-publishers/index.md
@@ -4,6 +4,7 @@ title: Set up a group publisher
 date: 2020-06-20
 description: How to share ownership of your Chrome Web Store items with other developers.
 ---
+<!--lint disable code-block-style-->
 
 You can share ownership of your items in Google Chrome Web Store with other developers by setting up
 a *group publisher*. This page explains how group publishers work and how to set one up.

--- a/site/en/docs/webstore/group-publishers/index.md
+++ b/site/en/docs/webstore/group-publishers/index.md
@@ -48,8 +48,8 @@ Keep these important notes in mind:
 
 * You can be a *member* of any number of group publishers.
 
-* You cannot change which group is linked to the Group Publisher account.
-* You still retain your personal publisherx account and can publish from either your group or personal account.
+* You cannot change which group is linked to the group publisher account.
+* You still retain your personal publisher account and can publish from either your group or personal account.
 
 ## Create a group publisher
 
@@ -73,11 +73,11 @@ validated. Use either "Only invited users" or "Anyone can ask", as shown below:
 
     {% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/LV2itIZXoZTLdgetsUwz.png", alt="ALT_TEXT_HERE", width="800", height="211" %}
 
-These steps create a new Group Publisher account. The Google Group you selected is linked to this new publisher account, and the group email is the new group publisher account's email.
+These steps create a new group publisher account. The Google Group you selected is linked to this new publisher account, and the group email is the new group publisher account's email.
 
 ## Adding developers to the group publisher
 
-Your dashboard page will show the new Group Publisher account and the linked
+Your dashboard page will show the new group publisher account and the linked
 Google Group. You can [add or remove developers](https://groups.google.com/).
 
 **Any Chrome Web Store developer who is a member of the linked group can act on behalf of the new publisher account**. For example, they can edit items, publish items, and edit the publisher's display name.
@@ -97,29 +97,40 @@ Select the publisher you want to use. This displays the items already uploaded f
 * You must be the owner or manager of a Google Group to link the group. The drop-down list on the dashboard page only shows groups that you're a direct member of (for example, if you are a member of Group A and Group A is a member of Group B, you are not a direct member of Group B, and Group B is not shown on the drop-down list).
 * Once you finish the group publishing setup, it can take up to 30 minutes for developers in your group to see the changes.
 * A developer can act on behalf of multiple publishers if the developer is a member of multiple Google Groups linked to publishers.
-* If a merchant account is needed or is already set up, any member of the group can choose to re-link their own merchant accounts to the publisher on the dashboard page.
 * Before you upload a new Chrome Web Store item, check that you have selected the publisher you want to own that item. This may be your personal publisher account or any group publisher account you belong to.
 
-## Move existing items to a Group Publisher account
+## Move existing items to a group publisher account
 
 Once you set up a group publisher (or once you're added as a member of a Google Group linked to a group publisher), you can transfer your own items to the group publisher.
 
-<p class="note">Once you move items to a Group Publisher account, you can't move them back to your personal publishing account.</p>
+{% Aside 'warning' %}
+Once you move items to a group publisher account, you can't move them back to your personal publishing account.
+{% endAside %}
 
-To transfer items to a group publisher account you need to use the old developer dashboard:
+To transfer items to a group publisher account, start from the item page in your personal publisher
+account, then transfer the item as described below:
 
-1. Sign in to the [Chrome Web Store developer console](https://chrome.google.com/webstore/devconsole).
-1. To bring up the old developer dashboard, click **Show More** in the "Welcome" tile at the bottom-left, and then click **opt out**:
-    {% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/QdnQIblmYyzHAeb1zgmL.png", alt="ALT_TEXT_HERE", width="618", height="434" %}
-1. From the publisher selection drop-down at the top of the dashboard, select the Group Publisher you want to transfer your items to. It will load the dashboard page for the selected Group Publisher.
-1. Select **Transfer existing item(s)**, next to the **Add new item** button. You'll see a page with a list of items you own personally.
-1. Select the item(s) you want to transfer, and click the **Transfer** link to the right of the item.
-1. Click **Transfer** in the confirmation box.
+1. In the [developer dashboard][dashboard], open the item that you want to transfer.
+1. Go to the **Store listing** detail tab for the item.
+1. Click the "..." menu in the upper corner, then select **Transfer to group publisher**. The
+following dialog appears:
 
-Remember to opt back in to the new developer console when you're done tranferring items.
+    {% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/xMqFS3lPkdW5NWTiO4gJ.png", alt="ALT_TEXT_HERE", width="800", height="506" %}
+
+1. Choose carefully (because this is a permanent change) the group publisher you want to transfer
+the item to.
+1. Click **Transfer** to confirm the transfer.
+
+To verify that the item was transferred:
+
+1. [Select the group publisher][use-publisher] you transferred the item to.
+1. Check that the item is listed there.
 
 ## Group publishing troubleshooting
 
-* If either your personal publishing account or the Group Publisher account is suspended, you won't be able to transfer items.
-* If the Group Publisher account has reached its published item limit, you won't be able to transfer your published items to this Group Publisher.
+* If either your personal publishing account or the group publisher account is suspended, you won't be able to transfer items.
+* If the group publisher account has reached its published item limit, you won't be able to transfer your published items to this group publisher.
+
+[dashboard]: https://chrome.google.com/webstore/devconsole
+[use-publisher]: #publishing-using-a-group-publisher
 

--- a/site/en/docs/webstore/group-publishers/index.md
+++ b/site/en/docs/webstore/group-publishers/index.md
@@ -5,124 +5,123 @@ date: 2020-06-20
 description: How to share ownership of your Chrome Web Store items with other developers.
 ---
 
-You can share ownership of your items in Google Chrome Web Store with other developers by setting up
-group publishing. With group publishing, you can add developers to a Google Group, who can then act
-on your behalf. They'll have access to all the items you own and can make any changes to them that
-you can make.
+You can share ownership of your items in Google Chrome Web Store with other developers by setting up group publishing.
 
-{% Aside 'warning' %}
+This guide tells you how to set up group publishing.
 
-It's important that the Google Group you use for group publishing is private and that you carefully
-control the group membership. For this reason, we recommend:
+## About group publishers
 
-* Use a Google Group that is dedicated just to group publishing on the Chrome Web Store. Don't use
-  an existing group that has other purposes.
+Use a group publisher to establish an entity that owns Chrome Web Store items, so that publishing isn't tied to any individual developer. Consider how this differs from the more basic individual publisher role.
 
-* Keep this group private. This is the default; make sure not to change it to public.
+**Individual publisher** When an individual developer acts as a publisher of an item, only that developer can upload and publish updates to the item. The following diagram describes this scenario:
 
-Remember that anyone who is a  member of the group can make changes to your published items!
-{% endAside %}
+<object data="images/individual-publisher.svg" width="700">
+</object>
+
+**Group publisher** By setting up a *group publisher*, a Google Group associates a number of individuals developers into a composite entity. Any Chrome Web Store developer who belongs to the group can publish updates to the item, as depicted in the following diagram:
+
+<object data="images/group-publishers.svg" width="700">
+</object>
+
+Group publishers provide a number of benefits for organizations and development teams:
+
+* It's a convenient way for teams to share the publishing capability among all their members.
+* It's easy to transfer ownership of items when a developer leaves the organization.
+* It avoids unintended deletion of items that can happen when a developer leaves the org (because their account gets deleted and that individual account was the item's publisher).
+
+You can only create a group publisher once. If you need additional group 
+publishers, you'll need a separate developer account for each one.
 
 ## Before you set up group publishing
 
 Keep these important notes in mind:
 
-- Creating a Group Publisher is not reversible: a new Group Publisher account is created and the
-  Google Group you select is permanently linked to that account.
-- You cannot change which group is linked to the Group Publisher account.
-- You still retain your personal publishing account and can publish from either your group or
-  personal account.
+* A Chrome Web Store developer account can only create one group publisher,
+  **ever**. You cannot replenish this quota, even if you delete the group. 
+* Once the group publisher account is created, the Google Group you select 
+  remains linked to that account. Only the group owner or manager (or the last
+  remaining group member) can delete the group publisher, unlinking the Google 
+  Group from the Chrome Web Store.
 
-## Set up group publishing
+    <p class="warning">
+    Deleting the group publisher and the Google Group does not restore your
+  lifetime quota of one group publisher activation.
+    </p>
 
-To set up group publishing, follow these steps:
+* You can be a *member* of any number of group publishers.
 
-1.  Sign in to your [Chrome Web Store dashboard page][1].
-2.  If you don't see a drop-down at the top of dashboard page, go to step 3.
-3.  If you do see a drop-down, you've already been added to group publishing by another developer.
-    From the drop-down, select your own account instead of the group publisher account.
-4.  At the bottom of the dashboard page, you'll see one of two links:
-    - **Google Group publishing: Choose existing group or create new group** This link shows up if
-      you're the owner of one or more Google Groups, and those groups haven't already been linked to
-      a publisher account.
-    - **Google Group publishing: Create new group** You'll see this link if you aren't an owner of
-      any Google Groups, or if all the groups that you are an owner of have already been linked to
-      other publisher accounts.
-5.  You can do one of the following:
-    - Create a new Google group and link to this new group: 1. Click **Create new group**. You'll
-      see the Google Groups page in a new tab. 2. Create your new group. 3. Reload the Chrome Web
-      Store dashboard page in your browser, then follow the steps below under "Link to an existing
-      Google Group."
-    - Link to an existing Google group: 1. Click **Choose existing group**. 2. Select a group from
-      the drop-down. (We recommend linking to a group that you're using only for group publishing of
-      your items.) 3. Click **OK** in the confirmation box. 4. Click **Save Changes** at the bottom
-      of dashboard page.
+* You cannot change which group is linked to the Group Publisher account.
+* You still retain your personal publisherx account and can publish from either your group or personal account.
 
-After you complete the steps above, a new Group Publisher account is created. The Google Group you
-selected or created is linked to this new publisher account, and the group email is the new
-publisher account's email.
+## Create a group publisher
 
-## After you set up group publishing
+To create a group publisher, follow these steps:
 
-Your dashboard page will show the new Group Publisher account and the linked Google Group. You can
-[add or remove developers][2]. **All members of the linked group can act on behalf of the new
-publisher account**. For example, they can edit items, publish items, edit the publisher's display
-name, etc.
+1. Sign in to the [Chrome Web Store developer console](https://chrome.google.com/webstore/devconsole) and go to the **Account** tab.
+
+1. Scroll down to the **Google group publishing** field:
+
+    ![Screenshot of the Google Group publishing field](images/group-publisher-create.png)
+
+1. Select the Google Group that you want to associate with the new group
+publisher, then click **Convert to group publisher**.
+
+1. Make sure that the Google Group has mail turned on, as shown below:
+
+    ![Screenshot of the group's email setting](images/group-publisher-email-setting.png)
+
+1. Make sure that the Google Group doesn't allow anyone to join without being
+validated. Use either "Only invited users" or "Anyone can ask", as shown below:
+
+    ![Screenshot of the group's joining setting](images/group-publisher-who-can-join.png)
+
+These steps create a new Group Publisher account. The Google Group you selected is linked to this new publisher account, and the group email is the new group publisher account's email.
+
+## Adding developers to the group publisher
+
+Your dashboard page will show the new Group Publisher account and the linked
+Google Group. You can [add or remove developers](https://groups.google.com/).
+
+**Any Chrome Web Store developer who is a member of the linked group can act on behalf of the new publisher account**. For example, they can edit items, publish items, and edit the publisher's display name.
+
+## Publishing using a group publisher
+
+In the top right-hand corner of the [Chrome Web Store developer console](https://chrome.google.com/webstore/devconsole) is a pull-down that contains the following items:
+
+* Your developer user name (your individual publisher)
+* Any group publishers that you are a member of.
+
+Select the publisher you want to use. This displays the items already uploaded for that publisher. Any new items that you upload are associated with the selected publisher.
 
 ## Things to note
 
-- Each member of the group must pay the developer fee.
-- You can only set up group publishing once and create one group publisher account.
-- You must be the owner or administrator of a Google Group to link the group. The drop-down list on
-  the dashboard page only shows groups that you're a direct member of (for example, if you are a
-  member of Group A and Group A is a member of Group B, you are not a direct member of Group B, and
-  Group B is not shown on the drop-down list).
-- Once you finish the group publishing setup, it can take up to 30 minutes for developers in your
-  group to see the changes.
-- Your domain is the default domain of the new group publisher account. A group publisher can
-  publish items either to the public or to its default domain. A publisher cannot publish to other
-  domains.
-- A developer can act on behalf of multiple publishers if the developer is a member of multiple
-  Google Groups linked to publishers.
-- If a merchant account is needed or is already set up, any member of the group can choose to
-  re-link their own merchant accounts to the publisher on the dashboard page.
-- When you want to create new store items, you will have the opportunity to choose whether to make
-  them part of your personal publisher account or the group publisher account before you upload the
-  item.
+* You can only set up group publishing once and create one group publisher account.
+* You must be the owner or manager of a Google Group to link the group. The drop-down list on the dashboard page only shows groups that you're a direct member of (for example, if you are a member of Group A and Group A is a member of Group B, you are not a direct member of Group B, and Group B is not shown on the drop-down list).
+* Once you finish the group publishing setup, it can take up to 30 minutes for developers in your group to see the changes.
+* A developer can act on behalf of multiple publishers if the developer is a member of multiple Google Groups linked to publishers.
+* If a merchant account is needed or is already set up, any member of the group can choose to re-link their own merchant accounts to the publisher on the dashboard page.
+* Before you upload a new Chrome Web Store item, check that you have selected the publisher you want to own that item. This may be your personal publisher account or any group publisher account you belong to.
 
 ## Move existing items to a Group Publisher account
 
-Once you set up a Group Publisher account (or once you're added as a member of a Google Group linked
-to a Group Publisher account), you can transfer your own items to the Group Publisher.
+Once you set up a group publisher (or once you're added as a member of a Google Group linked to a group publisher), you can transfer your own items to the group publisher.
 
-Remember that once you move items to a Group Publisher account, you won't be able to move them back
-to your personal publishing account.
+<p class="note">Once you move items to a Group Publisher account, you can't move them back to your personal publishing account.</p>
 
-To transfer items to a Group Publisher account:
+To transfer items to a group publisher account you need to use the old developer dashboard:
 
-1.  Sign into your [Chrome Web Store dashboard page][3].
-2.  From the publisher selection drop-down at the top of the dashboard, select the Group Publisher
-    you want to transfer your items to. It will load the dashboard page for the selected Group
-    Publisher.
-3.  Select **Transfer existing item(s)**, next to the **Add new item** button. You'll see a page
-    with a list of items you own personally.
-4.  Select the item(s) you want to transfer, and click the **Transfer** link to the right of the
-    item.
-5.  Click **Transfer** in the confirmation box.
+1. Sign in to the [Chrome Web Store developer console](https://chrome.google.com/webstore/devconsole).
+1. To bring up the old developer dashboard, click **Show More** in the "Welcome" tile at the bottom-left, and then click **opt out**:
+    <br/><img src="images/cws-opt-out" width="350"/>
+1. From the publisher selection drop-down at the top of the dashboard, select the Group Publisher you want to transfer your items to. It will load the dashboard page for the selected Group Publisher.
+1. Select **Transfer existing item(s)**, next to the **Add new item** button. You'll see a page with a list of items you own personally.
+1. Select the item(s) you want to transfer, and click the **Transfer** link to the right of the item.
+1. Click **Transfer** in the confirmation box.
 
-After your items are moved, you'll see the item transfer page again. Any items you transferred will
-no longer be on the page. At the top of the page, you'll see a yellow bar with the status of the
-last item transfer.
+Remember to opt back in to the new developer console when you're done tranferring items.
 
 ## Group publishing troubleshooting
 
-- If either your personal publishing account or the Group Publisher account is suspended, you won't
-  be able to transfer items.
-- If the Group Publisher account has reached its published item limit, you won't be able to transfer
-  your published items to this Group Publisher.
-- You can't transfer a paid item to a Group Publisher account that doesn't have a Google Wallet
-  merchant account set up and linked.
+* If either your personal publishing account or the Group Publisher account is suspended, you won't be able to transfer items.
+* If the Group Publisher account has reached its published item limit, you won't be able to transfer your published items to this Group Publisher.
 
-[1]: https://chrome.google.com/webstore/developer/dashboard
-[2]: https://groups.google.com/
-[3]: https://chrome.google.com/webstore/developer/dashboard

--- a/site/en/docs/webstore/group-publishers/index.md
+++ b/site/en/docs/webstore/group-publishers/index.md
@@ -1,18 +1,23 @@
 ---
 layout: "layouts/doc-post.njk"
-title: Set up group publishing
+title: Set up a group publisher
 date: 2020-06-20
 description: How to share ownership of your Chrome Web Store items with other developers.
 ---
 
 You can share ownership of your items in Google Chrome Web Store with other developers by setting up
-*group publishing*. This guide tells you how to set up and use a group publisher.
+a *group publisher*. This page explains how group publishers work and how to set one up.
 
 ## About group publishers
 
-Use a group publisher to establish an entity that owns Chrome Web Store items, so that publishing
-isn't tied to any individual developer. Consider how this differs from the more basic individual
-publisher role.
+Use a group publisher to establish an entity that owns Chrome Web Store items, allowing multiple
+developers to share ownership of a published item. Consider how this differs from the more basic
+individual publisher role.
+
+{% Aside %}
+When you [register as a Chrome Web Store developer][cws-register], your developer account is
+automatically enrolled as an individual publisher.
+{% endAside %}
 
 **Individual publisher** When an individual developer acts as a publisher of an item, only that
 developer can upload and publish updates to the item. The following diagram describes this scenario:
@@ -20,7 +25,9 @@ developer can upload and publish updates to the item. The following diagram desc
 {% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/VCMoTUiD0xFT5pZVj3kO.svg", alt="Diagram of individual
 publishing process", width="800", height="145" %}
 
-**Group publisher** By setting up a *group publisher*, a Google Group associates a number of individuals developers into a composite entity. Any Chrome Web Store developer who belongs to the group can publish updates to the item, as depicted in the following diagram:
+**Group publisher** By setting up a *group publisher*, you use a Google Group to associate multiple
+developers into a composite entity. Any Chrome Web Store developer who belongs to the group can
+publish updates to the item, as depicted in the following diagram:
 
 {% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/pgzFlq6rxiKFQ5NjYlBi.svg", alt="Diagram of group
 publishing process", width="800", height="395" %}
@@ -29,10 +36,11 @@ Group publishers provide a number of benefits for organizations and development 
 
 * It's a convenient way for teams to share the publishing capability among all their members.
 * It's easy to transfer ownership of items when a developer leaves the organization.
-* It avoids unintended deletion of items that can happen when a developer leaves the org (because their account gets deleted and that individual account was the item's publisher).
+* It avoids unintended deletion of items that can happen when a developer leaves the org (because
+  their account gets deleted and that individual account was the item's publisher).
 
-You can only create a group publisher once. If you need additional group 
-publishers, you'll need a separate developer account for each one.
+You can only create a group publisher once. However, you can be a member of other
+developers' group publishers.
 
 ## Before you set up group publishing
 
@@ -53,13 +61,19 @@ Keep these important notes in mind:
 * You can be a *member* of any number of group publishers.
 
 * You cannot change which group is linked to the group publisher account.
-* You still retain your personal publisher account and can publish from either your group or personal account.
+* You still retain your individual publisher account and can publish from either your group or
+  individual account.
 
 ## Create a group publisher
 
 To create a group publisher, follow these steps:
 
-1. Sign in to the [Chrome Web Store developer console](https://chrome.google.com/webstore/devconsole) and go to the **Account** tab.
+{% Aside %}
+If you haven't already done so, you may wish to create a private Google Group before you begin.
+{% endAside %}
+
+1. Sign in to the [Chrome Web Store developer
+  console](https://chrome.google.com/webstore/devconsole) and go to the **Account** tab.
 
 1. Scroll down to the **Google group publishing** field:
 
@@ -80,17 +94,23 @@ validated. Use either "Only invited users" or "Anyone can ask", as shown below:
     {% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/LV2itIZXoZTLdgetsUwz.png", alt="Screenshot of
     selecting the only-invited-users option", width="800", height="211" %}
 
-These steps create a new group publisher account. The Google Group you selected is linked to this new publisher account, and the group email is the new group publisher account's email.
+These steps create a new group publisher account. The Google Group you selected is linked to this
+new publisher account, and the group email is the new group publisher account's email.
+
+{% Aside %}
+Once you finish the group publishing setup, it can take up to 30 minutes for developers in your
+group to see the changes.
+{% endAside %}
 
 ## Adding developers to the group publisher
 
-Your dashboard page will show the new group publisher account and the linked
+Your developer console will show the new group publisher account and the linked
 Google Group. You can [add or remove developers](https://groups.google.com/).
 
-{% Aside %}
-Any Chrome Web Store developer who is a member of the linked group can act on behalf of the new
-publisher account. For example, they can edit items, publish items, and edit the publisher's display
-name.
+{% Aside "caution" %}
+Be careful with the membership of your group publisher groups. Any Chrome Web Store developer who is
+a member of the linked group can act on behalf of the new publisher account. For example, they can
+edit items, publish items, and edit the publisher's display name. 
 {% endAside %}
 
 To maintain security over your items, we recommend that you manage your group in carefully:
@@ -100,35 +120,39 @@ To maintain security over your items, we recommend that you manage your group in
 * Keep the group private using the "Only invited users" option.
 * Minimize the number of members of the group.
 
+{% Aside "gotchas" %}
+Group publishing does not recognize "indirect" membership of Google Groups: only explicit
+  members of a group can publish. For example, suppose that:
+* You are a member of Group A, and
+* Group A is a member of Group B, which is a group publisher.
+In this case you are not a direct member of Group B, and cannot publish using that group.
+{% endAside %}
+
 ## Publishing using a group publisher
 
-In the top right-hand corner of the [Chrome Web Store developer console](https://chrome.google.com/webstore/devconsole) is a pull-down that contains the following items:
+In the top right-hand corner of the [Chrome Web Store developer
+console](https://chrome.google.com/webstore/devconsole) is a pull-down that contains the following
+items:
 
 * Your developer user name (your individual publisher)
 * Any group publishers that you are a member of.
 
-Select the publisher you want to use. This displays the items already uploaded for that publisher. Any new items that you upload are associated with the selected publisher.
-
-## Things to note
-
-* You can only set up group publishing once and create one group publisher account.
-* You must be the owner or manager of a Google Group to link the group. The drop-down list on the dashboard page only shows groups that you're a direct member of (for example, if you are a member of Group A and Group A is a member of Group B, you are not a direct member of Group B, and Group B is not shown on the drop-down list).
-* Once you finish the group publishing setup, it can take up to 30 minutes for developers in your group to see the changes.
-* A developer can act on behalf of multiple publishers if the developer is a member of multiple Google Groups linked to publishers.
-* Before you upload a new Chrome Web Store item, check that you have selected the publisher you want to own that item. This may be your personal publisher account or any group publisher account you belong to.
+Select the publisher you want to use. This displays the items already uploaded for that publisher.
+Any new items that you upload are associated with the selected publisher.
 
 ## Move existing items to a group publisher account
 
-Once you set up a group publisher (or once you're added as a member of a Google Group linked to a group publisher), you can transfer your own items to the group publisher.
+Once you set up a group publisher (or once you're added as a member of a Google Group linked to a
+group publisher), you can transfer your own items to the group publisher.
 
 {% Aside 'warning' %}
-Once you move items to a group publisher account, you can't move them back to your personal publishing account.
+Once you move items to a group publisher account, you can't move them back to your individual publishing account.
 {% endAside %}
 
-To transfer items to a group publisher account, start from the item page in your personal publisher
+To transfer items to a group publisher account, start from the item page in your individual publisher
 account, then transfer the item as described below:
 
-1. In the [developer dashboard][dashboard], open the item that you want to transfer.
+1. In the [developer console][devconsole], open the item that you want to transfer.
 1. Go to the **Store listing** detail tab for the item.
 1. Click the "..." menu in the upper corner, then select **Transfer to group publisher**. The
 following dialog appears:
@@ -147,9 +171,10 @@ To verify that the item was transferred:
 
 ## Group publishing troubleshooting
 
-* If either your personal publishing account or the group publisher account is suspended, you won't be able to transfer items.
+* If either your individual publishing account or the group publisher account is suspended, you won't be able to transfer items.
 * If the group publisher account has reached its published item limit, you won't be able to transfer your published items to this group publisher.
 
-[dashboard]: https://chrome.google.com/webstore/devconsole
+[cws-register]: /docs/webstore/register/
+[devconsole]: https://chrome.google.com/webstore/devconsole
 [use-publisher]: #publishing-using-a-group-publisher
 

--- a/site/en/docs/webstore/group-publishers/index.md
+++ b/site/en/docs/webstore/group-publishers/index.md
@@ -15,13 +15,11 @@ Use a group publisher to establish an entity that owns Chrome Web Store items, s
 
 **Individual publisher** When an individual developer acts as a publisher of an item, only that developer can upload and publish updates to the item. The following diagram describes this scenario:
 
-<object data="images/individual-publisher.svg" width="700">
-</object>
+{% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/VCMoTUiD0xFT5pZVj3kO.svg", alt="ALT_TEXT_HERE", width="800", height="145" %}
 
 **Group publisher** By setting up a *group publisher*, a Google Group associates a number of individuals developers into a composite entity. Any Chrome Web Store developer who belongs to the group can publish updates to the item, as depicted in the following diagram:
 
-<object data="images/group-publishers.svg" width="700">
-</object>
+{% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/pgzFlq6rxiKFQ5NjYlBi.svg", alt="ALT_TEXT_HERE", width="800", height="395" %}
 
 Group publishers provide a number of benefits for organizations and development teams:
 
@@ -61,19 +59,19 @@ To create a group publisher, follow these steps:
 
 1. Scroll down to the **Google group publishing** field:
 
-    ![Screenshot of the Google Group publishing field](images/group-publisher-create.png)
+    {% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/ozixwtnU0bikOAzhBaPM.png", alt="ALT_TEXT_HERE", width="800", height="291" %}
 
 1. Select the Google Group that you want to associate with the new group
 publisher, then click **Convert to group publisher**.
 
 1. Make sure that the Google Group has mail turned on, as shown below:
 
-    ![Screenshot of the group's email setting](images/group-publisher-email-setting.png)
+{% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/TU0AD2DYks5nPZGNWGLb.png", alt="ALT_TEXT_HERE", width="800", height="104" %}
 
 1. Make sure that the Google Group doesn't allow anyone to join without being
 validated. Use either "Only invited users" or "Anyone can ask", as shown below:
 
-    ![Screenshot of the group's joining setting](images/group-publisher-who-can-join.png)
+    {% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/LV2itIZXoZTLdgetsUwz.png", alt="ALT_TEXT_HERE", width="800", height="211" %}
 
 These steps create a new Group Publisher account. The Google Group you selected is linked to this new publisher account, and the group email is the new group publisher account's email.
 
@@ -112,7 +110,7 @@ To transfer items to a group publisher account you need to use the old developer
 
 1. Sign in to the [Chrome Web Store developer console](https://chrome.google.com/webstore/devconsole).
 1. To bring up the old developer dashboard, click **Show More** in the "Welcome" tile at the bottom-left, and then click **opt out**:
-    <br/><img src="images/cws-opt-out" width="350"/>
+    {% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/QdnQIblmYyzHAeb1zgmL.png", alt="ALT_TEXT_HERE", width="618", height="434" %}
 1. From the publisher selection drop-down at the top of the dashboard, select the Group Publisher you want to transfer your items to. It will load the dashboard page for the selected Group Publisher.
 1. Select **Transfer existing item(s)**, next to the **Add new item** button. You'll see a page with a list of items you own personally.
 1. Select the item(s) you want to transfer, and click the **Transfer** link to the right of the item.

--- a/site/en/docs/webstore/group-publishers/index.md
+++ b/site/en/docs/webstore/group-publishers/index.md
@@ -5,21 +5,25 @@ date: 2020-06-20
 description: How to share ownership of your Chrome Web Store items with other developers.
 ---
 
-You can share ownership of your items in Google Chrome Web Store with other developers by setting up group publishing.
-
-This guide tells you how to set up group publishing.
+You can share ownership of your items in Google Chrome Web Store with other developers by setting up
+*group publishing*. This guide tells you how to set up and use a group publisher.
 
 ## About group publishers
 
-Use a group publisher to establish an entity that owns Chrome Web Store items, so that publishing isn't tied to any individual developer. Consider how this differs from the more basic individual publisher role.
+Use a group publisher to establish an entity that owns Chrome Web Store items, so that publishing
+isn't tied to any individual developer. Consider how this differs from the more basic individual
+publisher role.
 
-**Individual publisher** When an individual developer acts as a publisher of an item, only that developer can upload and publish updates to the item. The following diagram describes this scenario:
+**Individual publisher** When an individual developer acts as a publisher of an item, only that
+developer can upload and publish updates to the item. The following diagram describes this scenario:
 
-{% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/VCMoTUiD0xFT5pZVj3kO.svg", alt="ALT_TEXT_HERE", width="800", height="145" %}
+{% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/VCMoTUiD0xFT5pZVj3kO.svg", alt="Diagram of individual
+publishing process", width="800", height="145" %}
 
 **Group publisher** By setting up a *group publisher*, a Google Group associates a number of individuals developers into a composite entity. Any Chrome Web Store developer who belongs to the group can publish updates to the item, as depicted in the following diagram:
 
-{% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/pgzFlq6rxiKFQ5NjYlBi.svg", alt="ALT_TEXT_HERE", width="800", height="395" %}
+{% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/pgzFlq6rxiKFQ5NjYlBi.svg", alt="Diagram of group
+publishing process", width="800", height="395" %}
 
 Group publishers provide a number of benefits for organizations and development teams:
 
@@ -41,10 +45,10 @@ Keep these important notes in mind:
   remaining group member) can delete the group publisher, unlinking the Google 
   Group from the Chrome Web Store.
 
-    <p class="warning">
+    {% Aside "caution" %}
     Deleting the group publisher and the Google Group does not restore your
-  lifetime quota of one group publisher activation.
-    </p>
+    lifetime quota of one group publisher activation.
+    {% endAside %}
 
 * You can be a *member* of any number of group publishers.
 
@@ -59,19 +63,22 @@ To create a group publisher, follow these steps:
 
 1. Scroll down to the **Google group publishing** field:
 
-    {% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/ozixwtnU0bikOAzhBaPM.png", alt="ALT_TEXT_HERE", width="800", height="291" %}
+    {% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/ozixwtnU0bikOAzhBaPM.png", alt="Screenshot of the
+    Google group publishing field", width="800", height="291" %}
 
 1. Select the Google Group that you want to associate with the new group
 publisher, then click **Convert to group publisher**.
 
 1. Make sure that the Google Group has mail turned on, as shown below:
 
-{% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/TU0AD2DYks5nPZGNWGLb.png", alt="ALT_TEXT_HERE", width="800", height="104" %}
+    {% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/TU0AD2DYks5nPZGNWGLb.png", alt="Screenshot of Allow
+    posting by email option", width="800", height="104" %}
 
 1. Make sure that the Google Group doesn't allow anyone to join without being
 validated. Use either "Only invited users" or "Anyone can ask", as shown below:
 
-    {% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/LV2itIZXoZTLdgetsUwz.png", alt="ALT_TEXT_HERE", width="800", height="211" %}
+    {% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/LV2itIZXoZTLdgetsUwz.png", alt="Screenshot of
+    selecting the only-invited-users option", width="800", height="211" %}
 
 These steps create a new group publisher account. The Google Group you selected is linked to this new publisher account, and the group email is the new group publisher account's email.
 
@@ -80,7 +87,18 @@ These steps create a new group publisher account. The Google Group you selected 
 Your dashboard page will show the new group publisher account and the linked
 Google Group. You can [add or remove developers](https://groups.google.com/).
 
-**Any Chrome Web Store developer who is a member of the linked group can act on behalf of the new publisher account**. For example, they can edit items, publish items, and edit the publisher's display name.
+{% Aside %}
+Any Chrome Web Store developer who is a member of the linked group can act on behalf of the new
+publisher account. For example, they can edit items, publish items, and edit the publisher's display
+name.
+{% endAside %}
+
+To maintain security over your items, we recommend that you manage your group in carefully:
+
+* Create a Google Group for exclusive use as the group publisher; don't use an existing group that
+  you also use for other purposes.
+* Keep the group private using the "Only invited users" option.
+* Minimize the number of members of the group.
 
 ## Publishing using a group publisher
 
@@ -115,7 +133,8 @@ account, then transfer the item as described below:
 1. Click the "..." menu in the upper corner, then select **Transfer to group publisher**. The
 following dialog appears:
 
-    {% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/xMqFS3lPkdW5NWTiO4gJ.png", alt="ALT_TEXT_HERE", width="800", height="506" %}
+    {% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/xMqFS3lPkdW5NWTiO4gJ.png", alt="Screenshot of
+    transfer to group publisher dialog", width="800", height="506" %}
 
 1. Choose carefully (because this is a permanent change) the group publisher you want to transfer
 the item to.


### PR DESCRIPTION
Test of the linter problem I've been having. The linter rejects my push (unless I use --no-verify) with the following error:

site/en/docs/webstore/group-publishers/dummy.md
  31:1-32:75  warning  Code blocks should be fenced  code-block-style  remark-lint

The odd thing is that this is the only error it throws, though I have several similar shortcodes in this file.