### PR TITLE
move privacy sandbox to architecture section

### DIFF
--- a/site/_data/docs/projects.yml
+++ b/site/_data/docs/projects.yml
@@ -4,8 +4,8 @@ crx:
   - url: extensions
   - url: webstore
   - url: apps
-  - url: privacy-sandbox
 architecture:
+  - url: privacy-sandbox
   - url: native-client
   - url: multidevice
   - url: android


### PR DESCRIPTION
Small fix. privacy sandbox was under the same heading as extensions and webstore. this moves it to the architecture heading.