### PR TITLE
blackbox => "ignore script"

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -42,6 +42,9 @@ redirects:
 - from: /docs/webstore/pricing/
   to: /docs/webstore/money/
 
+- from: /docs/devtools/javascript/blackbox-chrome-extension-scripts/
+  to: /docs/devtools/javascript/ignore-chrome-extension-scripts/
+
 # CWS payments/apps purge
 - from: /docs/webstore/hosted_apps
   to: /docs/webstore
@@ -166,7 +169,7 @@ redirects:
   to: https://developers.google.com/web/tools/chrome-devtools
 
 - from: /devtools/docs/blackboxing
-  to: https://developers.google.com/web/tools/chrome-devtools/javascript/reference#blackbox
+  to: https://developers.google.com/web/tools/chrome-devtools/javascript/reference#ignore-list
 
 - from: /devtools/docs/commandline-api
   to: https://developers.google.com/web/tools/chrome-devtools/console/utilities

--- a/site/_data/docs/devtools/toc.yml
+++ b/site/_data/docs/devtools/toc.yml
@@ -53,7 +53,7 @@
     - url: /docs/devtools/javascript/snippets/
     - url: /docs/devtools/javascript/sources/
     - url: /docs/devtools/javascript/background-services/
-    - url: /docs/devtools/javascript/blackbox-chrome-extension-scripts/
+    - url: /docs/devtools/javascript/ignore-chrome-extension-scripts/
     - url: /docs/devtools/javascript/disable/
 - title: i18n.docs.devtools.performance
   sections:

--- a/site/en/blog/new-in-devtools-66/index.md
+++ b/site/en/blog/new-in-devtools-66/index.md
@@ -5,7 +5,7 @@ authors:
   - kaycebasques
 date: 2018-02-26
 #updated: YYYY-MM-DD
-description: "Blackboxing in the Network panel, auto-adjust zooming in Device Mode, and more."
+description: "Ignore script in the Network panel, auto-adjust zooming in Device Mode, and more."
 hero: 'image/dPDCek3EhZgLQPGtEG3y0fTn4v82/3K94BKdNuYeQQpXJgwxF.jpg'
 alt: ''
 tags:
@@ -16,7 +16,7 @@ tags:
 
 New features and major changes coming to DevTools in Chrome 66 include:
 
-- [Blackboxing in the **Network** panel][1]
+- [Ignore script in the **Network** panel][1]
 - [Auto-adjust zooming in **Device Mode**][2]
 - [Pretty-printing in the **Preview** and **Response** tabs][3]
 - [Previewing HTML content in the **Preview** tab][4]
@@ -34,7 +34,7 @@ Read on, or watch the video version of the release notes below.
 
 {% YouTube id="eaYXFTJVewA" %}
 
-## Blackboxing in the Network panel {: #blackboxing }
+## Ignore script in the Network panel {: #ignore-script }
 
 The **Initiator** column in the **Network** panel tells you why a resource was requested. For
 example, if JavaScript causes an image to be fetched, the **Initiator** column shows you the line of
@@ -49,31 +49,21 @@ JavaScript code that caused the request.
 Previously, if your framework wrapped network requests in a wrapper, the **Initiator** column
 wouldn't be that helpful. All network requests pointed to the same line of wrapper code.
 
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/8LJ6KpBZs1LYKTWzCO5f.png", alt="The Initiator column shows that all of the requests were initiated by line 2 of requests.js.", width="800", height="500" %}
-
-**Figure 1**. The **Initiator** column shows that all of the requests were initiated by line 2 of
-`requests.js`
-
 What you really want in this scenario is to see the application code that causes the request. That's
 now possible:
 
 1.  Hover over the **Initiator** column. The call stack that caused the request appears in a pop-up.
 2.  Right-click the call that you want to hide from the initiator results.
-3.  Select **Blackbox script**. The **Initiator** column now hides any calls from the script that
-    you blackboxed.
+3.  Select **Add script to ignore list**. The **Initiator** column now hides any calls from the script that
+    you ignored.
 
-{% Img src="image/admin/hpgshbdiwKtYMcRsfVt9.png", alt="Blackboxing requests.js.", width="800", height="518" %}
+{% Img src="image/QMjXarRXcMarxQddwrEdPvHVM242/q7leDy8D975ZlhtiB3f6.png", alt="Ignoring 'requests.js'.", width="800", height="575" %}
 
