### PR TITLE
Remove unneeded flexbox on columns widget

### DIFF
--- a/site/_scss/blocks/_columns.scss
+++ b/site/_scss/blocks/_columns.scss
@@ -2,16 +2,9 @@
   display: grid;
   gap: get-size(300);
   grid-auto-flow: row;
-  
+
   @include media-query('md') {
     grid-auto-columns: 1fr;
     grid-auto-flow: column;
-  }
-}
-
-.columns__column {
-  @include media-query('md') {
-    display: flex;
-    flex-direction: column;
   }
 }


### PR DESCRIPTION
Fixes #549

I checked every page that currently uses the Columns shortcode and they all render the same with this change.

Changes proposed in this pull request:

- Don't flexbox the `Column` shortcode