### PR TITLE
Service worker migration cleanup

### DIFF
--- a/site/en/docs/extensions/mv3/migrating_to_service_workers/index.md
+++ b/site/en/docs/extensions/mv3/migrating_to_service_workers/index.md
@@ -49,6 +49,7 @@ The below snippet shows how an existing extension initializes its browser action
 persistent background page.
 
 ```js
+//// background.js
 chrome.storage.local.get(["badgeText"], ({ badgeText }) => {
   chrome.action.setBadgeText({ text: badgeText });
 
@@ -68,6 +69,7 @@ that Chrome will be able to immediately find and invoke your action's click hand
 extension hasn't finished executing its async startup logic.
 
 ```js
+//// background.js
 chrome.storage.local.get(["badgeText"], ({ badgeText }) => {
   chrome.action.setBadgeText({ text: badgeText });
 });
@@ -93,6 +95,7 @@ This example is taken from a simple manifest version 2 extension that receives a
 content script and persists it in a global variable for later use.
 
 ```js
+//// background.js
 let name = undefined;
 
 chrome.runtime.onMessage.addListener(({ type, name }) => {
@@ -113,6 +116,7 @@ set name will have been lost and name variable will again be undefined.
 We can fix this bug by treating the [Storage APIs][storage] as our source of truth.
 
 ```js
+//// background.js
 chrome.runtime.onMessage.addListener(({ type, name }) => {
   if (type === "set-name") {
     chrome.storage.local.set({ name });
@@ -138,6 +142,7 @@ It's common for web developers to perform delayed or periodic operations using t
 cancel the timers when the service worker is terminated.
 
 ```js
+//// background.js
 const TIMEOUT = 3 * 60 * 1000; // 3 minutes in milliseconds
 window.setTimeout(() => {
   chrome.action.setIcon({
@@ -150,6 +155,7 @@ Instead, we can use the [Alarms API][alarms]. Like other listeners, alarm listen
 registered in the top level of your script.
 
 ```js
+//// background.js
 chrome.alarms.create({ delayInMinutes: 3 });
 
 chrome.alarms.onAlarm.addListener(() => {
@@ -202,6 +208,7 @@ create and cache assets. While service workers don't have access to DOM and ther
 `<canvas>` elements, service workers do have access to the [OffscreenCanvas API][17].
 
 ```js
+//// background.js
 function buildCanvas(width, height) {
   const canvas = document.createElement("canvas");
   canvas.width = width;
@@ -215,6 +222,7 @@ migrate to offscreen canvas, replace `document.createElement('canvas')` with `ne
 OffscreenCanvas(width, height)`.
 
 ```js
+//// background.js
 function buildCanvas(width, height) {
   const canvas = new OffscreenCanvas(width, height);
   return canvas;

--- a/site/en/docs/extensions/mv3/migrating_to_service_workers/index.md
+++ b/site/en/docs/extensions/mv3/migrating_to_service_workers/index.md
@@ -52,7 +52,7 @@ persistent background page.
 chrome.storage.local.get(["badgeText"], ({ badgeText }) => {
   chrome.action.setBadgeText({ text: badgeText });
 
-  // Listener is registered asynchronously.
+  // Listener is registered asynchronously
   chrome.action.onClicked.addListener(handleActionClick);
 });
 ```
@@ -72,7 +72,7 @@ chrome.storage.local.get(["badgeText"], ({ badgeText }) => {
   chrome.action.setBadgeText({ text: badgeText });
 });
 
-// Listener is registered on on startup.
+// Listener is registered on startup
 chrome.action.onClicked.addListener(handleActionClick);
 ```
 
@@ -150,7 +150,7 @@ Instead, we can use the [Alarms API][alarms]. Like other listeners, alarm listen
 registered in the top level of your script.
 
 ```js
-chrome.alarms.create({ delayInMinutes: 3.0 });
+chrome.alarms.create({ delayInMinutes: 3 });
 
 chrome.alarms.onAlarm.addListener(() => {
   chrome.action.setIcon({


### PR DESCRIPTION
This PR is primarily intended for discussion purposes. It introduces two primary changes:

1. Remove the terminal period from one-sentence comments in JS
2. Add a comment to JS blocks to indicate where the example might live

@awfuchs, I'd like to get your thoughts on these changes and the adoption of these patterns across other documentation pages.

(1) is largely personal preference and reflects my personal style. The broader question this touches on is whether or not code comments in both inline snippets and our examples repo should always conform to standard English grammar.

(2) The initial motivation for this change was seeing an exchange where one developer included a code snippet in their comment, but it wasn't clear from the developer's comment where that snippet would be used. While in the context of this page I think it's clear, in another page (e.g. message passing) it may not be. 