### PR TITLE
Incorrect usage the passed argument to the listener

### DIFF
--- a/site/en/docs/extensions/reference/commands/index.md
+++ b/site/en/docs/extensions/reference/commands/index.md
@@ -212,7 +212,7 @@ registration as shown in the following example.
 ```js
 // background.js
 chrome.commands.onCommand.addListener((command) => {
-  console.log(`Command "${command.name}" triggered`);
+  console.log(`Command "${command}" triggered`);
 });
 ```
 


### PR DESCRIPTION
This example accesses a property `name` on `command` which the the argument that the listener for `onCommand` receives. However, this event listener receives the command as a [string](https://developer.chrome.com/docs/extensions/reference/commands/#event-onCommand) rather than an object.

You can also see the correct usage of it in the [second example](https://developer.chrome.com/docs/extensions/reference/commands/#action-command) in the same documentation.