### PR TITLE
Tweaks to adding blog post

### DIFF
--- a/site/en/docs/handbook/how-to/add-a-blog-post/index.md
+++ b/site/en/docs/handbook/how-to/add-a-blog-post/index.md
@@ -10,7 +10,14 @@ date: 2021-01-27
 Duplicate the example post located in `site/en/blog/_example/` and
 rename the folder to match whatever slug you want to use for your url.
 
-## Hero images
+Posts support markdown syntax with some additional features and shortcodes.
+
+## Metadata
+
+Each `index.md` file starts with YAML Front Matter. See
+`site/en/blog/_example/` for documentation of all supported metadata.
+
+### Hero images
 
 Hero images should be at least 1920 x 960. Use jpg unless you have a specific
 need for png or svg. Our image CDN will handle compressing and converting the
@@ -24,7 +31,7 @@ shortcode snippet, it should look like this:
 
 Paste that into the `hero` field in your YAML frontmatter.
 
-## Get busy writing! 👩🏽‍💻
+## Components
 
-Posts support markdown syntax with some additional features and shortcodes.
-See the [components guide](/docs/handbook/components/) for a full list of supported elements.
+See the [components guide](/docs/handbook/components/) for a full list of
+supported elements.


### PR DESCRIPTION
At first glance it seemed like hero images were the only documented piece of metadata. I've added a section clarifying where the rest is documented.

Fixes #1171