### PR TITLE
Runtime API examples

### DIFF
--- a/site/en/docs/extensions/reference/runtime/index.md
+++ b/site/en/docs/extensions/reference/runtime/index.md
@@ -4,13 +4,15 @@ api: runtime
 
 ## Examples
 
-### Use [`getURL`][getURL] to add an extension image to a page {: #example-getURL }
+### Use [`getURL`][getURL] to add an extension image to a page {: #example-get-url }
 
-Extensions can access their own resources using relative paths, but in order for the extension's
-assets to appear in a web page, you will need to specify the full URL of the asset (and expose it
-using the [web_accessible_resources][war] field).
+In order for a web page to access an asset hosted on another domain, it must specify the resource's
+full URL (e.g. `<img src-"https://example.com/logo.png">`). The same is true for when a web page
+wants to include assets included in an extension. The two main differences here are that the
+extension's assets must be exposed as [web_accessible_resources][war] and that typically content
+scripts are responsible for injecting extension assets.
 
-This example shows how a [content script][content] could add an image in the extension's package to
+This example shows how a [content script][content] can add an image in the extension's package to
 the page that the content script has been [injected][content-inject] into.
 
 ```js

--- a/site/en/docs/extensions/reference/runtime/index.md
+++ b/site/en/docs/extensions/reference/runtime/index.md
@@ -9,7 +9,7 @@ api: runtime
 In order for a web page to access an asset hosted on another domain, it must specify the resource's
 full URL (e.g. `<img src-"https://example.com/logo.png">`). The same is true for when a web page
 wants to include assets included in an extension. The two main differences here are that the
-extension's assets must be exposed as [web_accessible_resources][war] and that typically content
+extension's assets must be exposed as [web accessible resources][war] and that typically content
 scripts are responsible for injecting extension assets.
 
 This example shows how a [content script][content] can add an image in the extension's package to

--- a/site/en/docs/extensions/reference/runtime/index.md
+++ b/site/en/docs/extensions/reference/runtime/index.md
@@ -63,33 +63,21 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 });
 ```
 
-### Getting an extension's key from it's manifest {: #example-key }
+### Gathering feedback on uninstall {: #example-uninstall-url }
 
-When building an extension, there are occasionally times where you may need your unpacked extension
-to have the same extension ID as your production version. For example, [Google OAuth][oauth]
-identifies extensions by their IDs.
+Many extensions use post-uninstall surveys to understand how the extension could better serve its
+users and improve retention. The below example shows how one can add this functionality to their
+extension.
 
-
-Sometimes during development you may need the development version of your extension to have the same
-extension ID as the production version of your extension.
-
-production extension's [public key][key-prop].
-
-
-
-The following example shows a snippet that retrieves the public key; you can execute this in the
-DevTools console...
-
-
-
-Retrieve a production extension's [public key][key-prop] for use in development. Execute this
-snippet in a DevTools console for the production extension to copy the extension's key to your
-clipboard, then open your unpacked extension's manifest.json and paste the key on a new line.
 
 ```js
-//// DevTools console for a published extension
-copy(`"key": "${chrome.runtime.getManifest().key}"`)
+chrome.runtime.onInstalled.addListener(reason => {
+  if (reason === chrome.runtime.OnInstalledReason.INSTALL) {
+    chrome.runtime.setUninstallURL('https://example.com/extension-survey');
+  }
+});
 ```
+
 
 [content-inject]: https://developer.chrome.com/docs/extensions/mv3/content_scripts/#functionality
 [content]: /docs/extensions/mv3/content_scripts/

--- a/site/en/docs/extensions/reference/runtime/index.md
+++ b/site/en/docs/extensions/reference/runtime/index.md
@@ -27,9 +27,13 @@ the page that the content script has been [injected][content-inject] into.
 
 ### Getting background data into a content script {: #example-content-msg }
 
-Extensions often need to load data such as user settings or application state in a page shortly
-after a content script is injected. This example shows a simple pattern where a page's content
-script requests data and the background replies.
+It's common for an extension's content scripts to need data managed by another part of the
+extension, like the extension's background script. Much like two browser windows opened to the same
+web page, these two contexts cannot directly access each other's values. Instead, the page and background can use [message passing][message-passing] to coordinate with each other.
+
+In this example, the content script needs some data from the extension's background script in order
+to initialize it's UI. To get this data, it passes a `get-user-data` message to the background, and
+the background responds with a copy of the user's information.
 
 ```js
 //// content.js ////
@@ -37,6 +41,7 @@ script requests data and the background replies.
 // 1. Send the background a message requesting the user's data
 chrome.runtime.sendMessage('get-user-data', (response) => {
   // 3. Got an asynchronous response with the data from the background
+  console.log('received user data', response);
   initializeUI(response);
 });
 ```
