### PR TITLE
Revert revert the TOC changes

### DIFF
--- a/site/_includes/layouts/doc-post.njk
+++ b/site/_includes/layouts/doc-post.njk
@@ -14,7 +14,7 @@
     {% include 'partials/navigation-tree.njk' %}
 
     {# The article is wrapped again so that the ToC aligns on its right on desktop #}
-    <div class="center-margin display-flex width-full">
+    <div class="display-flex justify-content-center width-full">
       <article class="stack measure-long width-full pad-left-400 pad-right-400">
         <div class="stack flow-space-200">
           {% include 'partials/post-headline.njk' %}

--- a/site/_includes/layouts/doc-post.njk
+++ b/site/_includes/layouts/doc-post.njk
@@ -13,27 +13,30 @@
   <div class="display-flex gap-top-300 lg:gap-top-400">
     {% include 'partials/navigation-tree.njk' %}
 
-    <article class="post stack measure-long width-full pad-left-400 pad-right-400">
-      <div class="stack flow-space-200">
-        {% include 'partials/post-headline.njk' %}
-      </div>
-
-      {% if authors %}
-        <div class="stack-exception-600 lg:stack-exception-700">
-          {% include 'partials/post-authors.njk' %}
+    {# The article is wrapped again so that the ToC aligns on its right on desktop #}
+    <div class="center-margin display-flex width-full">
+      <article class="stack measure-long width-full pad-left-400 pad-right-400">
+        <div class="stack flow-space-200">
+          {% include 'partials/post-headline.njk' %}
         </div>
-      {% endif %}
 
-      {% include 'partials/toc-inner.njk' %}
-      {% include 'partials/draft.njk' %}
+        {% if authors %}
+          <div class="stack-exception-600 lg:stack-exception-700">
+            {% include 'partials/post-authors.njk' %}
+          </div>
+        {% endif %}
 
-      <div class="stack stack--block type center-images">
-        {{ content | safe }}
-      </div>
+        {% include 'partials/toc-inner.njk' %}
+        {% include 'partials/draft.njk' %}
 
-      {% include 'partials/updated.njk' %}
-    </article>
+        <div class="stack stack--block type center-images">
+          {{ content | safe }}
+        </div>
 
-    {% include 'partials/toc-side.njk' %}
+        {% include 'partials/updated.njk' %}
+      </article>
+
+      {% include 'partials/toc-side.njk' %}
+    </div>
   </div>
 {% endblock %}

--- a/site/_includes/layouts/namespace-reference.njk
+++ b/site/_includes/layouts/namespace-reference.njk
@@ -41,7 +41,7 @@
     {% set feature = namespace.feature %}
 
     {# The article is wrapped again so that the ToC aligns on its right on desktop #}
-    <div class="center-margin display-flex width-full">
+    <div class="display-flex justify-content-center width-full">
       <article class="stack measure-long width-full pad-left-400 pad-right-400">
         <h1 class="type--h2">{{ title }}</h1>
 

--- a/site/_includes/layouts/namespace-reference.njk
+++ b/site/_includes/layouts/namespace-reference.njk
@@ -40,61 +40,64 @@
     {% include 'partials/navigation-tree.njk' %}
     {% set feature = namespace.feature %}
 
-    <article class="stack measure-long center-margin pad-left-400 pad-right-400">
-      <h1 class="type--h2">{{ title }}</h1>
+    {# The article is wrapped again so that the ToC aligns on its right on desktop #}
+    <div class="center-margin display-flex width-full">
+      <article class="stack measure-long width-full pad-left-400 pad-right-400">
+        <h1 class="type--h2">{{ title }}</h1>
 
-      {% if feature.platformAppsOnly %}
-        <div class="aside aside--warning">
-          This API is part of the deprecated Chrome Apps platform.
-          Learn more about <a href="/docs/apps/migration">migrating your app</a>.
-        </div>
-      {% endif %}
+        {% if feature.platformAppsOnly %}
+          <div class="aside aside--warning">
+            This API is part of the deprecated Chrome Apps platform.
+            Learn more about <a href="/docs/apps/migration">migrating your app</a>.
+          </div>
+        {% endif %}
 
-      {% if feature.chromeOsOnly %}
-        {# There are some historic cases of multi-platform support in Platform Apps, but
-            the only restriction these days is CrOS vs everywhere. #}
-        <div class="aside aside--note">
-          <strong>Important:</strong> This API works <strong>only on Chrome OS</strong>
-        </div>
-      {% endif %}
+        {% if feature.chromeOsOnly %}
+          {# There are some historic cases of multi-platform support in Platform Apps, but
+              the only restriction these days is CrOS vs everywhere. #}
+          <div class="aside aside--note">
+            <strong>Important:</strong> This API works <strong>only on Chrome OS</strong>
+          </div>
+        {% endif %}
 
-      {% set availabilityHtml %}{{ macros.renderAvailabilityFeature(feature) }}{% endset %}
+        {% set availabilityHtml %}{{ macros.renderAvailabilityFeature(feature) }}{% endset %}
 
-      <div>{# This div prevents flow-space-300 from applying to the parent stack. #}
-        <ul class="code-sections code-sections--summary flow-space-300 stack">
-          <li>
-            <div class="code-sections__label">Description</div>
-            <div class="type">
-              {{ namespace.description | md | safe }}
-            </div>
-          </li>
-          {% if feature.permissions.length %}
+        <div>{# This div prevents flow-space-300 from applying to the parent stack. #}
+          <ul class="code-sections code-sections--summary flow-space-300 stack">
             <li>
-              <div class="code-sections__label">Permissions</div>
-              <div>
-                {% for permission in feature.permissions %}
-                  <code>{{ permission }}</code><br />
-                {% endfor %}
-                {{ extra_permissions_html | safe }}
+              <div class="code-sections__label">Description</div>
+              <div class="type">
+                {{ namespace.description | md | safe }}
               </div>
             </li>
-          {% endif %}
+            {% if feature.permissions.length %}
+              <li>
+                <div class="code-sections__label">Permissions</div>
+                <div>
+                  {% for permission in feature.permissions %}
+                    <code>{{ permission }}</code><br />
+                  {% endfor %}
+                  {{ extra_permissions_html | safe }}
+                </div>
+              </li>
+            {% endif %}
 
-          {% if availabilityHtml | trim %}
-            <li class="align-center">
-              <div class="code-sections__label">Availability</div>
-              {{ availabilityHtml | safe }}
-              {# As of Apr 2021, namespaces are never deprecated. #}
-            </li>
-          {% endif %}
-        </ul>
-      </div>
+            {% if availabilityHtml | trim %}
+              <li class="align-center">
+                <div class="code-sections__label">Availability</div>
+                {{ availabilityHtml | safe }}
+                {# As of Apr 2021, namespaces are never deprecated. #}
+              </li>
+            {% endif %}
+          </ul>
+        </div>
 
-      {% include 'partials/toc-inner.njk' %}
+        {% include 'partials/toc-inner.njk' %}
 
-      {{ content | safe }}
-    </article>
+        {{ content | safe }}
+      </article>
 
-    {% include 'partials/toc-side.njk' %}
+      {% include 'partials/toc-side.njk' %}
+    </div>
   </div>
 {% endblock %}

--- a/site/_includes/layouts/reference-landing.njk
+++ b/site/_includes/layouts/reference-landing.njk
@@ -58,7 +58,7 @@
     {% include 'partials/navigation-tree.njk' %}
 
     {# The article is wrapped again so that the ToC aligns on its right on desktop #}
-    <div class="center-margin display-flex width-full">
+    <div class="display-flex justify-content-center width-full">
       <article class="stack measure-long pad-left-400 pad-right-400">
         <h1 class="type--h2">{{ title }}</h1>
 

--- a/site/_includes/layouts/reference-landing.njk
+++ b/site/_includes/layouts/reference-landing.njk
@@ -57,17 +57,20 @@
   <div class="display-flex gap-top-300 lg:gap-top-400 ">
     {% include 'partials/navigation-tree.njk' %}
 
-    <article class="stack measure-long center-margin pad-left-400 pad-right-400">
-      <h1 class="type--h2">{{ title }}</h1>
+    {# The article is wrapped again so that the ToC aligns on its right on desktop #}
+    <div class="center-margin display-flex width-full">
+      <article class="stack measure-long pad-left-400 pad-right-400">
+        <h1 class="type--h2">{{ title }}</h1>
 
-      {% include 'partials/toc-inner.njk' %}
+        {% include 'partials/toc-inner.njk' %}
 
-      <div class="stack type">
-        {{ content | safe }}
-      </div>
+        <div class="stack type">
+          {{ content | safe }}
+        </div>
 
-    </article>
+      </article>
 
-    {% include 'partials/toc-side.njk' %}
+      {% include 'partials/toc-side.njk' %}
+    </div>
   </div>
 {% endblock %}

--- a/site/_includes/partials/toc-side.njk
+++ b/site/_includes/partials/toc-side.njk
@@ -6,7 +6,7 @@
   If we don't have any toc contents, set the toc to visiblity: hidden so we
   still have the right margin. Otherwise the article will shift out of place.
 #}
-<div class="toc-container display-none xl:display-block pad-left-400 pad-right-400 {% if not tocContents %}visibility-hidden{% endif %}">
+<div class="toc-container display-none xl:display-block pad-right-400 {% if not tocContents %}visibility-hidden{% endif %}">
   <toc-active class="scrollbar">
     <div class="type--h6 color-secondary-text">{{ 'i18n.common.toc' | i18n(locale) }}</div>
     <div class="toc__wrapper">{{ tocContents | safe }}</div>

--- a/site/_includes/partials/toc-side.njk
+++ b/site/_includes/partials/toc-side.njk
@@ -7,6 +7,8 @@
   still have the right margin. Otherwise the article will shift out of place.
 #}
 <div class="toc-container display-none xl:display-block pad-left-400 pad-right-400 {% if not tocContents %}visibility-hidden{% endif %}">
-  <div class="type--h6 color-secondary-text">{{ 'i18n.common.toc' | i18n(locale) }}</div>
-  <div class="toc__wrapper">{{ tocContents | safe }}</div>
+  <toc-active class="scrollbar">
+    <div class="type--h6 color-secondary-text">{{ 'i18n.common.toc' | i18n(locale) }}</div>
+    <div class="toc__wrapper">{{ tocContents | safe }}</div>
+  </toc-active>
 </div>

--- a/site/_js/main.js
+++ b/site/_js/main.js
@@ -25,4 +25,5 @@ import './web-components/top-nav';
 import './web-components/share-button';
 import './web-components/web-tabs';
 import './web-components/language-select';
+import './web-components/toc-active';
 import './third-party/announcement-banner/announcement-banner';

--- a/site/_js/web-components/toc-active.js
+++ b/site/_js/web-components/toc-active.js
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Selects the most relevant sub-element in a TOC. Sets
+ * `[toc--active]` on the contained <a href> that matches the heading most
+ * visible on the page.
+ *
+ * Operates on a single `<article>` found in the document. Refuses to operate
+ * if it's not found.
+ */
+import {BaseElement} from './base-element';
+
+export class TocActive extends BaseElement {
+  constructor() {
+    super();
+    this.updateHeading = () => {};
+
+    /** @type {HTMLAnchorElement?} */
+    this.previousActiveAnchor = null;
+
+    /** @type {Set<HTMLElement>} */
+    this.visibleHeadings = new Set();
+
+    let rafPending = 0;
+
+    const options = {threshold: 0.5};
+    this.observer = new IntersectionObserver(entries => {
+      entries.forEach(entry => {
+        const t = /** @type {HTMLElement} */ (entry.target);
+        if (entry.isIntersecting) {
+          this.visibleHeadings.add(t);
+        } else {
+          this.visibleHeadings.delete(t);
+        }
+
+        // After any heading becomes visible or invisible (most likely due to
+        // scroll or on startup), check which one is most active in a rAF.
+        if (rafPending) {
+          return;
+        }
+        rafPending = window.requestAnimationFrame(() => {
+          rafPending = 0;
+          this.updateHeading();
+        });
+      });
+    }, options);
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+
+    // Make sure we have an article. Abandon if not.
+    const se = document.scrollingElement;
+    const target = document.body.querySelector('article');
+    if (!target || !se) {
+      return;
+    }
+
+    /** @type {{[hash: string]: HTMLAnchorElement}} */
+    const tocLinkDict = {};
+    const links = /** @type {NodeListOf<HTMLAnchorElement>} */ (this.querySelectorAll(
+      'a[href]'
+    ));
+    /** @type {HTMLAnchorElement?} */
+    let firstLink = null;
+    for (const link of links) {
+      const rawHref = link.getAttribute('href') ?? '';
+      if (rawHref.startsWith('#')) {
+        tocLinkDict[rawHref.substr(1)] = link;
+        if (firstLink === null) {
+          firstLink = link;
+        }
+      }
+    }
+
+    // Add all the headings in the article to an IntersectionObserver.
+    const allArticleHeadings = /** @type {NodeListOf<HTMLElement>} */ (target.querySelectorAll(
+      '[id]'
+    ));
+    for (const articleHeading of allArticleHeadings) {
+      this.observer.observe(articleHeading);
+    }
+
+    this.updateHeading = () => {
+      // Find the first visible anchor element inside the article that has a
+      // matching link in the TOC.
+      // We assume the DOM order matches the display order.
+      /** @type {HTMLAnchorElement?} */
+      let found = null;
+      for (const articleHeading of allArticleHeadings) {
+        if (
+          this.visibleHeadings.has(articleHeading) &&
+          articleHeading.id in tocLinkDict
+        ) {
+          found = tocLinkDict[articleHeading.id];
+          break;
+        }
+      }
+
+      if (found === this.previousActiveAnchor) {
+        return;
+      }
+
+      // We don't remove `toc-active` from a previous anchor if there's no new
+      // best found heading: this is possible in long articles where there's no
+      // visible headings in a large section of text.
+      // This basically makes it appear as if something is always active.
+      if (found) {
+        if (this.previousActiveAnchor) {
+          this.previousActiveAnchor.removeAttribute('toc--active');
+        }
+        found.setAttribute('toc--active', '');
+        this.previousActiveAnchor = found;
+
+        // Scroll this heading into view, ensuring that long ToCs will always
+        // have the active heading visible in the scroll area. If it's the first
+        // heading, actually scroll to the top of the container (first element
+        // child), so the "Table of Contents" heading appears.
+        if (found === firstLink) {
+          this.scrollTop = 0;
+        } else {
+          localScrollIntoView(found, this);
+        }
+      }
+    };
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.observer.disconnect();
+
+    if (this.previousActiveAnchor) {
+      this.previousActiveAnchor.removeAttribute('toc--active');
+      this.previousActiveAnchor = null;
+    }
+  }
+}
+
+/**
+ * This is a simplified version of `scrollIntoView`, as that causes odd
+ * interactions with nested scroll containers in Chrome.
+ *
+ * @param {Element} target
+ * @param {Element} container
+ */
+function localScrollIntoView(target, container) {
+  const bounds = target.getBoundingClientRect();
+  const containerBounds = container.getBoundingClientRect();
+
+  const offTop = containerBounds.top - bounds.top;
+  if (offTop > 0) {
+    // Target is above the element.
+    container.scrollTop -= offTop;
+  } else {
+    const offEnd = bounds.bottom - containerBounds.bottom;
+    if (offEnd > 0) {
+      // Target is below the element.
+      container.scrollTop += offEnd;
+    }
+  }
+}
+
+customElements.define('toc-active', TocActive);

--- a/site/_scss/blocks/_post.scss
+++ b/site/_scss/blocks/_post.scss
@@ -1,8 +1,4 @@
 .post {
   margin-left: auto;
   margin-right: auto;
-
-  @include media-query('xl') {
-    margin-right: initial;
-  }
 }

--- a/site/_scss/blocks/_post.scss
+++ b/site/_scss/blocks/_post.scss
@@ -1,4 +1,0 @@
-.post {
-  margin-left: auto;
-  margin-right: auto;
-}

--- a/site/_scss/blocks/_toc.scss
+++ b/site/_scss/blocks/_toc.scss
@@ -1,10 +1,6 @@
 .toc-container {
   max-width: 100%;
-  width: px-to-rem(240px);
-  
-  @include media-query('xl') {
-    margin-right: auto;
-  }
+  width: px-to-rem(320px);
 }
 
 .toc > summary {
@@ -29,6 +25,22 @@
 .toc[open] .toc__icon > svg {
   transform: rotate(270deg);
 }
+
+toc-active {
+  display: block;
+  max-height: calc(100vh - #{get-size(200)} * 2);
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  position: sticky;
+  top: get-size(200);
+
+  [toc--active] {
+    font-weight: 600;
+    letter-spacing: -0.35px;  // makes the text roughly the same width
+  }
+}
+
 
 // The eleventy-plugin-toc doesn't let us put classes on ul/ol or li children
 // so we have to style them all with descendant selectors.

--- a/site/_scss/globals/_mixins.scss
+++ b/site/_scss/globals/_mixins.scss
@@ -73,3 +73,46 @@
   margin-left: calc(50% - 50vw);
   width: 100vw;
 }
+
+// Mixin to add custom scrollbars to an element
+// nb. Copied from web.dev's mixins
+
+// @param {?string=} $size - Width of the scrollbar in pixels
+// @param {?string=} $thumbColor - Color of the scrollbar thumb
+// @param {?string=} $trackColor - Color of the scrollbar track
+@mixin scrollbars(
+  $size: 10px,
+  $thumbColor: get-color('grey-500'),
+  $trackColor: transparent
+) {
+  /* stylelint-disable scss/selector-no-redundant-nesting-selector */
+  & {
+    // Sass Lint doesn't recognize these shiny new properties
+    scrollbar-color: $thumbColor $trackColor;
+    scrollbar-width: thin;
+  }
+
+  &::-webkit-scrollbar {
+    height: $size;
+    width: $size;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: $thumbColor;
+    background-clip: padding-box;
+    border: ($size / 4) solid $trackColor;
+    border-radius: ($size / 2);
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background-color: darken($thumbColor, 12%);
+  }
+
+  &::-webkit-scrollbar-thumb:active {
+    background-color: darken($thumbColor, 22%);
+  }
+
+  &::-webkit-scrollbar-track {
+    background: $trackColor;
+  }
+}

--- a/site/_scss/main.scss
+++ b/site/_scss/main.scss
@@ -28,7 +28,6 @@
 @import 'blocks/navigation-rail';
 @import 'blocks/navigation-tree';
 @import 'blocks/side-nav';
-@import 'blocks/post';
 @import 'blocks/post-authors';
 @import 'blocks/card-authors';
 @import 'blocks/dates';

--- a/site/_scss/main.scss
+++ b/site/_scss/main.scss
@@ -75,6 +75,7 @@
 @import 'utilities/elevation';
 @import 'utilities/hairline';
 @import 'utilities/colors';
+@import 'utilities/scrollbars';
 @import 'utilities/surface';
 @import 'utilities/visually-hidden';
 @import 'utilities/wrapper';

--- a/site/_scss/utilities/_scrollbars.scss
+++ b/site/_scss/utilities/_scrollbars.scss
@@ -1,0 +1,4 @@
+%scrollbar,
+.scrollbar {
+  @include scrollbars();
+}


### PR DESCRIPTION
Wrap all post content in another flex to keep it and its ToC centered. Adds a comment to make it clear on the three pages where this is done. Removes "post" CSS class.

<img width="2413" alt="Screen Shot 2021-07-30 at 11 07 34" src="https://user-images.githubusercontent.com/119184/127584671-42a32c5f-4b02-4932-b063-61e72b33378a.png">
<img width="612" alt="Screen Shot 2021-07-30 at 11 07 47" src="https://user-images.githubusercontent.com/119184/127584678-2c061d7f-2773-4f9e-b6ed-8c1bcec5e8e5.png">
