### PR TITLE
Correct last update date for the Developer Program Policies page

### DIFF
--- a/site/en/docs/webstore/program_policies/index.md
+++ b/site/en/docs/webstore/program_policies/index.md
@@ -2,7 +2,7 @@
 layout: "layouts/doc-post.njk"
 title: "Developer Program Policies"
 date: 2014-02-28
-updated: 2020-11-17
+updated: 2021-02-04
 description: Chrome Web Store developer program policies.
 ---
 


### PR DESCRIPTION
This PR modifies the "updated" date on the Developer Program Policies page to reflect the last substantial update to the page's content.

Fixes #372