### PR TITLE
[devtools-translate] Portuguese - What's New in DevTools (Chrome 93)

### DIFF
--- a/site/_includes/partials/devtools/pt/banner.md
+++ b/site/_includes/partials/devtools/pt/banner.md
@@ -1,3 +1,3 @@
 {% Aside %}
-Interested in helping improve DevTools? Sign up to participate in [Google User Research here](https://google.qualtrics.com/jfe/form/SV_9YbKj35IGoGsDBj?reserved=1&utm_source=Website%20feature&Q_Language=en&utm_medium=own_web&utm_campaign=Q4&productTag=chrm&campaignDate=November2020&referral_code=UXFm430458).
+Interessado em ajudar a melhorar o DevTools? Inscreva-se para participar da [Pesquisa de usuário do Google](https://google.qualtrics.com/jfe/form/SV_9YbKj35IGoGsDBj?reserved=1&utm_source=Website%20feature&Q_Language=en&utm_medium=own_web&utm_campaign=Q4&productTag=chrm&campaignDate=November2020&referral_code=UXFm430458).
 {% endAside %}

--- a/site/_includes/partials/devtools/pt/reach-out.md
+++ b/site/_includes/partials/devtools/pt/reach-out.md
@@ -1,11 +1,12 @@
-## Download the preview channels {: #preview-channels }
-Consider using the Chrome [Canary](https://www.google.com/chrome/canary/), [Dev](https://www.google.com/chrome/dev/) or [Beta](https://www.google.com/chrome/beta/) as your default development browser. These preview channels give you access to the latest DevTools features, test cutting-edge web platform APIs, and find issues on your site before your users do!
+## Baixe os canais de prévia {: #preview-channels }
 
+Considere usar o Chrome [Canary](https://www.google.com/chrome/canary/), [Dev](https://www.google.com/chrome/dev/) ou [Beta](https://www.google.com/chrome/beta/) como seu navegador de desenvolvimento padrão. Esses canais de prévia fornecem acesso aos recursos do DevTools mais recentes, testam nas últimas APIs da plataforma web lançadas e encontram problemas em seu site antes que seus usuários o façam!
 
-## Getting in touch with the Chrome DevTools team {: #contact-us }
-Use the following options to discuss the new features and changes in the post, or anything else related to DevTools.
+## Entre em contato com a equipe Chrome DevTools {: #contact-us }
 
-- Submit a suggestion or feedback to us via [crbug.com](https://crbug.com).
-- Report a DevTools issue using the **More options** &nbsp; {% Img src="image/admin/4sdCQbpBaG4MpoHB1J08.png", alt="More", width="4", height="20" %} &nbsp; > **Help** > **Report a DevTools issues** in DevTools.
-- Tweet at <a href="https://twitter.com/intent/tweet?text=@ChromeDevTools" target="_blank">@ChromeDevTools</a>.
-- Leave comments on our What's new in DevTools [YouTube videos](https://goo.gle/devtools-youtube).
+Use as opções a seguir para discutir os novos recursos e mudanças nesse artigo ou qualquer outra coisa relacionada ao DevTools.
+
+- Envie uma sugestão ou comentários para nós pelo [crbug.com](https://crbug.com).
+- Relate um problema de DevTools usando o **More options** &nbsp; {% Img src="image/admin/4sdCQbpBaG4MpoHB1J08.png", alt="More", width="4", height="20" %} &nbsp; > **Help** > **Report a DevTools issues** em DevTools.
+- Mande um tweet para <a href="https://twitter.com/intent/tweet?text=@ChromeDevTools" target="_blank">@ChromeDevTools</a>.
+- Deixe comentários em nossos vídeos *"What's new in DevTools"* no [YouTube](https://goo.gle/devtools-youtube).

--- a/site/_includes/partials/devtools/pt/whats-new.md
+++ b/site/_includes/partials/devtools/pt/whats-new.md
@@ -1,5 +1,6 @@
-## More DevTools features {: #whats-new }
-Please refer to the English version of [What's New In DevTools](/tags/new-in-devtools/) for a complete list of released features. Below are some content that has been translated into Portuguese.
+## Mais recursos do DevTools {: #whats-new }
+
+Consulte a versão em inglês do *"[What's New In DevTools](/tags/new-in-devtools/)"* para uma lista completa dos recursos lançados. Abaixo estão alguns conteúdos que foram traduzidos para o português.
 
 ### Chrome 93 {: #chrome93 }
 

--- a/site/_includes/partials/devtools/pt/whats-new.md
+++ b/site/_includes/partials/devtools/pt/whats-new.md
@@ -1,2 +1,14 @@
 ## More DevTools features {: #whats-new }
 Please refer to the English version of [What's New In DevTools](/tags/new-in-devtools/) for a complete list of released features. Below are some content that has been translated into Portuguese.
+
+### Chrome 93 {: #chrome93 }
+
+* [Consultas de contêiner CSS editáveis no painel Styles](/pt/blog/new-in-devtools-93/#container-queries)
+* [Prévia do web-bundle no painel Network](/pt/blog/new-in-devtools-93/#web-bundle)
+* [Depuração da Attribution Reporting API](/pt/blog/new-in-devtools-93/#attribution-reporting)
+* [Melhor manejo de string no console](/pt/blog/new-in-devtools-93/#string)
+* [Depuração CORS aprimorada](/pt/blog/new-in-devtools-93/#cors)
+* [Lighthouse 8.1](/pt/blog/new-in-devtools-93/#lighthouse)
+* [Exibir o novo URL da nota no painel Manifest](/pt/blog/new-in-devtools-93/#new-note-url)
+* [Seletores de correspondência de CSS corrigidos](/pt/blog/new-in-devtools-93/#matching-selectors)
+* [Respostas JSON Pretty-printing no painel Network](/pt/blog/new-in-devtools-93/#pretty-print-json)

--- a/site/pt/blog/new-in-devtools-93/index.md
+++ b/site/pt/blog/new-in-devtools-93/index.md
@@ -15,7 +15,7 @@ tags:
   - chrome-93
 ---
 
-*Tradução realizada por [Alvaro Camillo Neto](https://www.linkedin.com/in/alvarocamillont/).*
+*Tradução realizada por [Alvaro Camillo Neto](https://www.linkedin.com/in/alvarocamillont/). Revisão por [Lucas Santos](http://info.lsantos.dev)*
 
 {% include 'partials/devtools/pt/banner.md' %}
 
@@ -25,7 +25,7 @@ tags:
 
 Agora você pode visualizar e editar [Consultas de contêiner CSS](https://web.dev/new-responsive/#responsive-to-the-container) no painel **Styles**.
 
-As consultas de contêiner fornecem uma abordagem muito mais dinâmica para design responsivo. A regra `@container` funciona de maneira semelhante a uma consulta de mídia com `@media`. No entanto, em vez de consultar a viewport e o agente do usuário em busca de informações, `@container` consulta o container ancestral que corresponde a certos critérios.
+As consultas de contêiner fornecem uma abordagem muito mais dinâmica para design responsivo. A regra `@container` funciona de maneira semelhante a uma consulta de mídia com `@media`. No entanto, em vez de consultar a viewport e o agente do usuário em busca de informações, `@container` consulta o container antecessor que corresponde a certos critérios.
 
 No painel **Elements**, clique em um elemento DOM com a regra `@container`, DevTools agora exibe as informações `@container` no painel **Styles**. Clique nele para editar o tamanho. O painel **Styles** também exibe as informações do contêiner correspondente. Passe o mouse sobre ele para destacar o elemento do contêiner na página e verifique o tamanho do contêiner. Clique nele para selecionar o elemento do contêiner.
 
@@ -37,7 +37,7 @@ Atualmente o recurso de consultas de contêiner é experimental. Ative a sinaliz
 {# https://chromium.googlesource.com/devtools/devtools-frontend/+/a7e1eac63bee3728b41ae440f2ec250559e9c667 #}
 {# https://chromium.googlesource.com/devtools/devtools-frontend/+/ef157dab2ccf321941548a51d350f9383a78d283 #}
 
-Chromium issue: [1146422](https://crbug.com/1146422)
+Issue relacionada: [1146422](https://crbug.com/1146422)
 
 ## Prévia do web-bundle no painel Network  {: #web-bundle }
 
@@ -49,7 +49,7 @@ O recurso de web-bundle é atualmente experimental. Habilite a sinalização `#e
 
 {# https://chromium.googlesource.com/devtools/devtools-frontend/+/e7672c40f2febc80786632c188b6029b2f2ac7b7 #}
 
-Chromium issue: [1182537](https://crbug.com/1182537) 
+Issue relacionada: [1182537](https://crbug.com/1182537) 
 
 ## Depuração da Attribution Reporting API {: #attribution-reporting }
 
@@ -59,7 +59,7 @@ Os erros da Attribution Reporting API agora são relatados na guia **Issues**.
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/bkEGVEv5kKc9M6qBUmLz.png", alt="Attribution Reporting API errors in the Issues tab", width="800", height="501" %}
 
-Chromium issue: [1190735](https://crbug.com/1190735)
+Issue relacionada: [1190735](https://crbug.com/1190735)
 
 ## Melhor manejo de string no console {: #string }
 
@@ -67,15 +67,15 @@ O novo menu de contexto no **Console** permite que você copie qualquer string c
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/O5uMSgkHrQ2mQDSjmg3A.png", alt="New context menu in the Console", width="800", height="477" %}
 
-No Chrome 90, o DevTools atualizou o **Console** para sempre [formatar saídas de string como literais JSON válidos](/blog/new-in-devtools-90/#double-quotes). Recebemos feedback dos desenvolvedores de que essa mudança poderia ser confusa, alguns acharam que a quantidade de escape era excessiva e tornava a saída ilegível.
+No Chrome 90, o DevTools atualizou o **Console** para sempre [formatar saídas de string como literais JSON válidos](/blog/new-in-devtools-90/#double-quotes). Recebemos feedback dos desenvolvedores de que essa mudança poderia ser confusa, e alguns acharam que a quantidade de escape era excessiva e tornava a saída ilegível.
 
-O **Console** agora formata as saídas de string como literais JavaScript válidas e, além disso, fornece a você 3 opções de string de cópia. A opção **Copy as JavaScript literal** escapará dos caracteres especiais apropriados e envolverá a string entre aspas simples, aspas duplas ou barras, dependendo do conteúdo da string. Em vez disso, o **Copy string contents** copia o conteúdo da string bruta (incluindo nova linha e outros caracteres especiais) na íntegra para a área de transferência. Por fim, **Copy as JSON literal** formata a string como uma literal JSON válida e a copia para a área de transferência.
+O **Console** agora formata as saídas de string como literais JavaScript válidas e, além disso, fornece a você 3 opções de string de cópia. A opção **Copy as JavaScript literal** escapará dos caracteres especiais apropriados e envolverá a string entre aspas simples, aspas duplas ou barras, dependendo do conteúdo. Em vez disso, o **Copy string contents** copia o conteúdo da string bruta (incluindo nova linha e outros caracteres especiais) na íntegra para a área de transferência. Por fim, **Copy as JSON literal** formata a string como uma literal JSON válida e a copia para a área de transferência.
 
 {# https://chromium.googlesource.com/devtools/devtools-frontend/+/9242d13569e9fe67ac01e75d28fa2b6e6bf310d2 #}
 {# https://chromium.googlesource.com/devtools/devtools-frontend/+/5715a7b9800532d8b28e2c9fa2d3c1e220ba54a8 #}
 {# https://chromium.googlesource.com/devtools/devtools-frontend/+/29236e333a856ae5a952fe4182545b1e2bde5539 #}
 
-Chromium issue: [1208389](https://crbug.com/1208389)
+Issue relacionada: [1208389](https://crbug.com/1208389)
 
 ## Depuração CORS aprimorada {: #cors }
 
@@ -85,7 +85,7 @@ Clique nos dois novos ícones ao lado da mensagem de erro relacionada ao CORS pa
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/VzoUggSoM0FnkDlIFPhq.png", alt="Icons next to the CORS-related error message", width="800", height="485" %}
 
-Chromium issue: [1213393](https://crbug.com/1213393)
+Issue relacionada: [1213393](https://crbug.com/1213393)
 
 ## Lighthouse 8.1 {: #lighthouse }
 
@@ -99,28 +99,30 @@ O relatório também inclui um novo filtro de métrica (consulte **Mostrar audit
 
 A **Categoria de desempenho** teve uma série de alterações de pontuação para se alinhar com outras ferramentas de desempenho e refletir melhor o estado da web.
 
-Confira as [notas de lançamento](https://github.com/GoogleChrome/lighthouse/releases) for a full list of changes.
+Confira a lista completa de mudanças nas [notas de lançamento](https://github.com/GoogleChrome/lighthouse/releases).
 
 {# https://chromium.googlesource.com/devtools/devtools-frontend/+/62b16561e433f4aa1645826923222699ac4bad38 #}
 {# https://chromium.googlesource.com/devtools/devtools-frontend/+/16d96a25f24c934ef4dcbbc7b827015abdd228a1 #}
 
-Chromium issue: [772558](https://crbug.com/772558)
+Issue relacionada: [772558](https://crbug.com/772558)
 
 ## Exibir o novo URL da nota no painel Manifest {: #new-note-url }
 
 O painel Manifest agora exibe o [URL da nova nota](https://wicg.github.io/manifest-incubations/index.html#dfn-note_taking). 
 
-Atualmente no Chrome OS (CrOS), os aplicativos Chrome e aplicativos Android que declaram um recurso de "nova nota" podem ser selecionados como um aplicativo de anotações nas configurações da caneta (aparece se o dispositivo CrOS foi usado com uma caneta). Quando selecionado como um aplicativo de anotações, o aplicativo pode ser iniciado a partir do botão "Criar Anotação" da paleta da caneta. Adicionar o campo `new-note-url` no manifesto do aplicativo faz parte do esforço para adicionar funcionalidade equivalente aos aplicativos da web.
+Atualmente no Chrome OS (CrOS), os aplicativos Chrome e aplicativos Android que declaram um recurso de "nova nota", podem ser selecionados como um aplicativo de anotações nas configurações da caneta (aparece se o dispositivo CrOS foi usado com uma caneta). 
+
+Quando selecionado como um aplicativo de anotações, ele pode ser iniciado a partir do botão **"Criar Anotação"** da paleta da caneta. Para adicionar a aplicação web como uma das opções de aplicativo de anotação você precisará adicionar o campo `new-note-url` no manifesto web do aplicativo.
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/2Cwggroar7pNesfAQi4K.png", alt="New note URL in the Manifest pane", width="800", height="477" %}
 
 {# https://chromium.googlesource.com/devtools/devtools-frontend/+/51f8aaf568db256f3390c37393d294c82017565e #}
 
-Chromium issue: [1185678](https://crbug.com/1185678)
+Issue relacionada: [1185678](https://crbug.com/1185678)
 
 ## Seletores de correspondência de CSS corrigidos {: #matching-selectors }
 
-DevTools corrigiu os seletores de correspondência de CSS, não estava funcionando na última versão.
+O DevTools corrigiu os seletores de correspondência de CSS, que não estavam funcionando na versão anterior.
 
 Os seletores separados por vírgulas no painel **Styles** são coloridos de maneira diferente dependendo se eles correspondem ao nó DOM selecionado:
 
@@ -131,7 +133,7 @@ Os seletores separados por vírgulas no painel **Styles** são coloridos de mane
 
 {# https://chromium.googlesource.com/devtools/devtools-frontend/+/123eac3c8ceeb2e788aa4756d3104db0265f9ad3 #}
 
-Chromium issue: [1219153](https://crbug.com/1219153)
+Issue relacionada: [1219153](https://crbug.com/1219153)
 
 ## Respostas JSON Pretty-printing no painel Network {: #pretty-print-json }
 
@@ -143,7 +145,7 @@ Abra uma resposta JSON no painel **Network**, clique no ícone `{}` para transfo
 
 {# https://chromium.googlesource.com/devtools/devtools-frontend/+/250c88b4d02da283cd0a96204b1592f59fda2fcb #}
 
-Chromium bug: [998674](https://crbug.com/998674) 
+Bug relacionado: [998674](https://crbug.com/998674) 
 
 {% include 'partials/devtools/pt/reach-out.md' %}
 {% include 'partials/devtools/pt/whats-new.md' %}

--- a/site/pt/blog/new-in-devtools-93/index.md
+++ b/site/pt/blog/new-in-devtools-93/index.md
@@ -7,7 +7,7 @@ date: 2021-07-28
 updated: 2021-07-28
 description:
   "Consultas de contêiner CSS editáveis, prévia de web-bundles, melhor manejo de strings no Console e muito mais."
-hero: 'image/dPDCek3EhZgLQPGtEG3y0fTn4v82/xFq1Fb2KOrQfq1RG6x5e.jpg'
+hero: 'image/dPDCek3EhZgLQPGtEG3y0fTn4v82/TiDoAuzLse9uUSoylxNA.jpg'
 alt: ''
 tags:
   - new-in-devtools
@@ -17,7 +17,7 @@ tags:
 
 *Tradução realizada por [Alvaro Camillo Neto](https://www.linkedin.com/in/alvarocamillont/).*
 
-{% include 'partials/devtools/en/banner.md' %}
+{% include 'partials/devtools/pt/banner.md' %}
 
 {% YouTube id="1VaPAnUGRz8" %}
 
@@ -145,5 +145,5 @@ Abra uma resposta JSON no painel **Network**, clique no ícone `{}` para transfo
 
 Chromium bug: [998674](https://crbug.com/998674) 
 
-{% include 'partials/devtools/en/reach-out.md' %}
-{% include 'partials/devtools/en/whats-new.md' %}
+{% include 'partials/devtools/pt/reach-out.md' %}
+{% include 'partials/devtools/pt/whats-new.md' %}

--- a/site/pt/blog/new-in-devtools-93/index.md
+++ b/site/pt/blog/new-in-devtools-93/index.md
@@ -22,6 +22,7 @@ tags:
 {% YouTube id="1VaPAnUGRz8" %}
 
 ## Consultas de contêiner CSS editáveis no painel Styles {: #container-queries }
+
 Agora você pode visualizar e editar [Consultas de contêiner CSS](https://web.dev/new-responsive/#responsive-to-the-container) no painel **Styles**.
 
 As consultas de contêiner fornecem uma abordagem muito mais dinâmica para design responsivo. A regra `@container` funciona de maneira semelhante a uma consulta de mídia com `@media`. No entanto, em vez de consultar a viewport e o agente do usuário em busca de informações, `@container` consulta o container ancestral que corresponde a certos critérios.
@@ -38,8 +39,8 @@ Atualmente o recurso de consultas de contêiner é experimental. Ative a sinaliz
 
 Chromium issue: [1146422](https://crbug.com/1146422)
 
-
 ## Prévia do web-bundle no painel Network  {: #web-bundle }
+
 [Web bundle](https://web.dev/web-bundles/) é um formato de arquivo para encapsular um ou mais recursos HTTP em um único arquivo. Agora você pode visualizar o conteúdo do web bundle no painel **Network**.
 
 O recurso de web-bundle é atualmente experimental. Habilite a sinalização `#enable-experimental-web-platform-features` em `chrome://flags` para testá-la.
@@ -50,8 +51,8 @@ O recurso de web-bundle é atualmente experimental. Habilite a sinalização `#e
 
 Chromium issue: [1182537](https://crbug.com/1182537) 
 
-
 ## Depuração da Attribution Reporting API {: #attribution-reporting }
+
 Os erros da Attribution Reporting API agora são relatados na guia **Issues**.
 
 [Attribution Reporting](https://developer.chrome.com/docs/privacy-sandbox/attribution-reporting/) é uma nova API para ajudá-lo a medir quando uma ação do usuário (como um clique no anúncio ou visualização) leva a uma conversão, sem usar identificadores entre sites.
@@ -60,8 +61,8 @@ Os erros da Attribution Reporting API agora são relatados na guia **Issues**.
 
 Chromium issue: [1190735](https://crbug.com/1190735)
 
-
 ## Melhor manejo de string no console {: #string }
+
 O novo menu de contexto no **Console** permite que você copie qualquer string como conteúdo, literais de JavaScript ou literais de JSON.
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/O5uMSgkHrQ2mQDSjmg3A.png", alt="New context menu in the Console", width="800", height="477" %}
@@ -76,40 +77,40 @@ O **Console** agora formata as saídas de string como literais JavaScript válid
 
 Chromium issue: [1208389](https://crbug.com/1208389)
 
+## Depuração CORS aprimorada {: #cors }
 
-## Improved CORS debugging {: #cors }
-CORS-related TypeErrors in the **Console** are now linked to the Network panel and Issues tab. 
+Os TypeErrors relacionados ao CORS no **Console** agora estão vinculados ao painel Network e à guia Issues.
 
-Click on the two new icons next to the CORS-related error message to view the network request, or understand the error message further and get potential solutions in the Issues tab.
+Clique nos dois novos ícones ao lado da mensagem de erro relacionada ao CORS para visualizar a solicitação de rede ou entender melhor a mensagem de erro e obter possíveis soluções na guia Problemas.
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/VzoUggSoM0FnkDlIFPhq.png", alt="Icons next to the CORS-related error message", width="800", height="485" %}
 
 Chromium issue: [1213393](https://crbug.com/1213393)
 
-
 ## Lighthouse 8.1 {: #lighthouse }
-The **Lighthouse** panel is now running Lighthouse 8.1. 
+
+O painel **Lighthouse** agora está executando o Lighthouse 8.1.
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/wENi9RXYMxdhm3zI4NVu.png", alt="Lighthouse", width="800", height="628" %}
 
-If your site exposes source maps to Lighthouse, look for the **View Treemap** button to see a breakdown of your shipped JavaScript, filterable by size and coverage on load. 
+Se seu site expõe source maps para o Lighthouse, procure o botão **View Treemap** para ver uma análise do JavaScript enviado, filtrável por tamanho e cobertura no carregamento.
 
-The report also includes a new metric filter (Refer to the **Show audits relevant to** filter in the screenshot). Pick a metric to focus on the opportunities and diagnostics most relevant to improving just that metric.
+O relatório também inclui um novo filtro de métrica (consulte **Mostrar auditorias relevantes para** filtro na captura de tela). Escolha uma métrica para se concentrar nas oportunidades e diagnósticos mais relevantes para melhorar apenas essa métrica.
 
-The **Performance Category** had a number of scoring changes to align with other performance tools and to better reflect the state of the web.
+A **Categoria de desempenho** teve uma série de alterações de pontuação para se alinhar com outras ferramentas de desempenho e refletir melhor o estado da web.
 
-Check out the [release notes](https://github.com/GoogleChrome/lighthouse/releases) for a full list of changes.
+Confira as [notas de lançamento](https://github.com/GoogleChrome/lighthouse/releases) for a full list of changes.
 
 {# https://chromium.googlesource.com/devtools/devtools-frontend/+/62b16561e433f4aa1645826923222699ac4bad38 #}
 {# https://chromium.googlesource.com/devtools/devtools-frontend/+/16d96a25f24c934ef4dcbbc7b827015abdd228a1 #}
 
 Chromium issue: [772558](https://crbug.com/772558)
 
+## Exibir o novo URL da nota no painel Manifest {: #new-note-url }
 
-## Display new note URL in the Manifest pane {: #new-note-url }
-The Manifest pane now displays the the [new note URL](https://wicg.github.io/manifest-incubations/index.html#dfn-note_taking). 
+O painel Manifest agora exibe o [URL da nova nota](https://wicg.github.io/manifest-incubations/index.html#dfn-note_taking). 
 
-Currently on Chrome OS (CrOS), Chrome Apps and Android Apps that declare a "new-note" capability may be selected as a note-taking app in the Stylus settings (shows up if the CrOS device has been used with a stylus). When selected as a note-taking app, the app can be launched from the stylus palette's "Create Note" button. Adding `new-note-url` field in the application manifest is part of the effort to add equivalent functionality to web apps.
+Atualmente no Chrome OS (CrOS), os aplicativos Chrome e aplicativos Android que declaram um recurso de "nova nota" podem ser selecionados como um aplicativo de anotações nas configurações da caneta (aparece se o dispositivo CrOS foi usado com uma caneta). Quando selecionado como um aplicativo de anotações, o aplicativo pode ser iniciado a partir do botão "Criar Anotação" da paleta da caneta. Adicionar o campo `new-note-url` no manifesto do aplicativo faz parte do esforço para adicionar funcionalidade equivalente aos aplicativos da web.
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/2Cwggroar7pNesfAQi4K.png", alt="New note URL in the Manifest pane", width="800", height="477" %}
 
@@ -117,14 +118,14 @@ Currently on Chrome OS (CrOS), Chrome Apps and Android Apps that declare a "new-
 
 Chromium issue: [1185678](https://crbug.com/1185678)
 
+## Seletores de correspondência de CSS corrigidos {: #matching-selectors }
 
-## Fixed CSS matching selectors {: #matching-selectors }
-DevTools fixed the CSS matching selectors, it was not working in the last release.
+DevTools corrigiu os seletores de correspondência de CSS, não estava funcionando na última versão.
 
-The comma separated selectors in the **Styles** pane are colored differently depending on whether they match the selected DOM node:
+Os seletores separados por vírgulas no painel **Styles** são coloridos de maneira diferente dependendo se eles correspondem ao nó DOM selecionado:
 
-- An unmatched portion is shown in a light grey.
-- A matching selector portion is shown in black.
+- Uma parte sem correspondência é mostrada em cinza claro.
+- Uma parte do seletor correspondente é mostrada em preto.
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/O7CoHBrKA9cVKci1SM0M.png", alt="CSS matching selectors", width="800", height="477" %}
 
@@ -132,11 +133,11 @@ The comma separated selectors in the **Styles** pane are colored differently dep
 
 Chromium issue: [1219153](https://crbug.com/1219153)
 
+## Respostas JSON Pretty-printing no painel Network {: #pretty-print-json }
 
-## Pretty-printing JSON responses in the Network panel {: #pretty-print-json }
-You can now pretty print JSON responses in the **Network** panel.
+Agora você pode ver respostas JSON no painel **Network** de forma agradável (Pretty-printing).
 
-Open a JSON response in the **Network** panel, click on the `{}` icon to pretty-print it.
+Abra uma resposta JSON no painel **Network**, clique no ícone `{}` para transformar em pretty-print.
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/x2NKXwJPzjycjeD7cLH6.png", alt=" Pretty-printing JSON responses in the Network panel", width="800", height="523" %}
 

--- a/site/pt/blog/new-in-devtools-93/index.md
+++ b/site/pt/blog/new-in-devtools-93/index.md
@@ -1,0 +1,148 @@
+---
+layout: "layouts/blog-post.njk"
+title: "O que há de novo no DevTools (Chrome 93)"
+authors:
+  - jecelynyeen
+date: 2021-07-28
+updated: 2021-07-28
+description:
+  "Consultas de contêiner CSS editáveis, prévia de web-bundles, melhor manejo de strings no Console e muito mais."
+hero: 'image/dPDCek3EhZgLQPGtEG3y0fTn4v82/xFq1Fb2KOrQfq1RG6x5e.jpg'
+alt: ''
+tags:
+  - new-in-devtools
+  - devtools
+  - chrome-93
+---
+
+*Tradução realizada por [Alvaro Camillo Neto](https://www.linkedin.com/in/alvarocamillont/).*
+
+{% include 'partials/devtools/en/banner.md' %}
+
+{% YouTube id="1VaPAnUGRz8" %}
+
+## Consultas de contêiner CSS editáveis no painel Styles {: #container-queries }
+Agora você pode visualizar e editar [Consultas de contêiner CSS](https://web.dev/new-responsive/#responsive-to-the-container) no painel **Styles**.
+
+As consultas de contêiner fornecem uma abordagem muito mais dinâmica para design responsivo. A regra `@container` funciona de maneira semelhante a uma consulta de mídia com `@media`. No entanto, em vez de consultar a viewport e o agente do usuário em busca de informações, `@container` consulta o container ancestral que corresponde a certos critérios.
+
+No painel **Elements**, clique em um elemento DOM com a regra `@container`, DevTools agora exibe as informações `@container` no painel **Styles**. Clique nele para editar o tamanho. O painel **Styles** também exibe as informações do contêiner correspondente. Passe o mouse sobre ele para destacar o elemento do contêiner na página e verifique o tamanho do contêiner. Clique nele para selecionar o elemento do contêiner.
+
+Atualmente o recurso de consultas de contêiner é experimental. Ative a sinalização `#enable-container-queries` em `chrome://flags` para testá-las.
+
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/3NzGBpukHQfUZUKUpUgf.png", alt="Editable CSS container queries in the Styles pane", width="800", height="554" %}
+
+{# https://chromium.googlesource.com/devtools/devtools-frontend/+/46cdd9cd019f088e1134abe84dbc7d53ac60585a #}
+{# https://chromium.googlesource.com/devtools/devtools-frontend/+/a7e1eac63bee3728b41ae440f2ec250559e9c667 #}
+{# https://chromium.googlesource.com/devtools/devtools-frontend/+/ef157dab2ccf321941548a51d350f9383a78d283 #}
+
+Chromium issue: [1146422](https://crbug.com/1146422)
+
+
+## Prévia do web-bundle no painel Network  {: #web-bundle }
+[Web bundle](https://web.dev/web-bundles/) é um formato de arquivo para encapsular um ou mais recursos HTTP em um único arquivo. Agora você pode visualizar o conteúdo do web bundle no painel **Network**.
+
+O recurso de web-bundle é atualmente experimental. Habilite a sinalização `#enable-experimental-web-platform-features` em `chrome://flags` para testá-la.
+
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/PEv1mNA14K18t5P3N6Yj.png", alt="web bundle preview", width="800", height="492" %}
+
+{# https://chromium.googlesource.com/devtools/devtools-frontend/+/e7672c40f2febc80786632c188b6029b2f2ac7b7 #}
+
+Chromium issue: [1182537](https://crbug.com/1182537) 
+
+
+## Depuração da Attribution Reporting API {: #attribution-reporting }
+Os erros da Attribution Reporting API agora são relatados na guia **Issues**.
+
+[Attribution Reporting](https://developer.chrome.com/docs/privacy-sandbox/attribution-reporting/) é uma nova API para ajudá-lo a medir quando uma ação do usuário (como um clique no anúncio ou visualização) leva a uma conversão, sem usar identificadores entre sites.
+
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/bkEGVEv5kKc9M6qBUmLz.png", alt="Attribution Reporting API errors in the Issues tab", width="800", height="501" %}
+
+Chromium issue: [1190735](https://crbug.com/1190735)
+
+
+## Melhor manejo de string no console {: #string }
+O novo menu de contexto no **Console** permite que você copie qualquer string como conteúdo, literais de JavaScript ou literais de JSON.
+
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/O5uMSgkHrQ2mQDSjmg3A.png", alt="New context menu in the Console", width="800", height="477" %}
+
+No Chrome 90, o DevTools atualizou o **Console** para sempre [formatar saídas de string como literais JSON válidos](/blog/new-in-devtools-90/#double-quotes). Recebemos feedback dos desenvolvedores de que essa mudança poderia ser confusa, alguns acharam que a quantidade de escape era excessiva e tornava a saída ilegível.
+
+O **Console** agora formata as saídas de string como literais JavaScript válidas e, além disso, fornece a você 3 opções de string de cópia. A opção **Copy as JavaScript literal** escapará dos caracteres especiais apropriados e envolverá a string entre aspas simples, aspas duplas ou barras, dependendo do conteúdo da string. Em vez disso, o **Copy string contents** copia o conteúdo da string bruta (incluindo nova linha e outros caracteres especiais) na íntegra para a área de transferência. Por fim, **Copy as JSON literal** formata a string como uma literal JSON válida e a copia para a área de transferência.
+
+{# https://chromium.googlesource.com/devtools/devtools-frontend/+/9242d13569e9fe67ac01e75d28fa2b6e6bf310d2 #}
+{# https://chromium.googlesource.com/devtools/devtools-frontend/+/5715a7b9800532d8b28e2c9fa2d3c1e220ba54a8 #}
+{# https://chromium.googlesource.com/devtools/devtools-frontend/+/29236e333a856ae5a952fe4182545b1e2bde5539 #}
+
+Chromium issue: [1208389](https://crbug.com/1208389)
+
+
+## Improved CORS debugging {: #cors }
+CORS-related TypeErrors in the **Console** are now linked to the Network panel and Issues tab. 
+
+Click on the two new icons next to the CORS-related error message to view the network request, or understand the error message further and get potential solutions in the Issues tab.
+
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/VzoUggSoM0FnkDlIFPhq.png", alt="Icons next to the CORS-related error message", width="800", height="485" %}
+
+Chromium issue: [1213393](https://crbug.com/1213393)
+
+
+## Lighthouse 8.1 {: #lighthouse }
+The **Lighthouse** panel is now running Lighthouse 8.1. 
+
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/wENi9RXYMxdhm3zI4NVu.png", alt="Lighthouse", width="800", height="628" %}
+
+If your site exposes source maps to Lighthouse, look for the **View Treemap** button to see a breakdown of your shipped JavaScript, filterable by size and coverage on load. 
+
+The report also includes a new metric filter (Refer to the **Show audits relevant to** filter in the screenshot). Pick a metric to focus on the opportunities and diagnostics most relevant to improving just that metric.
+
+The **Performance Category** had a number of scoring changes to align with other performance tools and to better reflect the state of the web.
+
+Check out the [release notes](https://github.com/GoogleChrome/lighthouse/releases) for a full list of changes.
+
+{# https://chromium.googlesource.com/devtools/devtools-frontend/+/62b16561e433f4aa1645826923222699ac4bad38 #}
+{# https://chromium.googlesource.com/devtools/devtools-frontend/+/16d96a25f24c934ef4dcbbc7b827015abdd228a1 #}
+
+Chromium issue: [772558](https://crbug.com/772558)
+
+
+## Display new note URL in the Manifest pane {: #new-note-url }
+The Manifest pane now displays the the [new note URL](https://wicg.github.io/manifest-incubations/index.html#dfn-note_taking). 
+
+Currently on Chrome OS (CrOS), Chrome Apps and Android Apps that declare a "new-note" capability may be selected as a note-taking app in the Stylus settings (shows up if the CrOS device has been used with a stylus). When selected as a note-taking app, the app can be launched from the stylus palette's "Create Note" button. Adding `new-note-url` field in the application manifest is part of the effort to add equivalent functionality to web apps.
+
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/2Cwggroar7pNesfAQi4K.png", alt="New note URL in the Manifest pane", width="800", height="477" %}
+
+{# https://chromium.googlesource.com/devtools/devtools-frontend/+/51f8aaf568db256f3390c37393d294c82017565e #}
+
+Chromium issue: [1185678](https://crbug.com/1185678)
+
+
+## Fixed CSS matching selectors {: #matching-selectors }
+DevTools fixed the CSS matching selectors, it was not working in the last release.
+
+The comma separated selectors in the **Styles** pane are colored differently depending on whether they match the selected DOM node:
+
+- An unmatched portion is shown in a light grey.
+- A matching selector portion is shown in black.
+
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/O7CoHBrKA9cVKci1SM0M.png", alt="CSS matching selectors", width="800", height="477" %}
+
+{# https://chromium.googlesource.com/devtools/devtools-frontend/+/123eac3c8ceeb2e788aa4756d3104db0265f9ad3 #}
+
+Chromium issue: [1219153](https://crbug.com/1219153)
+
+
+## Pretty-printing JSON responses in the Network panel {: #pretty-print-json }
+You can now pretty print JSON responses in the **Network** panel.
+
+Open a JSON response in the **Network** panel, click on the `{}` icon to pretty-print it.
+
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/x2NKXwJPzjycjeD7cLH6.png", alt=" Pretty-printing JSON responses in the Network panel", width="800", height="523" %}
+
+{# https://chromium.googlesource.com/devtools/devtools-frontend/+/250c88b4d02da283cd0a96204b1592f59fda2fcb #}
+
+Chromium bug: [998674](https://crbug.com/998674) 
+
+{% include 'partials/devtools/en/reach-out.md' %}
+{% include 'partials/devtools/en/whats-new.md' %}


### PR DESCRIPTION
Fixes #1303

Changes proposed in this pull request:

- Add portuguese translations for What's New in DevTools M93