### PR TITLE
Add editorconfig, disable code block style indentation rule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Make sure every file:
+# - Uses utf-8
+# - Indents with spaces instead of tabs
+# - Uses two space indents
+# - Uses Unix-style newlines
+# - Has a newline at the end of every file
+# - Trims trailing whitespace
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.remarkrc.js
+++ b/.remarkrc.js
@@ -6,6 +6,7 @@ exports.plugins = [
 
   // Remark Lint Style Guide preset and overrides.
   require('remark-preset-lint-markdown-style-guide'),
+  ['lint-code-block-style', false],
   ['lint-blockquote-indentation', false],
   ['lint-emphasis-marker', false],
   ['lint-hard-break-spaces', false],


### PR DESCRIPTION
Adds an [.editorconfig](https://editorconfig.org/) file and disables the [code-block-style](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-code-block-style) lint rule. It looks like you have to use 4 space indentation if you want to nest something (like a shortcode) inside of an ordered list while still allowing the list counter to increment but remark isn't smart enough to grok that and it's annoying to have to keep disabling the linter if folks want to use images inside of ordered lists.

Changes proposed in this pull request:

- Adds a .editorconfig file to encourage consistency (web.dev already has one with these same settings).
- Disables the remark lint code block rule.