### PR TITLE
add includeRaw shortcode

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -29,6 +29,7 @@ const {YouTube} = require('./site/_shortcodes/YouTube');
 const {Columns, Column} = require('./site/_shortcodes/Columns');
 const {Compare, CompareCaption} = require('./site/_shortcodes/Compare');
 const {Aside} = require('./site/_shortcodes/Aside');
+const includeRaw = require('./site/_shortcodes/includeRaw');
 
 // Transforms
 const {domTransformer} = require('./site/_transforms/dom-transformer-pool');
@@ -118,6 +119,7 @@ module.exports = eleventyConfig => {
   eleventyConfig.addShortcode('Img', Img);
   eleventyConfig.addShortcode('Video', Video);
   eleventyConfig.addShortcode('YouTube', YouTube);
+  eleventyConfig.addShortcode('includeRaw', includeRaw);
   eleventyConfig.addPairedShortcode('Details', Details);
   eleventyConfig.addPairedShortcode('DetailsSummary', DetailsSummary);
   eleventyConfig.addPairedShortcode('Columns', Columns);

--- a/site/_includes/icons/README.md
+++ b/site/_includes/icons/README.md
@@ -1,11 +1,16 @@
-We use includes to inject SVG icons into our pages.
+We use includes to inject SVG icons into our pages, loading the basenames found in this folder.
 
 ```text
-{% include 'icons/arrow-back.svg' %}
+{{ icon('arrow-back', {
+  hidden: true,
+  label: 'i18n.common.string_id' | i18n(locale),
+  className: 'gap-300',
+  id: 'idToUseOnPage',
+}) }}
 ```
 
-This allows lets us use CSS to style the fill and color of the SVG elements
-and avoids FOUC that occurs when loading SVG with `img`.
+All of the options in the second argument are optional.
 
-This is similar to GitHub's approach outlined here:
-https://github.blog/2016-02-22-delivering-octicons-with-svg/
+This allows lets us use CSS to style the fill and color of the SVG elements and avoids FOUC that occurs when loading SVG with `img`.
+
+This is similar to GitHub's approach outlined here: https://github.blog/2016-02-22-delivering-octicons-with-svg/

--- a/site/_includes/layouts/base.njk
+++ b/site/_includes/layouts/base.njk
@@ -7,7 +7,7 @@
     <meta name="robots" content="noindex">
     {%- endif %}
 
-    {% include "partials/meta.njk" %}
+    {% include 'partials/meta.njk' %}
     {% block feed %}
       <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ site.url }}/feeds/blog.xml">
     {% endblock %}
@@ -35,7 +35,7 @@
       {% endfor %}
     {% endif %}
 
-    <script>{% include 'partials/script.js' %}</script>
+    <script>{% includeRaw 'partials/script.js' %}</script>
   </head>
   <body>
     <div class="scaffold">

--- a/site/_includes/macros/icon.njk
+++ b/site/_includes/macros/icon.njk
@@ -13,7 +13,7 @@
 #}
 {% macro svg(path, options) %}
 {% set rawSvg -%}
-  {% include path %}
+  {% includeRaw path %}
 {%- endset %}
 {{ rawSvg | updateSvgForInclude(options) | safe }}
 {% endmacro %}

--- a/site/_includes/macros/project-icon.njk
+++ b/site/_includes/macros/project-icon.njk
@@ -5,7 +5,8 @@
     {% set styles = docs[project_key].styles %}
     {% set color = styles.project_icon_color %}
     <div class="project-icon__cover"{% if color %} style="color: var(--{{color}})"{% endif %}>
-      {{ svg('../../_static/images/project/' + project_key + '.svg', {hidden: true}) }}
+      {# svg() looks in "_includes", so find the project image in the parent directory #}
+      {{ svg('../_static/images/project/' + project_key + '.svg', {hidden: true}) }}
     </div>
   </div>
 {% endmacro %}

--- a/site/_shortcodes/includeRaw.js
+++ b/site/_shortcodes/includeRaw.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const path = require('path');
+const fs = require('fs');
+
+// The path to the _includes folder inside developer.chrome.com.
+const includesPath = path.join(__dirname, '../_includes');
+
+/**
+ * @param {string} arg
+ * @return {string}
+ */
+module.exports = arg => {
+  const p = path.join(includesPath, arg);
+  return fs.readFileSync(p, 'utf-8');
+};

--- a/site/en/docs/handbook/how-to/add-media/index.md
+++ b/site/en/docs/handbook/how-to/add-media/index.md
@@ -61,7 +61,7 @@ in the shortode.
 #### Img Properties (`ImgArgs`)
 
 ```typescript
-{% include '../../../../../../node_modules/webdev-infra/types/shortcodes/Img.d.ts' %}
+{% includeRaw '../../../../../../node_modules/webdev-infra/types/shortcodes/Img.d.ts' %}
 ```
 
 The `{% raw %}`{% Img %}`{% endraw%}` `params` object exposes the entire [Imgix
@@ -99,5 +99,5 @@ directly.
 #### Video Properties (`VideoArgs`)
 
 ```typescript
-{% include '../../../../../../node_modules/webdev-infra/types/shortcodes/Video.d.ts' %}
+{% includeRaw '../../../../../../node_modules/webdev-infra/types/shortcodes/Video.d.ts' %}
 ```

--- a/site/en/docs/handbook/how-to/add-media/index.md
+++ b/site/en/docs/handbook/how-to/add-media/index.md
@@ -61,7 +61,7 @@ in the shortode.
 #### Img Properties (`ImgArgs`)
 
 ```typescript
-{% includeRaw '../../../../../../node_modules/webdev-infra/types/shortcodes/Img.d.ts' %}
+{% includeRaw '../../node_modules/webdev-infra/types/shortcodes/Img.d.ts' %}
 ```
 
 The `{% raw %}`{% Img %}`{% endraw%}` `params` object exposes the entire [Imgix
@@ -99,5 +99,5 @@ directly.
 #### Video Properties (`VideoArgs`)
 
 ```typescript
-{% includeRaw '../../../../../../node_modules/webdev-infra/types/shortcodes/Video.d.ts' %}
+{% includeRaw '../../node_modules/webdev-infra/types/shortcodes/Video.d.ts' %}
 ```


### PR DESCRIPTION
Matches web.dev. Minor speed increase / safety as we're not running SVGs through the Nunjucks filter.