### PR TITLE
add releases card on home page

### DIFF
--- a/site/_data/chrome.js
+++ b/site/_data/chrome.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 const {fetchFromCache} = require('./lib/cache');
 
 const OMAHA_PROXY_JSON = 'https://omahaproxy.appspot.com/all.json';
@@ -23,10 +39,11 @@ function extractMajorVersion(raw) {
  * Fetches Chrome release data for a major version from the Chromium Dashboard. Can return null
  * if the version or data returned is invalid.
  *
+ * @param {string} channel
  * @param {number} version
- * @return {!Promise<?Object>}
+ * @return {Promise<ChromeReleaseData?>}
  */
-async function dataForVersion(version) {
+async function dataForVersion(channel, version) {
   const url = `${SCHEDULE_JSON}?mstone=${version}`;
   const json = await fetchFromCache(url);
 
@@ -40,8 +57,13 @@ async function dataForVersion(version) {
     return null;
   }
 
-  // This contains useful keys "stable_date", "earliest_beta" and "final_beta", among others.
-  return data;
+  // This contains useful keys "stable_date", "earliest_beta" and "final_beta", among others, most
+  // of which are currently ignored.
+  return {
+    mstone: version,
+    key: channel,
+    stableDate: new Date(data['stable_date']),
+  };
 }
 
 /**
@@ -54,7 +76,9 @@ async function dataForVersion(version) {
  */
 module.exports = async function buildVersionInformation() {
   const json = await fetchFromCache(OMAHA_PROXY_JSON);
-  const channels = {};
+
+  /** @type {{[channel: string]: number}} */
+  const channelRelease = {};
 
   // Find the current version for every channel. The published data returns the versions for each
   // operating system. We take the highest major version found across each OS and use that.
@@ -68,26 +92,21 @@ module.exports = async function buildVersionInformation() {
       if (majorVersion === 0) {
         continue;
       }
-      if (channel in channels) {
-        channels[channel].mstone = Math.max(
-          channels[channel].mstone,
-          majorVersion
-        );
-      } else {
-        channels[channel] = {channel, mstone: majorVersion};
-      }
+      channelRelease[channel] = Math.max(
+        channelRelease[channel] ?? 0,
+        majorVersion
+      );
     }
   }
 
+  /** @type {{[channel: string]: ChromeReleaseData}} */
+  const channels = {};
+
   // Now that we have all major versions, look up and/or cache the schedule for each version. This
   // might be the same version for multiple channels, but Eleventy is caching the result for us.
-  for (const channel in channels) {
-    const {mstone} = channels[channel];
-    const update = await dataForVersion(mstone);
-
-    // dataForVersion doesn't know about the channel name, so we use Object.assign to ensure the
-    // channel name is still included in the value. This lets Eleventy paginate over just values.
-    Object.assign(channels[channel], update);
+  for (const [channel, mstone] of Object.entries(channelRelease)) {
+    const data = await dataForVersion(channel, mstone);
+    channels[channel] = data;
   }
 
   return {channels};

--- a/site/_data/chrome.js
+++ b/site/_data/chrome.js
@@ -57,8 +57,9 @@ async function dataForVersion(channel, version) {
     return null;
   }
 
-  // This contains useful keys "stable_date", "earliest_beta" and "final_beta", among others, most
-  // of which are currently ignored.
+  // The underlying data contains useful keys "stable_date", "earliest_beta" and "final_beta",
+  // among others, most of which are currently ignored.
+
   return {
     mstone: version,
     key: channel,
@@ -106,7 +107,9 @@ module.exports = async function buildVersionInformation() {
   // might be the same version for multiple channels, but Eleventy is caching the result for us.
   for (const [channel, mstone] of Object.entries(channelRelease)) {
     const data = await dataForVersion(channel, mstone);
-    channels[channel] = data;
+    if (data) {
+      channels[channel] = data;
+    }
   }
 
   return {channels};

--- a/site/_data/i18n/common.yml
+++ b/site/_data/i18n/common.yml
@@ -118,5 +118,14 @@ close:
 back:
   en: 'Back'
 
-current_stable:
+current_release_description:
+  en: 'The current stable version of Chrome is'
+
+future_release_description:
+  en: 'The current beta version of Chrome is'
+
+current_release_label:
   en: 'Current stable version'
+
+future_release_label:
+  en: 'Beta will promote to stable on'

--- a/site/_data/i18n/common.yml
+++ b/site/_data/i18n/common.yml
@@ -117,3 +117,6 @@ close:
 
 back:
   en: 'Back'
+
+current_stable:
+  en: 'Current stable version'

--- a/site/_includes/layouts/home.njk
+++ b/site/_includes/layouts/home.njk
@@ -4,6 +4,7 @@
 {% from 'macros/cards/featured-post-card.njk' import featuredPostCard with context %}
 {% from 'macros/cards/featured-docs-card.njk' import featuredDocsCard with context %}
 {% from 'macros/cards/featured-tweet-card.njk' import featuredTweetCard with context %}
+{% from 'macros/cards/releases-card.njk' import releasesCard with context %}
 
 {% block content %}
   <div class="home-container width-full center-margin pad-400">
@@ -13,6 +14,7 @@
       <div class="display-flex direction-column grid-gap-500">
         {% set blog = 'blog-' + locale %}
         {{ featuredPostCard(collections[blog][0]) }}
+        {{ releasesCard() }}
         {% include 'partials/report-a-bug.njk' %}
       </div>
       <div class="display-flex direction-column grid-gap-500">

--- a/site/_includes/layouts/releases-landing.njk
+++ b/site/_includes/layouts/releases-landing.njk
@@ -11,7 +11,7 @@
     <dt>{{ i18n.release_title }}</dt>
     <dd>{{ release.mstone }}</dd>
     <dt>{{ i18n.stabledate_title }}</dt>
-    <dd>{{ release.stable_date }}</dd>
+    <dd>{{ release.stableDate.toLocaleDateString(locale, {day: 'numeric', month: 'long', year: 'numeric'}) }}</dd>
   </dl>
 
   {% endfor %}

--- a/site/_includes/macros/cards/releases-card.njk
+++ b/site/_includes/macros/cards/releases-card.njk
@@ -9,9 +9,9 @@
     </span>
   </div>
 
-  <div class="display-flex justify-content-around gap-top-500 gap-bottom-200">
+  <div class="display-flex direction-column md:direction-row justify-content-around gap-top-200">
 
-    <div class="flex-1 gap-left-300 gap-right-300">
+    <div class="flex-1 gap-300">
       <div class="release-card__icon release-card__icon-stable">
         <span class="visually-hidden">{{ 'i18n.common.current_release_description' | i18n(locale) }}</span>
         {{ chrome.channels.stable.mstone }}
@@ -20,7 +20,7 @@
         {{ 'i18n.common.current_release_label' | i18n(locale) }}
       </p>
     </div>
-    <div class="flex-1 gap-left-300 gap-right-300">
+    <div class="flex-1 gap-300">
       <div class="release-card__icon release-card__icon-beta">
         <span class="visually-hidden">{{ 'i18n.common.future_release_description' | i18n(locale) }}</span>
         {{ chrome.channels.beta.mstone }}

--- a/site/_includes/macros/cards/releases-card.njk
+++ b/site/_includes/macros/cards/releases-card.njk
@@ -13,17 +13,20 @@
 
     <div class="flex-1 gap-left-300 gap-right-300">
       <div class="release-card__icon release-card__icon-stable">
+        <span class="visually-hidden">{{ 'i18n.common.current_release_description' | i18n(locale) }}</span>
         {{ chrome.channels.stable.mstone }}
       </div>
       <p class="type--caption text-align-center gap-top-300">
-        {{ 'i18n.common.current_stable' | i18n(locale) }}
+        {{ 'i18n.common.current_release_label' | i18n(locale) }}
       </p>
     </div>
     <div class="flex-1 gap-left-300 gap-right-300">
       <div class="release-card__icon release-card__icon-beta">
+        <span class="visually-hidden">{{ 'i18n.common.future_release_description' | i18n(locale) }}</span>
         {{ chrome.channels.beta.mstone }}
       </div>
       <p class="type--caption text-align-center gap-top-300">
+        {{ 'i18n.common.future_release_label' | i18n(locale) }}
         {{ chrome.channels.beta.stableDate.toLocaleDateString(locale, {day: 'numeric', month: 'long'}) }}
       </p>
     </div>

--- a/site/_includes/macros/cards/releases-card.njk
+++ b/site/_includes/macros/cards/releases-card.njk
@@ -1,0 +1,34 @@
+{% from 'macros/icon.njk' import icon with context %}
+
+{% macro releasesCard() %}
+<div class="featured-card hairline rounded-lg width-full">
+  <div class="card-title-bar color-green-medium">
+    {{ icon('releases', {hidden: true}) }}
+    <span class="gap-left-300 flex-1 user-select-none">
+      {{ 'i18n.nav.side_nav.releases' | i18n(locale) }}
+    </span>
+  </div>
+
+  <div class="display-flex justify-content-around gap-top-500 gap-bottom-200">
+
+    <div class="flex-1 gap-left-300 gap-right-300">
+      <div class="release-card__icon release-card__icon-stable">
+        {{ chrome.channels.stable.mstone }}
+      </div>
+      <p class="type--caption text-align-center gap-top-300">
+        {{ 'i18n.common.current_stable' | i18n(locale) }}
+      </p>
+    </div>
+    <div class="flex-1 gap-left-300 gap-right-300">
+      <div class="release-card__icon release-card__icon-beta">
+        {{ chrome.channels.beta.mstone }}
+      </div>
+      <p class="type--caption text-align-center gap-top-300">
+        {{ chrome.channels.beta.stableDate.toLocaleDateString(locale, {day: 'numeric', month: 'long'}) }}
+      </p>
+    </div>
+
+  </div>
+
+</div>
+{% endmacro %}

--- a/site/_scss/blocks/_release-card.scss
+++ b/site/_scss/blocks/_release-card.scss
@@ -1,0 +1,30 @@
+.release-card__icon {
+  width: get-size(600) * 3;
+  max-width: 25vw;
+  margin: 0 auto;
+  color: black;
+  background: red;
+  border-radius: 128px;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  font-size: 42px;
+
+  &::after {
+    content: '';
+    padding-bottom: 100%;
+    position: relative;
+  }
+}
+
+.release-card__icon-stable {
+  color: var(--color-green-darkest);
+  background: var(--color-green-lighter);
+}
+
+.release-card__icon-beta {
+  color: var(--color-blue-darkest);
+  background: var(--color-blue-lighter);
+}

--- a/site/_scss/blocks/_release-card.scss
+++ b/site/_scss/blocks/_release-card.scss
@@ -1,8 +1,8 @@
 .release-card__icon {
   align-items: center;
-  background: red;
+  background: var(--color-green-lighter);
   border-radius: 128px;
-  color: black;
+  color: var(--color-green-darkest);
   display: flex;
   font-size: 42px;
   justify-content: center;
@@ -15,11 +15,6 @@
     padding-bottom: 100%;
     position: relative;
   }
-}
-
-.release-card__icon-stable {
-  background: var(--color-green-lighter);
-  color: var(--color-green-darkest);
 }
 
 .release-card__icon-beta {

--- a/site/_scss/blocks/_release-card.scss
+++ b/site/_scss/blocks/_release-card.scss
@@ -1,16 +1,14 @@
 .release-card__icon {
-  width: get-size(600) * 3;
-  max-width: 25vw;
-  margin: 0 auto;
-  color: black;
+  align-items: center;
   background: red;
   border-radius: 128px;
-
+  color: black;
   display: flex;
-  align-items: center;
-  justify-content: center;
-
   font-size: 42px;
+  justify-content: center;
+  margin: 0 auto;
+  max-width: 25vw;
+  width: get-size(600) * 3;
 
   &::after {
     content: '';
@@ -20,11 +18,11 @@
 }
 
 .release-card__icon-stable {
-  color: var(--color-green-darkest);
   background: var(--color-green-lighter);
+  color: var(--color-green-darkest);
 }
 
 .release-card__icon-beta {
-  color: var(--color-blue-darkest);
   background: var(--color-blue-lighter);
+  color: var(--color-blue-darkest);
 }

--- a/site/_scss/main.scss
+++ b/site/_scss/main.scss
@@ -48,6 +48,7 @@
 @import 'blocks/featured-card';
 @import 'blocks/blog-card';
 @import 'blocks/tweet-card';
+@import 'blocks/release-card';
 @import 'blocks/tag-pill';
 @import 'blocks/tag-card';
 @import 'blocks/footer';

--- a/tests/site/_data/chrome.js
+++ b/tests/site/_data/chrome.js
@@ -61,13 +61,12 @@ test('returns version information', async t => {
   const expected = {
     channels: {
       stable: {
-        channel: 'stable',
+        key: 'stable',
         mstone: 42,
-        stable_date: '2020-01-01T00:00:00',
+        stableDate: new Date('2020-01-01T00:00:00'),
       },
-      beta: {channel: 'beta', mstone: 43},
     },
   };
 
-  t.assert(JSON.stringify(expected) === JSON.stringify(actual));
+  t.deepEqual(expected, actual);
 });

--- a/types/site/_data/chrome.d.ts
+++ b/types/site/_data/chrome.d.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare global {
+  export interface ChromeReleaseData {
+    mstone: number;
+    key: string;
+    stableDate: Date;
+  }
+}
+
+// empty export to keep file a module
+export {};


### PR DESCRIPTION
This actually isn't tracked but we have this data and I wanted to make the homepage more living.

This simply shows the current Chrome release along with the date for the release of the next on the homepage of the site. This could later lead to a complete Releases page. We have designs for both.

See screenshot for this in context:

<img width="1237" alt="Screen Shot 2021-08-20 at 16 38 26" src="https://user-images.githubusercontent.com/119184/130191656-d350d199-82cb-4917-9d15-42d75c3469db.png">
