### PR TITLE
adds 'pills' for types/version information

### DIFF
--- a/site/_includes/layouts/namespace-reference.njk
+++ b/site/_includes/layouts/namespace-reference.njk
@@ -18,14 +18,12 @@
   </div>
 
   <h2 class="type--h3">Summary</h2>
-  <div class="code-sections code-sections--summary">
-    <ul class="stack flow-space-300">
-      {{ macros.renderSummarySection(namespace.name, 'Types', 'type', namespace.types) }}
-      {{ macros.renderSummarySection(namespace.name, 'Properties', 'property', namespace.properties) }}
-      {{ macros.renderSummarySection(namespace.name, 'Methods', 'method', namespace.methods) }}
-      {{ macros.renderSummarySection(namespace.name, 'Events', 'event', namespace.events) }}
-    </ul>
-  </div>
+  <ul class="code-sections code-sections--summary flow-space-300 stack">
+    {{ macros.renderSummarySection(namespace.name, 'Types', 'type', namespace.types) }}
+    {{ macros.renderSummarySection(namespace.name, 'Properties', 'property', namespace.properties) }}
+    {{ macros.renderSummarySection(namespace.name, 'Methods', 'method', namespace.methods) }}
+    {{ macros.renderSummarySection(namespace.name, 'Events', 'event', namespace.events) }}
+  </ul>
 
   {{ macros.renderPrimarySection(namespace.name, 'types', 'Types', 'type', namespace.types) }}
   {{ macros.renderPrimarySection(namespace.name, 'properties', 'Properties', 'property', namespace.properties) }}
@@ -60,10 +58,10 @@
         </div>
       {% endif %}
 
-      {% set availabilityText %}{{ macros.renderAvailabilityFeature(feature) }}{% endset %}
+      {% set availabilityHtml %}{{ macros.renderAvailabilityFeature(feature) }}{% endset %}
 
