### PR TITLE
render markdown, strip html tags in indexing

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,5 @@
 const yaml = require('js-yaml');
-const {drafts} = require('./site/_utils/drafts');
+const {filterDrafts} = require('./site/_utils/drafts');
 
 // Filters
 const {
@@ -80,7 +80,7 @@ module.exports = eleventyConfig => {
 
   // Add collections
   locales.forEach(locale => eleventyConfig.addCollection(`blog-${locale}`, collections => {
-    let blogCollection = collections.getFilteredByGlob(`./site/${locale}/blog/*/*.md`).filter(drafts).reverse();
+    let blogCollection = collections.getFilteredByGlob(`./site/${locale}/blog/*/*.md`).filter(filterDrafts).reverse();
     // If we're running inside of Percy then just show the first six blog posts.
     if (process.env.PERCY_BRANCH) {
       blogCollection = blogCollection.slice(blogCollection.length - 6);

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,5 @@
 const yaml = require('js-yaml');
-const {filterDrafts} = require('./site/_utils/drafts');
+const {filterOutDrafts} = require('./site/_utils/drafts');
 
 // Filters
 const {
@@ -80,7 +80,10 @@ module.exports = eleventyConfig => {
 
   // Add collections
   locales.forEach(locale => eleventyConfig.addCollection(`blog-${locale}`, collections => {
-    let blogCollection = collections.getFilteredByGlob(`./site/${locale}/blog/*/*.md`).filter(filterDrafts).reverse();
+    let blogCollection = collections
+      .getFilteredByGlob(`./site/${locale}/blog/*/*.md`)
+      .filter(filterOutDrafts)
+      .reverse();
     // If we're running inside of Percy then just show the first six blog posts.
     if (process.env.PERCY_BRANCH) {
       blogCollection = blogCollection.slice(blogCollection.length - 6);

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -41,7 +41,7 @@ const rssPlugin = require('@11ty/eleventy-plugin-rss');
 const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
 
 // Supported locales
-const locales = require('./site/_data/site').locales;
+const locales = require('./site/_data/site.json').locales;
 
 // Collections
 const algoliaCollection = require('./site/_collections/algolia');

--- a/algolia.js
+++ b/algolia.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 require('dotenv').config();
-const algoliasearch = require('algoliasearch');
+const {default: algoliasearch} = require('algoliasearch');
 const fs = require('fs');
 const {sizeof} = require('sizeof');
 

--- a/cloud-secrets.js
+++ b/cloud-secrets.js
@@ -17,6 +17,9 @@ const cloudSecrets = async () => {
   const [secretsList] = await client.listSecrets({parent: project});
 
   for (const secretItem of secretsList) {
+    if (!secretItem.name) {
+      continue;
+    }
     const key = secretItem.name.split('/').pop();
     const [versions] = await client.listSecretVersions({
       parent: secretItem.name,
@@ -27,7 +30,7 @@ const cloudSecrets = async () => {
       const [accessedSecret] = await client.accessSecretVersion({
         name: version.name,
       });
-      const value = accessedSecret.payload.data.toString();
+      const value = accessedSecret.payload?.data?.toString() ?? '';
       dotenv += `${key}=${value}\n`;
       fetchedSecrets.push(key);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "querystring": "^0.2.0",
         "readdirp": "^3.4.0",
         "redirects-yaml": "^2.0.3",
-        "remove-markdown": "^0.3.0",
         "rollup": "^2.22.2",
         "striptags": "^3.1.1",
         "unistore": "^3.5.2",
@@ -23080,11 +23079,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/remove-markdown": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/remove-markdown/-/remove-markdown-0.3.0.tgz",
-      "integrity": "sha1-XktmdJOpNXlyjz1S7MHbnKUF3Jg="
     },
     "node_modules/remove-trailing-separator": {
       "version": "1.1.0",
@@ -46687,11 +46681,6 @@
         "safe-buffer": "^5.1.0",
         "through2": "^2.0.3"
       }
-    },
-    "remove-markdown": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/remove-markdown/-/remove-markdown-0.3.0.tgz",
-      "integrity": "sha1-XktmdJOpNXlyjz1S7MHbnKUF3Jg="
     },
     "remove-trailing-separator": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "querystring": "^0.2.0",
     "readdirp": "^3.4.0",
     "redirects-yaml": "^2.0.3",
-    "remove-markdown": "^0.3.0",
     "rollup": "^2.22.2",
     "striptags": "^3.1.1",
     "unistore": "^3.5.2",

--- a/site/_collections/feeds.js
+++ b/site/_collections/feeds.js
@@ -16,7 +16,7 @@
 
 const {defaultLocale} = require('../_data/site.json');
 const {i18n} = require('../_filters/i18n');
-const {filterDrafts} = require('../_utils/drafts');
+const {filterOutDrafts} = require('../_utils/drafts');
 
 const MAX_POSTS = 10;
 
@@ -48,7 +48,7 @@ module.exports = collection => {
   const posts = collection
     .getAllSorted()
     .reverse()
-    .filter(i => i.data.locale === defaultLocale && filterDrafts(i))
+    .filter(i => i.data.locale === defaultLocale && filterOutDrafts(i))
     .filter(item => {
       if (item.data.noindex || item.data.permalink === false) {
         return false;

--- a/site/_collections/feeds.js
+++ b/site/_collections/feeds.js
@@ -16,7 +16,9 @@
 
 const {defaultLocale} = require('../_data/site.json');
 const {i18n} = require('../_filters/i18n');
-const {drafts} = require('../_utils/drafts');
+const {filterDrafts} = require('../_utils/drafts');
+
+const MAX_POSTS = 10;
 
 /**
  * @param {EleventyData} data
@@ -43,12 +45,10 @@ function tagsForData(data) {
  * @returns {FeedsCollection} Key value pair of tag name with `FeedsCollectionItem`.
  */
 module.exports = collection => {
-  const MAX_POSTS = 10;
   const posts = collection
     .getAllSorted()
     .reverse()
-    .filter(i => i.data.locale === defaultLocale)
-    .filter(drafts)
+    .filter(i => i.data.locale === defaultLocale && filterDrafts(i))
     .filter(item => {
       if (item.data.noindex || item.data.permalink === false) {
         return false;

--- a/site/_collections/tags.js
+++ b/site/_collections/tags.js
@@ -15,7 +15,7 @@
  */
 const {locales} = require('../_data/site.json');
 const supportedTags = require('../_data/supportedTags.json');
-const {drafts} = require('../_utils/drafts');
+const {filterDrafts} = require('../_utils/drafts');
 
 /**
  * Returns an object with the keys being supported tags and the object
@@ -30,7 +30,7 @@ module.exports = function (collections) {
   /** @type Tags */
   const tags = {};
 
-  const allSorted = collections.getAllSorted().reverse().filter(drafts);
+  const allSorted = collections.getAllSorted().reverse().filter(filterDrafts);
 
   /**
    * Iterates over every post in order to place them in the proper tag collections.

--- a/site/_collections/tags.js
+++ b/site/_collections/tags.js
@@ -15,7 +15,7 @@
  */
 const {locales} = require('../_data/site.json');
 const supportedTags = require('../_data/supportedTags.json');
-const {filterDrafts} = require('../_utils/drafts');
+const {filterOutDrafts} = require('../_utils/drafts');
 
 /**
  * Returns an object with the keys being supported tags and the object
@@ -30,7 +30,10 @@ module.exports = function (collections) {
   /** @type Tags */
   const tags = {};
 
-  const allSorted = collections.getAllSorted().reverse().filter(filterDrafts);
+  const allSorted = collections
+    .getAllSorted()
+    .reverse()
+    .filter(filterOutDrafts);
 
   /**
    * Iterates over every post in order to place them in the proper tag collections.

--- a/site/_js/web-components/search-box.js
+++ b/site/_js/web-components/search-box.js
@@ -311,7 +311,12 @@ export class SearchBox extends BaseElement {
             r[highlightKey] = highlightValue.value;
           }
         }
-        r.snippet = r._snippetResult.content.value;
+        // Some pages don't get indexed with fulltext content, but they do have
+        // a meta description, so fall back to that.
+        r.snippet =
+          r._snippetResult.content?.value ||
+          r._snippetResult.description?.value ||
+          '';
         return r;
       });
 

--- a/site/_scss/blocks/_search-box.scss
+++ b/site/_scss/blocks/_search-box.scss
@@ -70,6 +70,8 @@ search-box[active] {
   position: absolute;
   // top = search-box's height + top-nav's bottom padding + gap
   top: calc(#{$search-box-height} + #{nth(map-get($top-nav-padding, 'lg'), 1)} + #{get-size(400)});
+  // Helpful for smaller screens in case we end up with long text in search results.
+  word-break: break-word;
 
   strong {
     color: var(--color-primary);

--- a/site/_utils/drafts.js
+++ b/site/_utils/drafts.js
@@ -1,15 +1,33 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
- * A filter to remove draft pages.
- * We allow drafts to appear in a dev environment, but omit them from
- * collections in a production environment.
+ * A filter to remove draft pages. We allow drafts to appear in a dev
+ * environment, but omit them from collections in a production environment.
+ *
+ * This is purely here as a convenience so drafts still get included in dev.
+ *
  * @param {EleventyCollectionItem} item
  * @return {boolean}
  */
-const filterDrafts = item => {
+const filterOutDrafts = item => {
   if (process.env.NODE_ENV === 'production') {
     return !item.data.draft;
   }
   return true; // include everything in non-prod
 };
 
-module.exports = {filterDrafts};
+module.exports = {filterOutDrafts};

--- a/site/_utils/drafts.js
+++ b/site/_utils/drafts.js
@@ -5,12 +5,11 @@
  * @param {EleventyCollectionItem} item
  * @return {boolean}
  */
-const drafts = item => {
-  if (process.env.NODE_ENV !== 'production') {
-    return true;
-  } else {
+const filterDrafts = item => {
+  if (process.env.NODE_ENV === 'production') {
     return !item.data.draft;
   }
+  return true; // include everything in non-prod
 };
 
-module.exports = {drafts};
+module.exports = {filterDrafts};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,7 @@
     "tools/**/*",
     "types/**/*.d.ts",
     "*.js",
+    ".eleventy.js",
   ],
   "exclude": [
     ".github",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,8 @@
     "server/**/*",
     "site/**/*",
     "tools/**/*",
-    "types/**/*.d.ts"
+    "types/**/*.d.ts",
+    "*.js",
   ],
   "exclude": [
     ".github",
@@ -38,7 +39,6 @@
     "dist",
     "node_modules",
     "test",
-    "./*.js",
-    "site/_js/prettify.js"
-  ]
+    "site/_js/prettify.js",
+  ],
 }

--- a/types/11ty/collection-item.d.ts
+++ b/types/11ty/collection-item.d.ts
@@ -43,7 +43,7 @@ declare global {
     /**
      * The rendered content of this template. This does not include layout wrappers.
      */
-    templateContent: unknown;
+    templateContent: string;
     /**
      * @UNDOCUMENTED
      */


### PR DESCRIPTION
Fixes #917 
Fixes #924 

I know @devnook tried to solve this in #923. I disagree with @robdodson 's comment, I think we should `break-word` just in case.

Fixes a minor display issue too; if we don't have content on page (which happens for some of the structural pages), fall back to the meta description.