### PR TITLE
Update externally_connectable example to use HTTPS

### DIFF
--- a/site/en/docs/extensions/mv3/messaging/index.md
+++ b/site/en/docs/extensions/mv3/messaging/index.md
@@ -208,7 +208,7 @@ which websites you want to communicate with. For example:
 
 ```json
 "externally_connectable": {
-  "matches": ["*://*.example.com/*"]
+  "matches": ["https://*.example.com/*"]
 }
 ```
 


### PR DESCRIPTION
The `externally_connectable` example in https://developer.chrome.com/docs/extensions/mv3/messaging/#external-webpage allows any protocol including HTTP, which allows MITM attackers to connect to the extension. To promote secure development, this PR changes the example to only allow HTTPS. This reduces risk if developer copy/pastes example and then edits only the hostname (like I did, before realizing the security implications).

See [this comment](#issuecomment-880395786) for other instances of similarly-insecure config examples in the docs.

Changes proposed in this pull request:

- Update `externally_connectable` example to use HTTPS