### PR TITLE
fix the broken link in API Reference for chrome.webRequest

### DIFF
--- a/site/en/docs/extensions/reference/webRequest/index.md
+++ b/site/en/docs/extensions/reference/webRequest/index.md
@@ -357,7 +357,7 @@ For more example code, see the [web request samples][16].
 [1]: /docs/extensions/mv2/tabs
 [2]: /docs/extensions/mv2/declare_permissions
 [3]: #life_cycle_footnote
-[4]: #implementation
+[4]: #implementation-details
 [5]: #life_cycle_footnote
 [6]: https://fetch.spec.whatwg.org/#cors-check
 [7]: https://fetch.spec.whatwg.org/#origin-header


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix the broken link in API Reference for chrome.webRequest

## Why does this PR need
The link for Implementation details is broken.

> see the **Implementation details** section for how this is handled. 

ref: https://developer.chrome.com/docs/extensions/reference/webRequest/#life-cycle-of-requests