### PR TITLE
issue #905 - fixed typo in site/en/docs/apps/chrome_apps_on_mobile/in…

### DIFF
--- a/site/en/docs/apps/chrome_apps_on_mobile/index.md
+++ b/site/en/docs/apps/chrome_apps_on_mobile/index.md
@@ -374,7 +374,7 @@ The Chrome ADT for Android is currently in a pre-alpha release. To try it out, v
 [14]: http://nodejs.org
 [15]: http://nodejs.org
 [16]: https://github.com/creationix/nvm
-[17]: http://ww'w.oracle.com/technetwork/java/javase/downloads/index.html
+[17]: http://www.oracle.com/technetwork/java/javase/downloads/index.html
 [18]: http://developer.android.com/sdk/index.html
 [19]: https://www.google.com/search?q=how+to+add+sdktools+to+path
 [20]: http://ant.apache.org/bindownload.cgi


### PR DESCRIPTION
…dex.md

Fixes #905

Changes proposed in this pull request: 
- Changed line 377 [17]: http://ww'w.oracle.com/technetwork/java/javase/downloads/index.html to remove typo in URL for Java JDK. Now: http://www.oracle.com/technetwork/java/javase/downloads/index.html - removed '
