### PR TITLE
Fix invalid xmlns for gupdate tag

### DIFF
--- a/site/en/docs/extensions/mv2/linux_hosting/index.md
+++ b/site/en/docs/extensions/mv2/linux_hosting/index.md
@@ -165,7 +165,7 @@ The update manifest returned by the server should be an XML document.
 
 ```xml
 <?xml version='1.0' encoding='UTF-8'?>
-<gupdate xmlns='https://www.google.com/update2/response' protocol='2.0'>
+<gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
   <app appid='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'>
     <updatecheck codebase='https://myhost.com/mytestextension/mte_v2.crx' version='2.0' />
   </app>

--- a/site/en/docs/extensions/mv3/linux_hosting/index.md
+++ b/site/en/docs/extensions/mv3/linux_hosting/index.md
@@ -165,7 +165,7 @@ The update manifest returned by the server should be an XML document.
 
 ```xml
 <?xml version='1.0' encoding='UTF-8'?>
-<gupdate xmlns='https://www.google.com/update2/response' protocol='2.0'>
+<gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
   <app appid='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'>
     <updatecheck codebase='https://myhost.com/mytestextension/mte_v2.crx' version='2.0' />
   </app>


### PR DESCRIPTION
The document uses both the HTTP and the HTTPS version of the URL in the xmlns attribute, but only the HTTP is valid. I replaced the appearances of the HTTPS version with the HTTP version.

Relevant code here:

https://source.chromium.org/chromium/chromium/src/+/main:extensions/browser/updater/safe_manifest_parser.cc;l=186;drc=d2f37a73b35d282c9b8aa553f01faa1bfbf453c8