### PR TITLE
show manifest keys required for API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "async-transforms": "^1.0.6",
         "chokidar": "^3.5.1",
         "chokidar-cli": "^2.1.0",
-        "chrome-types-helpers": "^0.1.6",
+        "chrome-types-helpers": "^0.1.7",
         "common-tags": "^1.8.0",
         "compression": "^1.7.4",
         "concurrently": "^5.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6186,9 +6186,9 @@
       }
     },
     "node_modules/chrome-types-helpers": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/chrome-types-helpers/-/chrome-types-helpers-0.1.6.tgz",
-      "integrity": "sha512-GGz3PKfS+SHVA8mCRxnI6X14/D5S5yd/z9nPUuXUmKaSJ+IAWDDEiwXXL/4dzCcxidY9GgeIYVYN4NBI8eVDGA==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/chrome-types-helpers/-/chrome-types-helpers-0.1.7.tgz",
+      "integrity": "sha512-dJ2JfhS75QsBx74orHMAgMZEo5PL1gKVJSGCGD3gVs8LEu7ZeUivUxrkuHhwGxqzwOPHYBvSvoLS54m1bdnqfw==",
       "dependencies": {
         "fast-glob": "^3.2.5",
         "find-cache-dir": "^3.3.1",
@@ -33392,9 +33392,9 @@
       }
     },
     "chrome-types-helpers": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/chrome-types-helpers/-/chrome-types-helpers-0.1.6.tgz",
-      "integrity": "sha512-GGz3PKfS+SHVA8mCRxnI6X14/D5S5yd/z9nPUuXUmKaSJ+IAWDDEiwXXL/4dzCcxidY9GgeIYVYN4NBI8eVDGA==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/chrome-types-helpers/-/chrome-types-helpers-0.1.7.tgz",
+      "integrity": "sha512-dJ2JfhS75QsBx74orHMAgMZEo5PL1gKVJSGCGD3gVs8LEu7ZeUivUxrkuHhwGxqzwOPHYBvSvoLS54m1bdnqfw==",
       "requires": {
         "fast-glob": "^3.2.5",
         "find-cache-dir": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "async-transforms": "^1.0.6",
     "chokidar": "^3.5.1",
     "chokidar-cli": "^2.1.0",
-    "chrome-types-helpers": "^0.1.6",
+    "chrome-types-helpers": "^0.1.7",
     "common-tags": "^1.8.0",
     "compression": "^1.7.4",
     "concurrently": "^5.2.0",

--- a/site/_includes/layouts/namespace-reference.njk
+++ b/site/_includes/layouts/namespace-reference.njk
@@ -81,11 +81,11 @@
                 </div>
               </li>
             {% endif %}
-            {% if feature.manifestKeys.length %}
+            {% if feature.manifestRequirements.length %}
               <li>
                 <div class="code-sections__label">Manifest Keys</div>
                 <div>
-                  {% for manifestKey in feature.manifestKeys %}
+                  {% for manifestKey in feature.manifestRequirements %}
                     <code>{{ manifestKey }}</code><br />
                   {% endfor %}
                 </div>

--- a/site/_includes/layouts/namespace-reference.njk
+++ b/site/_includes/layouts/namespace-reference.njk
@@ -81,7 +81,16 @@
                 </div>
               </li>
             {% endif %}
-
+            {% if feature.manifestKeys.length %}
+              <li>
+                <div class="code-sections__label">Manifest Keys</div>
+                <div>
+                  {% for manifestKey in feature.manifestKeys %}
+                    <code>{{ manifestKey }}</code><br />
+                  {% endfor %}
+                </div>
+              </li>
+            {% endif %}
             {% if availabilityHtml | trim %}
               <li class="align-center">
                 <div class="code-sections__label">Availability</div>

--- a/site/_includes/layouts/namespace-reference.njk
+++ b/site/_includes/layouts/namespace-reference.njk
@@ -85,6 +85,7 @@
               <li>
                 <div class="code-sections__label">Manifest Keys</div>
                 <div>
+                  <p>The following keys must be declared <a href="/docs/extensions/mv3/manifest/">in the manifest</a> to use this API.</p>
                   {% for manifestKey in feature.manifestRequirements %}
                     <code>{{ manifestKey }}</code><br />
                   {% endfor %}


### PR DESCRIPTION
We've had an issue or two which come down to the fact that APIs don't appear unless you set the appropriate key in the manifest, and that can be confusing.

I think we usually document this in the fulltext, but not always, so I'd like to add it to the top here. However, I'm not really sure if it needs more explanation—the [manifest page](https://developer.chrome.com/docs/extensions/mv3/manifest/) doesn't make it clear either (although to be fair it just has links to other things).

Fixes #622.

<img width="786" alt="Screen Shot 2021-08-11 at 09 48 39" src="https://user-images.githubusercontent.com/119184/128949205-23cfaa30-2bb2-4f82-8504-0babd7333c4c.png">
