### PR TITLE
[Introducing chrome.scripting] fixed fetch url typo of Manifest V3 example

### DIFF
--- a/site/en/blog/crx-scripting-api/index.md
+++ b/site/en/blog/crx-scripting-api/index.md
@@ -162,7 +162,7 @@ function greetUser(name) {
   alert(`Hello, ${name}!`);
 }
 chrome.action.onClicked.addListener(async (tab) => {
-  let userReq = await fetch('/https://example.com/user-data.json');
+  let userReq = await fetch('https://example.com/user-data.json');
   let user = await userReq.json();
   let givenName = user.givenName || '<GIVEN_NAME>';
 


### PR DESCRIPTION
Changes proposed in this pull request:

- fixed fetch url typo of Manifest V3 extension example in the **Changes between tabs.executeScript and scripting.executeScript** section of the article