### PR TITLE
Browser action docs use incorrect property name in sample manifest

### DIFF
--- a/site/en/docs/extensions/reference/browserAction/index.md
+++ b/site/en/docs/extensions/reference/browserAction/index.md
@@ -18,7 +18,7 @@ Register your browser action in the [extension manifest][2] like this:
 {
   "name": "My extension",
   ...
-  "action": {
+  "browser_action": {
     "default_icon": {                // optional
       "16": "images/icon16.png",     // optional
       "24": "images/icon24.png",     // optional

--- a/site/en/docs/extensions/reference/browserAction/index.md
+++ b/site/en/docs/extensions/reference/browserAction/index.md
@@ -7,7 +7,7 @@ browser action. A popup is below the icon.
 
 ![](browser-action.png)
 
-If you want to create an icon that isn't always visible, use a [page action][1] instead of a browser
+If you want to create an icon that isn't always active, use a [page action][1] instead of a browser
 action.
 
 ## Manifest


### PR DESCRIPTION
The first code sample in the browser action API docs indicates that the manifest key for a browser action is "action". This PR fixes that reference to say "browser_action".

This PR also contains a minor clarification on page action.