### PR TITLE
Allow non-heading Details elements and fix a few small CSS issues.

### DIFF
--- a/site/_scss/blocks/_details.scss
+++ b/site/_scss/blocks/_details.scss
@@ -35,7 +35,6 @@
 
   > :first-child {
     color: var(--color-primary);
-    font-size: var(--chevron-size);
     position: relative;
   }
 
@@ -59,4 +58,11 @@
 
 .details[open] > summary > .details__header > :first-child::after {
   transform: rotate(0deg) translateY(-50%);
+}
+
+// We generate clickable links for our markdown headings but if someone uses
+// a heading inside of a details shortcode then the link shows up on hover and
+// looks strange. This hides it.
+.details .heading-link {
+  display: none;
 }

--- a/site/_scss/blocks/_details.scss
+++ b/site/_scss/blocks/_details.scss
@@ -3,7 +3,6 @@
 .details {
   border: 1px solid var(--color-hairline);
   border-width: 1px 0;
-  margin: calc(var(--flow-space)) 0;
   padding: calc(var(--flow-space) / 2) 0;
   position: relative;
 }

--- a/site/en/docs/handbook/components/index.md
+++ b/site/en/docs/handbook/components/index.md
@@ -9,7 +9,27 @@ updated: 2021-01-27
 
 Use a details section to hide extra information from the user until it's needed. It can have an optional preview.
 
-<!-- Example 1 -->
+````md
+{% raw %}{% Details %}
+{% DetailsSummary %}
+A brief summary goes here
+{% endDetailsSummary %}
+
+The body of the Details component goes here, and **can** contain markdown.
+
+{% endDetails %}{% endraw %}
+````
+
+{% Details %}
+{% DetailsSummary %}
+A brief summary goes here
+{% endDetailsSummary %}
+
+The body of the Details component goes here, and **can** contain markdown.
+
+{% endDetails %}
+
+The details shortcode also supports using headers in the summary.
 
 ````md
 {% raw %}{% Details %}
@@ -30,8 +50,6 @@ The body of the Details component goes here, and **can** contain markdown.
 The body of the Details component goes here, and **can** contain markdown.
 
 {% endDetails %}
-
-<!-- Example 2 -->
 
 ````md
 {% raw %}{% Details %}


### PR DESCRIPTION
Changes proposed in this pull request:

- Removes the Details margin. Components shouldn't define their own margins, that should be left up to page layout components/styles. Otherwise you end up with really hard to control whitespace (like we have on web.dev 😟 ). This doesn't change the way Details are rendered in articles because the margin already comes from the `.stack` layout component.

- Allows non-heading Details elements

![image](https://user-images.githubusercontent.com/1066253/112229178-ba103100-8bef-11eb-8c84-5b54d64d1af5.png)

- Removes the explicit font-size on the details summary. If someone uses regular text it will be 1em, if someone uses a heading it'll be whatever font-size the heading is. Headings in Details still render pretty much like they used to.

![image](https://user-images.githubusercontent.com/1066253/112229262-e1ff9480-8bef-11eb-9d22-624d20657af3.png)

- Hides the heading anchor that appears on hover if a heading is used inside of a Details element. It was kind of weird that this little hash was showing up.
![image](https://user-images.githubusercontent.com/1066253/112229315-ff346300-8bef-11eb-8403-5c052b50b39c.png)
