### PR TITLE
Styling `<code>`

### DIFF
--- a/site/_scss/_typography.scss
+++ b/site/_scss/_typography.scss
@@ -125,9 +125,9 @@
 
   :not(pre)>code {
     background: var(--color-code-bg);
-    margin: 0 0.25em;
     border: 1px solid var(--color-hairline);
     border-radius: 3px;
+    margin: 0 0.25em;
     padding: 0.125em 0.25em;
   }
 

--- a/site/_scss/_typography.scss
+++ b/site/_scss/_typography.scss
@@ -125,10 +125,10 @@
 
   :not(pre)>code {
     background: var(--color-code-bg);
-    margin: 0 .25em;
-    padding: .125em .25em;
-    border-radius: 3px;
+    margin: 0 0.25em;
     border: 1px solid var(--color-hairline);
+    border-radius: 3px;
+    padding: 0.125em 0.25em;
   }
 
   // Both pre and code have their font-size set in ems, this is because we want

--- a/site/_scss/_typography.scss
+++ b/site/_scss/_typography.scss
@@ -123,6 +123,14 @@
     @extend %type--code;
   }
 
+  :not(pre)>code {
+    background: var(--color-code-bg);
+    margin: 0 .25em;
+    padding: .125em .25em;
+    border-radius: 3px;
+    border: 1px solid var(--color-hairline);
+  }
+
   // Both pre and code have their font-size set in ems, this is because we want
   // their size to be relative in case someone uses them inside of an h1-h6.
   // But for fenced code blocks, markdown will render a code element inside of

--- a/site/_scss/_typography.scss
+++ b/site/_scss/_typography.scss
@@ -123,14 +123,6 @@
     @extend %type--code;
   }
 
-  :not(pre)>code {
-    background: var(--color-code-bg);
-    border: 1px solid var(--color-hairline);
-    border-radius: 3px;
-    margin: 0 0.25em;
-    padding: 0.125em 0.25em;
-  }
-
   // Both pre and code have their font-size set in ems, this is because we want
   // their size to be relative in case someone uses them inside of an h1-h6.
   // But for fenced code blocks, markdown will render a code element inside of

--- a/site/_scss/blocks/_code.scss
+++ b/site/_scss/blocks/_code.scss
@@ -8,6 +8,13 @@ pre[class*='language-'] {
   padding: 0.5em;
 }
 
+:not(pre) > code {
+  background: var(--color-code-bg);
+  border: 1px solid var(--color-hairline);
+  border-radius: 3px;
+  padding: 0.125em 0.25em;
+}
+
 // Aggressively override the css loaded by prettify.js
 // prettify.js is only used by the legacy API docs at /docs/native-client/
 .prettyprint {


### PR DESCRIPTION
Example: Refer to `/blog/migrating-to-typescript/#making-any-call` for the updated styles.