### PR TITLE
New "make a great listing" page

### DIFF
--- a/site/_data/docs/webstore/toc.yml
+++ b/site/_data/docs/webstore/toc.yml
@@ -4,6 +4,7 @@
   sections:
     - url: /docs/webstore/get_started_simple/
     - url: /docs/webstore/best_practices/
+    - url: /docs/webstore/best_listing/
     - url: /docs/webstore/i18n/
     - url: /docs/webstore/identify_user/
 - title: i18n.docs.webstore.publish

--- a/site/_data/docs/webstore/toc.yml
+++ b/site/_data/docs/webstore/toc.yml
@@ -4,7 +4,6 @@
   sections:
     - url: /docs/webstore/get_started_simple/
     - url: /docs/webstore/best_practices/
-    - url: /docs/webstore/best_listing/
     - url: /docs/webstore/i18n/
     - url: /docs/webstore/identify_user/
 - title: i18n.docs.webstore.publish
@@ -21,6 +20,7 @@
   sections:
     - url: /docs/webstore/images/
     - url: /docs/webstore/cws-dashboard-listing/
+    - url: /docs/webstore/best_listing/
     - url: /docs/webstore/cws-dashboard-privacy/
     - url: /docs/webstore/cws-dashboard-distribution/
     - url: /docs/webstore/cws-enterprise/

