### PR TITLE
Remove extra trailing comma in manifest.json

### DIFF
--- a/site/en/docs/extensions/reference/action/index.md
+++ b/site/en/docs/extensions/reference/action/index.md
@@ -224,7 +224,7 @@ that everything worked as expected.
   "version": "1.0",
   "manifest_version": 3,
   "action": {
-    "default_title": "Click to show an alert",
+    "default_title": "Click to show an alert"
   },
   "permissions": ["activeTab", "scripting"],
   "background": {


### PR DESCRIPTION
Changes proposed in this pull request:

- The code example in `manifest.json` contains a trailing comma which is not valid JSON. This PR removes it.