### PR TITLE
Update links to reference MV3 docs

### DIFF
--- a/site/en/docs/extensions/reference/devtools_inspectedWindow/index.md
+++ b/site/en/docs/extensions/reference/devtools_inspectedWindow/index.md
@@ -94,10 +94,10 @@ chrome.devtools.inspectedWindow.eval(
 
 You can find more examples that use Developer Tools APIs in [Samples][8].
 
-[1]: /docs/extensions/mv2/devtools
+[1]: /docs/extensions/mv3/devtools
 [2]: #property-tabId
 [3]: /docs/extensions/reference/tabs
 [4]: /docs/extensions/reference/tabs#method-executeScript
 [5]: https://developers.google.com/web/tools/chrome-devtools/
 [7]: https://www.ietf.org/rfc/rfc6454.txt
-[8]: /docs/extensions/mv2/samples#search:devtools
+[8]: /docs/extensions/mv3/samples#search:devtools

--- a/site/en/docs/extensions/reference/devtools_network/index.md
+++ b/site/en/docs/extensions/reference/devtools_network/index.md
@@ -38,6 +38,6 @@ chrome.devtools.network.onRequestFinished.addListener(
 
 You can find more examples that use this API in [Samples][3].
 
-[1]: /docs/extensions/mv2/devtools
+[1]: /docs/extensions/mv3/devtools
 [2]: https://www.softwareishard.com/blog/har-12-spec/
-[3]: /docs/extensions/mv2/samples#search:devtools.network
+[3]: /docs/extensions/mv3/samples#search:devtools.network

--- a/site/en/docs/extensions/reference/devtools_panels/index.md
+++ b/site/en/docs/extensions/reference/devtools_panels/index.md
@@ -49,8 +49,8 @@ This screenshot demonstrates the effect the above examples would have on Develop
 
 You can find examples that use this API in [Samples][5].
 
-[1]: /docs/extensions/mv2/devtools
+[1]: /docs/extensions/mv3/devtools
 [2]: /docs/extensions/reference/extension/
-[3]: /docs/extensions/mv2/overview#contentScripts
+[3]: /docs/extensions/mv3/overview#contentScripts
 [4]: /docs/extensions/reference/devtools_panels#method-setOpenResourceHandler
 [5]: https://github.com/GoogleChrome/chrome-extensions-samples


### PR DESCRIPTION
While working on something unrelated, I noticed that our DevTools reference pages linked to MV2 docs rather than MV3. This PR addresses that.