--- a/site/en/docs/webstore/best_listing/index.md
+++ b/site/en/docs/webstore/best_listing/index.md
@@ -1,0 +1,163 @@
+---
+layout: "layouts/doc-post.njk"
+title: Create a great listing page
+date: 2017-08-30
+updated: 2021-06-21
+description: >
+  Best practices on how to make a high-quality, engaging listing page for your item in the Chrome
+  Web Store.
+---
+
+Chrome Web Store's focus on surfacing quality items to users encompases the entire user experience,
+including the store listing page. Build trust with users and make a strong first impression with a
+compelling and accurate store listing page.  Learn how to create a quality store listing page that
+clearly communicates what your item will offer from the description, images, and other metadata
+provided. You can build and maintain your store listing page through the developer dashboard.
+
+
+## Text
+
+
+### Item Summary
+
+Your summary is used to give an overview of your item in a concise phrase (132 characters or less).
+This is the main description of your item users see from the homepage, category pages and in search
+results. Ensure the most important text is included in your summary to help users understand what
+they can expect from your item in a quick glance. 
+
+{% Compare 'better' %}
+Highlight features of your item that resonate with your audience's main use cases.
+{% endCompare %}
+
+{% Compare 'worse' %}
+Include generic descriptions like "best extension ever".
+{% endCompare %}
+
+{% Aside %}
+The summary is plain text string (no HTML or other formatting) that describes the extension.
+The description should be suitable for both the browser's extension management UI and the Chrome
+Web Store. You can specify locale-specific strings for this
+field; see [Internationalization](/docs/extensions/i18n/) for details.
+{% endAside %}
+
+
+### Item Description
+
+Your item description is intended to give users a more in-depth overview of the main features and
+functionalities of your item. Item descriptions appear on the item listing page, underneath the
+screenshots. Descriptions should be concise, informative, and accurate, and should contain more than
+just one sentence. The ideal format is a paragraph followed by a short list of main features. Let
+users know why they'll love it. Avoid typos and symbols that commonly distract the user.
+
+{% Compare 'better' %}
+Focus on the keywords that represent the most important features of your extension.
+{% endCompare %}
+
+{% Compare 'worse' %}
+Add unnecessary keywords to your description in an attempt to improve search results.
+Repetitive or irrelevant use of keywords can create an unpleasant user experience and result in an
+item being suspended on Chrome Web Store.
+{% endCompare %}
+
+
+## Images
+
+
+### Store Icon
+
+Your item's icon is one of the first elements of your item that users see when they are on your
+store listing page. Use an icon that is simple and recognizable to your brand. Most often, this will
+simply be the brand or developer logo. Ensure your icon follows our [extension icon best
+practices].
+
+{% Compare 'better' %}
+Keep it simple, and use colors and design elements that are consistent with the branding of
+your other assets. 
+{% endCompare %}
+
+{% Compare 'worse' %}
+Include screenshots or UI elements. These details can be very hard to see in small sizes.
+{% endCompare %}
+
+See more examples of icons that follow the correct guidelines on the [extension icon best practices]
+page.
+
+
+### Screenshots
+
+Use screenshots (or videos) to convey capabilities, the look and feel, and experience of your item
+to users. You must provide at least 1—and preferably the maximum allowed 5—screenshots of your item
+to be displayed in the store. Screenshots should demonstrate the actual user experience, focusing on
+the core features and content so users can anticipate what the extension's experience will be like.
+Screenshots should reflect the most up-to-date functionalities according to the latest version of
+the extension.  Here are some rules of thumb for screenshots:
+
+
+
+* Do not include screenshots that are blurry, distorted, or pixelated in a way that is not an intentional aspect of your brand or user experience
+* Do not include images that are stretched or compressed
+* Rotate screenshots appropriately. Do not upload images upside down, sideways, or otherwise skewed
+* Branding on screenshots/videos should be consistent with other branding elements on the store listing page (icon, promotional images, etc), so users can immediately associate them with your extension and brand
+* Include visual aids like infographics, images and videos to explain the onboarding flow, user experience, and/or main functionalities of the item
+* Images should not use too much text to avoid overwhelming the user
+* Use square corners, no padding (full bleed)
+* 1280x800 or 640x400 pixels
+
+{% Aside %}
+Tip: If your extension supports multiple locales, you can provide locale-specific screenshots as
+described in Internationalizing Your App.
+{% endAside %}
+
+{% Aside %}
+Note: 1280x800 screenshots are preferable, as larger screenshots look better on high-resolution
+displays. Currently, all screenshots are downscaled to 640x400 pixels. If your screenshots do not
+look good when downscaled (for example, they have a lot of text) or if 1280x800 is too big for your
+extension (for example, screenshots for a low-resolution game), you can upload 640x400 screenshots.
+{% endAside %}
+
+
+### Promotional images (small promo tile, large promo tile, and marquee images)
+
+Promotional images are your chance to capture users' attention and entice them to learn more. Don't
+just use a screenshot; your images should communicate the brand and appear professional. Here are
+specifics about each promotional image:
+
+Small promo tile (440x280 pixels): appears on the homepage, category pages, and in search results.
+
+Large promo tile (920x680 pixels):
+
+Marquee images (1400x560 pixels): the image that is used if your item is chosen for the marquee
+feature (the rotating carousel on the top of the Chrome Web Store homepage). To increase your
+chances of being featured, ensure your marquee image is uncluttered, high-resolution, and has
+consistent branding elements to your other assets so users can immediately associate it with your
+extension and brand.
+
+Here are some rules of thumb for designing your promotional images:
+
+* Avoid too much text
+* Avoid an image that is too "busy"
+* Make sure your image works even when shrunk to half size
+* Use saturated colors if possible; they tend to work well
+* Avoid using a lot of white and light gray
+* Fill the entire region
+* Make sure the edges are well defined
+* Avoid claims that misrepresents the extension's or developer's current status or performance on the Chrome Web Store (e.g. "Editor's Choice" or "Number One")
+* Branding on promotional images should be consistent with other branding elements on the store listing page (icon, screenshots, etc)
+
+{% Compare 'better' %}
+Keep the image simple and clean, using colors and branding that matches your other assets.
+{% endCompare %}
+
+{% Compare 'worse' %}
+Include too much text that makes the image look overly "busy".
+{% endCompare %}
+
+## Additional Fields
+
+Including a website for your item and URLs for support pages can help build trust with users. Ensure
+these fields are filled out in the developer dashboard so users know where they can find more
+information about your item.
+
+
+[extension icon best practices]: /docs/webstore/images/#extension-icon
+

