### PR TITLE
Follow-up tweaks to promises page

### DIFF
--- a/site/en/docs/extensions/mv3/promises/index.md
+++ b/site/en/docs/extensions/mv3/promises/index.md
@@ -29,7 +29,7 @@ operation. For more about promises and their use, see the MDN documentation on
 ## Introduction
 
 Promises were introduced into Chrome not long after they were included in the ES6 specification.
-They are an important feature of modern JavaScript, providing several benefits, such as:
+They are an important feature of modern JavaScript, providing benefits such as:
 
 * Streamlined error handling
 * Coding in a synchronous style for invoking asynchronous functions
@@ -140,7 +140,8 @@ function openTabOnRight() {
 
 ### Error handling
 
-Returning errors works differently depending on if the extension is using a callback or a promise.
+Returning errors works differently depending on whether the extension is using a callback or a
+promise.
 
 #### Error handling with callbacks
 
@@ -179,7 +180,7 @@ promise.
 Extensions APIs don't set `chrome.runtime.lastError` with promises.
 {% endAside %}
 
-This form of error notification also lets you write async logic in a more synchronous style.
+This form of error notification also helps you write async logic in a more synchronous style.
 
 ### Using async/await
 

--- a/site/en/docs/extensions/mv3/promises/index.md
+++ b/site/en/docs/extensions/mv3/promises/index.md
@@ -137,13 +137,12 @@ function openTabOnRight() {
 ```
 
 
-<!-- notes here about the code fragments -->
 
 ### Error handling
 
 Returning errors works differently depending on if the extension is using a callback or a promise.
 
-#### Error handling with Callbacks
+#### Error handling with callbacks
 
 If using a callback, then `chrome.runtime.lastError` is set for the duration of the execution of the
 callback. It is not thrown as a JS Error (which would interrupt JS execution), and is not set
@@ -157,6 +156,8 @@ chrome.tabs.create({...}, (result) => {
   }
 });
 ```
+
+#### Error handling with promises
 
 Promises are designed to deliver asynchronous results, both success and failure.  A failure in a
 promise (a promise rejection) is handled differently.  It might look like this:

--- a/site/en/docs/extensions/mv3/promises/index.md
+++ b/site/en/docs/extensions/mv3/promises/index.md
@@ -23,7 +23,7 @@ calling these methods.
 {% Aside "key-term" %}
 A *promise* is a JavaScript object that represents the eventual outcome of an asynchronous
 operation. For more about promises and their use, see the MDN documentation on
-[using promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises).
+[using promises][mdn-promises].
 {% endAside %}
 
 ## Introduction
@@ -137,7 +137,6 @@ function openTabOnRight() {
 ```
 
 
-
 ### Error handling
 
 Returning errors works differently depending on whether the extension is using a callback or a
@@ -173,18 +172,21 @@ chrome.tabs.create({...})
   });
 ```
 
-Instead of setting `chrome.runtime.lastError`, we deliver the error directly to the "catch" of the
-promise.
+Extensions APIs don't set `chrome.runtime.lastError` when you use a promise, instead returning the
+error as an argument to the function in the catch().
 
 {% Aside %}
-Extensions APIs don't set `chrome.runtime.lastError` with promises.
+In simpler cases with a single promise, you can instead supply your error handler as the second
+parameter to `.then()` instead of chaining to a `.catch()`. For more about this topic, see this [MDN
+article on chained promises][mdn-promise-chain].
 {% endAside %}
 
-This form of error notification also helps you write async logic in a more synchronous style.
+Regardless of which syntax you use, this form of error notification also helps you write async logic
+in a more synchronous style.
 
 ### Using async/await
 
-JavaScript provides async/await as syntactic sugar on top of promises, letting you code in a more
+JavaScript also provides async/await as syntactic sugar on top of promises, letting you code in a more
 imperative style. The following example shows how to implement the [example shown
 earlier](#compare-to-callback) using async/await:
 
@@ -211,3 +213,6 @@ async function openTabOnRight() {
 {% Aside %}
 Note that `await` is only valid in async functions and the top-level bodies of modules.
 {% endAside %}
+
+[mdn-promise-chain]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#chained_promises
+[mdn-promises]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises

--- a/site/en/docs/extensions/mv3/promises/index.md
+++ b/site/en/docs/extensions/mv3/promises/index.md
@@ -173,7 +173,7 @@ chrome.tabs.create({...})
 ```
 
 Extensions APIs don't set `chrome.runtime.lastError` when you use a promise, instead returning the
-error as an argument to the function in the catch().
+error as an argument to the function in the `.catch()`.
 
 {% Aside %}
 In simpler cases with a single promise, you can instead supply your error handler as the second
@@ -181,8 +181,8 @@ parameter to `.then()` instead of chaining to a `.catch()`. For more about this 
 article on chained promises][mdn-promise-chain].
 {% endAside %}
 
-Regardless of which syntax you use, this form of error notification also helps you write async logic
-in a more synchronous style.
+Whether you receive the error using `.catch()` or the optional second parameter of `.then()`,
+this form of error handling helps you write async logic in a more synchronous style.
 
 ### Using async/await
 

--- a/site/en/docs/extensions/mv3/promises/index.md
+++ b/site/en/docs/extensions/mv3/promises/index.md
@@ -172,8 +172,8 @@ chrome.tabs.create({...})
   });
 ```
 
-Extensions APIs don't set `chrome.runtime.lastError` when you use a promise, instead returning the
-error as an argument to the function in the `.catch()`.
+Extensions APIs don't set `chrome.runtime.lastError` when you use a promise; instead they provide
+the error as an argument to the function in the `.catch()`.
 
 {% Aside %}
 In simpler cases with a single promise, you can instead supply your error handler as the second


### PR DESCRIPTION
Some additional cleanup of the new promises page:

- Missing heading: There's a heading "Error handling with callbacks" that introduces the callback version, but the promises version that follows it has no intervening heading.

- There are a few opportunities for minor phrasing improvements.
