### PR TITLE
Fix match pattern typos in example configs in Security page

### DIFF
--- a/site/en/docs/extensions/mv3/security/index.md
+++ b/site/en/docs/extensions/mv3/security/index.md
@@ -49,14 +49,14 @@ specified in the permissions.
   "description": "Example of a Secure Extension",
   "permissions": [
     "https://developer.chrome.com/*",
-    "https://*.google.com/"
+    "https://*.google.com/*"
   ],
   "manifest_version": 2
 }
 ```
 
 This extension requests access to anything on developer.chrome.com and subdomains of Google by
-listing `"https://developer.chrome.com/*"` and `"https://*.google.com/"` in the permissions. If the
+listing `"https://developer.chrome.com/*"` and `"https://*.google.com/*"` in the permissions. If the
 extension were compromised, it would still only have permission to interact with websites that meet
 the [match pattern][7]. The attacker would not be able to access `"https://user_bank_info.com"` or
 interact with `"https://malicious_website.com"`.
@@ -82,7 +82,7 @@ trusted sources.
     ],
     "matches": [
       "https://developer.chrome.com/*",
-      "https://*.google.com/"
+      "https://*.google.com/*"
     ],
     "accepts_tls_channel_id": false
   },

--- a/site/en/docs/extensions/mv3/security/index.md
+++ b/site/en/docs/extensions/mv3/security/index.md
@@ -56,7 +56,7 @@ specified in the permissions.
 ```
 
 This extension requests access to anything on developer.chrome.com and subdomains of Google by
-listing `"/*"` and `"https://*google.com/"` in the permissions. If the
+listing `"/*"` and `"https://*.google.com/"` in the permissions. If the
 extension were compromised, it would still only have permission to interact with websites that meet
 the [match pattern][7]. The attacker would not be able to access `"https://user_bank_info.com"` or
 interact with `"https://malicious_website.com"`.
@@ -82,7 +82,7 @@ trusted sources.
     ],
     "matches": [
       "/*",
-      "https://*google.com/"
+      "https://*.google.com/"
     ],
     "accepts_tls_channel_id": false
   },

--- a/site/en/docs/extensions/mv3/security/index.md
+++ b/site/en/docs/extensions/mv3/security/index.md
@@ -48,7 +48,7 @@ specified in the permissions.
   "version": "1.0",
   "description": "Example of a Secure Extension",
   "permissions": [
-    "/*",
+    "https://developer.chrome.com/*",
     "https://*.google.com/"
   ],
   "manifest_version": 2
@@ -56,7 +56,7 @@ specified in the permissions.
 ```
 
 This extension requests access to anything on developer.chrome.com and subdomains of Google by
-listing `"/*"` and `"https://*.google.com/"` in the permissions. If the
+listing `"https://developer.chrome.com/*"` and `"https://*.google.com/"` in the permissions. If the
 extension were compromised, it would still only have permission to interact with websites that meet
 the [match pattern][7]. The attacker would not be able to access `"https://user_bank_info.com"` or
 interact with `"https://malicious_website.com"`.
@@ -81,7 +81,7 @@ trusted sources.
       "iamafriendlyextensionhereisdatas"
     ],
     "matches": [
-      "/*",
+      "https://developer.chrome.com/*",
       "https://*.google.com/"
     ],
     "accepts_tls_channel_id": false


### PR DESCRIPTION
Fixes invalid match patterns in Security page.

~~As a related issue, I'm not sure if the first pattern (`/*`) is written as intended. I think it's intended to be `https://developer.chrome.com/*` but it's unclear due to lack of full file history. If someone lets me know in comments what it's intended to be, I can make the fix as part of this PR.~~ Also fixed per [comment](#issuecomment-885186796).

Changes proposed in this pull request:

- Fix match pattern typos in example configs in Security page