--- a/site/en/docs/webstore/best_listing/index.md
+++ b/site/en/docs/webstore/best_listing/index.md
@@ -8,8 +8,8 @@ description: >
 ---
 
 The Chrome Web Store works hard to surface quality items for users to discover.  Making sure yours
-is a "quality item" can help ensure its more prominence in the store, potentially increasing your
-installed base.
+is a "quality item" can help ensure its prominence in the store, potentially increasing your
+user base.
 
 Our focus on surfacing quality items to users encompases the entire user experience&mdash;including
 the store listing page. Build trust with users by making a strong first impression, with a

--- a/site/en/docs/webstore/best_listing/index.md
+++ b/site/en/docs/webstore/best_listing/index.md
@@ -7,16 +7,15 @@ description: >
   Web Store.
 ---
 
-The Chrome Web Store works hard to surface quality items for users to discover.  Making sure yours
+The Chrome Web Store works hard to help users discover and install quality items. Making sure yours
 is a "quality item" can help ensure its prominence in the store, potentially increasing your
 user base.
 
-Our focus on surfacing quality items to users encompases the entire user experience&mdash;including
-the store listing page. Build trust with users by making a strong first impression, with a
-compelling and accurate store listing page.  A quality listing page 
-clearly communicates what your item will offer, using the item description, images, and other
-listing metadata.
-You can build and maintain your store listing page using the [developer dashboard][devconsole].
+Our focus on surfacing quality items to users encompases the entire user experience&mdash;this
+includes the store listing page. Build trust with users by making a strong first impression, with a
+compelling and accurate store listing page.  A quality listing page clearly communicates what your
+item will offer, using the item description, images, and other listing metadata.  You can build and
+maintain your store listing page using the [developer dashboard][devconsole].
 
 
 ## Text
@@ -63,7 +62,7 @@ Focus on the keywords that represent the most important features of your extensi
 {% Compare 'worse' %}
 Add unnecessary keywords to your description in an attempt to improve search results.
 Repetitive or irrelevant use of keywords can create an unpleasant user experience and result in an
-item being suspended on Chrome Web Store.
+item being suspended from the Chrome Web Store.
 {% endCompare %}
 
 
@@ -103,7 +102,6 @@ Screenshots should reflect the most up-to-date functionality corresponding to th
 the extension. 
 
 *   Do not include screenshots that are blurry, distorted, or pixelated in a way that is not an intentional aspect of your brand or user experience
-*   Do not include images that are stretched or compressed
 *   Rotate screenshots appropriately. Do not upload images upside down, sideways, or otherwise skewed
 *   Branding on screenshots/videos should be consistent with other branding elements on the store listing page (icon, promotional images, etc), so users can immediately associate them with your extension and brand
 *   Include visual aids like infographics, images and videos to explain the onboarding flow, user experience, and/or main functionalities of the item
@@ -172,11 +170,13 @@ Keep the image simple and clean, using colors and branding that matches your oth
 tile image that works", width="800", height="467" %}
 {% endCompare %}
 
