### PR TITLE
add chromeOS warning as a pill

### DIFF
--- a/site/_includes/macros/render-type.njk
+++ b/site/_includes/macros/render-type.njk
@@ -506,12 +506,18 @@
     {% elif feature.unknownVersion %}
       {# This is stable but not yet visible in the version history data. It's probably coming next
         Chrome release. #}
-      <span class="aside--warning tag-pill type--label rounded-lg">
+      <span class="aside--warning tag-pill type--label rounded-lg" title="No version data available">
         Unknown version
       </span>
     {% elif feature.availableFromVersion %}
       <span class="aside--default tag-pill type--label rounded-lg">
         Chrome {{ feature.availableFromVersion }}+
+      </span>
+    {% endif %}
+
+    {% if feature.chromeOsOnly %}
+      <span class="aside--key-term tag-pill type--label rounded-lg">
+        Chrome OS only
       </span>
     {% endif %}
 


### PR DESCRIPTION
This updates the "Availability" section of APIs to include a notice about Chrome OS-only APIs. This is already a _giant_ warning at the top of the page, but this section should contain all the data you need to understand whether an API is available.

![image](https://user-images.githubusercontent.com/119184/127068125-6842009c-71d0-4f1e-9ef6-02db3098fa25.png)