### PR TITLE
Set card images to auto height to avoid cropping.

### DIFF
--- a/site/_scss/blocks/_blog-card.scss
+++ b/site/_scss/blocks/_blog-card.scss
@@ -10,6 +10,6 @@
 
 .blog-card__thumbnail {
   img {
-    height: px-to-rem(184px);
+    max-height: px-to-rem(184px);
   }
 }

--- a/site/_scss/blocks/_featured-card.scss
+++ b/site/_scss/blocks/_featured-card.scss
@@ -18,6 +18,6 @@
 
 .featured-card__thumbnail {
   img {
-    height: px-to-rem(208px);
+    max-height: px-to-rem(208px);
   }
 }


### PR DESCRIPTION
Fixes #891 

On web.dev we use object-fit: cover on our cards and that's usually OK since folks rarely include text in their images. But on d.c.c. folks use text in images a lot, because they're doing blog post series.

This changes makes the card image area `height: auto` (the default) so images don't inadvertently get cropped on smaller screens. We do still have a max-height to prevent the images from getting too tall. So in some situations there will be a tiny bit of cropping, but hopefully nothing too bad.

Separately, we should probably update our docs to include ideal aspect ratios for card thumbnails and hero images.