-**Figure 2**. Blackboxing `requests.js`
+**Figure 1**. Ignoring `requests.js`
 
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/QwQvjkwMlSyLLdzQGZKC.png", alt="After blackboxing requests.js, the Initiator column now shows more helpful results.", width="800", height="500" %}
+Manage your ignored scripts from the **Ignore List** tab in [Settings][6].
 
-**Figure 3**. After blackboxing `requests.js`, the **Initiator** column now shows more helpful
-results
-
-Manage your blackboxed scripts from the **Blackboxing** tab in [Settings][6].
-
-See [Ignore a script or pattern of scripts][7] to learn more about blackboxing.
+See [Ignore a script or pattern of scripts][7] to learn more about ignoring scripts.
 
 ## Pretty-printing in the Preview and Response tabs {: #pretty-printing }
 
@@ -82,14 +72,14 @@ that those resources have been minified.
 
 {% Img src="image/admin/pGztOri2zTIkZm559MvP.png", alt="The Preview tab pretty-printing the contents of analytics.js by default.", width="800", height="527" %}
 
-**Figure 4**. The **Preview** tab pretty-printing the contents of `analytics.js` by default
+**Figure 2**. The **Preview** tab pretty-printing the contents of `analytics.js` by default
 
 To view the unminified version of a resource, use the **Response** tab. You can also manually
 pretty-print resources from the **Response** tab, via the new **Format** button.
 
 {% Img src="image/admin/EvUzuxoqJEAd6US9bEzK.png", alt="Manually pretty-printing the contents of analytics.js via the Format button.", width="800", height="527" %}
 
-**Figure 5**. Manually pretty-printing the contents of `analytics.js` via the **Format** button
+**Figure 3**. Manually pretty-printing the contents of `analytics.js` via the **Format** button
 
 ## Previewing HTML content in the Preview tab {: #previews }
 
@@ -101,7 +91,7 @@ right-click a resource and select **Open in Sources panel**.
 
 {% Img src="image/admin/sZcyshIjXIgfT064asGm.png", alt="Previewing HTML in the Preview tab.", width="800", height="547" %}
 
-**Figure 6**. Previewing HTML in the **Preview** tab
+**Figure 4**. Previewing HTML in the **Preview** tab
 
 ## Auto-adjust zooming in Device Mode {: #auto-adjust }
 
@@ -118,7 +108,7 @@ rule in the `head` of the document that declares `font-weight: bold` for `h1` el
 
 {% Img src="image/admin/N4V6uciEsD8KxEJflPZc.png", alt="An example of styles defined within HTML", width="800", height="486" %}
 
-**Figure 7**. An example of styles defined within HTML
+**Figure 5**. An example of styles defined within HTML
 
 In Chrome 65, if you changed the `font-weight` declaration via the DevTools **Style** pane, **Local
 Overrides** wouldn't track the change. In other words, on the next reload, the style would revert
@@ -132,7 +122,7 @@ an HTML document, **Local Overrides** still won't be able to detect those change
 
 {% endAside %}
 
-## Bonus tip: Blackbox framework scripts to make Event Listener Breakpoints more useful {: #tip }
+## Bonus tip: Ignore framework scripts to make Event Listener Breakpoints more useful {: #tip }
 
 {% Aside %}
 
@@ -150,14 +140,14 @@ isn't that helpful.
 
 {% Img src="image/admin/R6aqGqlETYfPt229gX88.png", alt="The click breakpoint pauses in Vue.js' wrapper code.", width="800", height="486" %}
 
-**Figure 8**. The `click` breakpoint pauses in Vue.js' wrapper code
+**Figure 6**. The `click` breakpoint pauses in Vue.js' wrapper code
 
-Since the Vue.js script is in a separate file, I can blackbox that script from the **Call Stack**
+Since the Vue.js script is in a separate file, I can ignore that script from the **Call Stack**
 pane in order to make this `click` breakpoint more useful.
 
-{% Img src="image/admin/HthqwHAzXf5v61dwRZFh.png", alt="Blackboxing the Vue.js script from the Call Stack pane.", width="800", height="454" %}
+{% Img src="image/admin/HthqwHAzXf5v61dwRZFh.png", alt="Ignoring the Vue.js script from the Call Stack pane.", width="800", height="454" %}
 
