### PR TITLE
Update manifest_version page to suggest using v3

### DIFF
--- a/site/en/docs/extensions/mv3/manifest/manifest_version/index.md
+++ b/site/en/docs/extensions/mv3/manifest/manifest_version/index.md
@@ -2,27 +2,18 @@
 layout: "layouts/doc-post.njk"
 title: "Manifest Version"
 date: 2013-05-12
-updated: 2018-04-26
+updated: 2020-06-20
 description: Reference documentation for the manifest_version property of manifest.json.
 ---
 
 One integer specifying the version of the manifest file format your package requires. As of Chrome
-18, developers _should_ specify `2` (without quotes) to use the format as described by this
+88, developers _should_ specify `3` (without quotes) to use the format as described by this
 document:
 
 ```json
-"manifest_version": 2
+"manifest_version": 3
 ```
 
-Consider manifest version 1 _deprecated_ as of Chrome 18. Version 2 is not yet _required_, but we
-will, at some point in the not-too-distant future, stop supporting packages using deprecated
-manifest versions. Extensions, applications, and themes that aren't ready to make the jump to the
-new manifest version in Chrome 18 can either explicitly specify version `1`, or leave the key off
-entirely.
+The Version 2 deprecation timeline is not yet published.
 
-The changes between version 1 and version 2 of the manifest file format are described in detail in
-[the `manifest_version` documentation.][1]
-
-<div class="aside aside--caution">Setting <code>manifest_version</code> 2 in Chrome 17 or lower is not recommended. If your extension needs to work in older versions of Chrome, stick with version 1 for the moment. We'll give you ample warning before version 1 stops working.</div>
-
-[1]: /docs/extensions/mv3/manifestVersion
+The changes in between Version 2 and Version 3 are described in detail in the [Overview of Manifest V3](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-overview/).


### PR DESCRIPTION
Fixes #906

Changes proposed in this pull request:

- I updated the page about "manifest_version" in the manifest file to recommend using "3", where this page used to just be a copy of the v2 information, which recommended using "2".
- The mention of "Chrome 88" is based on https://en.wikipedia.org/wiki/Google_Chrome_version_history which says v88 is when v3 started being allowed on the chrome web store. If there is a better source of truth, please update accordingly.
- The line "Version 2 timeline not yet published" comes from #56.
- I removed some paragraphs that are no longer timely and relevant, and that I don't have substitute information for.
- Updated "changes between 2 and 3" link to point to the v3 Overview page.

Please update this as you see fit. I just thought that this changeset would at least make the documentation page less confusing for now until a deprecation timeline is released.

