### PR TITLE
Fix busted site url for social images

### DIFF
--- a/site/_includes/partials/meta.njk
+++ b/site/_includes/partials/meta.njk
@@ -30,7 +30,7 @@
 
 {% if hero %}
   {# Twitter thumbanils are 507px on their website, so this is a 3x version. #}
-  {% set heroSrc = 'https://' + site.imgix + '/' + hero + '?auto=format&w=1521' %}
+  {% set heroSrc = 'https://' + site.imgixDomain + '/' + hero + '?auto=format&w=1521' %}
   <meta name="twitter:card" content="summary_large_image" />
   <meta property="og:image" content="{{ heroSrc }}" />
   <meta name="twitter:image" content="{{ heroSrc }}" />


### PR DESCRIPTION
Fixes #1057

We must have renamed `site.imgix` at some point but forgot to update our social images 😅