-**Figure 9**. Blackboxing the Vue.js script from the **Call Stack** pane
+**Figure 7**. Ignoring the Vue.js script from the **Call Stack** pane
 
 The next time I click the button and trigger the `click` breakpoint, it executes the Vue.js code
 without pausing in it, and then pauses on the first line of code in my app's listener, which is
@@ -165,15 +155,15 @@ where I really wanted to pause all along.
 
 {% Img src="image/admin/0UHBfrZykjGbEfFkrCwE.png", alt="The click breakpoint now pauses on the app's listener code.", width="800", height="486" %}
 
-**Figure 10**. The `click` breakpoint now pauses on the app's listener code
+**Figure 8**. The `click` breakpoint now pauses on the app's listener code
 
-[1]: #blackboxing
+[1]: #ignore-script
 [2]: #auto-adjust
 [3]: #pretty-printing
 [4]: #previews
 [5]: #overrides
 [6]: /docs/devtools/customize/#settings
-[7]: /docs/devtools/javascript/reference#blackbox
+[7]: /docs/devtools/javascript/reference#ignore-script
 [8]: /docs/devtools/device-mode
 [9]: /blog/new-in-devtools-65#overrides
 [10]: https://youtu.be/H0XScE08hy8

--- a/site/en/blog/new-in-devtools-70/index.md
+++ b/site/en/blog/new-in-devtools-70/index.md
@@ -101,8 +101,8 @@ took multiple seconds to load. Processing and visualizing is faster in Chrome 70
 
 Chrome 70 fixes some bugs that were causing breakpoints to disappear or not get triggered.
 
-It also fixes bugs related to sourcemaps. Some TypeScript users would instruct DevTools to blackbox
-a certain TypeScript file while stepping through code, and instead DevTools would blackbox the
+It also fixes bugs related to sourcemaps. Some TypeScript users would instruct DevTools to ignore
+a certain TypeScript file while stepping through code, and instead DevTools would ignore the
 entire bundled JavaScript file. These fixes also address an issue that was causing the Sources panel
 to generally run slowly.
 
@@ -150,7 +150,7 @@ through DevTools][18], ndb also offers:
 - Detecting and attaching to child processes.
 - Placing breakpoints before modules are required.
 - Editing files within the DevTools UI.
-- Blackboxing all scripts outside of the current working directory by default.
+- Ignoring all scripts outside of the current working directory by default.
 
 {% Img src="image/admin/P6mBnxfW1xelxoTbdVWK.png", alt="The ndb UI.", width="800", height="432" %}
 

--- a/site/en/docs/devtools/javascript/ignore-chrome-extension-scripts/index.md
+++ b/site/en/docs/devtools/javascript/ignore-chrome-extension-scripts/index.md
@@ -1,11 +1,11 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Blackbox Chrome Extension Scripts"
+title: "Ignore Chrome Extension Scripts"
 authors:
   - kaycebasques
 date: 2018-12-14
-#updated: YYYY-MM-DD
-description: "Enable Blackbox content scripts from Settings > Blackboxing."
+updated: 2021-08-11
+description: "Ignore content scripts from Settings > Ignore List."
 ---
 
 When using the **Sources** panel of Chrome DevTools to [step through code][1], sometimes you pause
@@ -14,11 +14,11 @@ that you've installed. To never pause on extension code:
 
 1.  Press <kbd>F1</kbd> to open **Settings**. Or click **Settings**
     {% Img src="image/admin/alL4Um6RCmypEOSCEBgj.png", alt="Settings", width="28", height="28" %}.
-2.  Open the **Blackboxing** tab.
-3.  Enable the **Blackbox content scripts** checkbox.
+2.  Open the **Ignore List** tab.
+3.  Enable the **Add content scripts to ignore list** checkbox.
 
-    {% Img src="image/admin/SHrse0pfDPQ3fsdwkKbb.png", alt="Enabling the 'Blackbox content scripts' checkbox.", width="800", height="562" %}
+    {% Img src="image/QMjXarRXcMarxQddwrEdPvHVM242/DFANGZspw5B4IlgO04I6.png", alt="Enabling the 'Add content scripts to ignore list' checkbox.", width="800", height="552" %}
 
