### PR TITLE
always render 'authors'

### DIFF
--- a/site/_includes/macros/cards/blog-card.njk
+++ b/site/_includes/macros/cards/blog-card.njk
@@ -47,11 +47,10 @@
     </div>
   {% endif %}
 
-  {% if pd.authors and pd.authors.length %}
-    <div class="gap-top-300">
-      {{ cardAuthors(pd.authors, pd.date) }}
-    </div>
-  {% endif %}
+  {# Always render "authors" even with zero authors, as this renders the date #}
+  <div class="gap-top-300">
+    {{ cardAuthors(pd.authors, pd.date) }}
+  </div>
 
 </div>
 {% endmacro %}


### PR DESCRIPTION
Fixes #496. Renders authors even if we have zero, which causes the date to render.

<img width="828" alt="Screen Shot 2021-08-14 at 08 25 20" src="https://user-images.githubusercontent.com/119184/129423839-0c69ff5a-230d-43a4-b028-1551ab621897.png">
