### PR TITLE
migrate SW page update re: fetch and module import

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -33,7 +33,7 @@ redirects:
 - from: /docs/extensions/mv3/background_pages
   to: /docs/extensions/mv3/service_workers
 
-  - from: /docs/multidevice/android/customtabs/
+- from: /docs/multidevice/android/customtabs/
   to: /docs/android/custom-tabs/overview
 
 - from: /multidevice/android/customtabs/

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -30,7 +30,10 @@ redirects:
 - from: /docs/extensions/mv3/background_migration
   to: /docs/extensions/mv3/migrating_to_service_workers
 
-- from: /docs/multidevice/android/customtabs/
+- from: /docs/extensions/mv3/background_pages
+  to: /docs/extensions/mv3/service_workers
+
+  - from: /docs/multidevice/android/customtabs/
   to: /docs/android/custom-tabs/overview
 
 - from: /multidevice/android/customtabs/

--- a/site/en/docs/extensions/mv3/manifest/index.md
+++ b/site/en/docs/extensions/mv3/manifest/index.md
@@ -32,9 +32,12 @@ discusses each field.
   <span class="token property">"action"</span><span class="token operator">:</span> ...<span class="token punctuation">,</span>
   <span class="token property">"author"</span><span class="token operator">:</span> ...<span class="token punctuation">,</span>
   <span class="token property">"automation"</span><span class="token operator">:</span> ...<span class="token punctuation">,</span>
-  <span class="token property">"<a href="/docs/extensions/mv3/background_pages">background</a>"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
+  <span class="token property">"<a href="/docs/extensions/mv3/service_workers">background</a>"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
     <span class="token comment">// Required</span>
-    <span class="token property">"<a href="/docs/extensions/mv3/migrating_to_service_workers">service_worker</a>"</span><span class="token operator">:</span>
+    <span class="token property">"<a href="/docs/extensions/mv3/service_workers">service_worker</a>"</span><span class="token operator">:</span>
+    <span class="token string">"service-worker.js"</span>,
+    <span class="token comment">// Optional</span>
+    <span class="token string">"<a href="/docs/extensions/mv3/migrating_to_service_workers">module</a>"</span>
   <span class="token punctuation">}</span><span class="token punctuation">,</span>
   <span class="token property">"<a href="/docs/extensions/mv3/settings_override">chrome_settings_overrides</a>"</span><span class="token operator">:</span> <span class="token punctuation">{</span>...<span class="token punctuation">}</span><span class="token punctuation">,</span>
   <span class="token property">"<a href="/docs/extensions/mv3/manifest/override">chrome_url_overrides</a>"</span><span class="token operator">:</span> <span class="token punctuation">{</span>...<span class="token punctuation">}</span><span class="token punctuation">,</span>

--- a/site/en/docs/extensions/mv3/migrating_to_service_workers/index.md
+++ b/site/en/docs/extensions/mv3/migrating_to_service_workers/index.md
@@ -24,8 +24,26 @@ improve on this model by tuning it for web-scale.
 When migrating to this new background context, you'll need to keep two main things in mind. First,
 service workers are terminated when not in use and restarted when needed (similar to event pages).
 Second, service workers don't have access to DOM. We'll explore how to adapt to these challenges in
-the [Thinking with Events][3] and [Working with Workers][4] sections below, respectively. If you
-already use an event page, skip straight to the second section.
+the [Thinking with Events][3] and [Working with Workers][4] sections below, respectively.
+
+## Update your manifest {: #manifest }
+
+Extensions register their background service workers in the [manifest][3] under the `"background"`
+field. This field uses the `"service_worker"` key, which specifies a single JavaScript file.
+In Manifest V2, this field was called `"scripts"` and allowed multiple scripts.
+
+```json/3-6
+{
+  "name": "Awesome Test Extension",
+  ...
+  "background": {
+    "service_worker": "background.js"
+  },
+  ...
+}
+```
+
+Find out more on the [Manage events with service workers][manage-sw] reference page.
 
 ## Thinking with events {: #events }
 