-    **Figure 1**. Enabling the **Blackbox content scripts** checkbox
+    **Figure 1**. Enabling the **ignore list** checkbox
 
 [1]: /docs/devtools/javascript#code-stepping

--- a/site/en/docs/devtools/javascript/reference/index.md
+++ b/site/en/docs/devtools/javascript/reference/index.md
@@ -210,9 +210,9 @@ inputsAreEmpty (get-started.js:22)
 onClick (get-started.js:15)
 ```
 
-## Ignore a script or pattern of scripts {: #blackbox }
+## Ignore a script or pattern of scripts {: #ignore-list }
 
-Blackbox a script when you want to ignore that script while debugging. When blackboxed, a script is
+Ignore a script to skip it while debugging. When ignored, a script is
 obscured in the Call Stack pane, and you never step into the script's functions when you step
 through your code.
 
@@ -227,44 +227,44 @@ function animate() {
 ```
 
 `A` is a third-party library that you trust. If you're confident that the problem you're debugging
-is not related to the third-party library, then it makes sense to blackbox the script.
+is not related to the third-party library, then it makes sense to ignore the script.
 
-### Blackbox a script from the Editor pane {: #editor-blackbox }
+### Ignore a script from the Editor pane {: #editor-ignore-list }
 
-To blackbox a script from the Editor pane:
+To ignore a script from the Editor pane:
 
 1.  Open the file.
 2.  Right-click anywhere.
-3.  Select **Blackbox script**.
+3.  Select **Add script to ignore list**.
 
-{% Img src="image/admin/GhNf369siGvdo9lt8m6Z.png", alt="Blackboxing a script from the Editor pane.", width="800", height="632" %}
+{% Img src="image/QMjXarRXcMarxQddwrEdPvHVM242/q7leDy8D975ZlhtiB3f6.png", alt="Ignoring a script from the Editor pane.", width="800", height="575" %}
 
-**Figure 12**. Blackboxing a script from the Editor pane
+**Figure 12**. Ignoring a script from the Editor pane
 
-### Blackbox a script from the Call Stack pane {: #call-stack-blackbox }
+### Ignore a script from the Call Stack pane {: #call-stack-ignore-list }
 
-To blackbox a script from the Call Stack pane:
+To ignore a script from the Call Stack pane:
 
 1.  Right-click on a function from the script.
-2.  Select **Blackbox script**.
+2.  Select **Add script to ignore list**.
 
-{% Img src="image/admin/e7zpqaYG9tHW7u1s0slX.png", alt="Blackboxing a script from the Call Stack pane.", width="800", height="634" %}
+{% Img src="image/QMjXarRXcMarxQddwrEdPvHVM242/y2NiIZH9UURpEtXAuVCZ.png", alt="Ignoring a script from the Call Stack pane.", width="800", height="575" %}
 
-**Figure 13**. Blackboxing a script from the Call Stack pane
+**Figure 13**. Ignoring a script from the Call Stack pane
 
-### Blackbox a script from Settings {: #settings-blackbox }
+### Ignore a script from Settings {: #settings-ignore-list }
 
-To blackbox a single script or pattern of scripts from Settings:
+To ignore a single script or pattern of scripts from Settings:
 
 1.  Open [Settings][3].
-2.  Go to the **Blackboxing** tab.
+2.  Go to the **Ignore List** tab.
 3.  Click **Add pattern**.
-4.  Enter the script name or a regex pattern of script names to blackbox.
+4.  Enter the script name or a regex pattern of script names to ignore.
 5.  Click **Add**.
 
-{% Img src="image/admin/htNiY3e0ygFegu9yeLiJ.png", alt="Blackboxing a script from Settings.", width="800", height="598" %}
+{% Img src="image/QMjXarRXcMarxQddwrEdPvHVM242/DFANGZspw5B4IlgO04I6.png", alt="Ignoring a script from Settings.", width="800", height="552" %}
 
-**Figure 14**. Blackboxing a script from Settings
+**Figure 14**. Ignoring a script from Settings
 
 ## Run snippets of debug code from any page {: #snippets }
 


### PR DESCRIPTION
Fixes #1074.

This won't fix Kayce's video, where he talks about blackboxing—I think that's out of scope. But I've updated:

- article content
- "what new in devtools" content

to use the updated term.