### PR TITLE
Migrate three articles from web.dev

### DIFF
--- a/site/_data/authorsData.json
+++ b/site/_data/authorsData.json
@@ -650,7 +650,7 @@
     "glitch": "samdutton",
     "image": "image/80mq7dk16vVEg8BBhsVe42n6zn82/F3Df3SeugXYQEUUiMslu.jpg"
   },
-    "maudn": {
+  "maudn": {
     "name": {
       "given": "Maud",
       "family": "Nalpas"
@@ -666,5 +666,24 @@
     "twitter": "maudnals",
     "github": "maudnals",
     "image": "image/80mq7dk16vVEg8BBhsVe42n6zn82/fJP5RRP6pcCnfctkaQhu.jpg"
+  },
+  "thomassteiner": {
+    "name": {
+      "given": "Thomas",
+      "family": "Steiner"
+    },
+    "homepage": "https://blog.tomayac.com/",
+    "twitter": "tomayac",
+    "github": "tomayac",
+    "glitch": "tomayac",
+    "descriptions": {
+      "en": "Tom is a Developer Advocate"
+    },
+    "org": {
+      "name": "Google",
+      "unit": "Developer Relations"
+    },
+    "country": "DE",
+    "image": "image/8WbTDNrhLsU0El80frMBGE4eMCD3/TbY7HP8KuTtQ6Y1186nt.jpg"
   }
 }

--- a/site/en/blog/browser-flags/index.md
+++ b/site/en/blog/browser-flags/index.md
@@ -38,7 +38,7 @@ flag for experimentation. You guessed it, `chrome://flags` is where this happens
 ask you to set is `chrome://flags/#enable-experimental-web-platform-features`, which, as the name
 suggests, enables experimental web platform features.
 
-{% Aside 'warning' %} As the name suggests, experimental web platform features are _experimental_.
+{% Aside 'warning' %} As the name suggests, experimental web platform features are <em>experimental</em>.
 We do not recommend you set flags on your daily production browser. Instead, we prefer you to use a
 development browser version like the Beta, Dev, or Canary channel for your development needs where
 you can set flags as required, and the Stable channel for everything else.
@@ -46,7 +46,7 @@ Also be sure to only set flags based on instructions from sources you trust. {% 
 
 {% Img src="image/8WbTDNrhLsU0El80frMBGE4eMCD3/Fnn0rmiT8XY9IaOGdvL4.png", alt="Toggling the 'experimental web platform features' flag.", width="800", height="125" %}
 
-{% Aside %} Browser flags are distinct from [origin trials](https://web.dev/origin-trials/).
+{% Aside %} Browser flags are distinct from <a href="/blog/origin-trials/">origin trials</a>.
 
 Origin trials are set by website owners and opt a user's browser into supporting a given feature. Only
 features deemed safe for testing with real users are available for origin trials.

--- a/site/en/blog/browser-flags/index.md
+++ b/site/en/blog/browser-flags/index.md
@@ -1,0 +1,83 @@
+---
+layout: 'layouts/blog-post.njk'
+title: How to set browser flags in Chromium
+subhead: |
+  For some of the new APIs we introduce in Chromium, you need to set a browser flag for experimentation.
+  This article explains how to do this in the various Chromium derivatives like Google Chrome, Microsoft Edge, and others.
+authors:
+  - thomassteiner
+date: 2021-05-18
+updated: 2021-06-03
+description: |
+  For some of the new APIs we introduce in Chromium, you need to set a browser flag for experimentation.
+  This article explains how to do this in the various Chromium derivatives like Google Chrome, Microsoft Edge, and others.
+hero: image/8WbTDNrhLsU0El80frMBGE4eMCD3/LKYqNS9Pe2pETyU0zaSs.jpg
+alt: Various party flags.
+tags:
+  - capabilities
+---
+
+[Chromium](https://www.chromium.org/) is an open-source browser project that aims to build a safer,
+faster, and more stable way for all users to experience the web. A lot of web browsers are built on
+Chromium, including the popular browsers [Google Chrome](https://www.google.com/chrome/) by
+[Google](https://www.google.com/), [Microsoft Edge](https://www.microsoft.com/en-us/edge) by
+[Microsoft](https://www.microsoft.com/), [Opera Web Browser](https://www.opera.com/) by
+[Opera](https://www.opera.com/about), and
+[many others](<https://en.wikipedia.org/wiki/Chromium_(web_browser)#Browsers_based_on_Chromium>).
+
+## The `chrome://` scheme
+
+Google Chrome has since the beginning supported a special scheme called `chrome://` for accessing
+browser-internal settings or features. You can see the full list by putting
+`chrome://chrome-urls` into the URL bar. The special URL of interest here is `chrome://flags`.
+
+## Setting browser flags
+
+For some [new APIs](https://web.dev/tags/capabilities/) in Chromium, you need to set a browser
+flag for experimentation. You guessed it, `chrome://flags` is where this happens. The most popular flag we
+ask you to set is `chrome://flags/#enable-experimental-web-platform-features`, which, as the name
+suggests, enables experimental web platform features.
+
+{% Aside 'warning' %} As the name suggests, experimental web platform features are _experimental_.
+We do not recommend you set flags on your daily production browser. Instead, we prefer you to use a
+development browser version like the Beta, Dev, or Canary channel for your development needs where
+you can set flags as required, and the Stable channel for everything else.
+Also be sure to only set flags based on instructions from sources you trust. {% endAside %}
+
+{% Img src="image/8WbTDNrhLsU0El80frMBGE4eMCD3/Fnn0rmiT8XY9IaOGdvL4.png", alt="Toggling the 'experimental web platform features' flag.", width="800", height="125" %}
+
+{% Aside %} Browser flags are distinct from [origin trials](https://web.dev/origin-trials/).
+
+Origin trials are set by website owners and opt a user's browser into supporting a given feature. Only
+features deemed safe for testing with real users are available for origin trials.
+
+Browser flags are set by you and opt in your local browser to a given feature. Not all features that
+are available behind a flag are ripe for production—sometimes quite the opposite. {% endAside %}
+
+## Scheme rewrites
+
+Something interesting happens, though, if you enter a `chrome://` URL into a browser that is not
+Chrome. For example, if you enter `chrome://flags/#enable-experimental-web-platform-features` into
+Microsoft Edge, you will notice that it gets rewritten as
+`edge://flags/#enable-experimental-web-platform-features`. All vendors have created this rewrite
+mechanism, which makes sense, as Edge is not Chrome, although it is based on Chromium.
+
+## Inclusive documentation
+
+We strive for making our documentation inclusive of different browsers, so, for example, telling a
+[Brave](https://brave.com/) user to navigate to `chrome://flags` to toggle a given flag—while it
+works thanks to the rewrite mechanism—may not be the most welcoming experience. At the same time,
+listing all possible vendor schemes like `edge://`, `chrome://`, `brave://`, etc. is not a great
+solution either.
+
+## One scheme to rule them all
+
+Luckily there is a hidden champion scheme that fits all our needs: `about://`. In Chrome, `about://`
+URLs get rewritten to `chrome://`, in Edge to `edge://`, and so on for all vendors. We are in this
+web thing together, and this is `about://` all of us! Whenever you see instructions that include the
+`about://` scheme, your Chromium browser of choice will do the right thing.
+
+## Acknowledgements
+
+Hero image by [Photos by Lanty](https://unsplash.com/@photos_by_lanty) on
+[Unsplash](https://unsplash.com/s/photos/flags).

--- a/site/en/blog/origin-trials/index.md
+++ b/site/en/blog/origin-trials/index.md
@@ -1,0 +1,91 @@
+---
+layout: 'layouts/blog-post.njk'
+title: Getting started with Chrome's origin trials
+subhead: Origin trials are a way to test a new or experimental web platform feature, and give feedback to the web standards community on the feature's usability, practicality, and effectiveness, before the feature is made available to all users.
+authors:
+  - samdutton
+date: 2020-06-22
+updated: 2021-06-03
+hero: image/8WbTDNrhLsU0El80frMBGE4eMCD3/KeaVCdXHWzrI35QRvsZL.jpg
+alt: Pipette with purple liquid
+tags:
+  - origin-trials
+---
+
+Origin trials give you access to a new or experimental feature, to build
+functionality your users can try out for a limited time before the feature
+is made available to everyone.
+
+When Chrome offers an origin trial for a feature, you can register for the trial to enable
+the feature for all users on your [origin](https://web.dev/same-site-same-origin/#origin),
+without requiring them to toggle any flags or switch to an alternative build
+of Chrome (though they may need to upgrade). Origin trials enable developers
+to build demos and prototypes using new features. The trials also help Chrome engineers
+understand how new features are used, and how they may interact with other web technologies.
+
+Origin trials are public and open to all developers. They are limited in duration and
+usage. Participation is a self-managed process with limited documentation and support.
+Participants should be willing and able to work relatively independently using the
+documentation available, which, at this stage, will likely be limited to API
+specifications and explainers, though web.dev tries to provide guidance whenever
+possible.
+
+If you register for a trial, the Chrome team will periodically ask you for specific
+feedback on your use of the trial feature. Some features may undergo multiple origin
+trials, as learnings are incorporated and adjustments are made.
+
+{% Aside %}
+**Third-party origin trials**
+
+Origin trials are usually only available on a first-party basis: they only work for a single
+registered [origin](https://web.dev/same-site-same-origin/#origin). Third-party origin trials make
+it possible for providers of embedded content to try a new feature across multiple sites
+without requiring a token for every origin.
+
+Find out more: [What are third-party origin trials?](/blog/third-party-origin-trials/).
+{% endAside %}
+
+## How to register for an origin trial
+
+1. Choose an origin trial from the [list of active trials](https://developers.chrome.com/origintrials/#/trials/active).
+1. Request a token by clicking the **Register** button and filling out the form.
+1. Add the token to your web pages,
+   using one of the following methods:
+   -  As a meta tag in the &lt;head&gt; of each page served:
+      `<meta http-equiv="origin-trial" content="TOKEN_GOES_HERE">`
+   -  As an HTTP header:
+      `Origin-Trial: TOKEN_GOES_HERE`
+1. Try out the new feature.
+1. Submit feedback. Do this through the origin trial site. This feedback is
+   not public and is available only to a limited group of people on the Chrome
+   team. Each trial also provides a link for spontaneous community feedback.
+   This typically points to the feature on GitHub or some other public
+   channel.
+1. When your token expires, you will get an email with a renewal link.
+   To do so, you are again asked to submit feedback.
+
+{% Aside 'warning' %}
+Usually if an API lands unchanged after a successful origin trial, there is a short period between the
+end of the origin trial and the date the implementation ships in the browser when the API will not
+be available. This is by design. If Chrome were to avoid the mandatory total-breakage period, that would
+bias toward also avoiding breakages in the API surface, which are often needed to improve the API.
+The final shipping API might be worse for it.
+
+In rare circumstances, if there was clear evidence that developers engaged with the origin trial and that their
+concerns were taken into account in the final API design and implementation,
+this breakage period may be skipped
+[upon request](https://sites.google.com/a/chromium.org/dev/blink/launching-features#sites-canvas-main-content:~:text=If%20you%20wish%20to%20skip%20the,Ship%20imply%20approval%20of%20the%20request.).
+{% endAside %}
+
+## Find out more
+
+-  [Origin trials guide for web developers](https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md)
+-  [Origin trial explainer](https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/explainer.md)
+-  [Running an origin trial](https://www.chromium.org/blink/origin-trials/running-an-origin-trial)
+-  [Process for launching new features in Chromium](https://www.chromium.org/blink/launching-features)
+-  [Intent to explain: Demystifying the Blink shipping process](https://www.youtube.com/watch?time_continue=291&v=y3EZx_b-7tk)
+-  [What are third-party origin trials?](/blog/third-party-origin-trials/)
+---
+
+Photo by [Louis Reed
+](https://unsplash.com/@_louisreed) on [Unsplash](https://unsplash.com/photos/pwcKF7L4-no).

--- a/site/en/blog/third-party-origin-trials/index.md
+++ b/site/en/blog/third-party-origin-trials/index.md
@@ -1,0 +1,90 @@
+---
+layout: 'layouts/blog-post.njk'
+title: What are third-party origin trials?
+subhead: Origin trials are a way to test a new or experimental web platform feature. A third-party origin trial makes it possible for providers of embedded content to try out a new feature across multiple sites.
+authors:
+  - samdutton
+date: 2020-10-01
+updated: 2021-06-03
+hero: image/8WbTDNrhLsU0El80frMBGE4eMCD3/gPlFs9TIUayaQ1MvxRlP.jpg
+alt: Person wearing medical gloves pouring purple liquid from glass beaker into flask. Bristol Robotics Laboratory, UK.
+tags:
+  - origin-trials
+---
+
+[Origin trials](/blog/origin-trials/) are a way to test a new or experimental web platform
+feature.
+
+Origin trials are usually only available on a first-party basis: they only work for a single
+registered [origin](https://web.dev/same-site-same-origin/#origin). If a developer wants to test an
+experimental feature on other origins where their content is embedded, those origins all need to be
+registered for the origin trial, each with a unique trial token. This is not a scalable approach for
+testing scripts that are embedded across a number of sites.
+
+Third-party origin trials make it possible for providers of embedded content to try out a new
+feature across multiple sites.
+
+{% Img src="image/8WbTDNrhLsU0El80frMBGE4eMCD3/fCachIuiBjh3XPo10CrN.png", alt="Diagram showing how third-party origin trials enable a single registration token to be used across multiple origins", width="800", height="400" %}
+
+Third-party origin trials don't make sense for all features. Chrome will only make the third-party
+origin trial option available for features where embedding code on third-party sites is a common use
+case.  [Getting started with Chrome's origin trials](https://developers.chrome.com/origintrials/)
+provides more general information about how to participate in Chrome origin trials.
+
+If you participate in an origin trial as a third-party provider, it will be your responsibility to
+notify and set expectations with any partners or customers whose sites you intend to include in the
+origin trial. Experimental features may cause unexpected issues and browser vendors may not be able
+to provide troubleshooting support.
+
+{% Aside %}
+Supporting third-party origin trials allows for broader participation, but also increases the
+potential for overuse or abuse of experimental features, so a "trusted tester" approach is more
+appropriate. The greater reach of third-party origin trials requires additional scrutiny and
+additional responsibility for web developers that participate as third-party providers. Requests to
+enable a third-party origin trial may be reviewed in order to avoid problematic third-party scripts
+affecting multiple sites. The Origin Trials Developer Guide explains the
+[approval process](https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md#18-how-can-i-enable-an-experimental-feature-as-embedded-content-on-different-domains).
+{% endAside %}
+
+Check [Chrome Platform Status](https://www.chromestatus.com/features/5691464711405568) for updates
+on progress with third-party origin trials.
+
+## How to register for a third-party origin trial
+
+1. Select a trial from the [list of active
+   trials](https://developers.chrome.com/origintrials/#/trials/active).
+1. On the trial's registration page, enable the option to request a third-party token, if
+   available.
+1. Select one of the choices for restricting usage for a third-party token:
+   1. Standard Limit: This is the usual limit of
+      [0.5% of Chrome page loads](https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md#3-what-happens-if-a-large-site-such-as-a-google-service-starts-depending-on-an-experimental-feature).
+   1. User Subset: A small percentage of Chrome users will always be excluded from the trial,
+      even when a valid third-party token is provided. The exclusion percentage varies (or might
+      not apply) for each trial, but is typically less than 5%.
+
+1. Click the Register button to submit your request.
+1. Your third-party token will be issued immediately, unless further review of the request is
+   required. (Depending on the trial, token requests may require review.)
+1. If review is required, you'll be notified by email when the review is complete and your
+   third-party token is ready.
+
+   <figure class="w-figure">
+     {% Img src="image/8WbTDNrhLsU0El80frMBGE4eMCD3/r07Zb0QoHnlgiItETR6q.png", alt="Chrome origin trials registration page for the Conversion Measurement API, with third-party matching checkbox selected.", width="800", height="618" %}
+     <figcaption class="w-figcaption">Registration page for the Conversion Measurement trial.</figcaption>
+   </figure>
+
+## How to provide feedback
+
+If you're registering for a third-party origin trial and have feedback to share on the process or
+ideas on how we can improve it, please [create an
+issue](https://github.com/GoogleChrome/OriginTrials/issues/new) on the Origin Trials GitHub code
+repo.
+
+## Find out more
+
+-  [Getting started with Chrome's origin trials](/blog/origin-trials/)
+-  [Origin Trials Guide for Web Developers](https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md)
+-  [Chrome Platform Status](https://www.chromestatus.com/features/5691464711405568)
+
+Photo by [Louis Reed
+](https://unsplash.com/@_louisreed) on [Unsplash](https://unsplash.com/photos/JeInkKlI2Po).


### PR DESCRIPTION
Fixes https://github.com/GoogleChrome/web.dev/issues/5496#issuecomment-853242456

Changes proposed in this pull request:

- Migrate https://web.dev/browser-flags/ to `/blog/browser-flags/`.
- Migrate https://web.dev/origin-trials/ to `/blog/origin-trials/`.
- Migrate https://web.dev/third-party-origin-trials/ to `/blog/third-party-origin-trials/`.