@@ -34,9 +52,8 @@ events they're interested in and are terminated when they're no longer needed. T
 sections provide recommendations for writing code in an ephemeral, evented execution context.
 
 {% Aside %}
-
-Several of these concepts are covered in [Migrate to Event Driven Background Scripts][eventbgscripts].
-
+Several of these concepts are covered in the Manifest V2 page, [Migrate to Event Driven Background
+Scripts][eventbgscripts].
 {% endAside %}
 
 ## Top-level event listeners {: #event_listeners }
@@ -250,6 +267,7 @@ Operations with a Web Worker][18].
 [18]: https://developers.google.com/web/updates/2018/08/offscreen-canvas
 [action]: /docs/extensions/reference/action/
 [alarms]: /docs/extensions/reference/alarms/
-[eventbgscripts]: /docs/extensions/mv3/background_migration/
+[eventbgscripts]: /docs/extensions/mv2/background_migration/
 [storage]: /docs/extensions/reference/storage/
 [fetch-link]: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
+[manage-sw]: /docs/extensions/mv3/background_pages/#manifest

--- a/site/en/docs/extensions/mv3/service_workers/index.md
+++ b/site/en/docs/extensions/mv3/service_workers/index.md
@@ -47,13 +47,24 @@ uses the `"service_worker"` key, which specifies a single JavaScript file.
 }
 ```
 
+You can optionally specify an extra field of `"type": "module"` to include the service worker as an
+ES Module, which allows you to `import` futher code. See [ES modules in service workers][sw-module]
+for more information. For example:
+
+```json/2-3
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  }
+```
+
 ## Initialize the extension {: #initialization }
 
 Listen to the [`runtime.onInstalled`][6] event to initialize an extension on installation. Use this
 event to set a state or for one-time initialization, such as a [context menu][7].
 
 ```js
