### PR TITLE
Add intro text and headings

### DIFF
--- a/site/en/docs/extensions/reference/storage/index.md
+++ b/site/en/docs/extensions/reference/storage/index.md
@@ -86,6 +86,10 @@ exceeded, please see the quota information for [sync][prop-sync] and [local][pro
 
 ## Examples
 
+The following sections demonstrate how to use `chrome.storage` to address some common use cases.
+
+### Synchronous response to storage updates
+
 If you're interested in tracking changes made to a data object, you can add a listener to its
 `onChanged` event. Whenever anything changes in storage, that event fires. Here's sample code to
 listen for saved changes:
@@ -150,6 +154,8 @@ chrome.storage.onChanged.addListener((changes, area) => {
   }
 });
 ```
+
+### Asynchronous preload from storage
 
 Since service workers are not always running, Manifest V3 extensions sometimes need to
 asynchronously load data from storage before they execute their event handlers. To do this, the


### PR DESCRIPTION
Minor adjustment of the "Examples" section of chrome.storage. This change adds the following:

- Headings around each separate example (or example cluster)
- Introductory text for the examples section as a whole.