### PR TITLE
Remove conditional logic from MV2 legacy page prompt

### DIFF
--- a/site/_includes/partials/extensions/mv2-legacy-page.md
+++ b/site/_includes/partials/extensions/mv2-legacy-page.md
@@ -1,17 +1,5 @@
-{% if process.env.HAS_MV3 %}
-
 {% Aside 'warning' %}
 The page you're viewing describes extensions using Manifest V2. Now that
 [Manifest V3 has launched](/docs/extensions/mv3/intro), we strongly recommend
 that you use it for any new extensions that you create.
 {% endAside %}
-
-{% else %}
-
-{% Aside %}
-Manifest V3 is launching soon! See [the MV3 documentation](/docs/extensions/mv3/intro)
-for more information, and consider developing your extension in MV3.
-{% endAside %}
-
-
-{% endif %}


### PR DESCRIPTION
Updates the prompt on MV2 pages to reflect that MV3 is in stable.