### PR TITLE
update the manifest.json code example to mv3 

### DIFF
--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -36,8 +36,7 @@ as the most important files and the capabilities the extension might use.
     "128": "icon_128.png"
   },
   "background": {
-    "persistent": false,
-    "scripts": ["background_script.js"]
+    "service_worker": "background.js"
   },
   "permissions": ["https://*.google.com/", "activeTab"],
   "browser_action": {

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -38,8 +38,8 @@ as the most important files and the capabilities the extension might use.
   "background": {
     "service_worker": "background.js"
   },
-  "permissions": ["https://*.google.com/", "activeTab"],
-  "browser_action": {
+  "permissions": ["activeTab"],
+  "action": {
     "default_icon": "icon_16.png",
     "default_popup": "popup.html"
   }

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -39,6 +39,7 @@ as the most important files and the capabilities the extension might use.
     "service_worker": "background.js"
   },
   "permissions": ["activeTab"],
+  "host_permissions": ["*://*.example.com/*"],
   "action": {
     "default_icon": "icon_16.png",
     "default_popup": "popup.html"


### PR DESCRIPTION
I've updated the manifest.json code sample on the architecture overview page

Changes proposed in this pull request:

- The key background in the manifest.json no longer contain the field persistent and also update the value from scripts to service_worker
- browser_action or page_action property replaced with action