### PR TITLE
Rework "what's new" page

### DIFF
--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -30,6 +30,61 @@ date: 2021-02-25
 Check this page often to learn about changes to the Chrome extensions platform,
 its documentation, and related policy or other changes.
 
+
+
+### Chrome 91 (stable on May 25, 2021)
+
+Chrome 91 adds the following features to the extensions platform.
+
+#### ES modules for service workers
+
+JavaScript supports modules in service workers. Setting 'module' type by the constructor's type attribute, worker scripts are loaded as ES modules and the import statement is available on worker contexts. (https://www.chromestatus.com/guide/edit/4609574738853888)
+
+#### chrome.action.getUserSettings() available
+
+The new chrome.action.getUserSettings() API allows extensions to determine if the user has pinned the extension to the main toolbar.
+
+### Chrome 90 (stable on April 13, 2021)
+
+#### New chrome.scripting.removeCSS() method (MV3 only)
+
+The `chrome.scripting.removeCSS()` method lets extensions remove CSS that was previously inserted via
+chrome.scripting.insertCSS(). It replaces the MV2 method `chrome.tabs.removeCSS()`.
+
+#### chrome.scripting.executeScript() results now include frameId
+
+Results returned from `chrome.scripting.executeScript()` now include the frameId.  The frameId indicates the frame from which the result is from, allowing extensions to easily associate results with the individual frames when injecting in multiple frames.
+
+### April 8, 2021: Extension Manifest Converter
+
+The Chrome Extensions team has open sourced [Extension Manifest
+Converter](https://github.com/GoogleChromeLabs/extension-manifest-converter), a Python tool that
+helps to convert extensions to Manifest V3. 
+
+### Chrome 89 (stable on March 9, 2021)
+
+#### New chrome.tabGroups API
+
+Added the chrome.tabGroups API to let extensions read and manipulate tab groups. Manifest V3 only.
+
+#### Customizable permissions for MV3 Web Accessible Resources
+
+Manifest now supports permission definitions to restrict resources based on either the accessing site origin or extension ID.https://developer.chrome.com/docs/extensions/mv3/manifest/web_accessible_resources/
+
+
+### Chrome 88 (stable on January 19, 2021)
+
+#### Manifest V3 launched
+
+Manifest V3 launched in Chrome 88. This is a major update to the extensions platform; see Overview of Manifest V3 for a summary of new and changed features. Extensions may continue to use Manifest V2 for now, but this will be phased out in the near future. We strongly recommend that you use MV3 for any new extensions, and begin to migrate existing extensions to MV3 as soon as possible.
+
+
+
+
+
+{% if false %}
+
+
 ### 2021.01.19: Manifest V3 launched
 
 With the release of Chrome 88, the extensions platform now supports extensions
@@ -39,3 +94,4 @@ secure, performant, and privacy respecting, by default.
 
 Check out [Welcome to Manifest V3](/docs/extensions/mv3/intro/) for complete
 details about Manifest V3 and how to build or migrate extensions for it.
+{% endif %}

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -35,8 +35,8 @@ JavaScript supports modules in service workers. In your manifest, specify a modu
 }
 ```
 
-This loads the worker script as an ES module, so you can import it in other worker
-scripts.
+This loads the worker script as an ES module, which allows you to use the `import` keyword in the
+worker's script to import other modules.
 
 
 ### chrome.action.getUserSettings() available
@@ -52,7 +52,7 @@ method allows extensions to determine if the user has pinned the extension to th
 The new [chrome.scripting.removeCSS()](/docs/extensions/reference/scripting/#method-removeCSS)
 method allows extensions to remove CSS that was previously inserted
 via [chrome.scripting.insertCSS()](/docs/extensions/reference/scripting/#method-insertCSS).
-It replaces [chrome.tabs.removeCSS()](/docs/extensions/reference/tabs/#method-removeCSS)`.
+It replaces [chrome.tabs.removeCSS()](/docs/extensions/reference/tabs/#method-removeCSS).
 
 ### chrome.scripting.executeScript() results include frameId
 #### Launched in Chrome 90
@@ -60,13 +60,13 @@ It replaces [chrome.tabs.removeCSS()](/docs/extensions/reference/tabs/#method-re
 Results returned from
 [chrome.scripting.executeScript()](/docs/extensions/reference/scripting/#method-executeScript)
 now include the [frameId](/docs/extensions/reference/webNavigation/#a-note-about-frame-ids).
-The frameId indicates the frame from which the result is from, allowing
+The `frameId` property indicates the frame from which the result is from, allowing
 extensions to easily associate results with the individual frames when injecting in multiple frames.
 
 ### New API for tab groups (MV3 only)
 #### Launched in Chrome 89
 
-There is now a [chrome.tabGroups](/docs/extensions/reference/tabGroups/) API to let extensions read
+The new [chrome.tabGroups](/docs/extensions/reference/tabGroups/) API to lets extensions read
 and manipulate tab groups. Manifest V3 only.
 
 ### Customizable permissions for MV3 Web Accessible Resources

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -30,7 +30,58 @@ date: 2021-02-25
 Check this page often to learn about changes to the Chrome extensions platform,
 its documentation, and related policy or other changes.
 
+### ES modules for service workers
+#### Launched in Chrome 91
 
+JavaScript supports modules in service workers. Setting 'module' type by the constructor's type attribute, worker scripts are loaded as ES modules and the import statement is available on worker contexts. (https://www.chromestatus.com/guide/edit/4609574738853888)
+
+### chrome.action.getUserSettings() available
+#### Launched in Chrome 91
+
+The new `chrome.action.getUserSettings()` API allows extensions to determine if the user has pinned the extension to the main toolbar.
+
+### chrome.scripting.removeCSS() available
+#### Launched in Chrome 90
+
+The `chrome.scripting.removeCSS()` API allows extensions to remove CSS that was previously inserted
+via `chrome.scripting.insertCSS()`.  It replaces `chrome.tabs.removeCSS()`.
+
+### chrome.scripting.executeScript() results include frameId
+#### Launched in Chrome 90
+
+Results returned from `chrome.scripting.executeScript()` now include the frameId.  The frameId indicates the frame from which the result is from, allowing extensions to easily associate results with the individual frames when injecting in multiple frames.
+
+### New API for tab groups
+#### Launched in Chrome 89
+
+Added the `chrome.tabGroups` API to let extensions read and manipulate tab groups. Manifest V3 only.
+
+### Customizable permissions for MV3 Web Accessible Resources
+#### Launched in Chrome 89
+
+Manifest now supports permission definitions to restrict resources based on either the accessing site origin or extension ID.
+See the [updated documentation][war-docs].
+
+### Extension Manifest Converter
+#### Launched 2021-04-08
+
+The Chrome Extensions team has open sourced "Extension Manifest Converter", a Python tool that
+automates some of the mechanical aspects of converting extensions to Manifest V3. See the
+[announcement blog post][emc-announce].
+https://github.com/GoogleChromeLabs/extension-manifest-converter
+
+### Manifest V3 launched
+#### Launched in Chrome 88
+
+Manifest V3 is a major update to the extensions platform; see [Overview of Manifest
+V3][mv3-overview] for a summary of new and changed features. Extensions may continue to use Manifest V2 for now, but this will be phased out in the near future. We strongly recommend that you use MV3 for any new extensions, and begin to migrate existing extensions to MV3 as soon as possible.
+
+[emc-announce]: https://github.com/GoogleChromeLabs/extension-manifest-converter
+[mv3-overview]: /docs/extensions/mv3/intro/mv3-overview/
+[war-docs]: /docs/extensions/mv3/manifest/web_accessible_resources/
+
+
+{% if false %}
 
 ### Chrome 91 (stable on May 25, 2021)
 
@@ -78,13 +129,6 @@ Manifest now supports permission definitions to restrict resources based on eith
 
 Manifest V3 launched in Chrome 88. This is a major update to the extensions platform; see Overview of Manifest V3 for a summary of new and changed features. Extensions may continue to use Manifest V2 for now, but this will be phased out in the near future. We strongly recommend that you use MV3 for any new extensions, and begin to migrate existing extensions to MV3 as soon as possible.
 
-
-
-
-
-{% if false %}
-
-
 ### 2021.01.19: Manifest V3 launched
 
 With the release of Chrome 88, the extensions platform now supports extensions
@@ -94,4 +138,5 @@ secure, performant, and privacy respecting, by default.
 
 Check out [Welcome to Manifest V3](/docs/extensions/mv3/intro/) for complete
 details about Manifest V3 and how to build or migrate extensions for it.
+
 {% endif %}

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -2,23 +2,9 @@
 layout: 'layouts/doc-post.njk'
 
 title: What's new in Chrome extensions
-
-# This appears below the title and is an optional teaser
-# subhead:
-
-# This appears in the ToC of the project landing page at
-# /docs/[project-name]/. It also appears in the <meta description> used in
-# Google Search.
 description: 'Recent changes to the Chrome extensions platform, documentation, and policy'
-
-# The publish date
 date: 2021-02-25
-
-# An optional updated date
-# updated: 2020-10-16
-
-# A list of authors. These usernames correspond to the keys in the
-# _data/authorsData.json file.
+updated: 2021-06-09
 
 # Note: disabling the linter for duplicate headings because this isn't hierarchical and it needs
 # smaller font headings.
@@ -29,6 +15,13 @@ date: 2021-02-25
 
 Check this page often to learn about changes to the Chrome extensions platform,
 its documentation, and related policy or other changes.
+
+### New "Introducing chrome.scripting" blog post
+#### Published 2021.06.08
+
+The [Scripting API](/docs/extensions/reference/scripting/) is a new Manifest V3 API focused on,
+well, scripting. In this post we dig into the motivations for this change and take a closer look at
+some of the new capabilities it introduces. [Read the post](/blog/crx-scripting-api).
 
 ### ES modules for service workers
 #### Launched in Chrome 91
@@ -99,12 +92,3 @@ V3](/docs/extensions/mv3/intro/mv3-overview/) for a summary of new and changed f
 may continue to use Manifest V2 for now, but this will be phased out in the near future. We strongly
 recommend that you use MV3 for any new extensions, and begin to migrate existing extensions to MV3
 as soon as possible.
-### 2021.06.08: Introducing chrome.scripting (blog post)
-
-The [Scripting API](/docs/extensions/reference/scripting/) is a new Manifest V3 API focused on,
-well, scripting. In this post we dig into the motivations for this change and take a closer look at
-some of the new capabilities it introduces. [Read the post](/blog/crx-scripting-api).
-
-### 2021.01.19: Manifest V3 launched
-
-

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -26,7 +26,7 @@ some of the new capabilities it introduces. [Read the post](/blog/crx-scripting-
 ### ES modules for service workers
 #### Launched in Chrome 91
 
-JavaScript supports modules in service workers. In your manifest, specify a module in your manifest:
+Chrome now supports modules in service workers. In your manifest, specify a module in your manifest:
 
 ```js
 "background": {

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -33,28 +33,38 @@ its documentation, and related policy or other changes.
 ### ES modules for service workers
 #### Launched in Chrome 91
 
-JavaScript supports modules in service workers. Setting 'module' type by the constructor's type attribute, worker scripts are loaded as ES modules and the import statement is available on worker contexts. (https://www.chromestatus.com/guide/edit/4609574738853888)
+JavaScript supports modules in service workers. Setting 'module' type by the constructor's type
+attribute, worker scripts are loaded as ES modules and the import statement is available on worker
+contexts. (https://www.chromestatus.com/guide/edit/4609574738853888)
 
 ### chrome.action.getUserSettings() available
 #### Launched in Chrome 91
 
-The new `chrome.action.getUserSettings()` API allows extensions to determine if the user has pinned the extension to the main toolbar.
+The new
+[chrome.action.getUserSettings()](/docs/extensions/reference/action/#method-getUserSettings)
+API allows extensions to determine if the user has pinned the extension to the main toolbar.
 
 ### chrome.scripting.removeCSS() available
 #### Launched in Chrome 90
 
-The `chrome.scripting.removeCSS()` API allows extensions to remove CSS that was previously inserted
-via `chrome.scripting.insertCSS()`.  It replaces `chrome.tabs.removeCSS()`.
+The [chrome.scripting.removeCSS()](/docs/extensions/reference/scripting/#method-removeCSS)
+API allows extensions to remove CSS that was previously inserted
+via [chrome.scripting.insertCSS()](/docs/extensions/reference/scripting/#method-insertCSS).
+It replaces [chrome.tabs.removeCSS()](/docs/extensions/reference/tabs/#method-removeCSS)`.
 
 ### chrome.scripting.executeScript() results include frameId
 #### Launched in Chrome 90
 
-Results returned from `chrome.scripting.executeScript()` now include the frameId.  The frameId indicates the frame from which the result is from, allowing extensions to easily associate results with the individual frames when injecting in multiple frames.
+Results returned from
+[chrome.scripting.executeScript()](/docs/extensions/reference/scripting/#method-executeScript)
+now include the frameId. The frameId indicates the frame from which the result is from, allowing
+extensions to easily associate results with the individual frames when injecting in multiple frames.
 
 ### New API for tab groups
 #### Launched in Chrome 89
 
-Added the `chrome.tabGroups` API to let extensions read and manipulate tab groups. Manifest V3 only.
+Added the [chrome.tabGroups](/docs/extensions/reference/tabGroups/) API to let extensions read and
+manipulate tab groups. Manifest V3 only.
 
 ### Customizable permissions for MV3 Web Accessible Resources
 #### Launched in Chrome 89

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -33,22 +33,31 @@ its documentation, and related policy or other changes.
 ### ES modules for service workers
 #### Launched in Chrome 91
 
-JavaScript supports modules in service workers. Setting 'module' type by the constructor's type
-attribute, worker scripts are loaded as ES modules and the import statement is available on worker
-contexts. (https://www.chromestatus.com/guide/edit/4609574738853888)
+JavaScript supports modules in service workers. In your manifest, specify a module in your manifest:
+
+```
+"background": {
+  "service_worker": "script.js",
+  "type": "module"
+}
+```
+
+This loads the worker script as an ES module, so you can import it in other worker
+scripts.
+
 
 ### chrome.action.getUserSettings() available
 #### Launched in Chrome 91
 
 The new
 [chrome.action.getUserSettings()](/docs/extensions/reference/action/#method-getUserSettings)
-API allows extensions to determine if the user has pinned the extension to the main toolbar.
+method allows extensions to determine if the user has pinned the extension to the main toolbar.
 
 ### chrome.scripting.removeCSS() available
 #### Launched in Chrome 90
 
-The [chrome.scripting.removeCSS()](/docs/extensions/reference/scripting/#method-removeCSS)
-API allows extensions to remove CSS that was previously inserted
+The new [chrome.scripting.removeCSS()](/docs/extensions/reference/scripting/#method-removeCSS)
+method allows extensions to remove CSS that was previously inserted
 via [chrome.scripting.insertCSS()](/docs/extensions/reference/scripting/#method-insertCSS).
 It replaces [chrome.tabs.removeCSS()](/docs/extensions/reference/tabs/#method-removeCSS)`.
 
@@ -57,96 +66,38 @@ It replaces [chrome.tabs.removeCSS()](/docs/extensions/reference/tabs/#method-re
 
 Results returned from
 [chrome.scripting.executeScript()](/docs/extensions/reference/scripting/#method-executeScript)
-now include the frameId. The frameId indicates the frame from which the result is from, allowing
+now include the [frameId](/docs/extensions/reference/webNavigation/#a-note-about-frame-ids).
+The frameId indicates the frame from which the result is from, allowing
 extensions to easily associate results with the individual frames when injecting in multiple frames.
 
-### New API for tab groups
+### New API for tab groups (MV3 only)
 #### Launched in Chrome 89
 
-Added the [chrome.tabGroups](/docs/extensions/reference/tabGroups/) API to let extensions read and
-manipulate tab groups. Manifest V3 only.
+There is now a [chrome.tabGroups](/docs/extensions/reference/tabGroups/) API to let extensions read
+and manipulate tab groups. Manifest V3 only.
 
 ### Customizable permissions for MV3 Web Accessible Resources
 #### Launched in Chrome 89
 
-Manifest now supports permission definitions to restrict resources based on either the accessing site origin or extension ID.
-See the [updated documentation][war-docs].
+[Web accessible resources](/docs/extensions/mv3/manifest/web_accessible_resources/) definitions in
+Manifest V3 have changed to let extensions restrict resource access based on the requester's origin
+or extension ID.
 
 ### Extension Manifest Converter
 #### Launched 2021-04-08
 
 The Chrome Extensions team has open sourced "Extension Manifest Converter", a Python tool that
 automates some of the mechanical aspects of converting extensions to Manifest V3. See the
-[announcement blog post][emc-announce].
-https://github.com/GoogleChromeLabs/extension-manifest-converter
+[announcement blog post](/blog/extension-manifest-converter/) and [get it from
+GitHub](https://github.com/GoogleChromeLabs/extension-manifest-converter).
 
 ### Manifest V3 launched
 #### Launched in Chrome 88
 
 Manifest V3 is a major update to the extensions platform; see [Overview of Manifest
-V3][mv3-overview] for a summary of new and changed features. Extensions may continue to use Manifest V2 for now, but this will be phased out in the near future. We strongly recommend that you use MV3 for any new extensions, and begin to migrate existing extensions to MV3 as soon as possible.
-
-[emc-announce]: https://github.com/GoogleChromeLabs/extension-manifest-converter
-[mv3-overview]: /docs/extensions/mv3/intro/mv3-overview/
-[war-docs]: /docs/extensions/mv3/manifest/web_accessible_resources/
-
-
-{% if false %}
-
-### Chrome 91 (stable on May 25, 2021)
-
-Chrome 91 adds the following features to the extensions platform.
-
-#### ES modules for service workers
-
-JavaScript supports modules in service workers. Setting 'module' type by the constructor's type attribute, worker scripts are loaded as ES modules and the import statement is available on worker contexts. (https://www.chromestatus.com/guide/edit/4609574738853888)
-
-#### chrome.action.getUserSettings() available
-
-The new chrome.action.getUserSettings() API allows extensions to determine if the user has pinned the extension to the main toolbar.
-
-### Chrome 90 (stable on April 13, 2021)
-
-#### New chrome.scripting.removeCSS() method (MV3 only)
-
-The `chrome.scripting.removeCSS()` method lets extensions remove CSS that was previously inserted via
-chrome.scripting.insertCSS(). It replaces the MV2 method `chrome.tabs.removeCSS()`.
-
-#### chrome.scripting.executeScript() results now include frameId
-
-Results returned from `chrome.scripting.executeScript()` now include the frameId.  The frameId indicates the frame from which the result is from, allowing extensions to easily associate results with the individual frames when injecting in multiple frames.
-
-### April 8, 2021: Extension Manifest Converter
-
-The Chrome Extensions team has open sourced [Extension Manifest
-Converter](https://github.com/GoogleChromeLabs/extension-manifest-converter), a Python tool that
-helps to convert extensions to Manifest V3. 
-
-### Chrome 89 (stable on March 9, 2021)
-
-#### New chrome.tabGroups API
-
-Added the chrome.tabGroups API to let extensions read and manipulate tab groups. Manifest V3 only.
-
-#### Customizable permissions for MV3 Web Accessible Resources
-
-Manifest now supports permission definitions to restrict resources based on either the accessing site origin or extension ID.https://developer.chrome.com/docs/extensions/mv3/manifest/web_accessible_resources/
+V3](/docs/extensions/mv3/intro/mv3-overview/) for a summary of new and changed features. Extensions
+may continue to use Manifest V2 for now, but this will be phased out in the near future. We strongly
+recommend that you use MV3 for any new extensions, and begin to migrate existing extensions to MV3
+as soon as possible.
 
 
-### Chrome 88 (stable on January 19, 2021)
-
-#### Manifest V3 launched
-
-Manifest V3 launched in Chrome 88. This is a major update to the extensions platform; see Overview of Manifest V3 for a summary of new and changed features. Extensions may continue to use Manifest V2 for now, but this will be phased out in the near future. We strongly recommend that you use MV3 for any new extensions, and begin to migrate existing extensions to MV3 as soon as possible.
-
-### 2021.01.19: Manifest V3 launched
-
-With the release of Chrome 88, the extensions platform now supports extensions
-built with Manifest v3, and you can upload them to the Chrome Web Store.
-Manifest v3 is a new extension platform that makes Chrome extensions more
-secure, performant, and privacy respecting, by default.
-
-Check out [Welcome to Manifest V3](/docs/extensions/mv3/intro/) for complete
-details about Manifest V3 and how to build or migrate extensions for it.
-
-{% endif %}

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -35,7 +35,7 @@ JavaScript supports modules in service workers. In your manifest, specify a modu
 }
 ```
 
-This loads the worker script as an ES module, which allows you to use the `import` keyword in the
+This loads the worker script as an ES module, which lets you use the `import` keyword in the
 worker's script to import other modules.
 
 
@@ -60,13 +60,13 @@ It replaces [chrome.tabs.removeCSS()](/docs/extensions/reference/tabs/#method-re
 Results returned from
 [chrome.scripting.executeScript()](/docs/extensions/reference/scripting/#method-executeScript)
 now include the [frameId](/docs/extensions/reference/webNavigation/#a-note-about-frame-ids).
-The `frameId` property indicates the frame from which the result is from, allowing
-extensions to easily associate results with the individual frames when injecting in multiple frames.
+The `frameId` property indicates the frame that the result is from, letting
+extensions easily associate results with the individual frames when injecting in multiple frames.
 
 ### New API for tab groups (MV3 only)
 #### Launched in Chrome 89
 
-The new [chrome.tabGroups](/docs/extensions/reference/tabGroups/) API to lets extensions read
+The new [chrome.tabGroups](/docs/extensions/reference/tabGroups/) API lets extensions read
 and manipulate tab groups. Manifest V3 only.
 
 ### Customizable permissions for MV3 Web Accessible Resources
@@ -84,7 +84,7 @@ automates some of the mechanical aspects of converting extensions to Manifest V3
 [announcement blog post](/blog/extension-manifest-converter/) and [get it from
 GitHub](https://github.com/GoogleChromeLabs/extension-manifest-converter).
 
-### Manifest V3 launched
+### Manifest V3 general availability
 #### Launched in Chrome 88
 
 Manifest V3 is a major update to the extensions platform; see [Overview of Manifest

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -35,7 +35,7 @@ its documentation, and related policy or other changes.
 
 JavaScript supports modules in service workers. In your manifest, specify a module in your manifest:
 
-```
+```js
 "background": {
   "service_worker": "script.js",
   "type": "module"


### PR DESCRIPTION
Push initial batch of "what's new backlog" items to the what's new page. This is like a commit log with coarse granularity: features that got pushed to Chrome, rather than a series of Chrome release announcements. 

[Staged draft page](https://deploy-preview-663--developer-chrome-com.netlify.app/docs/extensions/whatsnew/)