### PR TITLE
Update index.md

### DIFF
--- a/site/en/docs/webstore/program_policies/index.md
+++ b/site/en/docs/webstore/program_policies/index.md
@@ -323,8 +323,7 @@ Privacy Policy Requirements
   Product collects, uses and shares user data, including the types of parties with whom it's shared.
   You must make the the policy accessible by providing a link:
 
-  - In the designated field in the Chrome Web Store Developer Dashboard, and
-  - In the Product's inline installation page (if applicable).
+  - In the designated field in the Chrome Web Store Developer Dashboard.
 
 Prominent Disclosure Requirement
 


### PR DESCRIPTION
As of 06/12/2018, inline installation is deprecated 'In the Product's inline installation page (if applicable)' option is redundant.

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

-
-
-