### PR TITLE
Fix broken types

### DIFF
--- a/tools/types/build.js
+++ b/tools/types/build.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const chromeTypesRepoBase = 'https://unpkg.com/chrome-types@latest/';
+const chromeTypesRepoBase = 'https://unpkg.com/chrome-types@0.0.23/';
 
 require('dotenv').config();
 const fs = require('fs');


### PR DESCRIPTION
Fixes broken build.

Changes proposed in this pull request:

- Hardcodes the build.js to use 0.0.23 until we can sort out what's up with 0.1.0