### PR TITLE
boop webdev-infra for imgix auto format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "rollup": "^2.22.2",
         "striptags": "^3.1.1",
         "unistore": "^3.5.2",
-        "webdev-infra": "^1.0.23"
+        "webdev-infra": "^1.0.24"
       },
       "devDependencies": {
         "@11ty/eleventy-plugin-syntaxhighlight": "^3.0.4",
@@ -27871,9 +27871,9 @@
       }
     },
     "node_modules/webdev-infra": {
-      "version": "1.0.23",
-      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.23.tgz",
-      "integrity": "sha512-k0y5ipDnKS9vCp9FKOUt/trQnQDmX5zcabHtjD79nqgquCkkS6yQl2e+2ntyGvxZmmTjJBOg+tfMsEhQrZzSgw==",
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.24.tgz",
+      "integrity": "sha512-sa4rFFQf8gy+l0YzQBTW710OrnL+nqMdimIva4XfdZyj2o1ti0jgzyU25mVoMAtG54YoqnTWd4wCqJfke3D4dA==",
       "dependencies": {
         "@imgix/js-core": "^3.1.3",
         "@justinribeiro/lite-youtube": "^0.9.1",
@@ -50521,9 +50521,9 @@
       }
     },
     "webdev-infra": {
-      "version": "1.0.23",
-      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.23.tgz",
-      "integrity": "sha512-k0y5ipDnKS9vCp9FKOUt/trQnQDmX5zcabHtjD79nqgquCkkS6yQl2e+2ntyGvxZmmTjJBOg+tfMsEhQrZzSgw==",
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.24.tgz",
+      "integrity": "sha512-sa4rFFQf8gy+l0YzQBTW710OrnL+nqMdimIva4XfdZyj2o1ti0jgzyU25mVoMAtG54YoqnTWd4wCqJfke3D4dA==",
       "requires": {
         "@imgix/js-core": "^3.1.3",
         "@justinribeiro/lite-youtube": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "rollup": "^2.22.2",
     "striptags": "^3.1.1",
     "unistore": "^3.5.2",
-    "webdev-infra": "^1.0.23"
+    "webdev-infra": "^1.0.24"
   },
   "devDependencies": {
     "@11ty/eleventy-plugin-syntaxhighlight": "^3.0.4",

--- a/site/_includes/partials/meta.njk
+++ b/site/_includes/partials/meta.njk
@@ -30,6 +30,7 @@
 
 {% if hero %}
   {# Twitter thumbanils are 507px on their website, so this is a 3x version. #}
+  {# This skips the filter and always rasterizes the image (auto=format) in case we have a SVG. #}
   {% set heroSrc = 'https://' + site.imgixDomain + '/' + hero + '?auto=format&w=1521' %}
   <meta name="twitter:card" content="summary_large_image" />
   <meta property="og:image" content="{{ heroSrc }}" />

--- a/site/_shortcodes/Img.js
+++ b/site/_shortcodes/Img.js
@@ -1,8 +1,19 @@
-/**
- * Temporarily disable TS type check as the global `wd` namespace
- * that comes from `webdev-infra` is currently broken.
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-// @ts-nocheck
+
 const {imgix: imgixFilter} = require('webdev-infra/filters/imgix');
 const {Img: BuildImgShortcode} = require('webdev-infra/shortcodes/Img');
 

--- a/site/_shortcodes/Video.js
+++ b/site/_shortcodes/Video.js
@@ -1,8 +1,19 @@
-/**
- * Temporarily disable TS type check as the global `wd` namespace
- * that comes from `webdev-infra` is currently broken.
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-// @ts-nocheck
+
 const {Video: BuildVideoShortcode} = require('webdev-infra/shortcodes/Video');
 const {bucket, imgixDomain} = require('../_data/site.json');
 


### PR DESCRIPTION
No specific issue, but we weren't setting "auto=format" in our srcset URLs, so the correctly sized images weren't being served with an optimal format for the current browser.

- bumps the webdev-infra version
- adds some missing license headers
- removes TODOs around types (fixed now)