### PR TITLE
Add an Extensions tag

### DIFF
--- a/site/_data/i18n/tags.yml
+++ b/site/_data/i18n/tags.yml
@@ -25,9 +25,6 @@ devices:
 
 encryption:
   en: Encryption
-  
-extensions:
-  en: Extensions
 
 extensions:
   en: Extensions

--- a/site/_data/i18n/tags.yml
+++ b/site/_data/i18n/tags.yml
@@ -25,6 +25,9 @@ devices:
 
 encryption:
   en: Encryption
+  
+extensions:
+  en: Extensions
 
 feature-policy:
   en: Feature-policy

--- a/site/_data/i18n/tags.yml
+++ b/site/_data/i18n/tags.yml
@@ -29,6 +29,9 @@ encryption:
 extensions:
   en: Extensions
 
+extensions:
+  en: Extensions
+
 feature-policy:
   en: Feature-policy
 

--- a/site/_data/supportedTags.json
+++ b/site/_data/supportedTags.json
@@ -26,6 +26,9 @@
   "encryption": {
     "title": "i18n.tags.encryption"
   },
+  "extensions": {
+    "title": "i18n.tags.extensions"
+  },
   "feature-policy": {
     "title": "i18n.tags.feature-policy"
   },


### PR DESCRIPTION
Allows us to tag blog posts and other content as extensions-related. Required for upcoming extensions blog posts.