### PR TITLE
Corrected the pane name to access

### DIFF
--- a/site/en/docs/devtools/storage/applicationcache/index.md
+++ b/site/en/docs/devtools/storage/applicationcache/index.md
@@ -18,7 +18,7 @@ This guide shows you how to use [Chrome DevTools][2] to inspect [Application Cac
 
 ## View Application Cache Data {: #view }
 
-1.  Click the **Sources** tab to open the **Sources** panel. The **Manifest** pane usually opens by
+1.  Click the **Sources** tab to open the **Application** panel. The **Manifest** pane usually opens by
     default.
 
     {% Img src="image/admin/DWM2ZTX1pMb2BuJmIPNd.png", alt="The Manifest pane.", width="800", height="619" %}


### PR DESCRIPTION
Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- Replaced reference to "Sources" pane by the newer "Application" one