@@ -50,7 +55,7 @@ let user = {
 }
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  // 2. A page requested user data, respond with a copy of the user object
+  // 2. A page requested user data, respond with a copy of `user`
   if (message === 'get-user-data') {
     sendResponse(user);
   }
@@ -68,9 +73,10 @@ clipboard, then open your unpacked extension's manifest.json and paste the key o
 copy(`"key": "${chrome.runtime.getManifest().key}"`)
 ```
 
-[content]: /docs/extensions/mv3/content_scripts/
 [content-inject]: https://developer.chrome.com/docs/extensions/mv3/content_scripts/#functionality
+[content]: /docs/extensions/mv3/content_scripts/
 [get-url]: #method-getURL
 [handshake]: https://en.wikipedia.org/wiki/Transmission_Control_Protocol#Connection_establishment
 [key-prop]: /docs/extensions/mv3/manifest/key/
+[message-passing]: /docs/extensions/mv3/messaging/
 [war]: /docs/extensions/mv3/manifest/web_accessible_resources/

--- a/site/en/docs/extensions/reference/runtime/index.md
+++ b/site/en/docs/extensions/reference/runtime/index.md
@@ -29,8 +29,8 @@ the page that the content script has been [injected][content-inject] into.
 
 It's common for an extension's content scripts to need data managed by another part of the
 extension, like the extension's background script. Much like two browser windows opened to the same
-web page, these two contexts cannot directly access each other's values. Instead, the page and
-background can use [message passing][message-passing] to coordinate with each other.
+web page, these two contexts cannot directly access each other's values. Instead, the extension can
+use [message passing][message-passing] to coordinate across these different contexts.
 
 In this example, the content script needs some data from the extension's background script in order
 to initialize it's UI. To get this data, it passes a `get-user-data` message to the background, and

--- a/site/en/docs/extensions/reference/runtime/index.md
+++ b/site/en/docs/extensions/reference/runtime/index.md
@@ -65,6 +65,23 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
 ### Getting an extension's key from it's manifest {: #example-key }
 
+When building an extension, there are occasionally times where you may need your unpacked extension
+to have the same extension ID as your production version. For example, [Google OAuth][oauth]
+identifies extensions by their IDs.
+
+
+Sometimes during development you may need the development version of your extension to have the same
+extension ID as the production version of your extension.
+
+production extension's [public key][key-prop].
+
+
+
+The following example shows a snippet that retrieves the public key; you can execute this in the
+DevTools console...
+
+
+
 Retrieve a production extension's [public key][key-prop] for use in development. Execute this
 snippet in a DevTools console for the production extension to copy the extension's key to your
 clipboard, then open your unpacked extension's manifest.json and paste the key on a new line.
@@ -80,4 +97,5 @@ copy(`"key": "${chrome.runtime.getManifest().key}"`)
 [handshake]: https://en.wikipedia.org/wiki/Transmission_Control_Protocol#Connection_establishment
 [key-prop]: /docs/extensions/mv3/manifest/key/
 [message-passing]: /docs/extensions/mv3/messaging/
+[oauth]: https://developer.chrome.com/docs/extensions/mv3/tut_oauth/
 [war]: /docs/extensions/mv3/manifest/web_accessible_resources/

--- a/site/en/docs/extensions/reference/runtime/index.md
+++ b/site/en/docs/extensions/reference/runtime/index.md
@@ -29,7 +29,8 @@ the page that the content script has been [injected][content-inject] into.
 
 It's common for an extension's content scripts to need data managed by another part of the
 extension, like the extension's background script. Much like two browser windows opened to the same
-web page, these two contexts cannot directly access each other's values. Instead, the page and background can use [message passing][message-passing] to coordinate with each other.
+web page, these two contexts cannot directly access each other's values. Instead, the page and
+background can use [message passing][message-passing] to coordinate with each other.
 
 In this example, the content script needs some data from the extension's background script in order
 to initialize it's UI. To get this data, it passes a `get-user-data` message to the background, and

--- a/site/en/docs/extensions/reference/runtime/index.md
+++ b/site/en/docs/extensions/reference/runtime/index.md
@@ -4,11 +4,11 @@ api: runtime
 
 ## Examples
 
-### Use [`getURL`][getURL] to add an extension image to a page
+### Use [`getURL`][getURL] to add an extension image to a page {: #example-getURL }
 
 Extensions can access their own resources using relative paths, but in order for the extension's
-assets to appear in a web page, you will need to specify the fully URL of the asset (and expose it
-using [web_accessible_resources][war]).
+assets to appear in a web page, you will need to specify the full URL of the asset (and expose it
+using the [web_accessible_resources][war] field).
 
 This example shows how a [content script][content] could add an image in the extension's package to
 the page that the content script has been [injected][content-inject] into.
@@ -22,6 +22,8 @@ the page that the content script has been [injected][content-inject] into.
   document.body.append(img);
 }
 ```
