### PR TITLE
Rephrased tabs.executeScript() as scripting.executeScript() except wh…

### DIFF
--- a/site/en/docs/extensions/mv3/background_pages/index.md
+++ b/site/en/docs/extensions/mv3/background_pages/index.md
@@ -139,9 +139,9 @@ chrome.runtime.onMessage.addListener(function(message, callback) {
   if (message.data == "setAlarm") {
     chrome.alarms.create({delayInMinutes: 5})
   } else if (message.data == "runLogic") {
-    chrome.tabs.executeScript({file: 'logic.js'});
+    chrome.scripting.executeScript({file: 'logic.js'});
   } else if (message.data == "changeColor") {
-    chrome.tabs.executeScript(
+    chrome.scripting.executeScript(
         {code: 'document.body.style.backgroundColor="orange"'});
   };
 });

--- a/site/en/docs/extensions/mv3/devtools/index.md
+++ b/site/en/docs/extensions/mv3/devtools/index.md
@@ -138,10 +138,10 @@ components of a DevTools extension.
 
 ### Injecting a content script {: #injecting }
 
-The DevTools page can't call [`tabs.executeScript`][17] directly. To inject a content script from
+The DevTools page can't call [`scripting.executeScript`][17] directly. To inject a content script from
 the DevTools page, you must retrieve the ID of the inspected window's tab using the
 [`inspectedWindow.tabId`][18] property and send a message to the background page. From the
-background page, call [`tabs.executeScript`][19] to inject the script.
+background page, call [`scripting.executeScript`][19] to inject the script.
 
 {% Aside %}
 
@@ -178,7 +178,7 @@ chrome.runtime.onConnect.addListener(function(devToolsConnection) {
     // assign the listener function to a variable so we can remove it later
     var devToolsListener = function(message, sender, sendResponse) {
         // Inject a content script into the identified tab
-        chrome.tabs.executeScript(message.tabId,
+        chrome.scripting.executeScript(message.tabId,
             { file: message.scriptToInject });
     }
     // add the listener
@@ -219,7 +219,7 @@ Once the context script context exists, you can use this option to inject additi
 scripts.
 
 The `eval` method is powerful when used in the right context and dangerous when used
-inappropriately. Use the [`tabs.executeScript`][24] method if you don't need access to the
+inappropriately. Use the [`scripting.executeScript`][24] method if you don't need access to the
 JavaScript context of the inspected page. For detailed cautions and a comparison of the two methods,
 see [`inspectedWindow`][25].
 
@@ -472,20 +472,20 @@ You can find examples that use DevTools APIs in [Samples][46].
 [15]: /docs/extensions/mv3/devtools.panels#method-ExtensionSidebarPane-setObject
 [16]:
   /extensions/devtools.panels#method-ExtensionSidebarPane-setExpression
-[17]: /docs/extensions/tabs#method-executeScript
+[17]: /docs/extensions/scripting#method-executeScript
 [18]: /docs/extensions/mv3/devtools.inspectedWindow#property-tabId
-[19]: /docs/extensions/tabs#method-executeScript
+[19]: /docs/extensions/scripting#method-executeScript
 [20]: #selected-element
 [21]: /docs/extensions/mv3/devtools.inspectedWindow#method-eval
 [22]: /docs/devtools/docs/commandline-api
 [23]:
   https://github.com/RedRibbon/SOAK/blob/ffdfad68ffb6051fa2d4e9db0219b3d234ac1ae8/pages/devtools.js#L6-L8
-[24]: /docs/extensions/tabs#method-executeScript
+[24]: /docs/extensions/scripting#method-executeScript
 [25]: /docs/extensions/mv3/devtools.inspectedWindow
 [26]: /docs/extensions/mv3/devtools.inspectedWindow#method-eval
 [27]: /docs/extensions/mv3/devtools.inspectedWindow#method-eval
 [28]: /docs/extensions/reference/devtools_panels#event-ExtensionPanel-onShown
-[29]: /docs/extensions/tabs#method-sendMessage
+[29]: /docs/extensions/scripting#method-sendMessage
 [30]: #injecting
 [31]: /docs/extensions/mv3/devtools.inspectedWindow#method-eval
 [32]: /docs/extensions/runtime#method-sendMessage

--- a/site/en/docs/extensions/mv3/faq/index.md
+++ b/site/en/docs/extensions/mv3/faq/index.md
@@ -223,8 +223,8 @@ The steps you should follow to ensure this are:
     this way, which is a good indicator that the bug is in their own code.
 2.  Search the issue tracker at [http://crbug.com][55] to see whether someone has reported a similar
     issue. Most issues related to extensions are filed under **component=Platform>Extensions**, so
-    to look for an extension bug related to the chrome.tabs.executeScript function (for example),
-    search for "`component=Platform>Extensions Type=Bug chrome.tabs.executeScript`", which will give
+    to look for an extension bug related to the chrome.scripting.executeScript function (for example),
+    search for "`component=Platform>Extensions Type=Bug chrome.scripting.executeScript`", which will give
     you [this list of results][56].
 3.  If you find a bug that describes your issue, click the star icon to be notified when the bug
     receives an update. _Do not respond to the bug to say "me too" or ask "when will this be
@@ -327,7 +327,7 @@ The steps you should follow to ensure this are:
 [54]: #faq-lifecycle-events
 [55]: http://crbug.com
 [56]:
-  https://bugs.chromium.org/p/chromium/issues/list?can=2&q=component%3DPlatform>Extensions+Type%3DBug+chrome.tabs.executeScript
+  https://bugs.chromium.org/p/chromium/issues/list?can=2&q=component%3DPlatform>Extensions+Type%3DBug+chrome.scripting.executeScript
 [57]: http://crbug.com/new
 [58]: http://groups.google.com/a/chromium.org/group/chromium-extensions/topics
 [59]: http://crbug.com

--- a/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
+++ b/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
@@ -269,12 +269,14 @@ strings at runtime, you'll need to update your code execution strategies when
 migrating to MV3.
 
 {% Aside %}
-With Manifest V3 the executeScript() method also moves to a different API.
+With Manifest V3 the `executeScript()` method also moves to a different API.
 
 * **MV2:**&emsp;[chrome.tabs.executeScript()](/docs/extensions/reference/tabs/#method-executeScript)
 * **MV3:**&emsp;[chrome.scripting.executeScript()](/docs/extensions/reference/scripting/#method-executeScript).
 
-If you use executeScript() anywhere in your code, you'll need to update that call to use the new API.
+If you use executeScript() anywhere in your code, you'll need to update that call to use the new
+API. The `insertCSS()` and `removeCSS()` methods similarly move from chrome.tabs to
+chrome.scripting.
 {% endAside %}
 
 

--- a/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
+++ b/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
@@ -268,14 +268,21 @@ executes remotely hosted scripts, injects code strings into pages, or evals
 strings at runtime, you'll need to update your code execution strategies when
 migrating to MV3.
 
+{% Aside %}
+With Manifest V3 the executeScript() method also moves to a different API.
+
+* **MV2:**&emsp;[chrome.tabs.executeScript()](/docs/extensions/reference/tabs/#method-executeScript)
+* **MV3:**&emsp;[chrome.scripting.executeScript()](/docs/extensions/reference/scripting/#method-executeScript).
+
+If you use executeScript() anywhere in your code, you'll need to update that call to use the new API.
+{% endAside %}
+
 
 ### Remotely hosted code  {: #remotely-hosted-code }
 
 _Remotely hosted code_ refers to any code that is not included in an
 extension's package as a loadable resource. For example, both of the following
 are considered remotely hosted code:
-
-
 
 *   JavaScript files pulled from a remote server
 *   a code string passed into eval at runtime

--- a/site/en/docs/extensions/mv3/manifest/activeTab/index.md
+++ b/site/en/docs/extensions/mv3/manifest/activeTab/index.md
@@ -55,7 +55,7 @@ See the [Page Redder][2] sample extension:
 chrome.browserAction.onClicked.addListener(function(tab) {
   // No tabs or host permissions needed!
   console.log('Turning ' + tab.url + ' red!');
-  chrome.tabs.executeScript({
+  chrome.scripting.executeScript({
     code: 'document.body.style.backgroundColor="red"'
   });
 });
@@ -81,7 +81,7 @@ navigated or is closed.
 
 While the `activeTab` permission is enabled for a tab, an extension can:
 
-- Call [`tabs.executeScript`][5] or [`tabs.insertCSS`][6] on that tab.
+- Call [`tabs.insertCSS`][6] on that tab.
 - Get the URL, title, and favicon for that tab via an API that returns a [`tabs.Tab`][7] object
   (essentially, `activeTab` grants the [`tabs`][8] permission temporarily).
 - Intercept network requests in the tab to the tab's main frame origin using the [webRequest][9]
@@ -101,7 +101,6 @@ The following user gestures enable `activeTab`:
 [2]: /docs/extensions/mv3/samples#page-redder
 [3]: /docs/extensions/reference/browserAction
 [4]: /docs/extensions/reference/contextMenus
-[5]: /docs/extensions/reference/tabs#method-executeScript
 [6]: /docs/extensions/reference/tabs#method-insertCSS
 [7]: /docs/extensions/reference/tabs#type-Tab
 [8]: /docs/extensions/reference/tabs#manifest

--- a/site/en/docs/extensions/mv3/manifest/activeTab/index.md
+++ b/site/en/docs/extensions/mv3/manifest/activeTab/index.md
@@ -81,7 +81,7 @@ navigated or is closed.
 
 While the `activeTab` permission is enabled for a tab, an extension can:
 
-- Call [`scripting.insertCSS`][insertCSSmethod] on that tab.
+- Call [`scripting.insertCSS`][insert-css-method] on that tab.
 - Get the URL, title, and favicon for that tab via an API that returns a [`tabs.Tab`][7] object
   (essentially, `activeTab` grants the [`tabs`][8] permission temporarily).
 - Intercept network requests in the tab to the tab's main frame origin using the [webRequest][9]
@@ -97,7 +97,7 @@ The following user gestures enable `activeTab`:
 - Executing a keyboard shortcut from the [commands API][13]
 - Accepting a suggestion from the [omnibox API][14]
 
-[insertCSSmethod]: /docs/extensions/reference/scripting#method-insertCSS
+[insert-css-method]: /docs/extensions/reference/scripting#method-insertCSS
 [1]: /docs/extensions/reference/browserAction
 [2]: /docs/extensions/mv3/samples#page-redder
 [3]: /docs/extensions/reference/browserAction

--- a/site/en/docs/extensions/mv3/manifest/activeTab/index.md
+++ b/site/en/docs/extensions/mv3/manifest/activeTab/index.md
@@ -81,7 +81,7 @@ navigated or is closed.
 
 While the `activeTab` permission is enabled for a tab, an extension can:
 
-- Call [`tabs.insertCSS`][6] on that tab.
+- Call [`scripting.insertCSS`][insertCSSmethod] on that tab.
 - Get the URL, title, and favicon for that tab via an API that returns a [`tabs.Tab`][7] object
   (essentially, `activeTab` grants the [`tabs`][8] permission temporarily).
 - Intercept network requests in the tab to the tab's main frame origin using the [webRequest][9]
@@ -97,11 +97,11 @@ The following user gestures enable `activeTab`:
 - Executing a keyboard shortcut from the [commands API][13]
 - Accepting a suggestion from the [omnibox API][14]
 
+[insertCSSmethod]: /docs/extensions/reference/scripting#method-insertCSS
 [1]: /docs/extensions/reference/browserAction
 [2]: /docs/extensions/mv3/samples#page-redder
 [3]: /docs/extensions/reference/browserAction
 [4]: /docs/extensions/reference/contextMenus
-[6]: /docs/extensions/reference/tabs#method-insertCSS
 [7]: /docs/extensions/reference/tabs#type-Tab
 [8]: /docs/extensions/reference/tabs#manifest
 [9]: /docs/extensions/reference/webRequest

--- a/site/en/docs/extensions/mv3/mv3-migration-checklist/index.md
+++ b/site/en/docs/extensions/mv3/mv3-migration-checklist/index.md
@@ -64,11 +64,32 @@ still use the blocking version of `chrome.webRequest`.
 - Remove unnecessary host permissions; blocking a request or upgrading a request's protocol
   doesn't require host permissions with `declarativeNetRequest`.
 
-**Are you using tabs.executeScript?**
+**Are you using these scripting/CSS methods in the chrome.tabs API?**
 <br/>
-*In Manifest V3, the executeScript() method moves to the chrome.scripting API.*
+*In Manifest V3, several methods move from `chrome.tabs` to the `chrome.scripting` API.*
 
-- Change any `chrome.tabs.executeScript(...)` calls to `chrome.scripting.executeScript(...)`.
+- Change any of the following MV2 calls to use the correct MV3 API:
+
+<table class="with-heading-tint">
+  <thead>
+    <tr>
+      <th>Manifest V2</th>
+      <th>Manifest V3</th>
+    </tr>
+  </thead>
+    <tr>
+      <td>tabs.executeScript()</td>
+      <td>scripting.executeScript()</td>
+    </tr>
+    <tr>
+      <td>tabs.insertCSS()</td>
+      <td>scripting.insertCSS()</td>
+    </tr>
+    <tr>
+      <td>tabs.removeCSS()</td>
+      <td>scripting.removeCSS()</td>
+    </tr>
+</table>
 
 **Are you executing remote code or arbitrary strings?**
 <br/>

--- a/site/en/docs/extensions/mv3/mv3-migration-checklist/index.md
+++ b/site/en/docs/extensions/mv3/mv3-migration-checklist/index.md
@@ -66,7 +66,8 @@ still use the blocking version of `chrome.webRequest`.
 
 **Are you executing remote code or arbitrary strings?**
 <br/>
-*You can no longer [execute external logic](/docs/extensions/mv3/intro/mv3-migration#remotely-hosted-code) using `chrome.tabs.executeScript({code: '...'})`, `eval()`, and `new Function()`.*
+*You can no longer [execute external
+logic](/docs/extensions/mv3/intro/mv3-migration#remotely-hosted-code) using `chrome.scripting.executeScript({code: '...'})`, `eval()`, and `new Function()`.*
 
 - Move all external code (JS, Wasm, CSS) into your extension bundle.
 - Update script and style references to load resources from the extension bundle.

--- a/site/en/docs/extensions/mv3/mv3-migration-checklist/index.md
+++ b/site/en/docs/extensions/mv3/mv3-migration-checklist/index.md
@@ -64,6 +64,12 @@ still use the blocking version of `chrome.webRequest`.
 - Remove unnecessary host permissions; blocking a request or upgrading a request's protocol
   doesn't require host permissions with `declarativeNetRequest`.
 
+**Are you using tabs.executeScript?**
+<br/>
+*In Manifest V3, the executeScript() method moves to the chrome.scripting API.*
+
+- Change any `chrome.tabs.executeScript(...)` calls to `chrome.scripting.executeScript(...)`.
+
 **Are you executing remote code or arbitrary strings?**
 <br/>
 *You can no longer [execute external

--- a/site/en/docs/extensions/mv3/permission_warnings/index.md
+++ b/site/en/docs/extensions/mv3/permission_warnings/index.md
@@ -102,7 +102,7 @@ the tab is navigated or closed.
 
 While the `activeTab` permission is enabled for a tab, an extension can:
 
-- Call [`tabs.insertCSS`][12] on that tab.
+- Call [`scripting.insertCSS`][12] on that tab.
 - Get the URL, title, and favicon for that tab via an API that returns a [`tabs.Tab`][13] object.
 - Intercept network requests in the tab to the tab's main frame origin using the [webRequest][14]
   API. The extension temporarily gets host permissions for the tab's main frame origin.
@@ -367,7 +367,7 @@ This can be avoided by making the new feature optional and adding new permission
 [8]: /docs/extensions/reference/topSites
 [9]: /docs/extensions/reference/tabs
 [10]: #p_activeTab_gestures
-[12]: /docs/extensions/reference/tabs#method-insertCSS
+[12]: /docs/extensions/reference/scripting#method-insertCSS
 [13]: /docs/extensions/reference/tabs#type-Tab
 [14]: /docs/extensions/reference/webRequest
 [15]: /docs/extensions/reference/browserAction

--- a/site/en/docs/extensions/mv3/permission_warnings/index.md
+++ b/site/en/docs/extensions/mv3/permission_warnings/index.md
@@ -102,7 +102,7 @@ the tab is navigated or closed.
 
 While the `activeTab` permission is enabled for a tab, an extension can:
 
-- Call [`tabs.executeScript`][11] or [`tabs.insertCSS`][12] on that tab.
+- Call [`tabs.insertCSS`][12] on that tab.
 - Get the URL, title, and favicon for that tab via an API that returns a [`tabs.Tab`][13] object.
 - Intercept network requests in the tab to the tab's main frame origin using the [webRequest][14]
   API. The extension temporarily gets host permissions for the tab's main frame origin.
@@ -367,7 +367,6 @@ This can be avoided by making the new feature optional and adding new permission
 [8]: /docs/extensions/reference/topSites
 [9]: /docs/extensions/reference/tabs
 [10]: #p_activeTab_gestures
-[11]: /docs/extensions/reference/tabs#method-executeScript
 [12]: /docs/extensions/reference/tabs#method-insertCSS
 [13]: /docs/extensions/reference/tabs#type-Tab
 [14]: /docs/extensions/reference/webRequest


### PR DESCRIPTION
Updates needed for the tabs.executeScript() -> scripting.executeScript() change. Changed the following:

* Added mention of this change in the MV3 migration guide.
* Fixed references to tabs.executeScript() across a number of files.
* Removed reference to executeScript() from a couple of tabs API discussions.

b/181773342