### PR TITLE
Don't resize SVGs

### DIFF
--- a/site/_shortcodes/Img.js
+++ b/site/_shortcodes/Img.js
@@ -50,22 +50,31 @@ const Img = function (args) {
     lazy = true;
   }
 
-  // https://docs.imgix.com/apis/rendering
-  params = {auto: 'format', ...params};
-  // https://github.com/imgix/imgix-core-js#imgixclientbuildsrcsetpath-params-options
-  options = {
-    minWidth: 200,
-    maxWidth: 1600,
-    widthTolerance: 0.07,
-    ...options,
-  };
+  let srcset = '';
 
-  const srcset = client.buildSrcSet(src, params, options);
-  if (sizes === undefined) {
-    if (widthAsNumber >= MAX_WIDTH) {
-      sizes = `(min-width: ${MAX_WIDTH}px) ${MAX_WIDTH}px, calc(100vw - 48px)`;
-    } else {
-      sizes = `(min-width: ${widthAsNumber}px) ${widthAsNumber}px, calc(100vw - 48px)`;
+  // If this is a SVG, then don't run imgix's rewrite path. As of March 2021, imgix won't render
+  // inline PNGs inside these SVGs, so many of devtools' images fail to display.
+  // In the long term, these should be replaced with pure PNGs so we can benefit from the CDN.
+  const isSvg = src.endsWith('.svg');
+  if (!isSvg) {
+    // https://docs.imgix.com/apis/rendering
+    params = {auto: 'format', ...params};
+
+    // https://github.com/imgix/imgix-core-js#imgixclientbuildsrcsetpath-params-options
+    const srcsetOptions = {
+      minWidth: 200,
+      maxWidth: 1600,
+      widthTolerance: 0.07,
+      ...options,
+    };
+
+    srcset = client.buildSrcSet(src, params, srcsetOptions);
+    if (sizes === undefined) {
+      if (widthAsNumber >= MAX_WIDTH) {
+        sizes = `(min-width: ${MAX_WIDTH}px) ${MAX_WIDTH}px, calc(100vw - 48px)`;
+      } else {
+        sizes = `(min-width: ${widthAsNumber}px) ${widthAsNumber}px, calc(100vw - 48px)`;
+      }
     }
   }
 

--- a/site/en/docs/devtools/network/reference/index.md
+++ b/site/en/docs/devtools/network/reference/index.md
@@ -32,9 +32,8 @@ By default, DevTools records all network requests in the Network panel, so long 
 To stop recording requests:
 
 - Click **Stop recording network log**
-  ![Stop recording network
-log](/docs/devtools/network/imgs/record-on.png) on the Network
-  panel. It turns grey to indicate that DevTools is no longer recording requests.
+  {% Img src="image/QMjXarRXcMarxQddwrEdPvHVM242/20E6CLcSzNV2GELQu7oC.png", alt="Stop recording network", width="18", height="18" %}
+  on the Network panel. It turns grey to indicate that DevTools is no longer recording requests.
 - Press Command+E (Mac) or Control+E (Windows, Linux) while the Network panel is in focus.
 
 ### Clear requests {: #clear }


### PR DESCRIPTION
Fixes #557.

See comment, but basically, imgix can't render these SVGs. They don't really make sense as SVGs to begin with, though: the embedded PNGs clearly have a known fixed size, so ideally we would re-render them as purely a PNG and then change them all.

This fixes the immediate issue though.