### PR TITLE
Update /docs/devtools/customize/placement/index.md with current placement options and add keyboard shortcuts for Linux/Windows/Mac

### DIFF
--- a/site/en/docs/devtools/customize/placement/index.md
+++ b/site/en/docs/devtools/customize/placement/index.md
@@ -40,7 +40,7 @@ left, or undock to a DevTools to a separate bottom.
 ## Change placement from the Command Menu {: #commandmenu }
 
 1.  [Open the Command Menu][1].
-2.  Run one of the following commands: `Dock to left`, `Dock to right`, `Dock to bottom`, `Undock Into Separate Window` or `Restore last dock position`. To toggle `Restore last dock position`, press <kbd>Control</kbd>+<kbd>Shift</kbd>+<kbd>D</kbd> (Linux/Windows) or <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>D</kbd> (Mac).
+2.  Run one of the following commands: `Dock to left`, `Dock to right`, `Dock to bottom`, `Undock into separate window` or `Restore last dock position`. To toggle `Restore last dock position` with a keyboard shortcut, press <kbd>Control</kbd>+<kbd>Shift</kbd>+<kbd>D</kbd> (Linux/Windows) or <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>D</kbd> (Mac).
 
     {% Img src="image/admin/VAHPOl8MveN1GYVP8o4C.png", alt="The undock command.", width="800", height="442" %}
 

--- a/site/en/docs/devtools/customize/placement/index.md
+++ b/site/en/docs/devtools/customize/placement/index.md
@@ -3,7 +3,7 @@ layout: "layouts/doc-post.njk"
 title: "Change placement: undock, dock to bottom, dock to left"
 authors:
   - kaycebasques
-date: 2019-05-14
+date: 2021-06-09
 #updated: YYYY-MM-DD
 description:
   "How to move Chrome DevTools to the bottom or left of your viewport, or to a separate window."

--- a/site/en/docs/devtools/customize/placement/index.md
+++ b/site/en/docs/devtools/customize/placement/index.md
@@ -40,12 +40,10 @@ left, or undock to a DevTools to a separate bottom.
 ## Change placement from the Command Menu {: #commandmenu }
 
 1.  [Open the Command Menu][1].
-2.  Run one of the following commands: `Dock To Bottom`, `Undock Into Separate Window`. Currently
-    there is no command for docking to left, but you can access it from the [main menu][2].
+2.  Run one of the following commands: `Dock to left`, `Dock to right`, `Dock to bottom`, `Undock Into Separate Window` or `Restore last dock position`. To toggle `Restore last dock position`, press <kbd>Control</kbd>+<kbd>Shift</kbd>+<kbd>D</kbd> (Linux/Windows) or <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>D</kbd> (Mac).
 
     {% Img src="image/admin/VAHPOl8MveN1GYVP8o4C.png", alt="The undock command.", width="800", height="442" %}
 
     **Figure 5**. The undock command.
 
 [1]: /docs/devtools/command-menu
-[2]: #menu


### PR DESCRIPTION
https://developer.chrome.com/docs/devtools/customize/placement/ comes up as the 2nd search result for "[toggle developer tools position](https://www.google.com/search?q=toggle+developer+tools+position)" on Google:

![image](https://user-images.githubusercontent.com/1504756/121439278-7ac5c680-c93a-11eb-92cd-7ed9eec91075.png)


Changes proposed in this pull request:

- Update docs to use current placement options as of Chrome 91. 
![image](https://user-images.githubusercontent.com/1504756/121439402-b9f41780-c93a-11eb-8c0d-279e0d3c75af.png)

- Add keyboard shortcut for Linux, Windows and Mac. Not actually sure the shortcut works on Mac though, need verification for Mac.