### PR TITLE
Update TWA support library version

### DIFF
--- a/site/en/docs/android/trusted-web-activity/android-browser-helper-migration/index.md
+++ b/site/en/docs/android/trusted-web-activity/android-browser-helper-migration/index.md
@@ -38,7 +38,7 @@ appllication `build.gradle`:
 ```groovy
 dependencies {
     //...
-    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.1.0'
+    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.2.0'
 }
 ```
 

--- a/site/en/docs/android/trusted-web-activity/integration-guide/index.md
+++ b/site/en/docs/android/trusted-web-activity/integration-guide/index.md
@@ -83,7 +83,7 @@ dependency to the `dependencies` section:
 
 ```groovy
 dependencies {
-    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.1.0'
+    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.2.0'
 }
 ```
 

--- a/site/en/docs/android/trusted-web-activity/web-share-target/index.md
+++ b/site/en/docs/android/trusted-web-activity/web-share-target/index.md
@@ -39,7 +39,7 @@ first step, update the application to use a version that is higher or equal to 2
 ```groovy
 dependencies {
     ...
-    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.1.0'
+    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.2.0'
 }
 ```
 


### PR DESCRIPTION
- Updates references to android-browser-helper to 2.2.0, which
  is the latest version.