-      <div class="code-sections code-sections--summary">
-        <ul class="stack flow-space-300">
+      <div>{# This div prevents flow-space-300 from applying to the parent stack. #}
+        <ul class="code-sections code-sections--summary flow-space-300 stack">
           <li>
             <div class="code-sections__label">Description</div>
             <div class="type">
@@ -82,11 +80,11 @@
             </li>
           {% endif %}
 
-
-          {% if availabilityText | trim %}
-            <li>
+          {% if availabilityHtml | trim %}
+            <li class="align-center">
               <div class="code-sections__label">Availability</div>
-              <div>{{ availabilityText | trim }}</div>
+              {{ availabilityHtml | safe }}
+              {# As of Apr 2021, namespaces are never deprecated. #}
             </li>
           {% endif %}
         </ul>

--- a/site/_includes/macros/render-type.njk
+++ b/site/_includes/macros/render-type.njk
@@ -485,6 +485,12 @@
 {% macro renderAvailabilityFeature(feature, prop) %}
 
   {% set inner %}
+    {% if prop.type.isReturnsAsync %}
+      <span class="aside--success tag-pill type--label rounded-lg" title="Can return its result via Promise">
+        Promise
+      </span>
+    {% endif %}
+
     {% if feature.supportedInChannel === 'dev' %}
       <span class="aside--warning tag-pill type--label rounded-lg">
         Dev channel

--- a/site/_includes/macros/render-type.njk
+++ b/site/_includes/macros/render-type.njk
@@ -2,11 +2,12 @@
 {#
   Top-level rendering of a model.Property.
 #}
-{% macro renderTopProperty(prop) %}
+{% macro renderTopProperty(prop, prefix) %}
 
   {% set type = prop.type %}
 
-  {% set declarativeNote = '' %}
+<div class="type stack">
+  <h3 id="{{ prefix }}-{{ prop.name }}">{{ prop.name }}</h3>
 
 {# Render the function signature. #}
 {% if type.key === 'function' %}
@@ -14,24 +15,20 @@
 {% elif type.key === 'ref' and type.name === 'events.Event' %}
   {% if type.templates[0].primitiveType === 'void' %}
     {# This is a declarative event listener as it has no listener function type. #}
-    {% set declarativeNote %}
-      <p>
-        Provides the <a href="/docs/extensions/reference/events/#declarative-event-handlers">Declarative Event API</a> consisting of <code>addRules</code>, <code>removeRules</code>, and <code>getRules</code>.
-      </p>
-    {% endset %}
+    <p>
+      Provides the <a href="/docs/extensions/reference/events/#declarative-event-handlers">Declarative Event API</a> consisting of <code>addRules</code>, <code>removeRules</code>, and <code>getRules</code>.
+    </p>
   {% else %}
     {# This isn't really part of the type but we show users how to add a listener. #}
-    <div class="code-sections__signature">
+    <div class="type--label">
       <code>
-        {{ prop.name }}.addListener(listener: <span class="code-sections__signature-type">function</span>)
+        {{ prop.name }}.addListener(listener: <span class="color-cyan-medium">function</span>)
       </code>
     </div>
   {% endif %}
 {% endif %}
 
-<div class="type stack code-sections__description">
   {{ renderComment(prop) }}
-  {{ declarativeNote | safe }}
 </div>
 
 {{ renderTopType(type, prop) }}
@@ -58,7 +55,7 @@
       {{ renderOptionalParametersSection(type.parametersForAsync, 'Parameters') }}
 
       <div class="code-sections">
-        <h4 class="type--label case-upper">Result</h4>
+        <h4 class="type--label code-sections__mode">Result</h4>
 
         <ul class="stack">
           <li class="stack">
@@ -88,7 +85,7 @@
       {{ renderOptionalParametersSection(type.parameters, 'Parameters') }}
       {% if type.returnProperty and type.returnType.primitiveType !== 'void' %}
         <div class="code-sections">
-          <h4 class="type--label case-upper">Returns</h4>
+          <h4 class="type--label code-sections__mode">Returns</h4>
 
           <ul class="stack">
             {{ internalRenderParameter(type.returnProperty) }}
@@ -105,7 +102,7 @@
       {{ renderOptionalTypesArray(type.templates[2].choices, 'Actions', prop) }}
     {% else %}
       <div class="code-sections">
-        <h4 class="type--label case-upper">Event</h4>
+        <h4 class="type--label code-sections__mode">Event</h4>
         <ul class="stack">
           {{ internalRenderListenerAsItem(type.templates[0]) }}
         </ul>
@@ -115,7 +112,7 @@
   {% elif type.key === 'literal' %}
     {# Top-level literal number or string. #}
     <div class="code-sections">
-      <h4 class="type--label case-upper">Value</h4>
+      <h4 class="type--label code-sections__mode">Value</h4>
 
       <div class="code-sections__overline code-sections__label">
         {{ renderSingleType(type, prop) }}
@@ -134,7 +131,7 @@
 
     {% if type.properties | length %}
       <div class="code-sections">
-        <h4 class="type--label case-upper">Properties</h4>
+        <h4 class="type--label code-sections__mode">Properties</h4>
 
         <ul class="stack">
           {% for name, prop in type.properties | dictsort %}
@@ -148,7 +145,7 @@
     {# Some other kind of type. #}
 
     <div class="code-sections">
-      <h4 class="type--label case-upper">Type</h4>
+      <h4 class="type--label code-sections__mode">Type</h4>
 
       <div class="code-sections__overline code-sections__label">
         {{ renderSingleType(type, prop) }}
@@ -167,7 +164,7 @@
   {% if parameters.length %}
     <div class="code-sections">
       {% if label %}
-        <h4 class="type--label case-upper">{{ label }}</h4>
+        <h4 class="type--label code-sections__mode">{{ label }}</h4>
       {% endif %}
 
       <ul class="stack">
@@ -188,7 +185,7 @@
   {% if types.length %}
     <div class="code-sections">
       {% if label %}
-        <h4 class="type--label case-upper">{{ label }}</h4>
+        <h4 class="type--label code-sections__mode">{{ label }}</h4>
       {% endif %}
 
       <div class="code-sections__overline code-sections__label">
@@ -208,9 +205,9 @@
   Renders a comment, its optional version information and deprecation notice.
 #}
 {% macro renderComment(prop) %}
-  {% set warningText %}{{ renderAvailabilityFeature(prop.feature) }}{% endset %}
-  {% if warningText | trim %}
-    <p class="code-sections__deprecated">{{ warningText | trim | safe }}</p>
+  {{ renderAvailabilityFeature(prop.feature, prop) }}
+  {% if prop.deprecated %}
+    <p class="code-sections__deprecated">{{ prop.deprecated | mdInline | safe }}<p>
   {% endif %}
   {# This |md filter will add <p> as appropriate. #}
   {{ prop.description | md | safe }}
@@ -414,7 +411,7 @@
 
   {% if prop.type.key === 'function' %}
     {% set type = prop.type %}
-    <div class="code-sections__signature">
+    <div class="type--label">
       {% if type.isReturnsAsync %}
         <code>
           {{ prop.name }}{{ renderFunctionParameters(type.parametersForAsync) }}:
@@ -437,7 +434,7 @@
   (
     {%- for parameter in parameters -%}
       {{ parameter.name }}{% if parameter.optional %}?{% endif %}:
-      <span class="code-sections__signature-type">{{ renderSingleType(parameter.type) | trim }}</span>
+      <span class="color-cyan-medium">{{ renderSingleType(parameter.type) | trim }}</span>
       {%- if not loop.last %}, {% endif -%}
     {%- endfor -%}
   )
@@ -470,12 +467,11 @@
 
   {% if array.length %}
     <h2 class="type--h3" id="{{ id }}">{{ label }}</h2>
+    <div class="stack flow-space-300">
     {% for prop in array %}
-      <div class="flow-space-300">
-        <h3 class="type--h4" id="{{ prefix }}-{{ prop.name }}">{{ prop.name }}</h3>
-        {{ renderTopProperty(prop, true) }}
-      </div>
+      {{ renderTopProperty(prop, prefix) }}
     {% endfor %}
+    </div>
   {% endif %}
 
 {% endmacro %}
@@ -486,45 +482,62 @@
 
   This returns valid HTML, so it should be rendered with `| safe`.
 #}
-{% macro renderAvailabilityFeature(feature) %}
+{% macro renderAvailabilityFeature(feature, prop) %}
 
-  {% if feature.supportedInChannel === 'dev' %}
-    Dev channel only.
-  {% elif feature.supportedInChannel === 'beta' %}
-    Beta and Dev channels only.
-  {% elif feature.supportedInChannel === 'canary' or feature.supportedInChannel === 'trunk' %}
-    In development.
-  {% elif feature.unknownVersion %}
-    {# This is stable but not yet visible in the version history data. It's probably coming next
-      Chrome release. #}
-    Unknown version.
-  {% elif feature.availableFromVersion %}
-    {# This implies stable. We don't specifically announce `supportedInChannel` of stable. #}
-    Since Chrome {{ feature.availableFromVersion }}.
-  {% endif %}
-  {% if feature.maxManifestVersion %}
-    Manifest V{{ feature.maxManifestVersion }}
-    {% if feature.maxManifestVersion === 2 %}
-      {# Nothing is actually before MV2. #}
-      only.
-    {% else %}
-      and below.
+  {% set inner %}
+    {% if feature.supportedInChannel === 'dev' %}
+      <span class="aside--warning tag-pill type--label rounded-lg">
+        Dev channel
+      </span>
+    {% elif feature.supportedInChannel === 'beta' %}
+      <span class="aside--warning tag-pill type--label rounded-lg">
+        Beta channel
+      </span>
+    {% elif feature.supportedInChannel === 'canary' or feature.supportedInChannel === 'trunk' %}
+      <span class="aside--warning tag-pill type--label rounded-lg">
+        In development
+      </span>
+    {% elif feature.unknownVersion %}
+      {# This is stable but not yet visible in the version history data. It's probably coming next
+        Chrome release. #}
+      <span class="aside--warning tag-pill type--label rounded-lg">
+        Unknown version
+      </span>
+    {% elif feature.availableFromVersion %}
+      <span class="aside--default tag-pill type--label rounded-lg">
+        Chrome {{ feature.availableFromVersion }}+
+      </span>
     {% endif %}
-  {% endif %}
-  {% if feature.minManifestVersion %}
-    Manifest V{{ feature.minManifestVersion }} and above.
-  {% endif %}
-  {% if feature.disallowForServiceWorkers %}
-    Unavailable in Service Workers.
-  {% endif %}
-  {% if prop.deprecated !== undefined or feature.deprecatedSinceVersion %}
-    <strong>
-      Deprecated
-      {%- if feature.deprecatedSinceVersion > 0 %}
-        since Chrome {{ feature.deprecatedSinceVersion }}
-      {%- endif -%}
-    </strong>.
-    {{ prop.deprecated | mdInline | safe }}
+
+    {% if feature.maxManifestVersion %}
+      <span class="aside--caution tag-pill type--label rounded-lg" title="Maximum manifest vesion">
+        Manifest V{{ feature.maxManifestVersion }}
+      </span>
+    {% endif %}
+    {% if feature.minManifestVersion %}
+      <span class="aside--gotchas tag-pill type--label rounded-lg">
+        Manifest V{{ feature.minManifestVersion }}+
+      </span>
+    {% endif %}
+
+    {% if feature.disallowForServiceWorkers %}
+      <span class="aside--gotchas tag-pill type--label rounded-lg" title="Not available in Service Workers">
+        Foreground only
+      </span>
+    {% endif %}
+
+    {% if prop.deprecated !== undefined or feature.deprecatedSinceVersion %}
+      <span class="aside--warning tag-pill type--label rounded-lg">
+        Deprecated
+        {%- if feature.deprecatedSinceVersion > 0 %}
+          {{ feature.deprecatedSinceVersion }}+
+        {%- endif -%}
+      </span>
+    {% endif %}
+  {% endset %}
+
+  {% if inner | trim %}
+    <div class="display-flex flex-flow-row-wrap">{{ inner | trim | safe }}</div>
   {% endif %}
 
 {% endmacro %}

--- a/site/_scss/blocks/_aside.scss
+++ b/site/_scss/blocks/_aside.scss
@@ -11,6 +11,15 @@
     margin-top: get-size(300);
   }
 
+  // This duplicates the above ".aside" for users who just want colors.
+  &--default {
+    --link-color: var(--color-blue-darkest);
+    --link-visited-color: var(--color-blue-darkest);
+    --link-rgb-background: var(--rgb-blue-darkest);
+    background-color: var(--color-blue-lightest);
+    color: var(--color-blue-darkest);
+  }
+
   &--caution {
     --link-color: var(--color-yellow-darkest);
     --link-visited-color: var(--color-yellow-darkest);

--- a/site/_scss/blocks/_code-sections.scss
+++ b/site/_scss/blocks/_code-sections.scss
@@ -19,10 +19,18 @@
     font-size: 0.875em;
     line-height: 2em;
   }
+}
 
-  strong {
-    font-weight: 500;
-  }
+.code-sections__tag {
+  border-radius: 10000px;
+  font-size: 0.875em;
+  line-height: 1.666667em;
+  display: inline-block;
+
+  background: rgba(0, 0, 255, 0.125);
+  color: blue;
+  padding: 0 12px;
+  font-weight: 500;
 }
 
 // This is a slightly smaller label used by API pages which doesn't match the
@@ -73,37 +81,6 @@
   }
 }
 
-// Ensure that .code-sections has a margin-top, except in cases where it's
-// already in a stack (as this will bring its margin).
-// purgecss tries to remove this bit.
-/* purgecss start ignore */
-/* stylelint-disable-next-line selector-max-compound-selectors */
-:not(.stack) > * + .code-sections {
-  margin: get-size(300) 0 get-size(600);
-}
-/* purgecss end ignore */
-
-// This makes the upper-case "PROPERTIES" etc sections stand out by being a lighter color.
-.code-sections .type--label {
-  color: get-color('grey-500');
-}
-
-// This is used for method signatures. We need to:
-//  - use opacity to make them less pronounced
-//  - allow overflow-wrap as often we have very long preambles, e.g.:
-//    "chrome.browserAction.getBadgeBackgroundColor(details:"
-.code-sections__signature {
-  color: get-color('grey-700');
-  font-size: 0.875em;
-  opacity: 0.9;
-  overflow-wrap: break-word;
-  padding-bottom: 1em;
-}
-
-.code-sections__signature-type {
-  color: var(--color-cyan-medium);
-}
-
 .code-sections__optional {
   color: var(--color-pink-medium);
 }
@@ -120,6 +97,12 @@
   background: get-color('grey-50');
   border: 1px solid var(--color-hairline);
   padding: 1em;
+
+  > code {
+    border: none;
+    border-radius: 0;
+    background: transparent;
+  }
 }
 
 .code-sections__overline {
@@ -127,6 +110,11 @@
   border-top: 1px solid var(--color-hairline);
   margin: 1em 0;
   padding-top: get-size(300);
+}
+
+.code-sections__mode {
+  color: var(--color-code-comment);
+  text-transform: uppercase;
 }
 
 .code-sections li {
@@ -149,13 +137,15 @@
   }
 }
 
-.code-sections--summary {
-  li:first-child {
+ul.code-sections--summary {
+  padding-left: 0;
+
+  > li:first-child {
     border-top: 0;
     padding-top: 0;
   }
 
-  li {
+  > li {
     @include media-query('lg') {
       flex-direction: row;
     }

--- a/site/_scss/blocks/_code-sections.scss
+++ b/site/_scss/blocks/_code-sections.scss
@@ -21,18 +21,6 @@
   }
 }
 
-.code-sections__tag {
-  border-radius: 10000px;
-  font-size: 0.875em;
-  line-height: 1.666667em;
-  display: inline-block;
-
-  background: rgba(0, 0, 255, 0.125);
-  color: blue;
-  padding: 0 12px;
-  font-weight: 500;
-}
-
 // This is a slightly smaller label used by API pages which doesn't match the
 // regular type system.
 .code-sections__label {
@@ -99,9 +87,9 @@
   padding: 1em;
 
   > code {
-    border: none;
-    border-radius: 0;
     background: transparent;
+    border: 0;
+    border-radius: 0;
   }
 }
 
@@ -137,7 +125,7 @@
   }
 }
 
-ul.code-sections--summary {
+.code-sections--summary {
   padding-left: 0;
 
   > li:first-child {


### PR DESCRIPTION
This resolves a design request we had internally, and adds small hints as to whether an API supports Promise, or is supported from a certain API version and so on.

These show up fairly rarely (although more on pages with `Promise`). Some good examples:

- [dev method](https://deploy-preview-720--developer-chrome-com.netlify.app/docs/extensions/reference/identity#method-getAccounts) inside a normally allowed namespace
- [deprecated method](https://deploy-preview-720--developer-chrome-com.netlify.app/docs/extensions/reference/extension#method-getExtensionTabs) that also only works in the foreground (not in the SW)
- [property of parameter](https://deploy-preview-720--developer-chrome-com.netlify.app/docs/extensions/reference/instanceID#method-getToken) that is deprecated in 89+
- [method which returns `Promise`](https://deploy-preview-720--developer-chrome-com.netlify.app/docs/extensions/reference/action/#method-getUserSettings) that also happens to be brand new (not released in any stable yet)