### PR TITLE
Examples of common Tabs API operations

### DIFF
--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -8,7 +8,7 @@ extra_permissions_html:
 
 You can use most `chrome.tabs` methods and events without declaring any permissions in the
 extension's [manifest][manifest] file. However, if you require access to the [`url`][prop-url],
-[`pendingUrl`][3], [`title`][prop-title], or [`favIconUrl`][prop-favIconUrl] properties of
+[`pendingUrl`][3], [`title`][prop-title], or [`favIconUrl`][prop-faviconurl] properties of
 [`tabs.Tab`][tab], you must declare the `"tabs"` permission in the manifest, as shown below:
 
 ```json
@@ -94,9 +94,9 @@ directory of the [chrome-extensions-samples][samples-repo] repository.
 
 [manifest]: /docs/extensions/mv3/manifest/
 [prop-url]: #property-Tab-url
-[prop-pendingUrl]: #property-Tab-pendingUrl
+[prop-pendingurl]: #property-Tab-pendingUrl
 [prop-title]: #property-Tab-title
-[prop-favIconUrl]: #property-Tab-favIconUrl
+[prop-faviconurl]: #property-Tab-favIconUrl
 [tab]: #type-Tab
 [mv2-tabs-samples]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/tabs/
 [samples-repo]: https://github.com/GoogleChrome/chrome-extensions-samples

--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -24,11 +24,57 @@ permission in the manifest, as shown below:
 
 ## Examples
 
+Opening the extension's onboarding page in new tab after the extension is installed for the first
+time. Must be called from a background context.
+
+```js
+chrome.runtime.onInstalled.addListener((reason) => {
+  if (reason === chrome.runtime.OnInstalledReason.INSTALL) {
+    chrome.tabs.create({
+      url: 'onboarding.html'
+    });
+  }
+});
+```
+
+Retrieve the user's currently focused tab. Requires Manifest V3. Cannot be used in a content
+script.
+
+```js
+async function getCurrentTab() {
+  let queryOptions = { active: true, currentWindow: true };
+  let [tab] = await chrome.tabs.query(queryOptions);
+  return tab;
+}
+```
+
+Content script asking a background script to navigate the current tab.
+
+```js
+// Content script
+function requestNavigation(url) {
+  chrome.runtime.sendMessage({ action: 'navigate', url });
+}
+
+// Background script
+chrome.runtime.onMessage.addListener(messageListener);
+
+function messageListener(request, sender, _sendResponse) {
+  if (request.action === 'navigate') {
+    // Sanitize URL in to guard against compromised content scripts
+    let url = new URL(request.url);
+    chrome.tabs.update(sender.tab.id, { url: url.toString() });
+  }
+}
+```
+
+### More samples
+
 ![Two tabs in a window](tabs.png)
 
-You can find simple examples of manipulating tabs with the `chrome.tabs` API in the
-[examples/api/tabs][7] directory. For other examples and for help in viewing the source code, see
-[Samples][8].
+More samples simple examples of manipulating tabs with the Tabs API can be found in the
+[mv2-archive/api/tabs][7] directory of the [chrome-extensions-samples][samples-repo] repository. For
+other examples and for help in viewing the source code, see [Samples][8].
 
 [1]: /docs/extensions/mv2/tabs
 [2]: #property-Tab-url
@@ -38,3 +84,5 @@ You can find simple examples of manipulating tabs with the `chrome.tabs` API in 
 [6]: #type-Tab
 [7]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/tabs/
 [8]: /docs/extensions/mv2/samples
+
+[samples-repo]: https://github.com/GoogleChrome/chrome-extensions-samples

--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -90,8 +90,7 @@ function toggleMuteState(tabId) {
 ### More samples
 
 For more examples that demonstrate the Tabs API, see the [mv2-archive/api/tabs][mv2-tabs-samples]
-directory of the [chrome-extensions-samples][samples-repo] repository. For other examples and for
-help in viewing the source code, see [Samples][mv2-samples].
+directory of the [chrome-extensions-samples][samples-repo] repository.
 
 [manifest]: /docs/extensions/mv3/manifest/
 [prop-url]: #property-Tab-url
@@ -100,5 +99,4 @@ help in viewing the source code, see [Samples][mv2-samples].
 [prop-favIconUrl]: #property-Tab-favIconUrl
 [tab]: #type-Tab
 [mv2-tabs-samples]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/tabs/
-[mv2-samples]: /docs/extensions/mv2/samples
 [samples-repo]: https://github.com/GoogleChrome/chrome-extensions-samples

--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -7,9 +7,9 @@ extra_permissions_html:
 ## Manifest
 
 You can use most `chrome.tabs` methods and events without declaring any permissions in the
-extension's [manifest][manifest] file. However, if you require access to the [`url`][prop-url], [`pendingUrl`][3],
-[`title`][prop-title], or [`favIconUrl`][prop-favIconUrl] properties of [`tabs.Tab`][tab], you must declare the `"tabs"`
-permission in the manifest, as shown below:
+extension's [manifest][manifest] file. However, if you require access to the [`url`][prop-url],
+[`pendingUrl`][3], [`title`][prop-title], or [`favIconUrl`][prop-favIconUrl] properties of
+[`tabs.Tab`][tab], you must declare the `"tabs"` permission in the manifest, as shown below:
 
 ```json
 {
@@ -28,7 +28,8 @@ The following sections demonstrate several common use cases for the chrome.tabs 
 
 ### Opening an extension page in a new tab
 
-A common pattern for extensions is to open an onboarding page in a new tab when the extension is installed. The following example shows how to do this.
+A common pattern for extensions is to open an onboarding page in a new tab when the extension is
+installed. The following example shows how to do this.
 
 {% Aside %} Cannot use `chrome.tabs.create()` in content scripts. {% endAside %}.
 
@@ -82,9 +83,9 @@ function toggleMuteState(tabId) {
 
 ### More samples
 
-For more examples that demonstrate the Tabs API, see the [mv2-archive/api/tabs][mv2-tabs-samples] directory of the
-[chrome-extensions-samples][samples-repo] repository. For other examples and for help in viewing the
-source code, see [Samples][mv2-samples].
+For more examples that demonstrate the Tabs API, see the [mv2-archive/api/tabs][mv2-tabs-samples]
+directory of the [chrome-extensions-samples][samples-repo] repository. For other examples and for
+help in viewing the source code, see [Samples][mv2-samples].
 
 [manifest]: /docs/extensions/mv3/manifest/
 [prop-url]: #property-Tab-url

--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -31,7 +31,9 @@ The following sections demonstrate several common use cases for the chrome.tabs 
 A common pattern for extensions is to open an onboarding page in a new tab when the extension is
 installed. The following example shows how to do this.
 
-{% Aside %} Cannot use `chrome.tabs.create()` in content scripts. {% endAside %}.
+{% Aside %}
+Cannot use `chrome.tabs.create()` in content scripts.
+{% endAside %}.
 
 ```js
 //// background.js
@@ -49,8 +51,10 @@ chrome.runtime.onInstalled.addListener((reason) => {
 
 This example demonstrates how the background script can retrieve the currently focused tab.
 
-{% Aside %} Requires Manifest V3 due to the use of Promises. Cannot use `tabs.query` in content
-scripts. {% endAside %}
+{% Aside %}
+Requires Manifest V3 due to the use of Promises. Cannot use `tabs.query` in content
+scripts.
+{% endAside %}
 
 ```js
 //// background.js
@@ -66,8 +70,10 @@ async function getCurrentTab() {
 
 This example shows how an extension can toggle the muted state for a given tab.
 
-{% Aside %} Requires Manifest V3 due to the use of Promises. Cannot use `tabs.get` or `tabs.update`
-in content scripts. {% endAside %}
+{% Aside %}
+Requires Manifest V3 due to the use of Promises. Cannot use `tabs.get` or `tabs.update`
+in content scripts.
+{% endAside %}
 
 ```js
 //// background.js

--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -32,8 +32,10 @@ A common pattern for extensions is to open an onboarding page in a new tab when 
 installed. The following example shows how to do this.
 
 {% Aside %}
-Cannot use `chrome.tabs.create()` in content scripts.
-{% endAside %}.
+
+Content scripts cannot use `chrome.tabs.create()`.
+
+{% endAside %}
 
 ```js
 //// background.js
@@ -52,8 +54,10 @@ chrome.runtime.onInstalled.addListener((reason) => {
 This example demonstrates how the background script can retrieve the currently focused tab.
 
 {% Aside %}
-Requires Manifest V3 due to the use of Promises. Cannot use `tabs.query` in content
-scripts.
+
+This example requires Manifest due to the use of [Promises][promises]. Additionally, content scripts
+cannot use `tabs.query`.
+
 {% endAside %}
 
 ```js
@@ -71,8 +75,10 @@ async function getCurrentTab() {
 This example shows how an extension can toggle the muted state for a given tab.
 
 {% Aside %}
-Requires Manifest V3 due to the use of Promises. Cannot use `tabs.get` or `tabs.update`
-in content scripts.
+
+Requires Manifest V3 due to the use of Promises. Content scripts cannot use `tabs.get` or
+`tabs.update`.
+
 {% endAside %}
 
 ```js
@@ -93,6 +99,7 @@ For more examples that demonstrate the Tabs API, see the [mv2-archive/api/tabs][
 directory of the [chrome-extensions-samples][samples-repo] repository.
 
 [manifest]: /docs/extensions/mv3/manifest/
+[promises]: /docs/extensions/mv3/promises/
 [prop-url]: #property-Tab-url
 [prop-pendingurl]: #property-Tab-pendingUrl
 [prop-title]: #property-Tab-title

--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -40,7 +40,11 @@ chrome.runtime.onInstalled.addListener((reason) => {
 });
 ```
 
-Retrieve the user's currently focused tab. Requires Manifest V3. Cannot be used in a content
+### Get the current tab
+
+This example demonstrates how the background script can retrieve the currently focused tab. {% Aside %} Requires Manifest V3. Cannot be used in a content script. {% end Aside %}
+
+{# Editor's note: what happened about converting this example to a promise with a note? #}
 script.
 
 ```js

--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -64,7 +64,9 @@ This example shows how a content script could ask the background script to navig
 function requestNavigation(url) {
   chrome.runtime.sendMessage({ action: 'navigate', url });
 }
+```
 
+```js
 // Background script
 chrome.runtime.onMessage.addListener(messageListener);
 

--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -28,7 +28,9 @@ The following sections demonstrate several common use cases for the chrome.tabs 
 
 ### Opening an extension page in a new tab
 
-A common pattern for extensions is to open an onboarding page in a new tab when the extension is installed. The following example shows how to do this. {% Aside %} Note that this code must be called from a background context, because tabs cannot use `chrome.tabs.create()`{% end Aside %}.
+A common pattern for extensions is to open an onboarding page in a new tab when the extension is installed. The following example shows how to do this.
+
+{% Aside %} Cannot use `chrome.tabs.create()` in content scripts. {% endAside %}.
 
 ```js
 //// background.js
@@ -44,9 +46,10 @@ chrome.runtime.onInstalled.addListener((reason) => {
 
 ### Get the current tab
 
-This example demonstrates how the background script can retrieve the currently focused tab. {% Aside %} Requires Manifest V3. Cannot be used in a content script. {% end Aside %}
+This example demonstrates how the background script can retrieve the currently focused tab.
 
-{# Editor's note: what happened about converting this example to a promise with a note? #}
+{% Aside %} Requires Manifest V3 due to the use of Promises. Cannot use `tabs.query` in content
+scripts. {% endAside %}
 
 ```js
 //// background.js

--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -31,6 +31,8 @@ The following sections demonstrate several common use cases for the chrome.tabs 
 A common pattern for extensions is to open an onboarding page in a new tab when the extension is installed. The following example shows how to do this. {% Aside %} Note that this code must be called from a background context, because tabs cannot use `chrome.tabs.create()`{% end Aside %}.
 
 ```js
+//// background.js
+
 chrome.runtime.onInstalled.addListener((reason) => {
   if (reason === chrome.runtime.OnInstalledReason.INSTALL) {
     chrome.tabs.create({
@@ -47,6 +49,8 @@ This example demonstrates how the background script can retrieve the currently f
 {# Editor's note: what happened about converting this example to a promise with a note? #}
 
 ```js
+//// background.js
+
 async function getCurrentTab() {
   let queryOptions = { active: true, currentWindow: true };
   let [tab] = await chrome.tabs.query(queryOptions);

--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -54,7 +54,10 @@ async function getCurrentTab() {
 }
 ```
 
-Content script asking a background script to navigate the current tab.
+### Request background script to navigate current tab
+
+This example shows how a content script could ask the background script to navigate the current tab.
+{# Editor's note: I'd like to frame this as a use case; is there an obvious one? #}
 
 ```js
 // Content script

--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -81,11 +81,9 @@ function messageListener(request, sender, _sendResponse) {
 
 ### More samples
 
-![Two tabs in a window](tabs.png)
-
-For more examples that demonstrate the Tabs API, see the
-[mv2-archive/api/tabs][7] directory of the [chrome-extensions-samples][samples-repo] repository. For
-other examples and for help in viewing the source code, see [Samples][8].
+For more examples that demonstrate the Tabs API, see the [mv2-archive/api/tabs][7] directory of the
+[chrome-extensions-samples][samples-repo] repository. For other examples and for help in viewing the
+source code, see [Samples][8].
 
 [1]: /docs/extensions/mv2/tabs
 [2]: #property-Tab-url

--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -7,8 +7,8 @@ extra_permissions_html:
 ## Manifest
 
 You can use most `chrome.tabs` methods and events without declaring any permissions in the
-extension's [manifest][1] file. However, if you require access to the [`url`][2], [`pendingUrl`][3],
-[`title`][4], or [`favIconUrl`][5] properties of [`tabs.Tab`][6], you must declare the `"tabs"`
+extension's [manifest][manifest] file. However, if you require access to the [`url`][prop-url], [`pendingUrl`][3],
+[`title`][prop-title], or [`favIconUrl`][prop-favIconUrl] properties of [`tabs.Tab`][tab], you must declare the `"tabs"`
 permission in the manifest, as shown below:
 
 ```json
@@ -82,17 +82,16 @@ function toggleMuteState(tabId) {
 
 ### More samples
 
-For more examples that demonstrate the Tabs API, see the [mv2-archive/api/tabs][7] directory of the
+For more examples that demonstrate the Tabs API, see the [mv2-archive/api/tabs][mv2-tabs-samples] directory of the
 [chrome-extensions-samples][samples-repo] repository. For other examples and for help in viewing the
-source code, see [Samples][8].
+source code, see [Samples][mv2-samples].
 
-[1]: /docs/extensions/mv2/tabs
-[2]: #property-Tab-url
-[3]: #property-Tab-pendingUrl
-[4]: #property-Tab-title
-[5]: #property-Tab-favIconUrl
-[6]: #type-Tab
-[7]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/tabs/
-[8]: /docs/extensions/mv2/samples
-
+[manifest]: /docs/extensions/mv3/manifest/
+[prop-url]: #property-Tab-url
+[prop-pendingUrl]: #property-Tab-pendingUrl
+[prop-title]: #property-Tab-title
+[prop-favIconUrl]: #property-Tab-favIconUrl
+[tab]: #type-Tab
+[mv2-tabs-samples]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/tabs/
+[mv2-samples]: /docs/extensions/mv2/samples
 [samples-repo]: https://github.com/GoogleChrome/chrome-extensions-samples

--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -83,7 +83,7 @@ function messageListener(request, sender, _sendResponse) {
 
 ![Two tabs in a window](tabs.png)
 
-More samples simple examples of manipulating tabs with the Tabs API can be found in the
+For more examples that demonstrate the Tabs API, see the
 [mv2-archive/api/tabs][7] directory of the [chrome-extensions-samples][samples-repo] repository. For
 other examples and for help in viewing the source code, see [Samples][8].
 

--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -24,8 +24,11 @@ permission in the manifest, as shown below:
 
 ## Examples
 
-Opening the extension's onboarding page in new tab after the extension is installed for the first
-time. Must be called from a background context.
+The following sections demonstrate several common use cases for the chrome.tabs API.
+
+### Opening an extension page in a new tab
+
+A common pattern for extensions is to open an onboarding page in a new tab when the extension is installed. The following example shows how to do this. {% Aside %} Note that this code must be called from a background context, because tabs cannot use `chrome.tabs.create()`{% end Aside %}.
 
 ```js
 chrome.runtime.onInstalled.addListener((reason) => {

--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -45,7 +45,6 @@ chrome.runtime.onInstalled.addListener((reason) => {
 This example demonstrates how the background script can retrieve the currently focused tab. {% Aside %} Requires Manifest V3. Cannot be used in a content script. {% end Aside %}
 
 {# Editor's note: what happened about converting this example to a promise with a note? #}
-script.
 
 ```js
 async function getCurrentTab() {

--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -54,28 +54,22 @@ async function getCurrentTab() {
 }
 ```
 
-### Request background script to navigate current tab
+### Mute the specified tab
 
-This example shows how a content script could ask the background script to navigate the current tab.
-{# Editor's note: I'd like to frame this as a use case; is there an obvious one? #}
+This example shows how an extension can toggle the muted state for a given tab.
 
-```js
-// Content script
-function requestNavigation(url) {
-  chrome.runtime.sendMessage({ action: 'navigate', url });
-}
-```
+{% Aside %} Requires Manifest V3 due to the use of Promises. Cannot use `tabs.get` or `tabs.update`
+in content scripts. {% endAside %}
 
 ```js
-// Background script
-chrome.runtime.onMessage.addListener(messageListener);
+//// background.js
 
-function messageListener(request, sender, _sendResponse) {
-  if (request.action === 'navigate') {
-    // Sanitize URL in to guard against compromised content scripts
-    let url = new URL(request.url);
-    chrome.tabs.update(sender.tab.id, { url: url.toString() });
-  }
+function toggleMuteState(tabId) {
+  chrome.tabs.get(tabId, async (tab) => {
+    let muted = !tab.mutedInfo.muted;
+    await chrome.tabs.update(tabId, { muted });
+    console.log(`Tab ${tab.id} is ${ muted ? 'muted' : 'unmuted' }`);
+  });
 }
 ```
 


### PR DESCRIPTION
Adds 3 examples of common operations that developers want to perform to the Tabs API reference page.