### PR TITLE
Don't track pyenv version file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ Thumbs.db
 .vscode
 .lighthouseci
 .idea*
+.python-version
 
 # Code coverage generated files
 .nyc_output


### PR DESCRIPTION
This PR adds a new rule to `.gitignore` that will ignore the `.python-version` file that [pyenv](https://github.com/pyenv/pyenv) creates when specifying a version of Python to use in a given directory.