### PR TITLE
[devtools] Add application cache documentation

### DIFF
--- a/site/_data/docs/devtools/toc.yml
+++ b/site/_data/docs/devtools/toc.yml
@@ -36,6 +36,7 @@
     - url: /docs/devtools/storage/localstorage/
     - url: /docs/devtools/storage/indexeddb/
     - url: /docs/devtools/storage/sessionstorage/
+    - url: /docs/devtools/storage/applicationcache/
     - url: /docs/devtools/storage/websql/
     - url: /docs/devtools/storage/cache/
 - url: /docs/devtools/issues/

--- a/site/_data/docs/devtools/toc.yml
+++ b/site/_data/docs/devtools/toc.yml
@@ -36,7 +36,6 @@
     - url: /docs/devtools/storage/localstorage/
     - url: /docs/devtools/storage/indexeddb/
     - url: /docs/devtools/storage/sessionstorage/
-    - url: /docs/devtools/storage/applicationcache/
     - url: /docs/devtools/storage/websql/
     - url: /docs/devtools/storage/cache/
 - url: /docs/devtools/issues/

--- a/site/en/docs/devtools/storage/applicationcache/index.md
+++ b/site/en/docs/devtools/storage/applicationcache/index.md
@@ -1,0 +1,48 @@
+---
+layout: "layouts/doc-post.njk"
+title: "View Application Cache Data With Chrome DevTools"
+authors:
+  - kaycebasques
+date: 2019-03-25
+#updated: YYYY-MM-DD
+description: "How to view Application Cache data from the Application panel of Chrome DevTools."
+---
+
+[MDN]: https://developer.mozilla.org/en-US/docs/Web/API/Window/applicationCache
+
+{% Aside 'warning' %}
+Support for [AppCache][MDN] will be removed from Chrome and other Chromium-based browsers. We encourage developers to migrate off of AppCache now, rather than waiting any longer. Read [more](https://web.dev/appcache-removal/).
+{% endAside %}
+
+This guide shows you how to use [Chrome DevTools](/docs/devtools/) to inspect
+[Application Cache][MDN]{: .external } resources.
+
+## View Application Cache Data {: #view }
+
+1. Click the **Sources** tab to open the **Sources** panel. The **Manifest** pane usually opens
+   by default.
+
+   {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/bzasEKrxVeISVxBqy42W.png", alt="The Manifest pane", width="800", height="619" %}
+
+1. Expand the **Application Cache** section and click a cache to view its resources.
+
+   {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/uWzKzxzWLNb1FeURUls6.png", alt="The Application Cache pane", width="800", height="427" %}
+
+Each row of the table represents a cached resource.
+
+The **Type** column represents the resource's category:
+
+* **Master**. The `manifest` attribute on the resource indicated that this cache is the resource's master.
+* **Explicit**. This resource was explicitly listed in the manifest.
+* **Network**. The manifest specified that this resource must come from the network.
+* **Fallback**. The URL is a fallback for another resource. The URL of the other resource is not listed in DevTools.
+
+At the bottom of the table there are status icons indicating your network
+connection and the status of the Application Cache. The Application Cache
+can have the following statuses:
+
+* **IDLE**. The cache has no new changes.
+* **CHECKING**. The manifest is being fetched and checked for updates.
+* **DOWNLOADING**. Resources are being added to the cache.
+* **UPDATEREADY**. A new version of the cache is available.
+* **OBSOLETE**. The cache is being deleted.

--- a/site/en/docs/devtools/storage/applicationcache/index.md
+++ b/site/en/docs/devtools/storage/applicationcache/index.md
@@ -8,14 +8,14 @@ date: 2019-03-25
 description: "How to view Application Cache data from the Application panel of Chrome DevTools."
 ---
 
-[MDN]: https://developer.mozilla.org/en-US/docs/Web/API/Window/applicationCache
+[mdn]: https://developer.mozilla.org/en-US/docs/Web/API/Window/applicationCache
 
 {% Aside 'warning' %}
-Support for [AppCache][MDN] will be removed from Chrome and other Chromium-based browsers. We encourage developers to migrate off of AppCache now, rather than waiting any longer. Read [more](https://web.dev/appcache-removal/).
+Support for [AppCache][mdn] will be removed from Chrome and other Chromium-based browsers. We encourage developers to migrate off of AppCache now, rather than waiting any longer. Read [more](https://web.dev/appcache-removal/).
 {% endAside %}
 
 This guide shows you how to use [Chrome DevTools](/docs/devtools/) to inspect
-[Application Cache][MDN]{: .external } resources.
+[Application Cache][mdn]{: .external } resources.
 
 ## View Application Cache Data {: #view }
 


### PR DESCRIPTION
Fixes [crbug.com/1243277](https://crbug.com/1243277)

Migrate old docs on WebFu: https://github.com/google/WebFundamentals/blob/060325e683329e41354a89f3893d9dc82f1472bb/src/content/en/tools/chrome-devtools/storage/applicationcache.md