### PR TITLE
Remove unnecessary msg object from example

### DIFF
--- a/site/en/docs/extensions/mv3/migrating_to_service_workers/index.md
+++ b/site/en/docs/extensions/mv3/migrating_to_service_workers/index.md
@@ -99,8 +99,8 @@ content script and persists it in a global variable for later use.
 let name = undefined;
 
 chrome.runtime.onMessage.addListener(({ type, name }) => {
-  if (msg.type === "set-name") {
-    name = msg.name;
+  if (type === "set-name") {
+    name = name;
   }
 });
 


### PR DESCRIPTION
In the persistent storage example, it referred to the type and name of a "msg" object that did not exist.

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

-
-
-