### PR TITLE
Note availibility of 'func' and 'args' parameters

### DIFF
--- a/site/en/blog/crx-scripting-api/index.md
+++ b/site/en/blog/crx-scripting-api/index.md
@@ -168,7 +168,7 @@ chrome.action.onClicked.addListener(async (tab) => {
 
   chrome.scripting.executeScript({
     target: {tabId: tab.id},
-    func: greetUser,
+    function: greetUser,
     args: [givenName],
   });
 });


### PR DESCRIPTION
Couple notes: In the current builds the 'func' parameter seems to be called 'function'

Also, 'args' is not implemented:

background.js:155 Uncaught (in promise) TypeError: Error in invocation of scripting.executeScript(scripting.ScriptInjection injection, optional function callback): Error at parameter 'injection': Unexpected property: 'args'.
    at copyLink (background.js:155)

Perhaps add a note that these are upcoming APIs?

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

-
-
-