### PR TITLE
Fix broken link in docs

### DIFF
--- a/site/en/docs/android/custom-tabs/overview/index.md
+++ b/site/en/docs/android/custom-tabs/overview/index.md
@@ -105,7 +105,7 @@ For questions, check the [chrome-custom-tabs][5] tag on StackOverflow.
 [5]: https://stackoverflow.com/questions/tagged/chrome-custom-tabs
 [6]: https://research.google/pubs/pub46739/
 [7]: https://android-developers.googleblog.com/2015/09/chrome-custom-tabs-smooth-transition.html
-[8]: /docs/android/trusted-web-activity
+[8]: /docs/android/trusted-web-activity/overview/
 [9]: https://web.dev/progressive-web-apps/
 [10]: https://developers.google.com/digital-asset-links
 [11]: /docs/android/custom-tabs/integration-guide/


### PR DESCRIPTION
Fixes #813 . My CLA is under the name on my Github account, @Binney.

Changes proposed in this pull request:

- Changes link 8 to https://developer.chrome.com/docs/android/trusted-web-activity/overview/