### PR TITLE
Add missing property in code example

### DIFF
--- a/site/en/docs/extensions/reference/runtime/index.md
+++ b/site/en/docs/extensions/reference/runtime/index.md
@@ -123,8 +123,8 @@ extension.
 
 
 ```js
-chrome.runtime.onInstalled.addListener(reason => {
-  if (reason === chrome.runtime.OnInstalledReason.INSTALL) {
+chrome.runtime.onInstalled.addListener(details => {
+  if (details.reason === chrome.runtime.OnInstalledReason.INSTALL) {
     chrome.runtime.setUninstallURL('https://example.com/extension-survey');
   }
 });


### PR DESCRIPTION
Changes proposed in this pull request:
- Add missing property in [Gathering feedback on uninstall](https://developer.chrome.com/docs/extensions/reference/runtime/#example-uninstall-url) in order for code example to function as expected
