### PR TITLE
Fix outdated `web_accessible_resources`

### DIFF
--- a/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
+++ b/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
@@ -247,8 +247,8 @@ of which can map to a set of resources to a set of URLs and extension IDs:
 {% endColumns %}
 
 {% Aside %}
-The `extension_ids`, and `use_dynamic_url` keys are not available
-yet. Support for these properties will be coming in a future release.
+The `use_dynamic_url` key is not available yet. Support for this property will
+be coming in a future release.
 {% endAside %}
 
 Previously, the list of web accessible resources applied to all websites and

--- a/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
+++ b/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
@@ -247,14 +247,15 @@ of which can map to a set of resources to a set of URLs and extension IDs:
 {% endColumns %}
 
 {% Aside %}
-The `matches`, `extension_ids`, and `use_dynamic_url` keys are not available
+The `extension_ids`, and `use_dynamic_url` keys are not available
 yet. Support for these properties will be coming in a future release.
 {% endAside %}
 
 Previously, the list of web accessible resources applied to all websites and
 extensions, which created opportunities for fingerprinting or unintentional
 resource access. The updated API lets extensions more tightly control what
-other sites or extensions can access extension resources.
+other sites or extensions can access extension resources. You must specify
+a value for `matches` in order for the manifest to be valid.
 
 
 ## Code execution  {: #code-execution }

--- a/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
+++ b/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
@@ -254,8 +254,9 @@ yet. Support for these properties will be coming in a future release.
 Previously, the list of web accessible resources applied to all websites and
 extensions, which created opportunities for fingerprinting or unintentional
 resource access. The updated API lets extensions more tightly control what
-other sites or extensions can access extension resources. You must specify
-a value for `matches` in order for the manifest to be valid.
+other sites or extensions can access extension resources. See the [web 
+accessible resources](/docs/extensions/mv3/manifest/web_accessible_resources/)
+documentation for usage information.
 
 
 ## Code execution  {: #code-execution }
@@ -478,4 +479,3 @@ As well as the undocumented:
 
 If your extensions use any of these deprecated APIs, you'll need to make the
 appropriate changes when you migrate to MV3.
-


### PR DESCRIPTION
The information appears to be out of date, as it suggests the only currently available key is `resources`. However, if only `resources` is provided then up-to-date Chrome (and Edge) both give the following error:

Invalid value for 'web_accessible_resources[0]'. Entry must at least have resources, and one other valid key.
Could not load manifest.

Fixes https://github.com/GoogleChrome/developer.chrome.com/issues/820

Changes proposed in this pull request:

- Update docs