### PR TITLE
Update mv3/content_scripts to reflect current MV3 impl

### DIFF
--- a/site/en/docs/extensions/mv3/content_scripts/index.md
+++ b/site/en/docs/extensions/mv3/content_scripts/index.md
@@ -232,7 +232,7 @@ document.body.style.backgroundColor = 'orange';
 //// background.js ////
 chrome.action.onClicked.addListener((tab) => {
   chrome.scripting.executeScript({
-    target: { tabId: tabId },
+    target: { tabId: tab.id },
     files: ['content-script.js']
   });
 });
@@ -248,7 +248,7 @@ function injectedFunction() {
 
 chrome.action.onClicked.addListener((message, callback) => {
   chrome.scripting.executeScript({
-    target: { tabId: tabId },
+    target: { tabId: tab.id },
     function: injectedFunction
   });
 });
@@ -268,7 +268,7 @@ function injectedFunction(color) {
 
 chrome.action.onClicked.addListener((tab) => {
   chrome.scripting.executeScript({
-    target: { tabId: tabId },
+    target: { tabId: tab.id },
     function: injectedFunction,
     arguments: ['orange']
   });

--- a/site/en/docs/extensions/mv3/content_scripts/index.md
+++ b/site/en/docs/extensions/mv3/content_scripts/index.md
@@ -254,9 +254,10 @@ chrome.action.onClicked.addListener((message, callback) => {
 });
 ```
 
-Be aware that the injected function is a copy the function referenced in the
+Be aware that the injected function is a copy of the function referenced in the
 `chrome.scripting.executeScript` call, not the original function itself. As a result, the function's
-body must be self contained; references to variables outside of the function will cause the content script to throw a [`ReferenceError`][ref-error].
+body must be self contained; references to variables outside of the function will cause the content
+script to throw a [`ReferenceError`][ref-error].
 
 {% if false %}
 When injecting as a function, you can also pass arguments to the function.

--- a/site/en/docs/extensions/mv3/content_scripts/index.md
+++ b/site/en/docs/extensions/mv3/content_scripts/index.md
@@ -43,7 +43,12 @@ Content scripts live in an isolated world, allowing a content script to make cha
 JavaScript environment without conflicting with the page or other extensions' content Scripts.
 
 {% Aside %}
-An *isolated world* is a private execution environment that isn't accessible from other extensions. A practical consequence of this isolation is that variables declared by one extension are not visible to another one. The concept was originally introduced with the initial launch of Chrome, providing isolation for browser tabs. 
+
+An *isolated world* is a private execution environment that isn't accessible to the page or other
+extensions. A practical consequence of this isolation is that JavaScript variables in an extension's
+content scripts are not visible to the host page or other extension content scripts. The concept was
+originally introduced with the initial launch of Chrome, providing isolation for browser tabs.
+
 {% endAside %}
 
 An extension may run in a web page with code similar to the example below.
@@ -87,8 +92,8 @@ the others.
 
 ## Inject scripts {: #functionality }
 
-Content Scripts can be injected [declared statically][14], [declared dynamically][32], or
-[programmatically injected][13].
+Content Scripts can be injected [declared statically][14]{% if false %}, [declared dynamically][32],
+{% endif %} or [programmatically injected][13].
 
 ### Inject with static declarations {: #static-declarative }
 
@@ -154,10 +159,14 @@ They can include JavaScript files, CSS files, or both. All auto-run content scri
   </tbody>
 </table>
 
+{% if false %}
 ### Inject with dynamic declarations {: #dynamic-declarative }
 
 {% Aside 'caution' %}
-This feature is not yet fully supported. It is currently in dev and is also available in Chrome Canary.
+
+This feature is not yet fully supported. It is currently in dev and is also available in Chrome
+Canary.
+
 {% endAside %}
 
 You should use dynamic declarations in the following cases:
@@ -165,7 +174,6 @@ You should use dynamic declarations in the following cases:
 - When the host is not well known
 - The script may need to be added/removed from a known host
 
-{% if false %}
 **TODO**
 
 - Uses the JS scripting API
@@ -177,18 +185,15 @@ You should use dynamic declarations in the following cases:
 See the [api
 proposal](https://docs.google.com/document/d/1p2jnIL3znAhD2VVuEbzOetgj1Qeya9yATa3B9gBGGUg/edit) for
 additional details.
-{% endif %}
-
 
 ```js
 chrome.scripting.registerContentScript(optionsObject, callback);
 ```
 
-
 ```js
 chrome.scripting.unregisterContentScript(idArray, callback);
 ```
-
+{% endif %}
 
 ### Inject programmatically {: #programmatic }
 
@@ -200,47 +205,60 @@ the page it's trying to inject scripts into. Host permissions can either be gran
 requesting them as part of your extension's manifest (see [`host_permissions`][33]) or temporarily
 via [activeTab][15].
 
-Below we'll look at an example that uses activeTab.
+Below we'll look at a couple different versions of an activeTab-based extension.
 
-```json/3-5
+```json/4-6
+//// manifest.json ////
 {
   "name": "My extension",
   ...
   "permissions": [
     "activeTab"
   ],
-  ...
+  "background": {
+    "service_worker": "background.js"
+  }
 }
 ```
 
-Content scripts can be injected as files.
+Content scripts can be injected as files…
 
 ```js
-chrome.runtime.onMessage.addListener((message, callback) => {
-  if (message == "runContentScript"){
-    chrome.scripting.executeScript({
-      file: 'contentScript.js'
-    });
-  }
+//// content-script.js ////
+document.body.style.backgroundColor = 'orange';
+```
+
+```js
+//// background.js ////
+chrome.action.onClicked.addListener((tab) => {
+  chrome.scripting.executeScript({
+    target: { tabId: tabId },
+    files: ['content-script.js']
+  });
 });
 ```
 
-Or an entire file can be injected.
+…or a function body can be injected and executed as a content script.
 
 ```js
+//// background.js ////
 function injectedFunction() {
   document.body.style.backgroundColor = 'orange';
 }
 
-chrome.runtime.onMessage.addListener((message, callback) => {
-  if (message == "changeColor"){
-    chrome.scripting.executeScript({
-      function: injectedFunction
-    });
-  }
+chrome.action.onClicked.addListener((message, callback) => {
+  chrome.scripting.executeScript({
+    target: { tabId: tabId },
+    function: injectedFunction
+  });
 });
 ```
 
+Be aware that the injected function is a copy the function referenced in the
+`chrome.scripting.executeScript` call, not the original function itself. As a result, the function's
+body must be self contained; references to variables outside of the function will cause the content script to throw a [`ReferenceError`][ref-error].
+
+{% if false %}
 When injecting as a function, you can also pass arguments to the function.
 
 ```js
@@ -248,18 +266,17 @@ function injectedFunction(color) {
   document.body.style.backgroundColor = color;
 }
 
-chrome.runtime.onMessage.addListener((message, callback) => {
-  if (message == "changeColor"){
-    chrome.scripting.executeScript({
-      function: injectedFunction,
-      arguments: ['orange']
-    });
-  }
+chrome.action.onClicked.addListener((tab) => {
+  chrome.scripting.executeScript({
+    target: { tabId: tabId },
+    function: injectedFunction,
+    arguments: ['orange']
+  });
 });
 ```
+{% endif %}
 
-
-#### Exclude matches and globs {: #matchAndGlob }
+### Exclude matches and globs {: #matchAndGlob }
 
 Specified page matching is customizable by including the following fields in a declarative
 registration.
@@ -428,7 +445,7 @@ chrome.scripting.registerContentScript({
 });
 ```
 
-#### Run time {: #run_time }
+### Run time {: #run_time }
 
 The `run_at` field controls when JavaScript files are injected into the web page. The
 preferred and default value is `"document_idle"`, but you can also specify `"document_start"` or
@@ -494,7 +511,7 @@ chrome.scripting.registerContentScript({
   </tbody>
 </table>
 
-#### Specify frames {: #frames }
+### Specify frames {: #frames }
 
 The `"all_frames"` field allows the extension to specify if JavaScript and CSS files should be
 injected into all frames matching the specified URL requirements or only into the topmost frame in a
@@ -650,3 +667,5 @@ window.setTimeout(() => animate(elmt_id), 200);
 [31]: #functionality
 [32]: #dynamic-declarative
 [33]: /docs/extensions/reference/permissions
+
+[ref-error]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ReferenceError


### PR DESCRIPTION
Fixes #691

Updates code samples to reflect the current implementation of `executeScript`. Hides references to features not yet supported by the MV3 platform.