### PR TITLE
Removes Manifest image on Cookies page

### DIFF
--- a/site/en/docs/devtools/storage/cookies/index.md
+++ b/site/en/docs/devtools/storage/cookies/index.md
@@ -16,18 +16,11 @@ page's cookies with Chrome DevTools.
 ## Open the Cookies pane {: #open }
 
 1.  [Open Chrome DevTools][2].
-2.  Click the **Application** tab to open the **Application** panel. The **Manifest** pane will
-    probably open.
-
-    {% Img src="image/admin/VdjVnm7S9Pbg4THMrlc0.png", alt="The Manifest pane", width="800", height="619" %}
-
-    **Figure 1**. The Manifest pane
-
-3.  Under **Storage** expand **Cookies**, then select an origin.
+2.  Click the **Application** tab to open the **Application** panel.  Under **Storage** expand **Cookies**, then select an origin.
 
     {% Img src="image/admin/Yl2rWrOQvnBHkZwjUzOi.png", alt="The Cookies pane", width="800", height="445" %}
 
-    **Figure 2**. The Cookies pane
+    **Figure 1**. The Cookies pane
 
 ## Fields {: #fields }
 


### PR DESCRIPTION
mentioning the manifest pane and having an image of it was irrelevant and distracting.  We just want to know where to head, and that leads the reader to believe that they should be in the manifest pane before they continue reading.  It's like telling someone "You see a fork in the road, and you will want to head not left".

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

-
-
-