### PR TITLE
Geolocation descriptor and option value changed

### DIFF
--- a/site/en/docs/devtools/device-mode/index.md
+++ b/site/en/docs/devtools/device-mode/index.md
@@ -238,7 +238,7 @@ Menu, type `Sensors`, and then select **Show Sensors**.
 
 **Figure 23**. Show Sensors
 
-Select one of the presets from the **Geolocation** list, or select **Custom location** to enter your
+Select one of the presets from the **Location** list, or select **Other...** to enter your
 own coordinates, or select **Location unavailable** to test out how your page behaves when
 geolocation is in an error state.
 


### PR DESCRIPTION
Here are the screenshots for reference. Figure 24 shows 'Geolocation'
<img width="278" alt="Screen Shot 2021-04-06 at 5 19 38 PM" src="https://user-images.githubusercontent.com/70674855/113794091-9e804c80-96fe-11eb-8c9b-5dbcfc33c0f1.png">

when console now shows 'Location'
<img width="461" alt="Screen Shot 2021-04-06 at 5 12 07 PM" src="https://user-images.githubusercontent.com/70674855/113794130-b8219400-96fe-11eb-9833-834247a7be53.png">

And here, option value has been changed to 'Other...'
<img width="428" alt="Screen Shot 2021-04-06 at 5 12 17 PM" src="https://user-images.githubusercontent.com/70674855/113794205-ddae9d80-96fe-11eb-9c56-83946bc25fa9.png">


