### PR TITLE
Fix code typo in Scripting API blog post

### DIFF
--- a/site/en/blog/crx-scripting-api/index.md
+++ b/site/en/blog/crx-scripting-api/index.md
@@ -162,7 +162,7 @@ function greetUser(name) {
   alert(`Hello, ${name}!`);
 }
 chrome.action.onClicked.addListener(async (tab) => {
-  let userReq = await fetch('/https://example.com/user-data.json');
+  let userReq = await fetch('https://example.com/user-data.json');
   let user = await userReq.json();
   let givenName = user.givenName || '<GIVEN_NAME>';
 


### PR DESCRIPTION
Fixes code typo in Scripting API blog post. Extraneous forward-slash (`/`) in code example.

Changes proposed in this pull request:

-  Fix code typo in Scripting API blog post