### PR TITLE
add Workbox documentation section

### DIFF
--- a/site/_data/docs/tocIndex.js
+++ b/site/_data/docs/tocIndex.js
@@ -34,7 +34,7 @@ const all = glob.sync('*/toc.y{a,}ml', {cwd: __dirname});
 
 for (const result of all) {
   const raw = YAML.load(fs.readFileSync(path.join(__dirname, result), 'utf-8'));
-  const sections = /** @type {Section[]} */ (raw);
+  const sections = /** @type {Section[]} */ (raw ?? []);
 
   const projectKey = path.dirname(result);
   tocIndex[projectKey] = buildProjectIndex(sections);

--- a/site/_data/docs/workbox/styles.yml
+++ b/site/_data/docs/workbox/styles.yml
@@ -1,0 +1,1 @@
+project_icon_color: 'color-project-workbox'

--- a/site/_data/docs/workbox/toc.yml
+++ b/site/_data/docs/workbox/toc.yml
@@ -1,0 +1,4 @@
+# Currently empty as Workbox has no pages.
+
+# TODO: _something_ needs to be here
+- url: /docs/webstore/about_webstore/

--- a/site/_data/docs/workbox/toc.yml
+++ b/site/_data/docs/workbox/toc.yml
@@ -1,4 +1,1 @@
 # Currently empty as Workbox has no pages.
-
-# TODO: _something_ needs to be here
-- url: /docs/webstore/about_webstore/

--- a/site/_data/lib/links.js
+++ b/site/_data/lib/links.js
@@ -44,13 +44,13 @@ let SectionLinkItem;
  * for the passed pageUrl, including partial matches (useful for generated
  * pages).
  *
- * @param {Section[]} sections
+ * @param {Section[]|undefined} sections
  * @param {string} pageUrl
  * @param {string} locale
  * @return {SectionLinkItem[]|undefined}
  */
 function expandSections(sections, pageUrl, locale) {
-  if (!pageUrl) {
+  if (!pageUrl || !sections) {
     return;
   }
 

--- a/site/_includes/layouts/project-landing.njk
+++ b/site/_includes/layouts/project-landing.njk
@@ -20,6 +20,21 @@
       <p class="type gap-top-300">{{ description }}</p>
     </div>
 
+    {# Render optional top content. #}
+    {% if content %}
+      <div class="gap-top-300 lg:gap-top-400">
+        <article class="post stack measure-long center-margin width-full center-images type">
+          {{ content | safe }}
+        </article>
+      </div>
+    {% endif %}
+
+    {% if cards %}
+      {% for card in cards %}
+        card=>{{ card }}
+      {% endfor %}
+    {% endif %}
+
     {# Render nested sections. #}
     {% import 'macros/project-sections.njk' as macros with context %}
     <div class="project-sections gap-top-800">

--- a/site/_scss/_theme.scss
+++ b/site/_scss/_theme.scss
@@ -36,6 +36,7 @@
 
   --color-project-default: #{get-color('blue-700')};
   --color-project-handbook: #{get-color('red-700')};
+  --color-project-workbox: #{get-color('orange-400')};
 
   --color-blue-lightest: #{rgb(get-color('blue-50'), 0.4)};
   --color-blue-lighter: #{rgb(get-color('blue-50'), 0.54)};

--- a/site/en/docs/handbook/how-to/add-a-project/index.md
+++ b/site/en/docs/handbook/how-to/add-a-project/index.md
@@ -27,13 +27,13 @@ Open the `index.md` file at the root of the project directory.
 ```bash
 .
 ├── cheese
-│   ├── cheese.11tydata.yml
 │   ├── index.md  # <-- this file!
 │   └── my-first-doc
 ```
 
 Update the `title` and the `description`. These will be displayed on the
-`/docs/` and `/docs/[project-key]` pages.
+`/docs/` and `/docs/[project-key]` pages. You'll need to create a matching page
+in other languages if it is ever translated.
 
 ## Add your first doc
 
@@ -43,7 +43,7 @@ See the guide on [adding a doc](/docs/handbook/how-to/add-a-doc/) for a detailed
 ## Configure the table of contents for your project
 
 Create a new folder in the `site/_data/docs/` directory, and name it after your
-project.
+project. This is language-agnostic.
 
 ```bash
 ├── _data
@@ -82,8 +82,8 @@ The `toc.yml` supports these fields:
 Add an icon at `site/_static/images/project/[project-key].svg`. This should be
 a small SVG rendered in white. See the existing icons for examples.
 
-If you'd like this icon to render on a different color than the default blue,
-you can optionally add a peer `styles.yml` to your `toc.yml` file. For example:
+If you'd like this icon to render on top of a different color than the default blue, you can optionally add a peer `styles.yml` to your `toc.yml` file.
+For example:
 
 ```yml
 # Color (CSS theme variable) to use for this project page

--- a/site/en/docs/index.md
+++ b/site/en/docs/index.md
@@ -6,7 +6,7 @@ type: landing
 i18n:
   projects:
     tools:
-      heading: 'Tools'
+      heading: 'Tools & Libraries'
     crx:
       heading: 'Extensions & Web Store'
     architecture:

--- a/site/en/docs/workbox/index.md
+++ b/site/en/docs/workbox/index.md
@@ -4,4 +4,7 @@ title: 'Workbox'
 description: 'Tooling! Workbox! Stuff!'
 ---
 
-<!-- Intentionally empty for now -->
+### Case Studies
+
+Learn more about how developers are using Workbox in production.
+

--- a/site/en/docs/workbox/index.md
+++ b/site/en/docs/workbox/index.md
@@ -1,0 +1,7 @@
+---
+layout: 'layouts/project-landing.njk'
+title: 'Workbox'
+description: 'Tooling! Workbox! Stuff!'
+---
+
+<!-- Intentionally empty for now -->

--- a/site/en/docs/workbox/index.md
+++ b/site/en/docs/workbox/index.md
@@ -4,7 +4,9 @@ title: 'Workbox'
 description: 'Tooling! Workbox! Stuff!'
 ---
 
-### Case Studies
+<!-- TODO(samthor): Using a h2 here doesn't match our designs, but it's a linter requirement -->
+
+## Case Studies
 
 Learn more about how developers are using Workbox in production.
 

--- a/site/en/docs/workbox/workbox.11tydata.js
+++ b/site/en/docs/workbox/workbox.11tydata.js
@@ -23,4 +23,6 @@
  */
 module.exports = {
   noindex: true,
+  // This is the default hero image for all Workbox pages.
+  hero: 'image/QMjXarRXcMarxQddwrEdPvHVM242/ZUBXF0hK0jo9q4RvELUs.png',
 };

--- a/site/en/docs/workbox/workbox.11tydata.js
+++ b/site/en/docs/workbox/workbox.11tydata.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Exists while Workbox is being ported across. Don't index pages on Algolia.
+ */
+
+/**
+ * @return {EleventyData}
+ */
+module.exports = {
+  noindex: true,
+};


### PR DESCRIPTION
This isn't specifically hidden or skipped for prod (because it makes testing in new PRs really hard, we build for "prod" there), but it's not exposed on the top-level /docs/ page and won't be indexed.