### PR TITLE
Changed incorrect property func to function

### DIFF
--- a/site/en/docs/extensions/reference/commands/index.md
+++ b/site/en/docs/extensions/reference/commands/index.md
@@ -250,7 +250,7 @@ keyboard shortcut.
 chrome.action.onClicked.addListener((tab) => {
   chrome.scripting.executeScript({
     target: {tabId: tab.id},
-    func: contentScriptFunc,
+    function: contentScriptFunc,
     args: ['action'],
   });
 });


### PR DESCRIPTION
In the [chrome.commands](https://developer.chrome.com/docs/extensions/reference/commands/#action-command) API reference, the example that uses the method `chrome.scripting.executeScript` uses an incorrect property in the object passed. Instead of `function`, it passes `func`. When this code of the example is used, an error is thrown.

This pull request fixes this issue by changing `func` to `function`

**To Reproduce**
Steps to reproduce the behavior:
1. Go to [chrome.commands](https://developer.chrome.com/docs/extensions/reference/commands/#action-command) documentation
2. Copy the code for the Action command example for `background.js`
3. Create a chrome extension with a service worker `background.js` and paste the content in it
4. get an error in service worker when command is triggered:

```
Error in event handler: TypeError: Error in invocation of scripting.executeScript(scripting.ScriptInjection injection, optional function callback): Error at parameter 'injection': Unexpected property: 'func'.
    at chrome-extension://enhjmpkahklpmbndljologkmjjinpihf/background.js:2:22
```