### PR TITLE
add reference page to percy, include 1600px screenshot

### DIFF
--- a/.percy.js
+++ b/.percy.js
@@ -1,7 +1,7 @@
 module.exports = {
   'version': 1,
   'snapshot': {
-    'widths': [375, 865, 1280],
+    'widths': [375, 865, 1280, 1600],
     'percy-css': `
       iframe, .cookie-banner {
         display: none !important;

--- a/.percy.js
+++ b/.percy.js
@@ -20,6 +20,7 @@ module.exports = {
       'docs/native-client/index.html',
       'blog/welcome/index.html',
       'docs/extensions/what-are-extensions/index.html',
+      'docs/extensions/reference/action/index.html',
       'docs/handbook/components/index.html'
     ].join(',')
   },


### PR DESCRIPTION
* Adds API reference page, which uses a different layout than most.
* Adds a 1600px screenshot. The TOC was only being shown at 1440px, so we weren't seeing changes in it.