+
+### Use runtime messaging to communicate between background and content scripts {: #example-background-content-messaging }
 
 A basic example of content script injected into a page and background script passing messages to
 each other. This exchange is modeled on a [TCP handshake][handshake].
@@ -60,6 +62,8 @@ chrome.runtime.onMessage.addListener((message, sender) => {
   }
 });
 ```
+
+### Getting an extension's key from it's manifest {: #example-key }
 
 Retrieve a production extension's [public key][key-prop] for use in development. Execute this snippet in a DevTools console for the production extension paste the value in your unpacked extension's manifest.json.
 

--- a/site/en/docs/extensions/reference/runtime/index.md
+++ b/site/en/docs/extensions/reference/runtime/index.md
@@ -4,7 +4,7 @@ api: runtime
 
 ## Examples
 
-### Use [`getURL`][getURL] to add an extension image to a page {: #example-get-url }
+### Use [`getURL`][get-url] to add an extension image to a page {: #example-get-url }
 
 In order for a web page to access an asset hosted on another domain, it must specify the resource's
 full URL (e.g. `<img src-"https://example.com/logo.png">`). The same is true for when a web page
@@ -70,7 +70,7 @@ copy(`"key": "${chrome.runtime.getManifest().key}"`)
 
 [content]: /docs/extensions/mv3/content_scripts/
 [content-inject]: https://developer.chrome.com/docs/extensions/mv3/content_scripts/#functionality
-[getURL]: #method-getURL
+[get-url]: #method-getURL
 [handshake]: https://en.wikipedia.org/wiki/Transmission_Control_Protocol#Connection_establishment
 [key-prop]: /docs/extensions/mv3/manifest/key/
 [war]: /docs/extensions/mv3/manifest/web_accessible_resources/

--- a/site/en/docs/extensions/reference/runtime/index.md
+++ b/site/en/docs/extensions/reference/runtime/index.md
@@ -2,18 +2,24 @@
 api: runtime
 ---
 
-<!-- Intentionally blank -->
-
 ## Examples
 
-Using a content script to inject an extension asset on a page.
+### Use [`getURL`][getURL] to add an extension image to a page
+
+Extensions can access their own resources using relative paths, but in order for the extension's
+assets to appear in a web page, you will need to specify the fully URL of the asset (and expose it
+using [web_accessible_resources][war]).
+
+This example shows how a [content script][content] could add an image in the extension's package to
+the page that the content script has been [injected][content-inject] into.
 
 ```js
 //// content.js
+
 { // Block used to avoid setting global variables
-  let el = document.createElement('img');
-  el.src = chrome.runtime.getURL('logo.png');
-  document.body.append(el);
+  let img = document.createElement('img');
+  img.src = chrome.runtime.getURL('logo.png');
+  document.body.append(img);
 }
 ```
 
@@ -21,7 +27,8 @@ A basic example of content script injected into a page and background script pas
 each other. This exchange is modeled on a [TCP handshake][handshake].
 
 ```js
-//// content.js
+//// content.js ////
+
 // 1. Send the background a message requesting receipt confirmation.
 console.log('[content] sending content-syn');
 chrome.runtime.sendMessage('content-syn');
@@ -34,8 +41,11 @@ chrome.runtime.onMessage.addListener((message, sender) => {
     chrome.runtime.sendMessage('content-ack');
   }
 });
