### PR TITLE
Breadcrumbs fixes

### DIFF
--- a/site/_data/i18n/tags.yml
+++ b/site/_data/i18n/tags.yml
@@ -12,7 +12,7 @@ amp:
   en: AMP
 
 autoplay:
-  en: autoplay
+  en: Autoplay
 
 capabilities:
   en: Capabilities

--- a/site/_data/lib/links.js
+++ b/site/_data/lib/links.js
@@ -34,7 +34,7 @@ function getLinkActiveState(itemUrl, pageUrl) {
  *   parent: SectionLinkItem|undefined,
  *   active: boolean,
  * }}
- * @type {{never}}
+ * @type {never}
  */
 // eslint-disable-next-line no-unused-vars
 let SectionLinkItem;

--- a/site/_data/lib/links.js
+++ b/site/_data/lib/links.js
@@ -28,12 +28,13 @@ function getLinkActiveState(itemUrl, pageUrl) {
 }
 
 /**
- * @type {{
- *   sections?: Section[],
+ * @typedef {{
+ *   sections?: SectionLinkItem[],
  *   url?: string,
  *   parent: SectionLinkItem|undefined,
  *   active: boolean,
  * }}
+ * @type {{never}}
  */
 // eslint-disable-next-line no-unused-vars
 let SectionLinkItem;
