### PR TITLE
Add clearer instructions for Auto-open DevTools

### DIFF
--- a/site/en/docs/devtools/open/index.md
+++ b/site/en/docs/devtools/open/index.md
@@ -55,7 +55,9 @@ Mac:
 /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --auto-open-devtools-for-tabs
 ```
 
-Will only work if an instance of Chrome is not already running. From then on, every new tab will automatically open DevTools until user fully quits Chrome <kbd>Command</kbd>+<kbd>Q</kbd>.
+This will only work if an instance of Chrome is not already running. From then
+on, every new tab will automatically open DevTools until the user fully quits
+Chrome.
 
 [1]: /docs/devtools/css
 [2]: /docs/devtools/console/get-started

--- a/site/en/docs/devtools/open/index.md
+++ b/site/en/docs/devtools/open/index.md
@@ -55,5 +55,7 @@ Mac:
 /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --auto-open-devtools-for-tabs
 ```
 
+Will only work if an instance of Chrome is not already running. From then on, every new tab will automatically open DevTools until user fully quits Chrome <kbd>Command</kbd>+<kbd>Q</kbd>.
+
 [1]: /docs/devtools/css
 [2]: /docs/devtools/console/get-started


### PR DESCRIPTION
Changes proposed in this pull request:

-If an instance of chrome is already running, using the auto-open command will not work as intended.
-If closing all tabs and browsers, new windows will still auto-open DevTools on each new tab unless fully quitting Chrome first.