### PR TITLE
Cleanup best practices page

### DIFF
--- a/site/en/docs/webstore/best_practices/index.md
+++ b/site/en/docs/webstore/best_practices/index.md
@@ -15,7 +15,7 @@ We encourage you to develop extensions that are of high quality. High-quality ex
 standards of performance, security, and user experience, as summarized by the following guidelines:
 
 * **Compliance:** Does the extension comply with our [program policies]? Extensions must not violate
-any of these policies.
+  any of these policies.
 
 * **Manifest V3:** Is the extension built on Manifest V3? Manifest V3 is the current version of the
   Chrome extension platform and all High Quality extensions should use it. (See the [Manifest V3
@@ -36,10 +36,11 @@ any of these policies.
   good-looking, intuitive, and seamless user experience while also respecting the end user's
   privacy.
 
-* **Store listing:** The extension's [Chrome Web Store listing][completing-listing] should sets the
-  user's expectations and clearly communicates what the extension does.   All image assets (icon,
-  tile, marquee, and screenshots) [should be provided][supplying-images]. Images should not be
-  blurry or too busy. [Privacy information][dashboard-privacy] (permissions justifications, the extension's privacy policy, data use disclosures, etc.) must be accurate and up to date.
+* **Store listing:** The extension's [Chrome Web Store listing][completing-listing] should set the
+  user's expectations and clearly communicate what the extension does. All image assets (icon, tile,
+  marquee, and screenshots) [should be provided][supplying-images]. Images should not be blurry or
+  too busy. [Privacy information][dashboard-privacy] (permissions justifications, the extension's
+  privacy policy, data use disclosures, etc.) must be accurate and up to date.
 
 ## Support Google Accounts
 
@@ -54,7 +55,7 @@ the same way that you store other data that's associated with a user's account. 
 logged into a Google Account but not your login system, you can automatically log them into their
 user account in your system.
 
-See [Identifying the User][3] for more information about supporting Google Accounts.
+See [Identifying the User][identify-user] for more information about supporting Google Accounts.
 
 ## Keep ex-users' data for 30 days or more
 
@@ -64,19 +65,19 @@ intentionally unsubscribe or uninstall the app, they might come back.
 
 ## Cache license data
 
-If you use a payment processor or other licensing manager, you may also want to cache the results
-so that **(a)** Your user can still use the extension when they are offline, and **(b)** you
-reduce the number of queries to the license server, reducing quota usage and traffic.
+If you use a payment processor or other licensing manager, you may also want to cache the results so
+that **(a)** Your user can still use the extension when they are offline, and **(b)** you reduce the
+number of queries to the license server, reducing quota usage and traffic.
 
 ## Create a compelling store listing
 
 The better your app's listing in the store, the more users will find and try your app. When choosing
 your app's name, writing its description, and designing its logo, keep in mind Google's [Branding
-Guidelines][7].
+Guidelines][cws-branding].
 
 ### Provide great images
 
-See [Supplying Images][8] for guidelines on the images you should supply to the store.
+See [Supplying Images][cws-images] for guidelines on the images you should supply to the store.
 
 ### Choose your app's category well
 
@@ -95,15 +96,13 @@ that is most appropriate:
 * Social & Communication
 * Sports
 
-
-[3]: /docs/webstore/identify_user
-[7]: /docs/webstore/branding
-[8]: /docs/webstore/images
-[9]: #top
 [completing-listing]: /docs/webstore/cws-dashboard-listing/
+[cws-branding]: /docs/webstore/branding
+[cws-images]: /docs/webstore/images
 [dashboard-privacy]: /docs/webstore/cws-dashboard-privacy/
+[identify-user]: /docs/webstore/identify_user
 [mv3-overview]: /docs/extensions/mv3/intro/mv3-overview/
 [program policies]: /docs/webstore/program_policies/
-[supplying-images]: /docs/webstore/images/
 [stay-secure]: /docs/extensions/mv3/security/
+[supplying-images]: /docs/webstore/images/
 [user-data-faq]: /docs/webstore/user_data/


### PR DESCRIPTION
* Fix incorrect grammar
  * old: "listing should sets the user's expectations and clearly communicates what the extension does"
  * new: "should set the user's expectations and clearly communicate what the extension does"
* Rewrap at col 100
* Replace numeric links with named ones
* Alphabetically sort named links

