### PR TITLE
Fix typo in id tag

### DIFF
--- a/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
+++ b/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
@@ -9,7 +9,7 @@ title: Migrating to Manifest V3
 subhead: 'Getting you headed in the right direction.'
 
 # This appears in the ToC of the project landing page at
-# /docs/[project-name]/. It also appears in the <meta description> used in 
+# /docs/[project-name]/. It also appears in the <meta description> used in
 # Google Search.
 description: 'A high-level guide to how you can migrate your MV2 extensions to MV3.'
 
@@ -30,7 +30,7 @@ will require very little change to make them MV3 compliant, while others will
 need to be redesigned to some degree. Developers experienced with MV2, and who
 are creating new MV3 extensions, may also find this helpful. For a quick
 reference guide see the [migration
-checklist](/docs/extensions/mv3/mv3-migration-checklist). 
+checklist](/docs/extensions/mv3/mv3-migration-checklist).
 
 Manifest V3 offers a number of improvements reflecting the aims of our
 [platform vision](/docs/extensions/mv3/intro/platform-vision).
@@ -130,7 +130,7 @@ permissions requests by the Chrome Web Store review process.
 {% endAside %}
 
 
-### Content security policy  {: #fcontent-security-policy }
+### Content security policy  {: #content-security-policy }
 
 An extension's [content security policy](https://content-security-policy.com/)
 (CSP) was specified in MV2 as a string; in MV3 it is an object with members
@@ -153,7 +153,7 @@ representing alternative CSP contexts:
 ```
 {% endColumns %}
 
-**`extension_pages`**:  This policy covers pages in your extension, including html files and service workers. 
+**`extension_pages`**:  This policy covers pages in your extension, including html files and service workers.
 
 
 {% Aside %}
@@ -173,7 +173,7 @@ directives may only have the following values:
 *   `none`
 *   Any localhost source, (`http://localhost`,  `http://127.0.0.1`, or any port on those domains)
 
-CSP modifications for `sandbox` have no such new restrictions. 
+CSP modifications for `sandbox` have no such new restrictions.
 
 
 ### Action API unification  {: #action-api-unification }
@@ -404,7 +404,7 @@ All other extensions must now use
 [declarativeNetRequest](/docs/extensions/reference/declarativeNetRequest) for
 network request modification. This moves the actual modification of the network
 request into the Chrome browser: the extension no longer can read the actual
-network request, and in most cases needs no host permissions. 
+network request, and in most cases needs no host permissions.
 
 {% Aside %}
 Request redirects and header modifications **do** require the user to grant host permissions.


### PR DESCRIPTION
Stumbled across this minor issue while sharing a link in an email.