+{% if false %}
 {% Compare 'worse' %}
 Include too much text so that it's hard to read or makes the image look overly "busy".
 {% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/rvcp453BSjDvdO3WlmIo.png", alt="A fictional promo
 tile image that has problems", width="800", height="467" %}
 {% endCompare %}
+{% endif %}
 
 {% Compare 'worse' %}
 Include claims that misrepresent your extension's status.

--- a/site/en/docs/webstore/best_listing/index.md
+++ b/site/en/docs/webstore/best_listing/index.md
@@ -8,7 +8,7 @@ description: >
   Web Store.
 ---
 
-Chrome Web Store's focus on surfacing quality items to users encompases the entire user experience,
+The Chrome Web Store's focus on surfacing quality items to users encompases the entire user experience,
 including the store listing page. Build trust with users and make a strong first impression with a
 compelling and accurate store listing page.  Learn how to create a quality store listing page that
 clearly communicates what your item will offer from the description, images, and other metadata
@@ -17,8 +17,11 @@ provided. You can build and maintain your store listing page through the develop
 
 ## Text
 
+There are two main text resources that you can use to make your listing compelling: The *item
+summary* and the *item description*. The following sections explain how to make best use of these
+text fields.
 
-### Item Summary
+### Item summary
 
 Your summary is used to give an overview of your item in a concise phrase (132 characters or less).
 This is the main description of your item users see from the homepage, category pages and in search
@@ -37,11 +40,11 @@ Include generic descriptions like "best extension ever".
 The summary is plain text string (no HTML or other formatting) that describes the extension.
 The description should be suitable for both the browser's extension management UI and the Chrome
 Web Store. You can specify locale-specific strings for this
-field; see [Internationalization](/docs/extensions/i18n/) for details.
+field; see [Internationalization](/docs/extensions/reference/i18n/) for details.
 {% endAside %}
 
 
-### Item Description
+### Item description
 
 Your item description is intended to give users a more in-depth overview of the main features and
 functionalities of your item. Item descriptions appear on the item listing page, underneath the
@@ -62,8 +65,11 @@ item being suspended on Chrome Web Store.
 
 ## Images
 
+The graphical assets that appear in your listing are the *store icon*, *screenshots*, and your
+*promotional images*. The following sections provide guidance for how you can best use these assets
+to provide a high-quality, compelling store listing.
 
-### Store Icon
+### Store icon
 
 Your item's icon is one of the first elements of your item that users see when they are on your
 store listing page. Use an icon that is simple and recognizable to your brand. Most often, this will
@@ -85,27 +91,25 @@ page.
 
 ### Screenshots
 
-Use screenshots (or videos) to convey capabilities, the look and feel, and experience of your item
-to users. You must provide at least 1—and preferably the maximum allowed 5—screenshots of your item
+Use screenshots (or videos) to convey the capabilities, look and feel, and experience of your item
+to users. You must provide at least one&mdash;and preferably the maximum allowed five&mdash;screenshots of your item
 to be displayed in the store. Screenshots should demonstrate the actual user experience, focusing on
 the core features and content so users can anticipate what the extension's experience will be like.
-Screenshots should reflect the most up-to-date functionalities according to the latest version of
-the extension.  Here are some rules of thumb for screenshots:
+Screenshots should reflect the most up-to-date functionality corresponding to the latest version of
+the extension. 
 
-
-
-* Do not include screenshots that are blurry, distorted, or pixelated in a way that is not an intentional aspect of your brand or user experience
-* Do not include images that are stretched or compressed
-* Rotate screenshots appropriately. Do not upload images upside down, sideways, or otherwise skewed
-* Branding on screenshots/videos should be consistent with other branding elements on the store listing page (icon, promotional images, etc), so users can immediately associate them with your extension and brand
-* Include visual aids like infographics, images and videos to explain the onboarding flow, user experience, and/or main functionalities of the item
-* Images should not use too much text to avoid overwhelming the user
-* Use square corners, no padding (full bleed)
-* 1280x800 or 640x400 pixels
+*   Do not include screenshots that are blurry, distorted, or pixelated in a way that is not an intentional aspect of your brand or user experience
+*   Do not include images that are stretched or compressed
+*   Rotate screenshots appropriately. Do not upload images upside down, sideways, or otherwise skewed
+*   Branding on screenshots/videos should be consistent with other branding elements on the store listing page (icon, promotional images, etc), so users can immediately associate them with your extension and brand
+*   Include visual aids like infographics, images and videos to explain the onboarding flow, user experience, and/or main functionalities of the item
+*   Images should not use too much text to avoid overwhelming the user
+*   Use square corners, no padding (full bleed)
+*   1280x800 or 640x400 pixels
 
 {% Aside %}
 Tip: If your extension supports multiple locales, you can provide locale-specific screenshots as
-described in Internationalizing Your App.
+described in [Internationalizing your app][i18n-your-app].
 {% endAside %}
 
 {% Aside %}
@@ -116,17 +120,19 @@ extension (for example, screenshots for a low-resolution game), you can upload 6
 {% endAside %}
 
 
-### Promotional images (small promo tile, large promo tile, and marquee images)
+### Promotional images: promo tiles and marquee image
 
 Promotional images are your chance to capture users' attention and entice them to learn more. Don't
 just use a screenshot; your images should communicate the brand and appear professional. Here are
 specifics about each promotional image:
 
-Small promo tile (440x280 pixels): appears on the homepage, category pages, and in search results.
+**Small promo tile: 440x280 pixels** &emsp; Appears on the homepage, category pages, and in search
+results.
 
-Large promo tile (920x680 pixels):
+**Large promo tile: 920x680 pixels** &emsp; Not currently used. You do not need to provide a large
+promo tile at this time.
 
-Marquee images (1400x560 pixels): the image that is used if your item is chosen for the marquee
+**Marquee image: 1400x560 pixels** &emsp; This image is used if your item is chosen for the marquee
 feature (the rotating carousel on the top of the Chrome Web Store homepage). To increase your
 chances of being featured, ensure your marquee image is uncluttered, high-resolution, and has
 consistent branding elements to your other assets so users can immediately associate it with your
@@ -152,7 +158,7 @@ Keep the image simple and clean, using colors and branding that matches your oth
 Include too much text that makes the image look overly "busy".
 {% endCompare %}
 
-## Additional Fields
+## Additional fields
 
 Including a website for your item and URLs for support pages can help build trust with users. Ensure
 these fields are filled out in the developer dashboard so users know where they can find more
@@ -160,4 +166,5 @@ information about your item.
 
 
 [extension icon best practices]: /docs/webstore/images/#extension-icon
+[i18n-your-app]: /docs/webstore/i18n/
 

--- a/site/en/docs/webstore/best_listing/index.md
+++ b/site/en/docs/webstore/best_listing/index.md
@@ -1,18 +1,22 @@
 ---
 layout: "layouts/doc-post.njk"
-title: Create a great listing page
-date: 2017-08-30
-updated: 2021-06-21
+title: Creating a great listing page
+date: 2021-08-10
 description: >
   Best practices on how to make a high-quality, engaging listing page for your item in the Chrome
   Web Store.
 ---
 
-The Chrome Web Store's focus on surfacing quality items to users encompases the entire user experience,
-including the store listing page. Build trust with users and make a strong first impression with a
-compelling and accurate store listing page.  Learn how to create a quality store listing page that
-clearly communicates what your item will offer from the description, images, and other metadata
-provided. You can build and maintain your store listing page through the developer dashboard.
+The Chrome Web Store works hard to surface quality items for users to discover.  Making sure yours
+is a "quality item" can help ensure its more prominence in the store, potentially increasing your
+installed base.
+
+Our focus on surfacing quality items to users encompases the entire user experience&mdash;including
+the store listing page. Build trust with users by making a strong first impression, with a
+compelling and accurate store listing page.  A quality listing page 
+clearly communicates what your item will offer, using the item description, images, and other
+listing metadata.
+You can build and maintain your store listing page using the [developer dashboard][devconsole].
 
 
 ## Text
@@ -37,19 +41,19 @@ Include generic descriptions like "best extension ever".
 {% endCompare %}
 
 {% Aside %}
-The summary is plain text string (no HTML or other formatting) that describes the extension.
+The summary is a plain text string (no HTML or other formatting) that describes the extension.
 The description should be suitable for both the browser's extension management UI and the Chrome
 Web Store. You can specify locale-specific strings for this
-field; see [Internationalization](/docs/extensions/reference/i18n/) for details.
+field; see [Internationalization][i18n] for details.
 {% endAside %}
 
 
 ### Item description
 
 Your item description is intended to give users a more in-depth overview of the main features and
-functionalities of your item. Item descriptions appear on the item listing page, underneath the
-screenshots. Descriptions should be concise, informative, and accurate, and should contain more than
-just one sentence. The ideal format is a paragraph followed by a short list of main features. Let
+capabilities of your item. Item descriptions appear on the item listing page, underneath the
+screenshots. Make your descriptions concise, informative, and accurate, using more than
+just one sentence. The ideal format is an overview paragraph followed by a short list of main features. Let
 users know why they'll love it. Avoid typos and symbols that commonly distract the user.
 
 {% Compare 'better' %}
@@ -108,15 +112,23 @@ the extension.
 *   1280x800 or 640x400 pixels
 
 {% Aside %}
-Tip: If your extension supports multiple locales, you can provide locale-specific screenshots as
-described in [Internationalizing your app][i18n-your-app].
+Screenshots at full 1280x800 resolution may look better on high-resolution displays. You can use
+640x400 screenshots instead&mdash;for example if 1280x800 is too big to show your extension
+properly.
 {% endAside %}
 
+{% Compare 'better' %}
+Make sure your screenshots are clear and sized correctly. Use visual aids in the screenshots to help
+explain how it works.
+{% endCompare %}
+
+{% Compare 'worse' %}
+Use screenshots that are distorted, are of low quality, or have overwhelming amounts of text.
+{% endCompare %}
+
 {% Aside %}
-Note: 1280x800 screenshots are preferable, as larger screenshots look better on high-resolution
-displays. Currently, all screenshots are downscaled to 640x400 pixels. If your screenshots do not
-look good when downscaled (for example, they have a lot of text) or if 1280x800 is too big for your
-extension (for example, screenshots for a low-resolution game), you can upload 640x400 screenshots.
+Tip: If your extension supports multiple locales, you can provide locale-specific screenshots as
+described in [Internationalizing your app][i18n-your-app].
 {% endAside %}
 
 
@@ -165,6 +177,7 @@ these fields are filled out in the developer dashboard so users know where they 
 information about your item.
 
 
+[devconsole]: https://chrome.google.com/webstore/devconsole
 [extension icon best practices]: /docs/webstore/images/#extension-icon
+[i18n]: /docs/extensions/reference/i18n/
 [i18n-your-app]: /docs/webstore/i18n/
-

--- a/site/en/docs/webstore/best_listing/index.md
+++ b/site/en/docs/webstore/best_listing/index.md
@@ -120,10 +120,14 @@ properly.
 {% Compare 'better' %}
 Make sure your screenshots are clear and sized correctly. Use visual aids in the screenshots to help
 explain how it works.
+{% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/w5wKTaZ5uDJe6EGQblak.png", alt="A fictional
+screenshot that is clear", width="800", height="467" %}
 {% endCompare %}
 
 {% Compare 'worse' %}
 Use screenshots that are distorted, are of low quality, or have overwhelming amounts of text.
+{% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/j9iGWTYXD7xxbsCYvmfh.png", alt="A fictional
+screenshot that is blurry", width="800", height="467" %}
 {% endCompare %}
 
 {% Aside %}
@@ -164,10 +168,20 @@ Here are some rules of thumb for designing your promotional images:
 
 {% Compare 'better' %}
 Keep the image simple and clean, using colors and branding that matches your other assets.
+{% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/kc5spLGOAa06QvOn6VdI.png", alt="A fictional promo
+tile image that works", width="800", height="467" %}
 {% endCompare %}
 
 {% Compare 'worse' %}
-Include too much text that makes the image look overly "busy".
+Include too much text so that it's hard to read or makes the image look overly "busy".
+{% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/rvcp453BSjDvdO3WlmIo.png", alt="A fictional promo
+tile image that has problems", width="800", height="467" %}
+{% endCompare %}
+
+{% Compare 'worse' %}
+Include claims that misrepresent your extension's status.
+{% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/NcoamGn5czoqDzW7SQuG.png", alt="A fictional listing
+image that includes a misleading badge", width="800", height="467" %}
 {% endCompare %}
 
 ## Additional fields

--- a/site/en/docs/webstore/best_practices/index.md
+++ b/site/en/docs/webstore/best_practices/index.md
@@ -76,6 +76,8 @@ The better your app's listing in the store, the more users will find and try you
 your app's name, writing its description, and designing its logo, keep in mind Google's [Branding
 Guidelines][cws-branding].
 
+To learn more, see [Creating a great listing page][great-listing-page].
+
 ### Provide great images
 
 See [Supplying Images][cws-images] for guidelines on the images you should supply to the store.
@@ -101,6 +103,7 @@ that is most appropriate:
 [cws-branding]: /docs/webstore/branding
 [cws-images]: /docs/webstore/images
 [dashboard-privacy]: /docs/webstore/cws-dashboard-privacy/
+[great-listing-page]: /docs/webstore/best_listing/
 [identify-user]: /docs/webstore/identify_user
 [mv3-overview]: /docs/extensions/mv3/intro/mv3-overview/
 [program policies]: /docs/webstore/program_policies/

--- a/site/en/docs/webstore/cws-dashboard-listing/index.md
+++ b/site/en/docs/webstore/cws-dashboard-listing/index.md
@@ -6,6 +6,9 @@ title: "Complete your listing information"
 description: How to add listing information for your Chrome Web Store item.
 ---
 
+This page describes the fields you must fill out to complete your store listing. To learn how to
+make your listing more compelling, be sure to read [Creating a great listing page][best-listing].
+
 {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/4RwZvdR4eACU46OCy7rm.png",
        alt="Screenshot of the Chrome Web Store developer dashboard item listing tab", height="472", width="800" %}
 
@@ -32,6 +35,11 @@ your item's store listing:
 See [Supplying Images][cws-images] for help on designing the images for your item, and [Branding
 Guidelines][cws-branding] for information on how you can use Google brands.
 
+{% Aside %}
+The quality of the images you supply can affect your item's prominence on the Chrome Web Store. Be
+sure and read [Creating a great listing page][best-listing] for more details.
+{% endAside %}
+
 ## Displaying your verified publisher status
 
 The Chrome Web Store highlights verified publishers by placing a linked, official URL in the
@@ -57,6 +65,7 @@ To add a verified site that you own, click on **Add a new site**. This opens the
 Console, where you can add and verify a site. See [Verify your site ownership][verify-owner] for
 more details.
 
+[best-listing]: /docs/webstore/best_listing
 [cws-branding]: /docs/webstore/branding
 [cws-images]: /docs/webstore/images
 [verify-owner]: https://support.google.com/webmasters/answer/9008080

--- a/site/en/docs/webstore/images/index.md
+++ b/site/en/docs/webstore/images/index.md
@@ -14,8 +14,13 @@ You need to supply several kinds of images to be used in the Chrome Web Store:
 Only the extension icon, a small promotional image, and a screenshot are mandatory. However, providing
 attractive versions of both required and optional images increases your extension's chances of getting
 noticed. For example, your extension can't be featured in marquee unless you provide a marquee promotional
-image. Follow our [Image best practices][11] to increase your chance of being featured.
+image.
 
+You can improve your item's performance in the Chrome Web Store by following our best practices for
+images and other listing information. To learn more about these best practices, see [Creating a
+compelling listing page][11].
+
+{% if false %}
 ## Image best practices
 
 - Avoid overloading images with text in small font sizes or backgrounds that compete with text.
@@ -25,6 +30,7 @@ image. Follow our [Image best practices][11] to increase your chance of being fe
 - Do not include images that are stretched or compressed.
 - Rotate images appropriately. Do not upload images upside down, sideways, or otherwise skewed.
 - Avoid inappropriate or repetitive image elements, such as third-party trademarked characters or logos without proper permission.
+{% endif %}
 
 ## Extension icon
 
@@ -310,7 +316,7 @@ Next, read [Publishing Your App][39].
 [8]: https://developers.google.com/chrome/apps/docs/developers_guide#installing
 [9]: https://tools.google.com/chrome/intl/en/themes/
 [10]: #perspective
-[11]: #image-best-practices
+[11]: /docs/webstore/best_listing
 [17]: #screenshots
 [18]: /docs/webstore/branding
 [27]: mailto:cws-assets@google.com


### PR DESCRIPTION
To complement the extension best practices, a new page for the CWS listing page itself.

[Page preview](https://deploy-preview-1124--developer-chrome-com.netlify.app/docs/webstore/best_listing)

Lightly adapted from a draft by @lsauser .