### PR TITLE
Add sitemap.xml

### DIFF
--- a/site/_data/helpers.js
+++ b/site/_data/helpers.js
@@ -6,7 +6,12 @@ const {
 } = require('./lib/links');
 const {hashForProd} = require('./lib/hash');
 const {findByUrl, findByProjectKey} = require('./lib/find');
-const {formatDate, formatDateLong, formatDateShort} = require('./lib/date');
+const {
+  formatDate,
+  formatDateLong,
+  formatDateShort,
+  formatDateNumeric,
+} = require('./lib/date');
 const {buildBreadcrumbs} = require('./lib/breadcrumbs');
 
 module.exports = {
@@ -21,5 +26,6 @@ module.exports = {
   formatDate,
   formatDateLong,
   formatDateShort,
+  formatDateNumeric,
   buildBreadcrumbs,
 };

--- a/site/_data/lib/date.js
+++ b/site/_data/lib/date.js
@@ -60,6 +60,7 @@ const formatDateShort = (date, locale = 'en', opts = {}) => {
 /**
  * Returns a date string formatted like "2021-12-31".
  * @param {Date} date
+ * @returns {string}
  */
 const formatDateNumeric = date => {
   return date.toISOString().split('T')[0];

--- a/site/_data/lib/date.js
+++ b/site/_data/lib/date.js
@@ -2,9 +2,9 @@
  * Returns a formatted date string.
  * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat
  * for a list of options.
- * @param {Date} date
+ * @param {Date|string} date
  * @param {string} [locale="en"]
- * @param {object} opts
+ * @param {object} [opts]
  * @returns {string}
  */
 const formatDate = (date, locale = 'en', opts = {}) => {
@@ -20,9 +20,9 @@ const formatDate = (date, locale = 'en', opts = {}) => {
 
 /**
  * Returns a date string formatted like "Monday, July 26, 2021".
- * @param {Date} date
+ * @param {Date|string} date
  * @param {string} [locale="en"]
- * @param {object} opts
+ * @param {object} [opts]
  * @returns {string}
  */
 const formatDateLong = (date, locale = 'en', opts = {}) => {
@@ -40,9 +40,9 @@ const formatDateLong = (date, locale = 'en', opts = {}) => {
 
 /**
  * Returns a date string formated like "July 26, 2021".
- * @param {Date} date
+ * @param {Date|string} date
  * @param {string} [locale="en"]
- * @param {object} opts
+ * @param {object} [opts]
  * @returns {string}
  */
 const formatDateShort = (date, locale = 'en', opts = {}) => {

--- a/site/_data/lib/date.js
+++ b/site/_data/lib/date.js
@@ -1,4 +1,13 @@
-const formatDate = (date, locale = 'en', opts) => {
+/**
+ * Returns a formatted date string.
+ * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat
+ * for a list of options.
+ * @param {Date} date
+ * @param {string} [locale="en"]
+ * @param {object} opts
+ * @returns {string}
+ */
+const formatDate = (date, locale = 'en', opts = {}) => {
   if (typeof date === 'string') {
     date = new Date(date);
   }
@@ -9,6 +18,13 @@ const formatDate = (date, locale = 'en', opts) => {
   return new Intl.DateTimeFormat(locale, opts).format(date);
 };
 
+/**
+ * Returns a date string formatted like "Monday, July 26, 2021".
+ * @param {Date} date
+ * @param {string} [locale="en"]
+ * @param {object} opts
+ * @returns {string}
+ */
 const formatDateLong = (date, locale = 'en', opts = {}) => {
   const options = {
     weekday: 'long',
@@ -22,6 +38,13 @@ const formatDateLong = (date, locale = 'en', opts = {}) => {
   return formatDate(date, locale, options);
 };
 
+/**
+ * Returns a date string formated like "July 26, 2021".
+ * @param {Date} date
+ * @param {string} [locale="en"]
+ * @param {object} opts
+ * @returns {string}
+ */
 const formatDateShort = (date, locale = 'en', opts = {}) => {
   const options = {
     month: 'long',
@@ -34,4 +57,17 @@ const formatDateShort = (date, locale = 'en', opts = {}) => {
   return formatDate(date, locale, options);
 };
 
-module.exports = {formatDate, formatDateLong, formatDateShort};
+/**
+ * Returns a date string formatted like "2021-12-31".
+ * @param {Date} date
+ */
+const formatDateNumeric = date => {
+  return date.toISOString().split('T')[0];
+};
+
+module.exports = {
+  formatDate,
+  formatDateLong,
+  formatDateShort,
+  formatDateNumeric,
+};

--- a/site/_includes/macros/card-authors.njk
+++ b/site/_includes/macros/card-authors.njk
@@ -28,7 +28,7 @@
         {%- if loop.index0 > 0 -%}, {% endif -%}{{ author.name.given }}&nbsp;{{ author.name.family }}
       {%- endfor -%}
     </p>
-    <time class="type--small color-secondary-text">{{ helpers.formatDateLong(date, locale) }}</time>
+    <time class="type--small color-secondary-text">{{ helpers.formatDateShort(date, locale) }}</time>
   </div>
 </div>
 

--- a/site/_includes/macros/card-authors.njk
+++ b/site/_includes/macros/card-authors.njk
@@ -28,7 +28,7 @@
         {%- if loop.index0 > 0 -%}, {% endif -%}{{ author.name.given }}&nbsp;{{ author.name.family }}
       {%- endfor -%}
     </p>
-    <time class="type--small color-secondary-text">{{ helpers.formatDateShort(date, locale) }}</time>
+    <time class="type--small color-secondary-text">{{ helpers.formatDateLong(date, locale) }}</time>
   </div>
 </div>
 

--- a/site/sitemap.xml.njk
+++ b/site/sitemap.xml.njk
@@ -6,9 +6,8 @@ permalink: "/sitemap.xml"
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 {%- for page in collections.all %}
 {%- if not page.data.noindex and not page.data.draft %}
-  {# Use the page's canonicalUrl which ignores the language directories. #}
   {%- if page.url %}
-  {% set fullUrl %}{{ site.url }}{{ page.url }}{% endset %}
+  {% set fullUrl %}{{ site.url }}{{ page.url | stripDefaultLocale }}{% endset %}
   <url>
     <loc>{{ fullUrl }}</loc>
     {%- set lastMod = page.data.date -%}

--- a/site/sitemap.xml.njk
+++ b/site/sitemap.xml.njk
@@ -1,0 +1,25 @@
+---
+noindex: true
+permalink: "/sitemap.xml"
+---
+<?xml version="1.0" encoding="utf-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{%- for page in collections.all %}
+{%- if not page.data.noindex and not page.data.draft %}
+  {# Use the page's canonicalUrl which ignores the language directories. #}
+  {%- if page.url %}
+  {% set fullUrl %}{{ site.url }}{{ page.url }}{% endset %}
+  <url>
+    <loc>{{ fullUrl }}</loc>
+    {%- set lastMod = page.data.date -%}
+    {%- if page.data.updated -%}
+      {%- set lastMod = page.data.updated -%}
+    {%- endif -%}
+    {%- if lastMod %}
+    <lastmod>{{ helpers.formatDateNumeric(lastMod) }}</lastmod>
+    {%- endif %}
+  </url>
+  {%- endif %}
+{%- endif %}
+{%- endfor %}
+</urlset>


### PR DESCRIPTION
We received an internal request to add a sitemap.xml so Googlers can index their docs internally.

- Adds a `formatDateNumeric` function to the date helpers.
- Adds a sitemap.xml.njk which is pretty similar to the one used on web.dev, but doesn't need the luxon dependency for dates.