### PR TITLE
Make banner dismissible

### DIFF
--- a/site/_data/banner.yml
+++ b/site/_data/banner.yml
@@ -1,5 +1,11 @@
+# This file can be used to display a site-wide banner.
+# The actions should contain at least one action with an href.
+# Clicking on any action will dismiss the banner.
+# An action without an href will use a <button> instead of an <a>.
+
 type: info
 text: I/O is back, online, and free for everyone! I/O connects developers from around the world for thoughtful discussions and hands-on learning with Google experts.
 actions:
   - text: Register now
     href: https://events.google.com/io/?utm_source=web&utm_medium=embedded_marketing
+  - text: Dismiss

--- a/site/_data/site.json
+++ b/site/_data/site.json
@@ -9,5 +9,6 @@
     "en",
     "es"
   ],
-  "defaultLocale": "en"
+  "defaultLocale": "en",
+  "cookiesCtaUrl": "https://policies.google.com/technologies/cookies"
 }

--- a/site/_includes/partials/banner.njk
+++ b/site/_includes/partials/banner.njk
@@ -1,6 +1,6 @@
 {% if banner %}
   {# Supports 'info' or 'warning' banners. #}
-  <div class="banner banner--{{ banner.type or 'info' }}">
+  <announcement-banner class="banner banner--{{ banner.type or 'info' }}" storage-key="user-banner">
     <div class="banner__inner">
       <div class="banner__text">
         {# These inline block wrappers are a little hack to make content #}
@@ -17,13 +17,19 @@
         <div class="display-inline-block">
           {% if banner.actions %}
             {% for action in banner.actions %}
-              <a class="banner__action material-button button-text" href="{{ action.href }}">
-                {{ action.text }}
-              </a>
+              {% if action.href %}
+                <a class="banner__action material-button button-text" href="{{ action.href }}" data-banner-close-btn>
+                  {{ action.text }}
+                </a>
+              {% else %}
+                <button class="banner__action material-button button-text" data-banner-close-btn>
+                  {{ action.text }}
+                </button>
+              {% endif %}
             {% endfor %}
           {% endif %}
         </div>
       </div>
     </div>
-  </div>
+  </announcement-banner>
 {% endif %}

--- a/site/_includes/partials/cookie-banner.njk
+++ b/site/_includes/partials/cookie-banner.njk
@@ -7,7 +7,7 @@
   </div>
   <div class="cookie-banner__controls">
     <a class="material-button button-text color-blue-medium display-inline-flex align-center"
-       href="https://policies.google.com/technologies/cookies">
+       href="{{ site.cookiesCtaUrl }}">
       More details {{ icon('external-link', {className: 'gap-left-200'}) }}
     </a>
     <button class="material-button button-filled color-bg bg-primary" data-banner-close-btn>

--- a/site/_includes/partials/script.js
+++ b/site/_includes/partials/script.js
@@ -38,12 +38,29 @@
   );
   ga('send', 'pageview');
 
+  // Check if the user has accepted cookies. If so, set an attribute on
+  // the html element which will hide the banner.
   try {
-    const ctaUrl = 'https://policies.google.com/technologies/cookies';
-    const savedCtaUrl = localStorage.getItem('user-cookies');
+    const cookiesCtaUrl = '{{ site.cookiesCtaUrl }}';
+    const savedCookiesCtaUrl = localStorage.getItem('user-cookies');
 
-    if (savedCtaUrl === ctaUrl) {
-      document.documentElement.classList.add('banner--hide');
+    if (savedCookiesCtaUrl === cookiesCtaUrl) {
+      document.documentElement.setAttribute('data-cookies-accepted', '');
+    }
+  } catch (e) {
+    // ignore
+  }
+
+  // If we're displaying a promotional banner, check if the user has dismissed
+  // it. If so, set an attribute on the html element to hide the banner.
+  // Note that it's possible for a banner to have more than one action but
+  // we always use the url from the first action as the localStorage value.
+  try {
+    const bannerCtaUrl = '{{ banner.actions[0].href }}';
+    const savedBannerCtaUrl = localStorage.getItem('user-banner');
+
+    if (savedBannerCtaUrl === bannerCtaUrl) {
+      document.documentElement.setAttribute('data-banner-dismissed', '');
     }
   } catch (e) {
     // ignore

--- a/site/_js/third-party/announcement-banner/announcement-banner.js
+++ b/site/_js/third-party/announcement-banner/announcement-banner.js
@@ -4,11 +4,13 @@ class Banner extends HTMLElement {
     // after this class is added—this prevents ghost clicks on the button before
     // the event listener is added.
     this.setAttribute('active', '');
-
-    const button = this.querySelector('[data-banner-close-btn]');
-    /** @type {HTMLElement} */ (button).addEventListener('click', () => {
-      this.savePreference();
-      this.close();
+    this.addEventListener('click', e => {
+      if (
+        /** @type {HTMLElement} */ (e.target).closest('[data-banner-close-btn]')
+      ) {
+        this.savePreference();
+        this.close();
+      }
     });
   }
 

--- a/site/_scss/blocks/_announcement-banner.scss
+++ b/site/_scss/blocks/_announcement-banner.scss
@@ -1,4 +1,7 @@
-.banner--hide announcement-banner,
+announcement-banner {
+  display: block;
+}
+
 announcement-banner[hidden] {
   display: none;
 }

--- a/site/_scss/blocks/_banner.scss
+++ b/site/_scss/blocks/_banner.scss
@@ -22,7 +22,7 @@
     justify-content: space-between;
     width: 100%;
 
-    @include media-query('md') {
+    @include media-query('lg') {
       align-items: baseline;
       flex-direction: row;
     }
@@ -36,8 +36,9 @@
     display: flex;
     justify-content: flex-end;
     margin-top: get-size(300);
+    white-space: nowrap;
 
-    @include media-query('md') {
+    @include media-query('lg') {
       align-items: flex-end;
       margin-left: get-size(300);
       margin-top: 0;
@@ -47,4 +48,8 @@
   &__action {
     @include apply-utility('weight', 'medium');
   }
+}
+
+[data-banner-dismissed] .banner {
+  display: none;
 }

--- a/site/_scss/blocks/_cookie-banner.scss
+++ b/site/_scss/blocks/_cookie-banner.scss
@@ -1,3 +1,7 @@
+[data-cookies-accepted] .cookie-banner {
+  display: none;
+}
+
 .cookie-banner {
   @include apply-utility('stack', '700');
   background-color: var(--color-bg);


### PR DESCRIPTION
Fixes #323

Changes proposed in this pull request:

- Clicking any of the actions on a site banner will now dismiss it and store the preference.
- We use the same `announcement-banner` custom element for our site banner that we use for our cookies banner (yay reuse!)