+```
 
-//// background.js
+```js
+//// background.js ////
+
 chrome.runtime.onMessage.addListener((message, sender) => {
   if (message.type === 'content-syn') {
     // 2. Content syn received, acknowledge receipt & request confirmation.
@@ -58,6 +68,9 @@ Retrieve a production extension's [public key][key-prop] for use in development.
 copy(`"key": "${chrome.runtime.getManifest().key}"`)
 ```
 
+[content]: /docs/extensions/mv3/content_scripts/
+[content-inject]: https://developer.chrome.com/docs/extensions/mv3/content_scripts/#functionality
+[getURL]: #method-getURL
 [handshake]: https://en.wikipedia.org/wiki/Transmission_Control_Protocol#Connection_establishment
-[key-prop]: https://developer.chrome.com/docs/extensions/mv3/manifest/key/
-
+[key-prop]: /docs/extensions/mv3/manifest/key/
+[war]: /docs/extensions/mv3/manifest/web_accessible_resources/

--- a/site/en/docs/extensions/reference/runtime/index.md
+++ b/site/en/docs/extensions/reference/runtime/index.md
@@ -16,10 +16,10 @@ This example shows how a [content script][content] can add an image in the exten
 the page that the content script has been [injected][content-inject] into.
 
 ```js
-//// content.js
+//// content.js ////
 
 { // Block used to avoid setting global variables
-  let img = document.createElement('img');
+  let const = document.createElement('img');
   img.src = chrome.runtime.getURL('logo.png');
   document.body.append(img);
 }
@@ -27,13 +27,13 @@ the page that the content script has been [injected][content-inject] into.
 
 ### Getting background data into a content script {: #example-content-msg }
 
-It's common for an extension's content scripts to need data managed by another part of the
-extension, like the extension's background script. Much like two browser windows opened to the same
-web page, these two contexts cannot directly access each other's values. Instead, the extension can
-use [message passing][message-passing] to coordinate across these different contexts.
+Its common for an extension's content scripts to need data managed by another part of the extension,
+like the extension's background script. Much like two browser windows opened to the same web page,
+these two contexts cannot directly access each other's values. Instead, the extension can use
+[message passing][message-passing] to coordinate across these different contexts.
 
 In this example, the content script needs some data from the extension's background script in order
-to initialize it's UI. To get this data, it passes a `get-user-data` message to the background, and
+to initialize its UI. To get this data, it passes a `get-user-data` message to the background, and
 the background responds with a copy of the user's information.
 
 ```js
@@ -51,9 +51,9 @@ chrome.runtime.sendMessage('get-user-data', (response) => {
 //// background.js ////
 
 // Example of a simple user data object
-let user = {
+const user = {
   username: 'demo-user'
-}
+};
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   // 2. A page requested user data, respond with a copy of `user`

--- a/site/en/docs/extensions/reference/runtime/index.md
+++ b/site/en/docs/extensions/reference/runtime/index.md
@@ -3,3 +3,61 @@ api: runtime
 ---
 
 <!-- Intentionally blank -->
+
+## Examples
+
+Using a content script to inject an extension asset on a page.
+
+```js
+//// content.js
+{ // Block used to avoid setting global variables
+  let el = document.createElement('img');
+  el.src = chrome.runtime.getURL('logo.png');
+  document.body.append(el);
+}
+```
+
+A basic example of content script injected into a page and background script passing messages to
+each other. This exchange is modeled on a [TCP handshake][handshake].
+
+```js
+//// content.js
+// 1. Send the background a message requesting receipt confirmation.
+console.log('[content] sending content-syn');
+chrome.runtime.sendMessage('content-syn');
+
+chrome.runtime.onMessage.addListener((message, sender) => {
+  if (message === 'bg-syn-ack') {
+    // 3. BG syn-ack received, acknowledged receipt.
+    console.log('[content] received bg-syn-ack');
+    console.log('[content] sending content-ack');
+    chrome.runtime.sendMessage('content-ack');
+  }
+});
+
+//// background.js
+chrome.runtime.onMessage.addListener((message, sender) => {
+  if (message.type === 'content-syn') {
+    // 2. Content syn received, acknowledge receipt & request confirmation.
+    console.log('[bg] received content-syn');
+    console.log('[bg] sending bg-syn-ack');
+    chrome.tabs.sendMessage(sender.tab.id, 'bg-syn-ack');
+  }
+  if (message.type === 'content-ack') {
+    // 4. Content ack received. Both ends have verified that message
+    //    passing works as expected.
+    console.log('[bg] received content-ack');
+  }
+});
+```
+
+Retrieve a production extension's [public key][key-prop] for use in development. Execute this snippet in a DevTools console for the production extension paste the value in your unpacked extension's manifest.json.
+
+```js
+//// DevTools console for a published extension
+copy(`"key": "${chrome.runtime.getManifest().key}"`)
+```
+
+[handshake]: https://en.wikipedia.org/wiki/Transmission_Control_Protocol#Connection_establishment
+[key-prop]: https://developer.chrome.com/docs/extensions/mv3/manifest/key/
+


### PR DESCRIPTION
This PR introduces 3 examples to the chrome.runtime API reference page

* An example of how to use getURL
* A TCP handshake style exchange between a content script and background page
* Retrieving a published extension's key for local development