### PR TITLE
add devtools and chrome on android to featured docs.

### DIFF
--- a/site/en/index.md
+++ b/site/en/index.md
@@ -2,6 +2,8 @@
 title: Chrome Developers
 layout: 'layouts/home.njk'
 featured_projects:
+  - devtools
   - extensions
   - webstore
+  - android
 ---


### PR DESCRIPTION
Adds devtools and chrome for android docs (recently updated) to featured card on homepage