### PR TITLE
fix < > to &lt; &gt; on match_patterns page

### DIFF
--- a/site/en/docs/extensions/mv2/match_patterns/index.md
+++ b/site/en/docs/extensions/mv2/match_patterns/index.md
@@ -25,10 +25,10 @@ any URL that starts with a permitted scheme. Each match pattern has 3 parts:
 Here's the basic syntax:
 
 ```text
-<url-pattern> := <scheme>://<host><path>
-<scheme> := '*' | 'http' | 'https' | 'file' | 'ftp' | 'urn'
-<host> := '*' | '*.' <any char except '/' and '*'>+
-<path> := '/' <any chars>
+&lt;url-pattern> := &lt;scheme>://&lt;host>&lt;path>
+&lt;scheme> := '*' | 'http' | 'https' | 'file' | 'ftp' | 'urn'
+&lt;host> := '*' | '*.' &lt;any char except '/' and '*'>+
+&lt;path> := '/' &lt;any chars>
 ```
 
 The meaning of '`*`' depends on whether it's in the _scheme_, _host_, or _path_ part. If the

--- a/site/en/docs/extensions/mv2/match_patterns/index.md
+++ b/site/en/docs/extensions/mv2/match_patterns/index.md
@@ -25,10 +25,10 @@ any URL that starts with a permitted scheme. Each match pattern has 3 parts:
 Here's the basic syntax:
 
 ```text
-&lt;url-pattern> := &lt;scheme>://&lt;host>&lt;path>
-&lt;scheme> := '*' | 'http' | 'https' | 'file' | 'ftp' | 'urn'
-&lt;host> := '*' | '*.' &lt;any char except '/' and '*'>+
-&lt;path> := '/' &lt;any chars>
+&lt;url-pattern&gt; := &lt;scheme&gt;://&lt;host&gt;&lt;path&gt;
+&lt;scheme&gt; := '*' | 'http' | 'https' | 'file' | 'ftp' | 'urn'
+&lt;host&gt; := '*' | '*.' &lt;any char except '/' and '*'&gt;+
+&lt;path&gt; := '/' &lt;any chars&gt;
 ```
 
 The meaning of '`*`' depends on whether it's in the _scheme_, _host_, or _path_ part. If the

--- a/site/en/docs/extensions/mv3/match_patterns/index.md
+++ b/site/en/docs/extensions/mv3/match_patterns/index.md
@@ -23,10 +23,10 @@ any URL that starts with a permitted scheme. Each match pattern has 3 parts:
 Here's the basic syntax:
 
 ```text
-<url-pattern> := <scheme>://<host><path>
-<scheme> := '*' | 'http' | 'https' | 'file' | 'ftp' | 'urn'
-<host> := '*' | '*.' <any char except '/' and '*'>+
-<path> := '/' <any chars>
+&lt;url-pattern&gt; := &lt;scheme&gt;://&lt;host&gt;&lt;path&gt;
+&lt;scheme&gt; := '*' | 'http' | 'https' | 'file' | 'ftp' | 'urn'
+&lt;host&gt; := '*' | '*.' &lt;any char except '/' and '*'&gt;+
+&lt;path&gt; := '/' &lt;any chars&gt;
 ```
 
 The meaning of '`*`' depends on whether it's in the _scheme_, _host_, or _path_ part. If the


### PR DESCRIPTION
Fixes #366. We literally rendered these as HTML elements.

This is a specific case; is there any case where we _want_ HTML elements to appear inside code blocks? Is this really a problem with our Markdown parser?