@@ -57,12 +58,14 @@ function expandSections(sections, pageUrl, locale) {
   let target;
   let matchLength = 0;
 
+  /** @type {(curr: SectionLinkItem) => boolean} */
   const internalExpand = curr => {
     if (curr.url) {
       const check = path.join('/', locale, '/', curr.url, '/');
       if (check === pageUrl) {
         target = curr;
         matchLength = pageUrl.length;
+        return true; // exact match
       }
 
       // If we don't have an exact match, update the best match.
@@ -76,8 +79,11 @@ function expandSections(sections, pageUrl, locale) {
 
     for (const section of curr.sections ?? []) {
       section.parent = curr;
-      internalExpand(section);
+      if (internalExpand(section)) {
+        return true;
+      }
     }
+    return false;
   };
 
   // We clone the input sections so they're not modified for the next page.

--- a/site/_data/supportedTags.json
+++ b/site/_data/supportedTags.json
@@ -54,7 +54,7 @@
     "title": "i18n.tags.html"
   },
   "identity": {
-    "title": "i81n.tags.identity"
+    "title": "i18n.tags.identity"
   },
   "media": {
     "title": "i18n.tags.media"

--- a/site/_data/supportedTags.json
+++ b/site/_data/supportedTags.json
@@ -14,6 +14,9 @@
   "amp": {
     "title": "i18n.tags.amp"
   },
+  "chrome": {
+    "title": "i18n.tags.chrome"
+  },
   "chromium-chronicle": {
     "title": "i18n.tags.chromium-chronicle"
   },
@@ -50,11 +53,17 @@
   "html": {
     "title": "i18n.tags.html"
   },
+  "identity": {
+    "title": "i81n.tags.identity"
+  },
   "media": {
     "title": "i18n.tags.media"
   },
   "new-in-chrome": {
     "title": "i18n.tags.new-in-chrome"
+  },
+  "origin-trials": {
+    "title": "i18n.tags.origin-trials"
   },
   "privacy": {
     "title": "i18n.tags.privacy"

--- a/site/_includes/layouts/blog-landing.njk
+++ b/site/_includes/layouts/blog-landing.njk
@@ -3,6 +3,7 @@
 {% from 'macros/cards/blog-card.njk' import blogCard with context %}
 
 {% block title_bar %}
+  {% set headingBreadcrumb = true %}
   {% include 'partials/breadcrumbs.njk' %}
 {% endblock %}
 

--- a/site/_includes/layouts/docs-landing.njk
+++ b/site/_includes/layouts/docs-landing.njk
@@ -7,6 +7,7 @@
 {% extends 'layouts/base.njk' %}
 
 {% block title_bar %}
+  {% set headingBreadcrumb = true %}
   {% include 'partials/breadcrumbs.njk' %}
 {% endblock %}
 

--- a/site/_includes/layouts/tag-landing.njk
+++ b/site/_includes/layouts/tag-landing.njk
@@ -3,6 +3,7 @@
 {% extends "layouts/base.njk" %}
 
 {% block title_bar %}
+  {% set headingBreadcrumb = true %}
   {% include 'partials/breadcrumbs-tag.njk' %}
 {% endblock %}
 

--- a/site/_includes/layouts/tags-landing.njk
+++ b/site/_includes/layouts/tags-landing.njk
@@ -1,6 +1,7 @@
 {% extends "layouts/base.njk" %}
 
 {% block title_bar %}
+  {% set headingBreadcrumb = true %}
   {% include 'partials/breadcrumbs.njk' %}
 {% endblock %}
 

--- a/site/_includes/macros/tag.njk
+++ b/site/_includes/macros/tag.njk
@@ -8,6 +8,9 @@
   {% set title = item | replace('-', ' ') | capitalize %}
 {% elif supportedTags[item] and supportedTags[item].title%}
   {% set title = supportedTags[item].title | i18n(locale) %}
+{% else %}
+  {# Fall back to the raw text of the tag. #}
+  {% set title = item %}
 {% endif %}
 
 {% if title and url %}

--- a/site/_includes/partials/breadcrumbs-tag.njk
+++ b/site/_includes/partials/breadcrumbs-tag.njk
@@ -13,7 +13,7 @@
     <a class="link type--h6 decoration-none no-visited" href="/tags/">{{ 'i18n.common.tags' | i18n(locale) }}</a>
     {{ icon('keyboard-arrow-right', {hidden: true}) }}
     <h1 class="type--h5">{{ title }}</h1>
-    <a href="/feeds/{{ feedName }}.xml" target="_blank" aria-label="RSS for {{ title }}">
+    <a class="display-flex" href="/feeds/{{ feedName }}.xml" target="_blank" aria-label="RSS for {{ title }}">
       {{ icon('rss', {hidden: true}) }}
     </a>
   </nav>

--- a/site/_includes/partials/breadcrumbs-tag.njk
+++ b/site/_includes/partials/breadcrumbs-tag.njk
@@ -9,14 +9,12 @@
 {% extends 'partials/title-bar.njk' %}
 
 {% block title_bar_content %}
-  <nav class="breadcrumbs cluster" aria-label="{{ 'i18n.common.breadcrumbs' | i18n(locale) }}">
-    <div class="align-center flow-space-200">
-      <a class="type--h6 color-primary surface decoration-none" href="/tags/">{{ 'i18n.common.tags' | i18n(locale) }}</a>
-      {{ icon('keyboard-arrow-right', {hidden: true}) }}
-      <h1 class="type--h5">{{ title }}</h1>
-      <a href="/feeds/{{ feedName }}.xml" target="_blank" aria-label="RSS for {{ title }}">
-        {{ icon('rss', {hidden: true}) }}
-      </a>
-    </div>
+  <nav class="breadcrumbs flow-space-200" aria-label="{{ 'i18n.common.breadcrumbs' | i18n(locale) }}">
+    <a class="link type--h6 decoration-none no-visited" href="/tags/">{{ 'i18n.common.tags' | i18n(locale) }}</a>
+    {{ icon('keyboard-arrow-right', {hidden: true}) }}
+    <h1 class="type--h5">{{ title }}</h1>
+    <a href="/feeds/{{ feedName }}.xml" target="_blank" aria-label="RSS for {{ title }}">
+      {{ icon('rss', {hidden: true}) }}
+    </a>
   </nav>
 {% endblock %}

--- a/site/_includes/partials/breadcrumbs.njk
+++ b/site/_includes/partials/breadcrumbs.njk
@@ -12,10 +12,26 @@
           {{ icon('keyboard-arrow-right', {hidden: true}) }}
         {%- endif %}
 
-        {% if part.url %}
-          <a class="link type--h6 decoration-none no-visited" href="{{ part.url }}">{{ part.title }}</a>
+        {% if headingBreadcrumb and loop.last %}
+          {# This is the last segment and we need to be a large <h1>. #}
+
+          {% if part.url %}
+            <h1 class="type--h5"><a class="link decoration-none no-visited" href="{{ part.url }}">{{ part.title }}</a></h1>
+          {% else %}
+            <h1 class="type--h5">{{ part.title }}</h1>
+          {% endif %}
+
         {% else %}
-          <span class="type--h5">{{ part.title }}</span>
+          {# This is a normal segment. #}
+
+          {% if part.url %}
+            <a class="link type-h6 decoration-none no-visited" href="{{ part.url }}">{{ part.title }}</a>
+          {% elif not loop.last %}
+            <span class="type-h6">{{ part.title }}</span>
+          {% else %}
+            {# This is the last text item of a segment, so make it large. #}
+            <span class="type-h5">{{ part.title }}</span>
+          {% endif %}
         {% endif %}
 
       {%- endfor %}

--- a/site/_includes/partials/breadcrumbs.njk
+++ b/site/_includes/partials/breadcrumbs.njk
@@ -21,7 +21,7 @@
         {% endif %}
 
       {% else %}
-        {# This is a normal segment. #}
+        {# This is a middle or normal segment. #}
 
         {% if part.url %}
           <a class="link type--h6 decoration-none no-visited" href="{{ part.url }}">{{ part.title }}</a>

--- a/site/_includes/partials/breadcrumbs.njk
+++ b/site/_includes/partials/breadcrumbs.njk
@@ -3,39 +3,37 @@
 {% extends 'partials/title-bar.njk' %}
 
 {% block title_bar_content %}
-  <nav class="breadcrumbs cluster" aria-label="{{ 'i18n.common.breadcrumbs' | i18n(locale) }}">
-    <div class="align-center flow-space-200">
-      {% set all = helpers.buildBreadcrumbs(page.url, collections) %}
-      {% for part in all -%}
+  <nav class="breadcrumbs flow-space-200" aria-label="{{ 'i18n.common.breadcrumbs' | i18n(locale) }}">
+    {% set all = helpers.buildBreadcrumbs(page.url, collections) %}
+    {% for part in all -%}
 
-        {% if not loop.first -%}
-          {{ icon('keyboard-arrow-right', {hidden: true}) }}
-        {%- endif %}
+      {% if not loop.first -%}
+        {{ icon('keyboard-arrow-right', {hidden: true}) }}
+      {%- endif %}
 
-        {% if headingBreadcrumb and loop.last %}
-          {# This is the last segment and we need to be a large <h1>. #}
+      {% if headingBreadcrumb and loop.last %}
+        {# This is the last segment and we need to be a large <h1>. #}
 
-          {% if part.url %}
-            <h1 class="type--h5"><a class="link decoration-none no-visited" href="{{ part.url }}">{{ part.title }}</a></h1>
-          {% else %}
-            <h1 class="type--h5">{{ part.title }}</h1>
-          {% endif %}
-
+        {% if part.url %}
+          <h1 class="type--h5"><a class="link decoration-none no-visited" href="{{ part.url }}">{{ part.title }}</a></h1>
         {% else %}
-          {# This is a normal segment. #}
-
-          {% if part.url %}
-            <a class="link type-h6 decoration-none no-visited" href="{{ part.url }}">{{ part.title }}</a>
-          {% elif not loop.last %}
-            <span class="type-h6">{{ part.title }}</span>
-          {% else %}
-            {# This is the last text item of a segment, so make it large. #}
-            <span class="type-h5">{{ part.title }}</span>
-          {% endif %}
+          <h1 class="type--h5">{{ part.title }}</h1>
         {% endif %}
 
-      {%- endfor %}
-    </div>
+      {% else %}
+        {# This is a normal segment. #}
+
+        {% if part.url %}
+          <a class="link type--h6 decoration-none no-visited" href="{{ part.url }}">{{ part.title }}</a>
+        {% elif not loop.last %}
+          <span class="type--h6">{{ part.title }}</span>
+        {% else %}
+          {# This is the last text item of a segment, so make it large. #}
+          <span class="type--h5">{{ part.title }}</span>
+        {% endif %}
+      {% endif %}
+
+    {%- endfor %}
   </nav>
   {% if sharingEnabled %}
     <share-button message="{{ title }}">

--- a/site/_includes/partials/title-bar.njk
+++ b/site/_includes/partials/title-bar.njk
@@ -1,3 +1,3 @@
-<div class="title-bar display-flex pad-left-400 pad-right-400 pad-top-300 pad-bottom-300 justify-content-between">
+<div class="title-bar display-flex pad-left-400 pad-right-400 pad-top-300 pad-bottom-300 justify-content-between align-center">
   {% block title_bar_content %}{% endblock %}
 </div>

--- a/site/_scss/blocks/_breadcrumbs.scss
+++ b/site/_scss/blocks/_breadcrumbs.scss
@@ -1,5 +1,11 @@
 .breadcrumbs {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-flow: row wrap;
+
   svg {
     fill: var(--color-secondary-text);
+    margin: 0 var(--flow-space);
   }
 }

--- a/site/_scss/blocks/_breadcrumbs.scss
+++ b/site/_scss/blocks/_breadcrumbs.scss
@@ -4,7 +4,8 @@
   flex-flow: row wrap;
   justify-content: center;
 
-  svg {
+  > a,
+  > svg {
     fill: var(--color-secondary-text);
     margin: 0 var(--flow-space);
   }

--- a/site/_scss/blocks/_breadcrumbs.scss
+++ b/site/_scss/blocks/_breadcrumbs.scss
@@ -1,8 +1,8 @@
 .breadcrumbs {
-  display: flex;
   align-items: center;
-  justify-content: center;
+  display: flex;
   flex-flow: row wrap;
+  justify-content: center;
 
   svg {
     fill: var(--color-secondary-text);

--- a/site/_scss/blocks/_share-button.scss
+++ b/site/_scss/blocks/_share-button.scss
@@ -2,6 +2,9 @@ share-button {
   border-radius: 50%;
   display: block;
   height: 32px;
+  // This ensures that the share button is in the vertical middle of the
+  // breadcrumbs and its won't shift the page (breadcrumbs are 28px high).
+  margin: -12px 0;
   width: 32px;
 
   &:hover {

--- a/site/_scss/globals/extends/_navigation.scss
+++ b/site/_scss/globals/extends/_navigation.scss
@@ -52,7 +52,7 @@
   }
 }
 
-%navigation__link[aria-current='page'] {
+%navigation__link[data-state='active'] {
   background: var(--color-secondary);
   color: var(--color-side-nav-active);
 }


### PR DESCRIPTION
Fixes #84, and lets us set the last breadcrumb as a heading on certain pages.

Fixes some other minor issues:
- Adds a title for "Origin Trials" tag, and fixes a bug that a missing tag would cause a random tag name to appear instead (Nunjucks needs us to set a default)
- makes sure e.g., "API Reference" is highlighted in navigation even on sub-pages
- puts the share button in the middle of the breadcrumbs, otherwise it caused pages with a share button to be "taller"
- removes `.cluster` from breadcrumbs as it did `overflow: hidden`, which caused:
<img width="468" alt="Screen Shot 2021-08-16 at 18 46 42" src="https://user-images.githubusercontent.com/119184/129537924-4f1f8966-c178-4869-837a-41dbdc30c255.png">

The Percy changes are actually relevant, they showcase a bunch of these issues.