### PR TITLE
Link MV2 docs to their MV3 counterparts

### DIFF
--- a/site/_includes/partials/extensions/mv2-legacy-page.md
+++ b/site/_includes/partials/extensions/mv2-legacy-page.md
@@ -1,5 +1,17 @@
+{% set found = false %}
+{% set mv3url = page.url | replace('/mv2/', '/mv3/') %}
+{% for item in collections.all %}
+  {% if item.url == mv3url %}
+    {% set found = true %}
+  {% endif %}
+{% endfor %}
+
 {% Aside 'warning' %}
 The page you're viewing describes extensions using Manifest V2. Now that
 [Manifest V3 has launched](/docs/extensions/mv3/intro), we strongly recommend
 that you use it for any new extensions that you create.
+
+{% if found %}
+[Click here]({{ mv3url }}) for the MV3 version of this page.
+{% endif %}
 {% endAside %}


### PR DESCRIPTION
Issue #576 noted that MV2 docs don't actually link to the MV3 versions of the same material. This PR aims to address that by adding some additional text to the deprecation warning that links the user to the appropriate MV3 page.

The initial implementation here is largely for discussion purposes. Credit to @robdodson on most of the heavy lifting here.