### PR TITLE
Correct the path to creating a release

### DIFF
--- a/site/en/docs/android/trusted-web-activity/quick-start/index.md
+++ b/site/en/docs/android/trusted-web-activity/quick-start/index.md
@@ -160,8 +160,9 @@ key:
 * Manually:
     1. Open the [Google Play Console](https://play.google.com/apps/publish/).
     2. Select your app.
-    3. Choose **Release management** and then **App signing** from the panel on the left.
-    4. Copy the **SHA-256 certificate fingerprint** from under the **App signing certificate**
+    3. Choose **Setup** under the **Release** section, and then click **App integrity** from the panel on the left.
+    4. Click on **Create Release** and then **Create new release** (if you are releasing for the first time on Play Store). Follow the steps on the next screens.
+    5. Copy the **SHA-256 certificate fingerprint** from under the **App signing certificate**
        section.
     5. Use this value in your Digital Asset Link file.
 


### PR DESCRIPTION
Changes proposed in this pull request:

- The documentation to create App Signing no longer matches the current UX workflow. This PR updates the steps

The demo is available 👇 

https://user-images.githubusercontent.com/6589036/126671450-b47ff909-d197-4c66-8ae0-d5f49d3d195f.mp4

