### PR TITLE
Redirect a DevTools link

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -72,6 +72,9 @@ redirects:
 
 # DevTools redirects
 
+- from: /docs/devtools/network-performance/reference
+  to: /docs/devtools/network/reference/
+
 - from: /docs/devtools/network/resource-loading/
   to: /docs/devtools/network/reference/
 


### PR DESCRIPTION
Fixes #656

Changes proposed in this pull request:

- Redirects `/docs/devtools/network-performance/reference` to `/docs/devtools/network/reference/`