### PR TITLE
Fix incorrect CWS FAQ links

### DIFF
--- a/site/en/docs/webstore/complaint-faq/index.md
+++ b/site/en/docs/webstore/complaint-faq/index.md
@@ -64,5 +64,5 @@ level of investigation needed to determine the root cause/explanation. For examp
 stats on the dashboard, extensions between developers, and developer account recovery have been
 known to require longer investigation times.
 
-[1]: /docs/webstore/faq#faq-gen-24
-[2]: /docs/webstore/faq#faq-gen-24
+[1]: /docs/webstore/faq/#faq-gen-24
+[2]: /docs/webstore/faq/#how-can-i-raise-p2b-concerns


### PR DESCRIPTION
The complaint handling FAQ contained two links, both of which pointed at the CWS FAQ entry on "How are items ranked in the store?" Neither of these items should have linked to that section.