-chrome.runtime.onInstalled.addListener(function() {
+chrome.runtime.onInstalled.addListener(() => {
   chrome.contextMenus.create({
     "id": "sampleContextMenu",
     "title": "Sample Context Menu",
@@ -71,16 +82,16 @@ extension from missing important triggers.
 Listeners must be registered synchronously from the start of the page.
 
 ```js
-chrome.runtime.onInstalled.addListener(function() {
+chrome.runtime.onInstalled.addListener(() => {
   chrome.contextMenus.create({
     "id": "sampleContextMenu",
     "title": "Sample Context Menu",
-    "contexts": ["selection"]
+    "contexts": ["selection"],
   });
 });
 
 // This will run when a bookmark is created.
-chrome.bookmarks.onCreated.addListener(function() {
+chrome.bookmarks.onCreated.addListener(() => {
   // do something
 });
 ```
@@ -88,10 +99,10 @@ chrome.bookmarks.onCreated.addListener(function() {
 Do not register listeners asynchronously, as they will not be properly triggered.
 
 ```js
-chrome.runtime.onInstalled.addListener(function() {
+chrome.runtime.onInstalled.addListener(() => {
   // ERROR! Events must be registered synchronously from the start of
   // the page.
-  chrome.bookmarks.onCreated.addListener(function() {
+  chrome.bookmarks.onCreated.addListener(() => {
     // do something
   });
 });
@@ -102,8 +113,8 @@ listeners for an event are removed, Chrome will no longer load the extension's b
 that event.
 
 ```js
-chrome.runtime.onMessage.addListener(function(message, sender, reply) {
-    chrome.runtime.onMessage.removeListener(event);
+chrome.runtime.onMessage.addListener((message, sender, reply) => {
+ chrome.runtime.onMessage.removeListener(event);
 });
 ```
 
@@ -115,9 +126,16 @@ about. If an extension is listening for the [`tabs.onUpdated`][9] event, try usi
 filters.
 
 ```js
-chrome.webNavigation.onCompleted.addListener(function() {
-    alert("This is my favorite website!");
-}, {url: [{urlMatches : 'https://www.google.com/'}]});
+const filter = {
+  url: [
+    {
+      urlMatches: 'https://www.google.com/',
+    },
+  ],
+};
+chrome.webNavigation.onCompleted.addListener(() => {
+  console.info("The user has loaded my favorite website!");
+}, filter);
 ```
 
 ## React to listeners {: #react }
@@ -126,14 +144,15 @@ Listeners exist to trigger functionality once an event has fired. To react to an
 the desired reaction inside of the listener event.
 
 ```js
-chrome.runtime.onMessage.addListener(function(message, callback) {
-  if (message.data == "setAlarm") {
+chrome.runtime.onMessage.addListener((message, callback) => {
+  const tabId = getForegroundTabId();
+  if (message.data === "setAlarm") {
     chrome.alarms.create({delayInMinutes: 5})
-  } else if (message.data == "runLogic") {
-    chrome.scripting.executeScript({file: 'logic.js'});
-  } else if (message.data == "changeColor") {
+  } else if (message.data === "runLogic") {
+    chrome.scripting.executeScript({file: 'logic.js', tabId});
+  } else if (message.data === "changeColor") {
     chrome.scripting.executeScript(
-        {code: 'document.body.style.backgroundColor="orange"'});
+        {func: () => document.body.style.backgroundColor="orange", tabId});
   };
 });
 ```
@@ -148,22 +167,22 @@ chrome.storage.local.set({variable: variableInformation});
 ```
 
 If an extension uses [message passing][12], ensure all ports are closed. The background script will
-not unload until all message ports have shut. Listening to the [runtime.Port.onDisconnect][13] event
-will give insight to when open ports are closing. Manually close them with
-[runtime.Port.disconnect][14].
+not unload until all message ports have shut. Listening to the [`runtime.Port.onDisconnect`][13]
+event will give insight to when open ports are closing. Manually close them with
+[`runtime.Port.disconnect`][14].
 
 ```js
-chrome.runtime.onMessage.addListener(function(message, callback) {
-  if (message == 'hello') {
+chrome.runtime.onMessage.addListener((message, callback) => {
+  if (message === 'hello') {
     sendResponse({greeting: 'welcome!'})
-  } else if (message == 'goodbye') {
+  } else if (message === 'goodbye') {
     chrome.runtime.Port.disconnect();
   }
 });
 ```
 
-The lifetime of a background service worker is observable by monitoring when an entry for the extension
-appears and disappears from Chrome's task manager.
+The lifetime of a background service worker is observable by monitoring when an entry for the
+extension appears and disappears from Chrome's task manager.
 
 {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/occ8HD81vNq2zboXIbiu.png",
        alt="Chrome with an extension's popup open.", height="623", width="730" %}
@@ -175,14 +194,15 @@ Service workers unload on their own after a few seconds of inactivity. If any la
 is required, listen to the [`runtime.onSuspend`][15] event.
 
 ```js
-chrome.runtime.onSuspend.addListener(function() {
+chrome.runtime.onSuspend.addListener(() => {
   console.log("Unloading.");
   chrome.browserAction.setBadgeText({text: ""});
 });
 ```
 
-However, persisting data should be prefered over relying on [`runtime.onSuspend`][16]. It doesn't
-allow for as much cleanup as may be needed and will not help in case of a crash.
+However, persisting data in the storage API should be prefered over relying on
+[`runtime.onSuspend`][16]. It doesn't allow for as much cleanup as may be needed and will not help
+in case of a crash.
 
 [1]: /docs/extensions/mv3/messaging
 [2]: /docs/extensions/runtime#method-getBackgroundPage
@@ -200,3 +220,4 @@ allow for as much cleanup as may be needed and will not help in case of a crash.
 [14]: /docs/extensions/reference/runtime#property-Port-disconnect
 [15]: /docs/extensions/reference/runtime#event-onSuspend
 [16]: /docs/extensions/reference/runtime#event-onSuspend
+[sw-module]: https://web.dev/es-modules-in-sw/

--- a/site/en/docs/extensions/mv3/service_workers/index.md
+++ b/site/en/docs/extensions/mv3/service_workers/index.md
@@ -33,8 +33,8 @@ specified instructions, then unload.
 
 ## Register background scripts {: #manifest }
 
-Extensions register their background service workers in the [manifest][3] under the `"background"` field. This field
-uses the `"service_worker"` key, which specifies a single JavaScript file.
+Extensions register their background service workers in the [manifest][3] under the `"background"`
+field. This field uses the `"service_worker"` key, which specifies a single JavaScript file.
 
 ```json/3-6
 {
@@ -46,6 +46,10 @@ uses the `"service_worker"` key, which specifies a single JavaScript file.
   ...
 }
 ```
+
+{% Aside %}
+The script used for `"service_worker"` must be located in your extension's root directory.
+{% endAside %}
 
 You can optionally specify an extra field of `"type": "module"` to include the service worker as an
 ES Module, which allows you to `import` futher code. See [ES modules in service workers][sw-module]

--- a/site/en/docs/extensions/mv3/xhr/index.md
+++ b/site/en/docs/extensions/mv3/xhr/index.md
@@ -6,7 +6,12 @@ updated: 2020-03-09
 description: How to implement cross-origin XHR in your Chrome Extension.
 ---
 
-Regular web pages can use the [XMLHttpRequest][1] object to send and receive data from remote
+{% Aside 'warning' %}
+In Manifest V3, `XMLHttpRequest` is not supported in background pages (provided by Service Workers).
+Please consider using its modern replacement, `fetch`.
+{% endAside %}
+
+Regular web pages can use the [`XMLHttpRequest`][1] object to send and receive data from remote
 servers, but they're limited by the [same origin policy][2]. [Content scripts][3] initiate requests
 on behalf of the web origin that the content script has been injected into and therefore content
 scripts are also subject to the [same origin policy][4]. (Content scripts have been subject to [CORB
@@ -17,7 +22,7 @@ its origin, as long as the extension requests cross-origin permissions.
 ## Extension origin {: #extension-origin }
 
 Each running extension exists within its own separate security origin. Without requesting additional
-privileges, the extension can use XMLHttpRequest to get resources within its installation. For
+privileges, the extension can use `XMLHttpRequest` to get resources within its installation. For
 example, if an extension contains a JSON configuration file called `config.json`, in a
 `config_resources` folder, the extension can retrieve the file's contents like this:
 
@@ -76,7 +81,7 @@ non-secure HTTP access to a given host or set of hosts, it must declare the perm
 
 ### Avoiding cross-site scripting vulnerabilities {: #xss }
 
-When using resources retrieved via XMLHttpRequest, your background page should be careful not to
+When using resources retrieved via `XMLHttpRequest`, your background page should be careful not to
 fall victim to [cross-site scripting][9]. Specifically, avoid using dangerous APIs such as the
 below:
 
@@ -125,8 +130,8 @@ var xhr = new XMLHttpRequest();
 xhr.open("GET", "https://api.example.com/data.json", true);
 xhr.onreadystatechange = function() {
   if (xhr.readyState == 4) {
-    // innerText does not let the attacker inject HTML elements.
-    document.getElementById("resp").innerText = xhr.responseText;
+    // textContent does not let the attacker inject HTML elements.
+    document.getElementById("resp").textContent = xhr.responseText;
   }
 }
 xhr.send();

--- a/site/en/docs/extensions/mv3/xhr/index.md
+++ b/site/en/docs/extensions/mv3/xhr/index.md
@@ -8,7 +8,7 @@ description: How to implement cross-origin XHR in your Chrome Extension.
 
 {% Aside 'warning' %}
 In Manifest V3, `XMLHttpRequest` is not supported in background pages (provided by Service Workers).
-Please consider using its modern replacement, `fetch`.
+Please consider using its modern replacement, `fetch()`.
 {% endAside %}
 
 Regular web pages can use the [`XMLHttpRequest`][1] object to send and receive data from remote


### PR DESCRIPTION
Fixes #522.
Fixes #228.

This also:

* Includes information on loading a Service Worker with `"type": "module"`
* Renames (and adds redirect) from "background_pages" => "service_workers"
* Does a bunch of minor cleanup/updates (e.g., removes `alert()` which isn't available in a SW!)

@dotproto there's some examples here that use `chrome.scripting`, which presumes they need a `tabId`. This is a bit confusing—do they need them even if running _in_ that tab? I think there's another open bug about your usage of `getTabId`?