### PR TITLE
Move media updates post from WebFu

### DIFF
--- a/site/en/blog/media-updates-in-chrome-58/index.md
+++ b/site/en/blog/media-updates-in-chrome-58/index.md
@@ -40,7 +40,7 @@ This API offers a way to show or hide native media controls that do not make
 sense or are not part of the expected user experience, or only allow a
 limited set of features.
 
-The current implementation for now is blocklist mechanism on native controls
+The current implementation for now is a blocklist mechanism on native controls
 with the ability to set them directly from HTML content using the new
 attribute `controlsList`. Check out the [official
 sample](https://googlechrome.github.io/samples/media/controlslist.html).
@@ -86,26 +86,25 @@ restrictions.
 }
 ```
 
+{% Compare 'better' %}
 ```html
 <html>
   <link rel="canonical" href="https://example.com/foo">
   <audio autoplay src="https://cdn.com/file.mp4"></audio>
 </html>
 ```
-{% Aside 'success' %}
 Audio will autoplay as <code>/foo</code> is in the scope.
-{% endAside %}
+{% endCompare %}
 
+{% Compare 'worse' %}
 ```html
 <html>
   <link rel="canonical" href="https://example.com/bar">
   <audio autoplay src="https://cdn.com/file.mp4"></audio>
 </html>
 ```
-
-{% Aside 'warning' %}
 Audio fails to autoplay as <code>/bar</code> is NOT in the scope.
-{% endAside %}
+{% endCompare %}
 
 [Intent to Ship](https://groups.google.com/a/chromium.org/d/topic/blink-dev/DW7_yxL_HjE/discussion) &#124;
 [Chromestatus Tracker](https://www.chromestatus.com/feature/5715456904134656) &#124;
@@ -119,11 +118,13 @@ without user interaction. If a video is marked as `muted` and has the
 to the user.
 
 From Chrome 58, in order to reduce power usage, playback of videos with
-the `autoplay` attribute will be paused when offscreen and resumed when back in
+the `autoplay` attribute will be paused when off screen and resumed when back in
 view, following Safari iOS behavior.'
 
-Note: This only applies to videos that are declared as `autoplay` but not videos
+{% Aside %}
+This only applies to videos that are declared as `autoplay` but not videos
 that start playing with `play()`.
+{% endAside %}
 
 [Intent to Ship](https://groups.google.com/a/chromium.org/d/topic/blink-dev/UtFM-kndhaI/discussion) &#124;
 [Chromestatus Tracker](https://www.chromestatus.com/feature/5651339115757568) &#124;
@@ -136,10 +137,10 @@ approximate range of colors supported by Chrome and output devices using the
 `color-gamut` media query.
 
 If you're not familiar yet with the definitions of color space, color profile,
-gamut, wide-gamut and color depth, I highly recommend you read the
+gamut, wide-gamut, and color depth, I highly recommend you read the
 [Improving Color on the Web] WebKit blog post. It goes into much detail on how
 to use the `color-gamut` media query to serve wide-gamut images when the user
-is on wide-gamut displays and fallback to sRGB images otherwise.
+is on wide-gamut displays and falls back to sRGB images otherwise.
 
 The current implementation in Chrome accepts the `srgb`, `p3` (gamut specified
 by the DCI P3 Color Space), and `rec2020` (gamut specified by the ITU-R

--- a/site/en/blog/media-updates-in-chrome-58/index.md
+++ b/site/en/blog/media-updates-in-chrome-58/index.md
@@ -11,6 +11,7 @@ authors:
   - beaufortfrancois
 tags:
   - media
+  - chrome-58
 ---
 
 - Developers can now [customize media controls](#controlslist) such as the

--- a/site/en/blog/media-updates-in-chrome-58/index.md
+++ b/site/en/blog/media-updates-in-chrome-58/index.md
@@ -1,0 +1,212 @@
+---
+title: Media updates in Chrome 58
+description: >
+  Media controls customization, autoplay for Progressive Web Apps added to the
+  home screen, pause the autoplaying of muted video when invisible, and
+  color-gamut media query are there!
+layout: 'layouts/blog-post.njk'
+date: 2017-03-21
+updated: 2020-07-24
+authors:
+  - beaufortfrancois
+tags:
+  - media
+---
+
+- Developers can now [customize media controls](#controlslist) such as the
+  download, fullscreen and remoteplayback buttons.
+- Sites installed using the "Add to Homescreen" flow can [autoplay audio
+  and video in the manifest's scope](#autoplay).
+- Chrome on Android now [pauses autoplaying a muted video when it is invisible](#offscreen).
+- Developers can now access the approximate range of colors supported by Chrome and
+  output devices using the [`color-gamut` Media Query](#colorgamut).
+- When using Media Source Extensions, it's now possible to
+  [switch between encrypted and clear streams].
+
+## Media controls customization {: #controlslist}
+
+Developers can now customize Chrome's native media controls such as the
+download, fullscreen and [remoteplayback] buttons using the new [ControlsList API].
+
+<figure>
+  {% Img src="image/vvhSqZboQoZZN9wBvoXq72wzGAf1/m2WIxAnaVhtvLD4Z0k3Z.png", alt="Native media controls in Chrome 58", width="800", height="507" %}
+  <figcaption>
+    Native media controls in Chrome 58
+  </figcaption>
+</figure>
+
+This API offers a way to show or hide native media controls that do not make
+sense or are not part of the expected user experience, or only allow a
+limited set of features.
+
+The current implementation for now is blocklist mechanism on native controls
+with the ability to set them directly from HTML content using the new
+attribute `controlsList`. Check out the [official
+sample](https://googlechrome.github.io/samples/media/controlslist.html).
+
+Usage in HTML:
+
+```html
+<video controls controlsList="nofullscreen nodownload noremoteplayback"></video>
+```
+
+Usage in JavaScript:
+
+```js
+var video = document.querySelector('video');
+video.controls; // true
+video.controlsList; // ["nofullscreen", "nodownload", "noremoteplayback"]
+video.controlsList.remove('noremoteplayback');
+video.controlsList; // ["nofullscreen", "nodownload"]
+video.getAttribute('controlsList'); // "nofullscreen nodownload"
+
+video.controlsList.supports('foo'); // false
+video.controlsList.supports('noremoteplayback'); // true
+```
+
+[Intent to Ship](https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/tFuQd3AcsIQ/discussion) &#124;
+[Chromestatus Tracker](https://www.chromestatus.com/feature/5737006365671424) &#124;
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=685018)
+
+## Autoplay for Progressive Web Apps added to home screen {: #autoplay }
+
+Previously, Chrome used to block all `autoplay` with sound on Android without
+exception. This is no longer true. From now on, sites installed using the
+[improved Add to Home Screen] flow are allowed to autoplay audio and video
+served from origins included in the [web app manifest]'s scope without
+restrictions.
+
+```json
+{
+  "name": "My Web App",
+  "description": "An awesome app",
+  "scope": "/foo",
+  ...
+}
+```
+
+```html
+<html>
+  <link rel="canonical" href="https://example.com/foo">
+  <audio autoplay src="https://cdn.com/file.mp4"></audio>
+</html>
+```
+{% Aside 'success' %}
+Audio will autoplay as <code>/foo</code> is in the scope.
+{% endAside %}
+
+```html
+<html>
+  <link rel="canonical" href="https://example.com/bar">
+  <audio autoplay src="https://cdn.com/file.mp4"></audio>
+</html>
+```
+
+{% Aside 'warning' %}
+Audio fails to autoplay as <code>/bar</code> is NOT in the scope.
+{% endAside %}
+
+[Intent to Ship](https://groups.google.com/a/chromium.org/d/topic/blink-dev/DW7_yxL_HjE/discussion) &#124;
+[Chromestatus Tracker](https://www.chromestatus.com/feature/5715456904134656) &#124;
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=676312)
+
+## Pause autoplaying muted video when invisible {: #offscreen }
+
+As you may already know, Chrome on Android allows `muted` videos to begin playing
+without user interaction. If a video is marked as `muted` and has the
+`autoplay` attribute, Chrome starts playing the video when it becomes visible
+to the user.
+
+From Chrome 58, in order to reduce power usage, playback of videos with
+the `autoplay` attribute will be paused when offscreen and resumed when back in
+view, following Safari iOS behavior.'
+
+Note: This only applies to videos that are declared as `autoplay` but not videos
+that start playing with `play()`.
+
+[Intent to Ship](https://groups.google.com/a/chromium.org/d/topic/blink-dev/UtFM-kndhaI/discussion) &#124;
+[Chromestatus Tracker](https://www.chromestatus.com/feature/5651339115757568) &#124;
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=690468)
+
+## color-gamut media query {: #colorgamut }
+
+As wide color gamut screens are more and more popular, sites can now access the
+approximate range of colors supported by Chrome and output devices using the
+`color-gamut` media query.
+
+If you're not familiar yet with the definitions of color space, color profile,
+gamut, wide-gamut and color depth, I highly recommend you read the
+[Improving Color on the Web] WebKit blog post. It goes into much detail on how
+to use the `color-gamut` media query to serve wide-gamut images when the user
+is on wide-gamut displays and fallback to sRGB images otherwise.
+
+The current implementation in Chrome accepts the `srgb`, `p3` (gamut specified
+by the DCI P3 Color Space), and `rec2020` (gamut specified by the ITU-R
+Recommendation BT.2020 Color Space) keywords. Check out the [official
+sample](https://googlechrome.github.io/samples/media/color-gamut-media-query.html).
+
+Usage in HTML:
+
+```html
+<picture>
+  <source media="(color-gamut: p3)" srcset="photo-p3.jpg">
+  <source media="(color-gamut: rec2020)" srcset="photo-rec2020.jpg">
+  <img src="photo-srgb.jpg">
+</picture>
+```
+
+Usage in CSS:
+
+```css
+main {
+  background-image: url("photo-srgb.jpg");
+}
+
+@media (color-gamut: p3) {
+  main {
+    background-image: url("photo-p3.jpg");
+  }
+}
+
+@media (color-gamut: rec2020) {
+  main {
+    background-image: url("photo-rec2020.jpg");
+  }
+}
+```
+
+Usage in JavaScript:
+
+```js
+// It is expected that the majority of color displays will return true.
+if (window.matchMedia("(color-gamut: srgb)").matches) {
+  document.querySelector('main').style.backgroundImage = 'url("photo-srgb.jpg")';
+}
+
+if (window.matchMedia("(color-gamut: p3)").matches) {
+  document.querySelector('main').style.backgroundImage = 'url("photo-p3.jpg")';
+}
+
+if (window.matchMedia("(color-gamut: rec2020)").matches) {
+  document.querySelector('main').style.backgroundImage = 'url("photo-rec2020.jpg")';
+}
+```
+
+{% Glitch {
+  id: 'color-gamut-media-query',
+  path: 'index.html',
+  previewSize: 100
+} %}
+
+[Intent to Ship](https://groups.google.com/a/chromium.org/forum/#!msg/blink-dev/36CcloDrB3E/1wMSNMl9BQAJ) &#124;
+[Chromestatus Tracker](https://www.chromestatus.com/feature/5354410980933632) &#124;
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=685456)
+
+<!-- lint disable definition-case -->
+
+[remoteplayback]: https://w3c.github.io/remote-playback/
+[ControlsList API]: https://github.com/WICG/controls-list/blob/gh-pages/explainer.md
+[improved Add to Home screen]: https://blog.chromium.org/2017/02/integrating-progressive-web-apps-deeply.html
+[web app manifest]: https://web.dev/add-manifest
+[Improving Color on the Web]: https://webkit.org/blog/6682/improving-color-on-the-web/
+[switch between encrypted and clear streams]: https://developers.google.com/web/updates/2017/03/mixing-streams

--- a/site/en/blog/media-updates-in-chrome-61/index.md
+++ b/site/en/blog/media-updates-in-chrome-61/index.md
@@ -13,7 +13,7 @@ tags:
   - chrome-61
 ---
 
-- Chrome now [disables video tracks when a MSE video is played in the
+- Chrome now [disables video tracks when an MSE video is played in the
   background](#background-video-track-optimizations) to optimize performance.
 - Video will [go fullscreen when device is rotated](#auto-fullscreen-rotate).
 
@@ -36,7 +36,7 @@ again, video track is re-enabled automatically.
 <figure>
   {% Img src="image/vvhSqZboQoZZN9wBvoXq72wzGAf1/4QmnUQGtBX1N3y64ucE6.png", alt="Log panel in the chrome://media-internals page", width="800", height="292" %}
   <figcaption>
-    Log panel in the <i>chrome://media-internals</i> page
+    Log panel in the <code>chrome://media-internals</code> page
   </figcaption>
 </figure>
 
@@ -81,7 +81,7 @@ If you rotate a device to landscape while a video is playing in the viewport,
 playback will automatically switch to fullscreen mode. Rotating the device to
 portrait puts the video back to windowed mode.
 
-Note that you can implement manually this behavior yourself. (See the [Mobile Web Video
+Note that you can manually implement this behavior yourself. (See the [Mobile Web Video
 Playback] article).
 
 <figure>

--- a/site/en/blog/media-updates-in-chrome-61/index.md
+++ b/site/en/blog/media-updates-in-chrome-61/index.md
@@ -10,6 +10,7 @@ authors:
   - beaufortfrancois
 tags:
   - media
+  - chrome-61
 ---
 
 - Chrome now [disables video tracks when a MSE video is played in the

--- a/site/en/blog/media-updates-in-chrome-61/index.md
+++ b/site/en/blog/media-updates-in-chrome-61/index.md
@@ -1,0 +1,111 @@
+---
+title: Media updates in Chrome 61
+description: >
+  Background video track optimizations and automatic video fullscreen when
+  device is rotated are here!
+layout: 'layouts/blog-post.njk'
+date: 2017-07-28
+updated: 2018-07-31
+authors:
+  - beaufortfrancois
+tags:
+  - media
+---
+
+- Chrome now [disables video tracks when a MSE video is played in the
+  background](#background-video-track-optimizations) to optimize performance.
+- Video will [go fullscreen when device is rotated](#auto-fullscreen-rotate).
+
+## Background video track optimizations (MSE only) {: #background-video-track-optimizations}
+
+{% Aside 'warning' %}
+This feature has been delayed until Chrome 62. See [crbug.com/752726](https://crbug.com/752726).
+{% endAside %}
+
+To improve battery life, Chrome now disables video tracks when the video is
+played in the background (e.g., in a non-visible tab) if the video uses [Media
+Source Extensions (MSE)].
+
+You can inspect these changes by going to the `chrome://media-internals` page,
+and filter for the "info" property. When the tab containing a playing video
+becomes inactive, you'll see a message like `Selected video track: []`
+indicating that the video track has been disabled. When the tab becomes active
+again, video track is re-enabled automatically.
+
+<figure>
+  {% Img src="image/vvhSqZboQoZZN9wBvoXq72wzGAf1/4QmnUQGtBX1N3y64ucE6.png", alt="Log panel in the chrome://media-internals page", width="800", height="292" %}
+  <figcaption>
+    Log panel in the <i>chrome://media-internals</i> page
+  </figcaption>
+</figure>
+
+For those who want to understand what is happening, here's a JavaScript code
+snippet that shows you what Chrome is roughly doing behind the scenes.
+
+```js
+var video = document.querySelector('video');
+var selectedVideoTrackIndex;
+
+document.addEventListener('visibilitychange', function() {
+  if (document.hidden) {
+    // Disable video track when page is hidden.
+    selectedVideoTrackIndex = video.videoTracks.selectedIndex;
+    video.videoTracks[selectedVideoTrackIndex].selected = false;
+  } else {
+    // Re-enable video track when page is not hidden anymore.
+    video.videoTracks[selectedVideoTrackIndex].selected = true;
+  }
+});
+```
+
+You may want to reduce the quality of the video stream when video track is
+disabled. It would be as simple as using the [Page Visibility API] as shown
+above to detect when a page is hidden.
+
+And here are some restrictions:
+
+- This optimization only applies to videos with a [keyframe] distance < 5s.
+- If the video doesn't contain any audio tracks, the video will be
+  automatically paused when played in the background.
+
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=663999)
+
+## Automatic video fullscreen when device is rotated {: #auto-fullscreen-rotate }
+
+{% Aside 'warning' %}
+This feature has been delayed until Chrome 62. See [crbug.com/713233](https://crbug.com/713233#c30).
+{% endAside %}
+
+If you rotate a device to landscape while a video is playing in the viewport,
+playback will automatically switch to fullscreen mode. Rotating the device to
+portrait puts the video back to windowed mode.
+
+Note that you can implement manually this behavior yourself. (See the [Mobile Web Video
+Playback] article).
+
+<figure>
+  {% Img src="image/vvhSqZboQoZZN9wBvoXq72wzGAf1/aJVkS8Qor8mNrUAhAuxl.png", alt="Automatic video fullscreen when device is rotated", width="800", height="385" %}
+</figure>
+
+This magic behavior only happens when:
+
+- device is an Android phone (not a tablet)
+- user's screen orientation is set to "Auto-rotate"
+- video size is at least 200x200px
+- video uses native controls
+- video is currently playing
+- at least 75% of the video is visible (on-screen)
+- orientation rotates by 90 degrees (not 180 degrees)
+- there is no [fullscreen element] yet
+- screen is not locked using the [Screen Orientation API]
+
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=713233)
+
+<!-- lint disable definition-case -->
+
+[Media Source Extensions (MSE)]: https://developers.google.com/web/fundamentals/media/mse/basics
+[Page Visibility API]: https://www.w3.org/TR/page-visibility/
+[keyframe]: https://en.wikipedia.org/wiki/Key_frame#Video_compression
+[Mobile Web Video Playback]: https://developers.google.com/web/fundamentals/media/mobile-web-video-playback#fullscreen
+[fullscreen element]: https://developer.mozilla.org/en-US/docs/Web/API/Document/fullscreenElement
+[Screen Orientation API]: https://w3c.github.io/screen-orientation/

--- a/site/en/blog/media-updates-in-chrome-62/index.md
+++ b/site/en/blog/media-updates-in-chrome-62/index.md
@@ -1,0 +1,213 @@
+---
+title: Media updates in Chrome 62
+description: >
+  Offline playback with persistent licenses and Widevine L1 on Android, video
+  track optimizations, automatic video fullscreen when device is rotated,
+  customizable seekable range on live MS streams, FLAC in MP4 with MSE are here!
+layout: 'layouts/blog-post.njk'
+date: 2017-09-12
+updated: 2018-03-20
+authors:
+  - beaufortfrancois
+tags:
+  - media
+---
+
+- [Offline playback with persistent licenses](#persistent_licenses) and [Widevine
+  L1](#widevine_l1) are now supported on Android.
+- Chrome now [disables video tracks when an MSE video is played in the
+  background](#background-video-track-optimizations) to optimize performance.
+- Web developers can [customize seekable range](#seekable)
+  on live MSE streams.
+- Chrome now supports [FLAC in MP4 with MSE](#flac-in-mp4-with-mse).
+- Video will [go fullscreen when the device is rotated](#auto-fullscreen-rotate).
+
+## Persistent licenses for Android {: #persistent_licenses }
+
+Persistent license in [Encrypted Media Extensions (EME)] means the license can
+be persisted on the device so that applications can load the license into
+memory without sending another license request to the server. This is how
+offline playback is supported in EME.
+
+Until now, Chrome OS was the only platform to support persistent licenses. It
+is not true anymore. Playing protected content through EME while the device is
+offline is now possible on Android as well.
+
+```js
+const config = [{
+  sessionTypes: ['persistent-license'],
+  videoCapabilities: [{
+    contentType: 'video/webm; codecs="vp09.00.10.08"',
+    robustness: 'SW_SECURE_DECODE' // Widevine L3
+  }]
+}];
+
+// Chrome will prompt user if website is allowed to uniquely identify
+// user's device to play protected content.
+navigator.requestMediaKeySystemAccess('com.widevine.alpha', config)
+.then(access => {
+  // User will be able to watch encrypted content while being offline when
+  // license is stored locally on device and loaded later.
+})
+.catch(error => {
+  // Persistent licenses are not supported on this platform yet.
+});
+```
+
+You can try persistent licenses yourself by checking out the [Sample Media PWA]
+and following these steps:
+
+1. Go to [https://biograf-155113.appspot.com/ttt/episode-2/]
+2. Click "Make available offline" and wait for the video to be downloaded.
+3. Turn airplane mode on.
+4. Click the "Play" button and enjoy the video!
+
+Note: Widevine support is disabled in [Incognito mode] in Android. That way
+users do not inadvertently lose paid licenses when closing Incognito tabs.
+
+## Widevine L1 for Android {: #widevine_l1 }
+
+As you may already know, all Android devices are required to support Widevine
+Security Level 3 (Widevine L3). However there are many devices out there
+that also support the highest security level: [Widevine Security Level 1]
+(Widevine L1) where all content processing, cryptography, and control is
+performed within the Trusted Execution Environment (TEE).
+
+Good news! Widevine L1 is now supported in Chrome for Android so that media can
+be played in the most secure way. Note that it was supported already on Chrome
+OS.
+
+```js
+const config = [{
+  videoCapabilities: [{
+    contentType: 'video/webm; codecs="vp09.00.10.08"',
+    robustness: 'HW_SECURE_ALL' // Widevine L1
+  }]
+}];
+
+// Chrome will prompt user if website is allowed to uniquely identify
+// user's device to play protected content.
+navigator.requestMediaKeySystemAccess('com.widevine.alpha', config)
+.then(access => {
+  // User will be able to watch encrypted content in the most secure way.
+})
+.catch(error => {
+  // Widevine L1 is not supported on this platform yet.
+});
+```
+
+[Shaka Player], the JavaScript library for adaptive media formats (such as DASH
+and HLS) has a demo for you to try Widevine L1 out:
+
+1. Go to [https://shaka-player-demo.appspot.com/demo/] and click "Allow" when prompted.
+2. Pick "Angel One (multicodec, multilingual, Widevine)".
+3. Enter `HW_SECURE_ALL` in the "Video Robustness" field of the "Configuration"
+   section.
+4. Click the "Load" button and enjoy the video!
+
+## Background video track optimizations (MSE only) {: #background-video-track-optimizations}
+
+The chrome team is always trying to find new ways to improve battery life and
+Chrome 62 is no exception.
+
+Chrome now disables video tracks when the video is played in the background
+(e.g., in a non-visible tab) if the video uses [Media Source Extensions (MSE)].
+Check out our [previous article] to learn more.
+
+## Customize seekable range on live MSE streams {: #seekable }
+
+As you may already know, the <code>seekable</code> attribute contains the ranges
+of the media resource to which the browser can seek. Typically, it contains a
+single time range which starts at 0 and ends at the media resource duration. If
+the duration is not available though, such as a live stream, the time range may
+continuously change.
+
+The good news is that you can now more effectively customize the
+<code>seekable</code> range logic with [Media Source Extensions (MSE)] by
+providing or removing a single seekable range that is union'ed with the current
+buffered ranges. It results in a single seekable range which fits both, when
+the media source duration is <code>+Infinity</code>.
+
+In the code below, the media source has already been attached to a media
+element and contains only its init segment:
+
+```js
+const mediaSource = new MediaSource();
+...
+
+mediaSource.duration = +Infinity;
+// Seekable time ranges: { }
+// Buffered time ranges: { }
+
+mediaSource.setLiveSeekableRange(1 /* start */, 4 /* end */);
+// Seekable time ranges: { [1.000, 4.000) }
+// Buffered time ranges: { }
+
+// Let's append a media segment that starts at 3 seconds and ends at 6.
+mediaSource.sourceBuffers[0].appendBuffer(someData);
+// Seekable time ranges: { [1.000, 6.000) }
+// Buffered time ranges: { [3.000, 6.000) }
+
+mediaSource.clearLiveSeekableRange();
+// Seekable time ranges: { [0.000, 6.000) }
+// Buffered time ranges: { [3.000, 6.000) }
+```
+
+There are many cases that I didn't cover above so I'd suggest you give a try
+to [the official sample] to see how buffered and seekable time ranges react to different
+MSE events.
+
+[Intent to Ship](https://groups.google.com/a/chromium.org/d/msg/blink-dev/-LTXhyDzS_E/LfjqN71kAAAJ) &#124;
+[Chromestatus Tracker](https://www.chromestatus.com/feature/5671401352593408) &#124;
+[Chromium Bug](https://crbug.com/623698)
+
+## FLAC in MP4 for MSE {: #flac-in-mp4-with-mse }
+
+The lossless audio coding format [FLAC] has been supported in regular media
+playback since Chrome 56. FLAC in ISO-BMFF support (aka FLAC in MP4) was added
+shortly after. And now FLAC in MP4 is available in Chrome 62 for [Media Source
+Extensions (MSE)].
+
+For info, Firefox folks are the ones who developed and implemented support for
+a [FLAC in MP4 encapsulation spec], and the BBC has been experimenting with
+using that with MSE. You can read the BBC's ["Delivering Radio 3 Concert
+Sound"] post to learn more.
+
+Here's how you can detect if FLAC in MP4 is supported for MSE:
+
+```js
+if (MediaSource.isTypeSupported('audio/mp4; codecs="flac"')) {
+  // TODO: Fetch data and feed it to a media source.
+}
+```
+
+If you want to see a full example, check out [our official sample].
+
+[Intent to Ship](https://groups.google.com/a/chromium.org/d/msg/blink-dev/ntoLfR7rbmE/3R1DQoBSAAAJ) &#124;
+[Chromestatus Tracker](https://www.chromestatus.com/feature/5713014258925568) &#124;
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=666000)
+
+## Automatic video goes to fullscreen when the device is rotated {: #auto-fullscreen-rotate }
+
+If you rotate a device to landscape while a video is playing in the viewport,
+playback will automatically switch to fullscreen mode. Rotating the device to
+portrait puts the video back to windowed mode. Check out our [past article] for
+more details.
+
+<!-- lint disable definition-case -->
+
+[Encrypted Media Extensions (EME)]: https://w3c.github.io/encrypted-media/
+[Widevine Security Level 1]: https://web.archive.org/web/20180122175750/https://storage.googleapis.com/wvdocs/Widevine_DRM_Architecture_Overview.pdf
+[Sample Media PWA]: https://github.com/GoogleChrome/sample-media-pwa
+[https://biograf-155113.appspot.com/ttt/episode-2/]: https://biograf-155113.appspot.com/ttt/episode-2/
+[Shaka Player]: https://github.com/google/shaka-player
+[https://shaka-player-demo.appspot.com/demo/]: https://shaka-player-demo.appspot.com/demo/
+[Incognito mode]: https://support.google.com/chrome/answer/7440301?co=GENIE.Platform%3DAndroid
+[previous article]: /blog/media-updates-in-chrome-61#background-video-track-optimizations
+[the official sample]: https://googlechrome.github.io/samples/media/live-seekable-range.html
+[FLAC]: https://xiph.org/flac/
+[Media Source Extensions (MSE)]: https://developers.google.com/web/fundamentals/media/mse/basics
+[FLAC in MP4 encapsulation spec]: https://github.com/xiph/flac/blob/master/doc/isoflac.txt
+["Delivering Radio 3 Concert Sound"]: http://www.bbc.co.uk/rd/blog/2017-04-radio-3-high-quality-flac-dash
+[our official sample]: https://googlechrome.github.io/samples/media/flac-in-mp4-for-mse.html
+[past article]: /blog/media-updates-in-chrome-61#auto-fullscreen-rotate

--- a/site/en/blog/media-updates-in-chrome-62/index.md
+++ b/site/en/blog/media-updates-in-chrome-62/index.md
@@ -11,6 +11,7 @@ authors:
   - beaufortfrancois
 tags:
   - media
+  - chrome-62
 ---
 
 - [Offline playback with persistent licenses](#persistent_licenses) and [Widevine

--- a/site/en/blog/media-updates-in-chrome-62/index.md
+++ b/site/en/blog/media-updates-in-chrome-62/index.md
@@ -63,8 +63,10 @@ and following these steps:
 3. Turn airplane mode on.
 4. Click the "Play" button and enjoy the video!
 
-Note: Widevine support is disabled in [Incognito mode] in Android. That way
+{% Aside %}
+Widevine support is disabled in [Incognito mode] in Android. That way
 users do not inadvertently lose paid licenses when closing Incognito tabs.
+{% endAside %}
 
 ## Widevine L1 for Android {: #widevine_l1 }
 
@@ -108,7 +110,7 @@ and HLS) has a demo for you to try Widevine L1 out:
 
 ## Background video track optimizations (MSE only) {: #background-video-track-optimizations}
 
-The chrome team is always trying to find new ways to improve battery life and
+The Chrome team is always trying to find new ways to improve battery life and
 Chrome 62 is no exception.
 
 Chrome now disables video tracks when the video is played in the background
@@ -117,17 +119,17 @@ Check out our [previous article] to learn more.
 
 ## Customize seekable range on live MSE streams {: #seekable }
 
-As you may already know, the <code>seekable</code> attribute contains the ranges
+As you may already know, the `seekable` attribute contains the ranges
 of the media resource to which the browser can seek. Typically, it contains a
 single time range which starts at 0 and ends at the media resource duration. If
 the duration is not available though, such as a live stream, the time range may
 continuously change.
 
 The good news is that you can now more effectively customize the
-<code>seekable</code> range logic with [Media Source Extensions (MSE)] by
+`seekable` range logic with [Media Source Extensions (MSE)] by
 providing or removing a single seekable range that is union'ed with the current
 buffered ranges. It results in a single seekable range which fits both, when
-the media source duration is <code>+Infinity</code>.
+the media source duration is `+Infinity`.
 
 In the code below, the media source has already been attached to a media
 element and contains only its init segment:

--- a/site/en/blog/media-updates-in-chrome-62/index.md
+++ b/site/en/blog/media-updates-in-chrome-62/index.md
@@ -211,6 +211,6 @@ more details.
 [FLAC]: https://xiph.org/flac/
 [Media Source Extensions (MSE)]: https://developers.google.com/web/fundamentals/media/mse/basics
 [FLAC in MP4 encapsulation spec]: https://github.com/xiph/flac/blob/master/doc/isoflac.txt
-["Delivering Radio 3 Concert Sound"]: http://www.bbc.co.uk/rd/blog/2017-04-radio-3-high-quality-flac-dash
+["Delivering Radio 3 Concert Sound"]: https://www.bbc.co.uk/rd/blog/2017-04-radio-3-high-quality-flac-dash
 [our official sample]: https://googlechrome.github.io/samples/media/flac-in-mp4-for-mse.html
 [past article]: /blog/media-updates-in-chrome-61#auto-fullscreen-rotate

--- a/site/en/blog/media-updates-in-chrome-63-64/index.md
+++ b/site/en/blog/media-updates-in-chrome-63-64/index.md
@@ -1,0 +1,323 @@
+---
+title: Media updates in Chrome 63/64
+description: >
+  Predictable media playback, HDR on Windows 10, offline playback with
+  persistent licenses, and more are waiting for you in Chrome 64.
+layout: 'layouts/blog-post.njk'
+date: 2017-12-08
+updated: 2020-07-24
+authors:
+  - beaufortfrancois
+tags:
+  - media
+---
+
+- Web developers can now [predict whether playback will be smooth and power
+  efficient](#media-capabilities-decoding-info-api).
+- Chrome now supports [HDR video playback on Windows
+  10](#hdr-video-playback-windows-10).
+- Offline playback with [persistent licenses](#persistent-licenses-windows-mac)
+  are now supported on Windows and Mac.
+- The [default preload value](#media-preload-defaults-metadata) for `<video>` and
+  `<audio>` elements is now "metadata".
+- An [error](#unsupported-playbackRate-raises-exception) is now thrown when media
+  playbackRate is unsupported.
+- Chrome now [pauses all background video-only
+  media](#background-video-track-optimizations).
+- Audio is [not muted anymore](#remove-muting-extreme-playbackrates) for
+  extreme playbackRate.
+
+## Media Capabilities - Decoding Info API {: #media-capabilities-decoding-info-api }
+
+Today, web developers rely on `isTypeSupported()` or `canPlayType()` to vaguely
+know if some media can be decoded or not. The real question though should be:
+"How well it would perform on this device?"
+
+This is exactly one of the things the proposed [Media Capabilities] wants to
+solve: An API to query the browser about the decoding abilities of the device
+based on information such as the codecs, profile, resolution, bitrates, etc. It
+would expose information such as whether the playback should be smooth and
+power efficient based on previous playback statistics recorded by the browser.
+
+Note: This API is available in all types of workers in [Chrome 76](https://www.chromestatus.com/feature/5730672977117184).
+
+In a nutshell, here's how the Decoding Info API works for now. Check out the
+[official
+sample](https://googlechrome.github.io/samples/media-capabilities/decoding-info.html).
+
+```js
+const mediaConfig = {
+  type: 'media-source', // or 'file'
+  audio: {
+    contentType: 'audio/webm; codecs=opus',
+    channels: '2', // audio channels used by the track
+    bitrate: 132266, // number of bits used to encode a second of audio
+    samplerate: 48000 // number of samples of audio carried per second
+  },
+  video: {
+    contentType: 'video/webm; codecs="vp09.00.10.08"',
+    width: 1920,
+    height: 1080,
+    bitrate: 2646242, // number of bits used to encode a second of video
+    framerate: '25' // number of frames used in one second
+  }
+};
+
+navigator.mediaCapabilities.decodingInfo(mediaConfig).then(result => {
+  console.log('This configuration is' +
+      (result.supported ? '' : ' NOT') + ' supported,' +
+      (result.smooth ? '' : ' NOT') + ' smooth and' +
+      (result.powerEfficient ? '' : ' NOT') + ' power efficient.');
+});
+```
+
+You can try different media configurations until you find the best one
+(`smooth` and `powerEfficient`) and use it to play the appropriate media
+stream. By the way, Chrome's current implementation is based on previously
+recorded playback information. It defines `smooth` as true when the percentage
+of dropped frames is less than 10% while `powerEfficient` is true when more
+than 50% of frames are decoded by the hardware. Small frames are always
+considered power efficient.
+
+Note: The result returned from `navigator.mediaCapabilities.decodingInfo` will
+always be reported as smooth and power-efficient if the media configuration is
+supported and playback stats have not been recorded yet by the browser.
+
+I recommend using a snippet similar to the one below to detect
+availability and fallback to your current implementation for browsers that
+don't support this API.
+
+```js
+function isMediaConfigSupported(mediaConfig) {
+
+  const promise = new Promise((resolve, reject) => {
+    if (!('mediaCapabilities' in navigator)) {
+      return reject('MediaCapabilities API not available');
+    }
+    if (!('decodingInfo' in navigator.mediaCapabilities)) {
+      return reject('Decoding Info not available');
+    }
+    return resolve(navigator.mediaCapabilities.decodingInfo(mediaConfig));
+  });
+
+  return promise.catch(_ => {
+    let fallbackResult = {
+      supported: false,
+      smooth: false, // always false
+      powerEfficient: false // always false
+    };
+    if ('video' in mediaConfig) {
+      fallbackResult.supported = MediaSource.isTypeSupported(mediaConfig.video.contentType);
+      if (!fallbackResult.supported) {
+        return fallbackResult;
+      }
+    }
+    if ('audio' in mediaConfig) {
+      fallbackResult.supported = MediaSource.isTypeSupported(mediaConfig.audio.contentType);
+    }
+    return fallbackResult;
+  });
+}
+```
+
+{% Aside 'caution' %}
+The snippet above must use `canPlayType()` instead of `isTypeSupported()`
+if the media configuration type is `"file"`.
+{% endAside %}
+
+### Available for Origin Trials
+
+In order to get as much feedback as possible from developers using the Decoding
+Info API (part of Media Capabilities) in the field, we've previously added this
+feature in Chrome 64 as an origin trial.
+
+The trial has successfully ended in April 2018.
+
+{% Aside %}
+The Decoding Info API is now enabled by default in Chrome 66.
+{% endAside %}
+
+[Intent to Experiment](https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/dsdTLv33r4w) &#124;
+[Intent to Ship](https://groups.google.com/a/chromium.org/d/msg/blink-dev/aXYvQ01tMhw/SqA09gD7AgAJ) &#124;
+[Chromestatus Tracker](https://www.chromestatus.com/feature/5869632707624960) &#124;
+[Chromium Bug](https://crbug.com/690380)
+
+## HDR video playback on Windows 10 {: #hdr-video-playback-windows-10 }
+
+High Dynamic Range (HDR) videos have higher contrast, revealing precise,
+detailed shadows and stunning highlights with more clarity than ever. Moreover
+support for wide color gamut means colors are more vibrant.
+
+<figure>
+  {% Img src="image/vvhSqZboQoZZN9wBvoXq72wzGAf1/tSk0xx9Cc11SsGeTA9y7.jpeg", alt="Simulated SDR vs HDR comparison (seeing true HDR requires an HDR display)", width="800", height="225" %}
+  <figcaption>
+    Simulated SDR vs HDR comparison (seeing true HDR requires an HDR display)
+  </figcaption>
+</figure>
+
+As VP9 Profile 2 10-bit playback is now supported in Chrome for Windows 10 Fall
+Creator Update, Chrome additionally supports HDR video playback when [Windows 10
+is in HDR mode]. On a technical note, Chrome 64 now supports the [scRGB] color
+profile which in turn allows media to play back in HDR.
+
+You can give it a try by watching [The World in HDR in 4K (ULTRA HD)] on YouTube
+and check that it plays HDR by looking at the YouTube player quality setting.
+
+<figure>
+  {% Img src="image/vvhSqZboQoZZN9wBvoXq72wzGAf1/3X4rsKW1OntLlirakQGT.png", alt="YouTube player quality setting featuring HDR", width="800", height="450" %}
+  <figcaption>
+    YouTube player quality setting featuring HDR
+  </figcaption>
+</figure>
+
+All you need for now is Windows 10 Fall Creator Update, an HDR-compatible
+graphics card and display (e.g. NVIDIA 10-series card, LG HDR TV or monitor),
+and turn on HDR mode in Windows display settings.
+
+Web developers can detect the approximate color gamut supported by the output
+device with the recent [color-gamut media query] and the number of bits used to
+display a color on the screen with [screen.colorDepth]. Here's one way of using
+those to detect if VP9 HDR is supported for instance:
+
+```js
+// Detect if display is in HDR mode and if browser supports VP9 HDR.
+function canPlayVp9Hdr() {
+
+  // TODO: Adjust VP9 codec string based on your video encoding properties.
+  return (window.matchMedia('(color-gamut: p3)').matches &&
+      screen.colorDepth >= 48 &&
+      MediaSource.isTypeSupported('video/webm; codecs="vp09.02.10.10.01.09.16.09.01"'))
+}
+```
+
+The [VP9 codec string with Profile 2] passed to `isTypeSupported()` in the
+example above needs to be updated based on your video encoding properties.
+
+{% Glitch {
+  id: 'screen-config',
+  path: 'index.html',
+  previewSize: 100
+} %}
+
+Note that it is not possible yet to define HDR [colors in CSS], [canvas],
+images and [protected content]. The Chrome team is working on it. Stay tuned!
+
+## Persistent licenses for Windows and Mac {: #persistent-licenses-windows-mac }
+
+Persistent license in [Encrypted Media Extensions (EME)] means the license can
+be persisted on the device so that applications can load the license into
+memory without sending another license request to the server. This is how
+offline playback is supported in EME.
+
+Until now, Chrome OS and Android were the only platforms to support persistent
+licenses. It is not true anymore. Playing protected content through EME while
+the device is offline is now possible in Chrome 64 on Windows and Mac as well.
+
+```js
+const config = [{
+  sessionTypes: ['persistent-license'],
+  videoCapabilities: [{
+    contentType: 'video/webm; codecs="vp09.00.10.08"',
+    robustness: 'SW_SECURE_DECODE' // Widevine L3
+  }]
+}];
+
+navigator.requestMediaKeySystemAccess('com.widevine.alpha', config)
+.then(access => {
+  // User will be able to watch encrypted content while being offline when
+  // license is stored locally on device and loaded later.
+})
+.catch(error => {
+  // Persistent licenses are not supported on this platform yet.
+});
+```
+
+You can try persistent licenses yourself by checking out the [Sample Media PWA]
+and following these steps:
+
+1. Go to [https://biograf-155113.appspot.com/ttt/episode-2/]
+2. Click "Make available offline" and wait for the video to be downloaded.
+3. Turn off your internet connection.
+4. Click the "Play" button and enjoy the video!
+
+## Media preload defaults to "metadata" {: #media-preload-defaults-metadata }
+
+Matching other browsers' implementations, Chrome desktop now sets the default
+preload value for `<video>` and `<audio>` elements to "metadata" in order to
+reduce bandwidth and resource usage. This new behavior only applies in Chrome
+64 to cases where no preload value is set. Note that the preload attribute's
+hint is discarded when a `MediaSource` is attached to the media element as the
+web site handles its own preload.
+
+In other words, `<video>` preload value is now "metadata" while `<video
+preload="auto">` preload value stays "auto". Give a try to the [official
+sample](https://googlechrome.github.io/samples/media/preload-metadata).
+
+[Intent to Ship](https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/5CDvJkdxyQ8) &#124;
+[Chromestatus Tracker](https://www.chromestatus.com/feature/5682169347309568) &#124;
+[Chromium Bug](https://crbug.com/310450)
+
+## Unsupported playbackRate raises an exception {: #unsupported-playbackRate-raises-exception }
+
+Following an [HTML specification change], when media elements' `playbackRate`
+is set to a value not supported by Chrome (e.g. a negative value), a
+"NotSupportedError" DOMException is thrown in Chrome 63.
+
+```js
+const audio = document.querySelector('audio');
+try {
+  audio.playbackRate = -1;
+} catch(error) {
+  console.log(error.message); // Failed to set the playbackRate property
+}
+```
+
+By the way, Chrome's current implementation raises this exception when
+`playbackRate` is either negative, less than 0.0625, or more than 16. Give a try
+to the [official
+sample](https://googlechrome.github.io/samples/media/playback-rate-exception)
+to see this in action.
+
+[Intent to Ship](https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/a0tguvcZZyk) &#124;
+[Chromestatus Tracker](https://www.chromestatus.com/feature/5750156230131712) &#124;
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=747082)
+
+## Background video track optimizations {: #background-video-track-optimizations }
+
+The chrome team is always trying to find new ways to improve battery life and
+Chrome 63 was no exception.
+
+If the video doesn't contain any audio tracks, the video will be automatically
+paused when played in the background (e.g., in a non-visible tab) in Chrome
+desktop (Windows, Mac, Linux, and Chrome OS). This is a follow-up from a
+similar change that was only applying to [MSE videos in Chrome 62].
+
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=663999)
+
+## Remove muting for extreme playbackRates {: #remove-muting-extreme-playbackrates }
+
+Before Chrome 64, sound was muted when `playbackRate` was below 0.5 or above 4
+as the quality degraded significantly. As Chrome has switched to a
+Waveform-Similarity-Overlap-Add (WSOLA) approach for quality degrading, sound
+doesn't need to be muted anymore. It means you can play sound super slow and
+super fast now.
+
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=289354)
+
+<!-- lint disable definition-case -->
+
+[Media Capabilities]: https://wicg.github.io/media-capabilities/
+[Windows 10 is in HDR mode]: https://support.microsoft.com/en-us/help/4040263/windows-10-hdr-advanced-color-settings
+[scRGB]: https://en.wikipedia.org/wiki/ScRGB
+[The World in HDR in 4K (ULTRA HD)]: https://www.youtube.com/watch?v=tO01J-M3g0U
+[color-gamut media query]: /blog/media-updates-in-chrome-58#colorgamut
+[screen.colorDepth]: https://www.chromestatus.com/feature/5743005361242112
+[VP9 codec string with Profile 2]: https://googlechrome.github.io/samples/media/vp9-codec-string.html
+[colors in CSS]: https://drafts.csswg.org/css-color/#working-color-space
+[canvas]: https://github.com/WICG/canvas-color-space/blob/main/CanvasColorSpaceProposal.md
+[protected content]: https://bugs.chromium.org/p/chromium/issues/detail?id=707128&desc=2
+[Encrypted Media Extensions (EME)]: https://w3c.github.io/encrypted-media/
+[Sample Media PWA]: https://github.com/GoogleChrome/sample-media-pwa
+[https://biograf-155113.appspot.com/ttt/episode-2/]: https://biograf-155113.appspot.com/ttt/episode-2/
+[HTML specification change]: https://github.com/whatwg/html/pull/2829
+[MSE videos in Chrome 62]: /blog/media-updates-in-chrome-62#background-video-track-optimizations

--- a/site/en/blog/media-updates-in-chrome-63-64/index.md
+++ b/site/en/blog/media-updates-in-chrome-63-64/index.md
@@ -10,6 +10,8 @@ authors:
   - beaufortfrancois
 tags:
   - media
+  - chrome-63
+  - chrome-64
 ---
 
 - Web developers can now [predict whether playback will be smooth and power

--- a/site/en/blog/media-updates-in-chrome-63-64/index.md
+++ b/site/en/blog/media-updates-in-chrome-63-64/index.md
@@ -21,9 +21,9 @@ tags:
 - Offline playback with [persistent licenses](#persistent-licenses-windows-mac)
   are now supported on Windows and Mac.
 - The [default preload value](#media-preload-defaults-metadata) for `<video>` and
-  `<audio>` elements is now "metadata".
+  `<audio>` elements is now `"metadata"`.
 - An [error](#unsupported-playbackRate-raises-exception) is now thrown when media
-  playbackRate is unsupported.
+  playback rate is unsupported.
 - Chrome now [pauses all background video-only
   media](#background-video-track-optimizations).
 - Audio is [not muted anymore](#remove-muting-extreme-playbackrates) for
@@ -33,15 +33,17 @@ tags:
 
 Today, web developers rely on `isTypeSupported()` or `canPlayType()` to vaguely
 know if some media can be decoded or not. The real question though should be:
-"How well it would perform on this device?"
+"how well it would perform on this device?"
 
 This is exactly one of the things the proposed [Media Capabilities] wants to
-solve: An API to query the browser about the decoding abilities of the device
+solve: an API to query the browser about the decoding abilities of the device
 based on information such as the codecs, profile, resolution, bitrates, etc. It
 would expose information such as whether the playback should be smooth and
 power efficient based on previous playback statistics recorded by the browser.
 
-Note: This API is available in all types of workers in [Chrome 76](https://www.chromestatus.com/feature/5730672977117184).
+{% Aside %}
+This API is available in all types of workers in [Chrome 76](https://www.chromestatus.com/feature/5730672977117184).
+{% endAside %}
 
 In a nutshell, here's how the Decoding Info API works for now. Check out the
 [official
@@ -81,12 +83,14 @@ of dropped frames is less than 10% while `powerEfficient` is true when more
 than 50% of frames are decoded by the hardware. Small frames are always
 considered power efficient.
 
-Note: The result returned from `navigator.mediaCapabilities.decodingInfo` will
+{% Aside %}
+The result returned from `navigator.mediaCapabilities.decodingInfo` will
 always be reported as smooth and power-efficient if the media configuration is
 supported and playback stats have not been recorded yet by the browser.
+{% endAside %}
 
 I recommend using a snippet similar to the one below to detect
-availability and fallback to your current implementation for browsers that
+availability and fall back to your current implementation for browsers that
 don't support this API.
 
 ```js
@@ -127,16 +131,16 @@ The snippet above must use `canPlayType()` instead of `isTypeSupported()`
 if the media configuration type is `"file"`.
 {% endAside %}
 
-### Available for Origin Trials
+### Available for origin trials
 
 In order to get as much feedback as possible from developers using the Decoding
 Info API (part of Media Capabilities) in the field, we've previously added this
 feature in Chrome 64 as an origin trial.
 
-The trial has successfully ended in April 2018.
+The trial successfully ended in April 2018.
 
 {% Aside %}
-The Decoding Info API is now enabled by default in Chrome 66.
+The Decoding Info API was enabled by default in Chrome 66.
 {% endAside %}
 
 [Intent to Experiment](https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/dsdTLv33r4w) &#124;
@@ -245,14 +249,14 @@ and following these steps:
 ## Media preload defaults to "metadata" {: #media-preload-defaults-metadata }
 
 Matching other browsers' implementations, Chrome desktop now sets the default
-preload value for `<video>` and `<audio>` elements to "metadata" in order to
-reduce bandwidth and resource usage. This new behavior only applies in Chrome
-64 to cases where no preload value is set. Note that the preload attribute's
+preload value for `<video>` and `<audio>` elements to `"metadata"` in order to
+reduce bandwidth and resource usage. Starting in Chrome 64, this new behavior only applies
+to cases where no preload value is set. Note that the preload attribute's
 hint is discarded when a `MediaSource` is attached to the media element as the
 web site handles its own preload.
 
-In other words, `<video>` preload value is now "metadata" while `<video
-preload="auto">` preload value stays "auto". Give a try to the [official
+In other words, `<video>` preload value is now `"metadata"` while `<video
+preload="auto">` preload value stays `"auto"`. Give a try to the [official
 sample](https://googlechrome.github.io/samples/media/preload-metadata).
 
 [Intent to Ship](https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/5CDvJkdxyQ8) &#124;
@@ -263,7 +267,7 @@ sample](https://googlechrome.github.io/samples/media/preload-metadata).
 
 Following an [HTML specification change], when media elements' `playbackRate`
 is set to a value not supported by Chrome (e.g. a negative value), a
-"NotSupportedError" DOMException is thrown in Chrome 63.
+`"NotSupportedError"` `DOMException` is thrown in Chrome 63.
 
 ```js
 const audio = document.querySelector('audio');

--- a/site/en/blog/media-updates-in-chrome-69/index.md
+++ b/site/en/blog/media-updates-in-chrome-69/index.md
@@ -1,0 +1,288 @@
+---
+title: Media updates in Chrome 69
+description: >
+  A round up of media updates in Chrome 69: AV1 and HDCP policy check.
+layout: 'layouts/blog-post.njk'
+date: 2018-08-01
+updated: 2019-02-06
+authors:
+  - beaufortfrancois
+tags:
+  - media
+---
+
+- Chrome supports [AV1 video decoding](#av1).
+- Querying [which encryption schemes are supported](#encryption_scheme) through
+  EME is now available.
+- Web developers can experiment with [querying whether a certain HDCP policy
+  can be enforced](#hdcp).
+- Media Source Extensions now use [PTS for buffered ranges and duration
+  values](#pts).
+- Android Go users can [open downloaded audio, video and images in Chrome](#media_intent_handler).
+- [Stalled events](#stalled) for media elements using MSE are removed.
+
+## AV1 video decoder {: #av1 }
+
+{% Aside %}
+AV1 video decoder support had to be pushed back to [Chrome 70] because of
+changes to the MP4 binding.
+{% endAside %}
+
+[Chromestatus Tracker](https://www.chromestatus.com/feature/5729898442260480) &#124;
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=838380)
+
+## EME: Querying encryption scheme support {: #encryption_scheme }
+
+Some platforms or key systems only support [CENC mode], while others only support
+[CBCS mode]. Still others are able to support both. These two encryption schemes
+are incompatible, so web developers must be able to make intelligent choices
+about what content to serve.
+
+To avoid having to determine which platform they're on to check for "known"
+encryption scheme support, a new `encryptionScheme` key is [added] in
+`MediaKeySystemMediaCapability` [dictionary] to allow websites to specify
+which encryption scheme could be used in [Encrypted Media Extensions (EME)].
+
+The new `encryptionScheme` key can be one of two values:
+
+- `'cenc'` AES-CTR mode full sample and video NAL subsample encryption.
+- `'cbcs'` AES-CBC mode partial video NAL pattern encryption.
+
+If not specified, it indicates that any encryption scheme is acceptable. Note
+that [Clear Key] always supports the `'cenc'` scheme.
+
+The example below shows how to query two configurations with different
+encryption schemes. In this case, only one will be chosen.
+
+```js
+await navigator.requestMediaKeySystemAccess('org.w3.clearkey', [
+    {
+      label: 'configuration using the "cenc" encryption scheme',
+      videoCapabilities: [{
+        contentType: 'video/mp4; codecs="avc1.640028"',
+        encryptionScheme: 'cenc'
+      }],
+      audioCapabilities: [{
+        contentType: 'audio/mp4; codecs="mp4a.40.2"',
+        encryptionScheme: 'cenc'
+      }],
+      initDataTypes: ['keyids']
+    },
+    {
+      label: 'configuration using the "cbcs" encryption scheme',
+      videoCapabilities: [{
+        contentType: 'video/mp4; codecs="avc1.640028"',
+        encryptionScheme: 'cbcs'
+      }],
+      audioCapabilities: [{
+        contentType: 'audio/mp4; codecs="mp4a.40.2"',
+        encryptionScheme: 'cbcs'
+      }],
+      initDataTypes: ['keyids']
+    },
+  ]);
+```
+
+In the example below, only one configuration with two different encryption
+schemes is queried. In that case, Chrome will discard any capabilities object
+it cannot support, so the accumulated configuration may contain one encryption
+scheme or both.
+
+```js
+await navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{
+    videoCapabilities: [
+      { // A video capability using the "cenc" encryption scheme
+        contentType: 'video/mp4; codecs="avc1.640028"',
+        encryptionScheme: 'cenc'
+      },
+      { // A video capability using the "cbcs" encryption scheme
+        contentType: 'video/mp4; codecs="avc1.640028"',
+        encryptionScheme: 'cbcs'
+      },
+    ],
+    audioCapabilities: [
+      { // An audio capability using the "cenc" encryption scheme
+        contentType: 'audio/mp4; codecs="mp4a.40.2"',
+        encryptionScheme: 'cenc'
+      },
+      { // An audio capability using the "cbcs" encryption scheme
+        contentType: 'audio/mp4; codecs="mp4a.40.2"',
+        encryptionScheme: 'cbcs'
+      },
+    ],
+    initDataTypes: ['keyids']
+  }]);
+```
+
+[Intent to Implement](https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/lMUKOaohUTY) &#124;
+[Chromestatus Tracker](https://www.chromestatus.com/feature/5184416120832000) &#124;
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=838416)
+
+## EME: HDCP policy check {: #hdcp}
+
+Nowadays [HDCP] is a common policy requirement for streaming high resolutions
+of [protected content]. And web developers who want to enforce an HDCP policy
+must either wait for the license exchange to complete or start streaming
+content at a low resolution. This, is a sad situation that the [HDCP Policy
+Check API] aims to solve.
+
+This proposed API allows web developers to query whether a certain HDCP policy
+can be enforced so that playback can be started at the optimum resolution for
+the best user experience. It consists of a simple method to query the status of
+a hypothetical key associated with an HDCP policy, without the need to create a
+`MediaKeySession` or fetch a real license. It does not require `MediaKeys` to be
+attached to any audio or video elements either.
+
+The HDCP Policy Check API works simply by calling
+`mediaKeys.getStatusForPolicy()` with an object that has a `minHdcpVersion` key
+and a valid value. If HDCP is available at the specified version, the returned
+promise resolves with a `MediaKeyStatus` of `'usable'`. Otherwise, the promise
+resolves with [other error values] of `MediaKeyStatus` such as
+`'output-restricted'` or `'output-downscaled'`. If the key system does not
+support HDCP Policy Check at all (e.g. Clear Key System), the promise rejects.
+
+In a nutshell, here's how the API works for now. Check out the [official sample]
+to try out all versions of HDCP.
+
+```js
+const config = [{
+  videoCapabilities: [{
+    contentType: 'video/webm; codecs="vp09.00.10.08"',
+    robustness: 'SW_SECURE_DECODE' // Widevine L3
+  }]
+}];
+
+navigator.requestMediaKeySystemAccess('com.widevine.alpha', config)
+.then(mediaKeySystemAccess => mediaKeySystemAccess.createMediaKeys())
+.then(mediaKeys => {
+
+  // Get status for HDCP 2.2
+  return mediaKeys.getStatusForPolicy({ minHdcpVersion: '2.2' })
+  .then(status => {
+    if (status !== 'usable')
+      return Promise.reject(status);
+
+    console.log('HDCP 2.2 can be enforced.');
+    // TODO: Fetch high resolution protected content...
+  });
+})
+.catch(error => {
+  // TODO: Fallback to fetch license or stream low-resolution content...
+});
+```
+
+### Available for Origin Trials
+
+To get feedback from web developers, we've previously added the HDCP Policy
+Check API feature in Chrome 69 for Desktop (Chrome OS, Linux, Mac, and Windows).
+
+The trial has successfully ended in November 2018.
+
+[Intent to Experiment](https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/ITzZ_yx4bF8) &#124;
+[Chromestatus Tracker](https://www.chromestatus.com/feature/5652917147140096) &#124;
+[Chromium Bug](https://crbug.com/709348)
+
+## MSE PTS/DTS compliance {: #pts }
+
+Buffered ranges and duration values are now reported by Presentation Time Stamp
+(PTS) intervals, rather than by Decode Time Stamp (DTS) intervals in [Media
+Source Extensions (MSE)].
+
+When MSE was new, Chrome's implementation was tested against WebM and MP3, some
+media stream formats where there was no distinction between PTS and DTS. And
+it was working fine until ISO BMFF (aka MP4) was added. This container
+frequently contains out-of-order presentation versus decode time streams (for
+codecs like H.264 for example) causing DTS and PTS to differ. That caused
+Chrome to report (usually just slightly) different buffered ranges and duration
+values than expected. This new behavior will roll out gradually in Chrome 69
+and make its MSE implementation compliant with the [MSE specification].
+
+<figure>
+  {% Img src="image/vvhSqZboQoZZN9wBvoXq72wzGAf1/MeaweyrpR2iIVbXZqemN.png", alt="PTS/DTS", width="800", height="434" %}
+  <figcaption>
+    PTS/DTS
+  </figcaption>
+</figure>
+
+This change affects `MediaSource.duration` (and consequently
+`HTMLMediaElement.duration`), `SourceBuffer.buffered` (and consequently
+`HTMLMediaElement.buffered)`, and `SourceBuffer.remove(start, end)`.
+
+If you're not sure which method is used to report buffered ranges and duration
+values, you can go to the internal `chrome://media-internals` page and search for
+"ChunkDemuxer: buffering by PTS" or  "ChunkDemuxer: buffering by DTS" in the
+logs.
+
+[Intent to Implement](https://groups.google.com/a/chromium.org/d/msg/blink-dev/I6oGJLym-Tk/Z46le9l4CQAJ) &#124;
+[Chromium Bug](https://crbug.com/718641)
+
+## Handling of media view intents on Android Go {: #media_intent_handler }
+
+[Android Go] is a lightweight version of Android designed for entry-level
+smartphones. To that end, it does not necessarily ship with some media-viewing
+applications, so if a user tries to open a downloaded video for instance, they
+won't have any applications to handle that intent.
+
+To fix this, Chrome 69 on Android Go now listens for media-viewing intents so
+users can view downloaded audio, videos, and images. In other words, it takes
+the place of the missing viewing applications.
+
+<figure>
+  {% Img src="image/vvhSqZboQoZZN9wBvoXq72wzGAf1/qGcEJcsQz6oRpoqE8mCE.png", alt="ALT_TEXT_HERE", width="800", height="369" %}
+  <figcaption>
+    Media intent handler
+  </figcaption>
+</figure>
+
+Note that this Chrome feature is enabled on all Android devices running Android
+O and onwards with 1 GB of RAM or less.
+
+[Chromium Bug](https://crbug.com/718641)
+
+## Removal of "stalled" events for media elements using MSE {: #stalled }
+
+A "stalled" event is raised on a media element if downloading media data has
+failed to progress for about 3 seconds. When using [Media Source Extensions
+(MSE)], the web app manages the download and the media element is not aware of
+its progress. This caused Chrome to raise "stalled" events at inappropriate
+times whenever the website has not appended new media data chunks with
+`SourceBuffer.appendBuffer()` in the last 3 seconds.
+
+As websites may decide to append large chunks of data at a low frequency, this
+is not a useful signal about buffering health. Removing "stalled" events for
+media elements using MSE clears up confusion and brings Chrome more in line
+with the MSE specification. Note that media elements that don't use MSE will
+continue to raise "stalled" events as they do today.
+
+[Intent to Deprecate and Remove](https://groups.google.com/a/chromium.org/d/msg/blink-dev/x54XtrTyOP8/4-5QZlZzDAAJ) &#124;
+[Chromestatus Tracker](https://www.chromestatus.com/feature/6338037575319552) &#124;
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=836951)
+
+<!-- lint disable definition-case -->
+
+[Chrome 70]: /blog/media-updates-in-chrome-70#av1-decoder
+[CENC mode]: https://www.iso.org/obp/ui/#iso:std:iso-iec:23001:-7:ed-2:v1:en
+[CBCS mode]: https://www.iso.org/obp/ui/#iso:std:iso-iec:23001:-7:ed-3:v1:en
+[added]: https://github.com/WICG/encrypted-media-encryption-scheme/blob/main/explainer.md
+[dictionary]: https://w3c.github.io/encrypted-media/#idl-def-mediakeysystemmediacapability
+[Encrypted Media Extensions (EME)]: https://w3c.github.io/encrypted-media/
+[Clear Key]: https://www.w3.org/TR/encrypted-media/#clear-key
+[HDCP]: https://en.wikipedia.org/wiki/High-bandwidth_Digital_Content_Protection
+[protected content]: https://developers.google.com/web/fundamentals/media/eme
+[HDCP Policy Check API]: https://github.com/WICG/hdcp-detection/blob/main/explainer.md
+[other error values]: https://w3c.github.io/encrypted-media/#dom-mediakeystatus
+[official sample]: https://googlechrome.github.io/samples/hdcp-detection/
+[Origin Trial]: https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md
+[request a token]: http://bit.ly/HdcpPolicyCheckOriginTrials
+[Alliance for Open Media]: http://aomedia.org/
+[improves compression efficiency by 30%]: https://code.fb.com/video-engineering/av1-beats-x264-and-libvpx-vp9-in-practical-use-case/
+[official bitstream specification]: https://aomedia.org/av1-bitstream-and-decoding-process-specification/
+[profile 0]: https://aomediacodec.github.io/av1-spec/#profiles
+[ISO-BMFF (MP4)]: https://aomediacodec.github.io/av1-isobmff
+[From raw video to web ready]: https://developers.google.com/web/fundamentals/media/manipulating/files#how_are_media_files_put_together
+[Media Source Extensions (MSE)]: https://developers.google.com/web/fundamentals/media/mse/basics
+[MSE specification]: https://w3c.github.io/media-source/
+[Android Go]: https://www.android.com/versions/oreo-8-0/go-edition/
+[raise]: https://bugs.chromium.org/p/chromium/issues/detail?id=517240
+[Removing]: https://chromium-review.googlesource.com/982564
+[more in line]: https://github.com/w3c/media-source/issues/88#issuecomment-374406928

--- a/site/en/blog/media-updates-in-chrome-69/index.md
+++ b/site/en/blog/media-updates-in-chrome-69/index.md
@@ -9,6 +9,7 @@ authors:
   - beaufortfrancois
 tags:
   - media
+  - chrome-69
 ---
 
 - Chrome supports [AV1 video decoding](#av1).

--- a/site/en/blog/media-updates-in-chrome-69/index.md
+++ b/site/en/blog/media-updates-in-chrome-69/index.md
@@ -172,12 +172,12 @@ navigator.requestMediaKeySystemAccess('com.widevine.alpha', config)
 });
 ```
 
-### Available for Origin Trials
+### Available for origin trials
 
 To get feedback from web developers, we've previously added the HDCP Policy
 Check API feature in Chrome 69 for Desktop (Chrome OS, Linux, Mac, and Windows).
 
-The trial has successfully ended in November 2018.
+The trial successfully ended in November 2018.
 
 [Intent to Experiment](https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/ITzZ_yx4bF8) &#124;
 [Chromestatus Tracker](https://www.chromestatus.com/feature/5652917147140096) &#124;

--- a/site/en/blog/media-updates-in-chrome-69/index.md
+++ b/site/en/blog/media-updates-in-chrome-69/index.md
@@ -274,8 +274,8 @@ continue to raise "stalled" events as they do today.
 [other error values]: https://w3c.github.io/encrypted-media/#dom-mediakeystatus
 [official sample]: https://googlechrome.github.io/samples/hdcp-detection/
 [Origin Trial]: https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md
-[request a token]: http://bit.ly/HdcpPolicyCheckOriginTrials
-[Alliance for Open Media]: http://aomedia.org/
+[request a token]: https://bit.ly/HdcpPolicyCheckOriginTrials
+[Alliance for Open Media]: https://aomedia.org/
 [improves compression efficiency by 30%]: https://code.fb.com/video-engineering/av1-beats-x264-and-libvpx-vp9-in-practical-use-case/
 [official bitstream specification]: https://aomedia.org/av1-bitstream-and-decoding-process-specification/
 [profile 0]: https://aomediacodec.github.io/av1-spec/#profiles

--- a/site/en/blog/media-updates-in-chrome-70/index.md
+++ b/site/en/blog/media-updates-in-chrome-70/index.md
@@ -47,12 +47,12 @@ codecs] for a brief explanation of containers).
 
 To try AV1:
 
-- Go to the [YouTube TestTube page].
-- Select "Prefer AV1 for SD" or "Always Prefer AV1" to get the desired
+1. Go to the [YouTube TestTube page].
+1. Select "Prefer AV1 for SD" or "Always Prefer AV1" to get the desired
   AV1 resolution. Note that at higher resolutions, AV1 is more likely to
   experience playback performance issues on some devices.
-- Try playing YouTube clips from the [AV1 Beta Launch Playlist].
-- Confirm the codec av01 in "Stats for nerds".
+1. Try playing YouTube clips from the [AV1 Beta Launch Playlist].
+1. Confirm the codec av01 in "Stats for nerds".
 
 <figure>
   {% Img src="image/vvhSqZboQoZZN9wBvoXq72wzGAf1/dkO4doRrngleSzL3VPW5.png", alt="Stats for nerds featuring AV1 in YouTube", width="800", height="257" %}

--- a/site/en/blog/media-updates-in-chrome-70/index.md
+++ b/site/en/blog/media-updates-in-chrome-70/index.md
@@ -1,0 +1,178 @@
+---
+title: Media updates in Chrome 70
+description: >
+  Cross-codec and cross-bytestream buffering and playback, Opus in MP4 with
+  MSE, and protected content playback allowed by default on Android.
+layout: 'layouts/blog-post.njk'
+date: 2018-09-18
+updated: 2018-10-19
+authors:
+  - beaufortfrancois
+tags:
+  - media
+---
+
+- Web developers can control [Picture-in-Picture for videos](#pip).
+- [AV1 decoder](#av1-decoder) is now supported in Chrome Desktop x86-64.
+- [Cross-codec and cross-bytestream buffering and
+  playback](#sourcebuffer-changetype) is possible in MSE.
+- Chrome now supports [Opus in MP4 with MSE](#opus-in-mp4-for-mse).
+- Protected content playback is [allowed by
+  default](#protected-content-allowed-by-default) on Android.
+
+## Watch video using Picture-in-Picture {: #pip }
+
+Picture-in-Picture (PiP) allows users to watch videos in a floating window
+(always on top of other windows) so they can keep an eye on what they're
+watching while interacting with other sites, or applications. With the new
+[Picture-in-Picture Web API], you can initiate and control Picture-in-Picture
+for videos on your website.
+
+Read [our article] to learn all about it.
+
+{% YouTube
+  id='t2QAzHZH-5s'
+%}
+
+## AV1 decoder {: #av1-decoder }
+
+AV1 is a next generation codec developed by the [Alliance for Open Media]. AV1
+[improves compression efficiency by greater than 30%] over the current
+state-of-the-art video codec, VP9. Chrome 70 adds an AV1 decoder to Chrome
+Desktop x86-64 based on the [official bitstream specification]. At this time,
+support is limited to "Main" [profile 0] and does not include encoding
+capabilities. The supported container is MP4 ([ISO-BMFF]) (see [Containers and
+codecs] for a brief explanation of containers).
+
+To try AV1:
+
+- Go to the [YouTube TestTube page].
+- Select "Prefer AV1 for SD" or "Always Prefer AV1" to get the desired
+  AV1 resolution. Note that at higher resolutions, AV1 is more likely to
+  experience playback performance issues on some devices.
+- Try playing YouTube clips from the [AV1 Beta Launch Playlist].
+- Confirm the codec av01 in "Stats for nerds".
+
+<figure>
+  {% Img src="image/vvhSqZboQoZZN9wBvoXq72wzGAf1/dkO4doRrngleSzL3VPW5.png", alt="Stats for nerds featuring AV1 in YouTube", width="800", height="257" %}
+  <figcaption>
+    Stats for nerds featuring AV1 in YouTube.
+  </figcaption>
+</figure>
+
+## Support for codec and container switching in MSE {: #sourcebuffer-changetype }
+
+Chrome is [adding support] for improved cross-codec or cross-bytestream
+transitions in [Media Source Extensions] (MSE) playback using a new
+`changeType()` method on `SourceBuffer`. It allows the type of media
+bytes appended to the `SourceBuffer` to be changed afterwards.
+
+The [current version of MSE] (W3C Recommendation 17 November 2016) supports
+adaptive playback of media; however adaptation requires that any media appended
+to a `SourceBuffer` must conform to the MIME type provided when initially
+creating the `SourceBuffer` via `MediaSource.addSourceBuffer(type)`. Codecs
+from that type and any previously parsed initialization segments must remain
+the same throughout. This means the website has to take explicit steps to
+accomplish codec or bytestream switching (by using multiple media elements or
+`SourceBuffer` tracks and switching among those), increasing application
+complexity and user-visible latency. (Such transitions require the web app to
+take synchronous action on the renderer main thread). This transition latency
+impairs the smoothness of media playback across transitions.
+
+With its new `changeType()` method, a `SourceBuffer` can buffer and support
+playback across different [bytestream formats] and codecs. This new method
+retains previously buffered media, modulo future MSE coded frame eviction or
+removal, and leverages the splicing and buffering logic in the existing MSE
+coded frame processing algorithm.
+
+Here's how to use the `changeType()` method:
+
+```js
+const sourceBuffer = myMediaSource.addSourceBuffer('video/webm; codecs="opus, vp09.00.10.08"');
+sourceBuffer.appendBuffer(someWebmOpusVP9Data);
+
+// Later on...
+if ('changeType' in sourceBuffer) {
+  // Change source buffer type and append new data.
+  sourceBuffer.changeType('video/mp4; codecs="mp4a.40.5, avc1.4d001e"');
+  sourceBuffer.appendBuffer(someMp4AacAvcData);
+}
+```
+
+As expected, if the passed type is not supported by the browser, this method
+throws a `NotSupportedError` exception.
+
+Check out the [sample] to play with cross-codec and
+cross-bytestream buffering and playback of an audio element.
+
+[Intent to Ship](https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/K_OFPxA_whE) &#124;
+[Chromestatus Tracker](https://www.chromestatus.com/feature/5719220952236032) &#124;
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=605134)
+
+## Opus in MP4 for MSE {: #opus-in-mp4-for-mse }
+
+The open and highly versatile audio codec [Opus] has been supported in the
+`<audio>` and `<video>` elements since Chrome 33. [Opus in ISO-BMFF] support
+(aka Opus in MP4) was added after. And now Opus in MP4 is available in Chrome
+70 for [Media Source Extensions] (MSE).
+
+Here's how you can detect if Opus in MP4 is supported for MSE:
+
+```js
+if (MediaSource.isTypeSupported('audio/mp4; codecs="opus"')) {
+  // TODO: Fetch data and feed it to a media source.
+}
+```
+
+If you want to see a full example, check out our [official sample].
+
+Due to lack of tools to mux Opus in MP4 with correct end trimming and preskip
+values, if such precision is important to you, you'll need to use
+`SourceBuffer.appendWindow{Start,End}` and `SourceBuffer.timestampOffset` in
+Chrome to obtain sample-accurate playback.
+
+{% Aside 'warning' %}
+Chrome for Android does not support encrypted Opus content on Android
+versions prior to Lollipop.
+{% endAside %}
+
+[Intent to Ship](https://groups.google.com/a/chromium.org/d/msg/blink-dev/Ce2j1tA_xdU/T9C6sxpTDQAJ) &#124;
+[Chromestatus Tracker](https://www.chromestatus.com/features/5100845653819392) &#124;
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=649438)
+
+## Allow protected content playback by default on Android {: #protected-content-allowed-by-default }
+
+In Chrome 70 for Android, the default value of the "protected content" site
+setting changes from "Ask first" to "Allowed", lowering the friction associated
+with playback of such media. This change is possible, in part, because of
+additional steps taken to clear media licenses alongside cookies and site data,
+ensuring that media licenses are not used by sites to track users who have
+cleared browsing data.
+
+<figure>
+{% Img src="image/vvhSqZboQoZZN9wBvoXq72wzGAf1/eRqu6e8CFh6PCPLaeMGK.png", alt="ALT_TEXT_HERE", width="800", height="800" %}
+  <figcaption>
+    Protected content setting in Android.
+  </figcaption>
+</figure>
+
+<!-- lint disable definition-case -->
+
+[Picture-in-Picture Web API]: https://wicg.github.io/picture-in-picture/
+[our article]: https://developers.google.com/web/updates/2018/10/watch-video-using-picture-in-picture
+[Alliance for Open Media]: http://aomedia.org/
+[improves compression efficiency by greater than 30%]: https://code.fb.com/video-engineering/av1-beats-x264-and-libvpx-vp9-in-practical-use-case/
+[official bitstream specification]: https://aomedia.org/av1-bitstream-and-decoding-process-specification/
+[profile 0]: https://aomediacodec.github.io/av1-spec/#profiles
+[ISO-BMFF]: https://aomediacodec.github.io/av1-isobmff
+[Containers and codecs]: https://web.dev/containers-and-codecs/
+[YouTube TestTube page]: https://www.youtube.com/testtube
+[AV1 Beta Launch Playlist]: https://www.youtube.com/playlist?list=PLyqf6gJt7KuHBmeVzZteZUlNUQAVLwrZS
+[adding support]: https://github.com/wicg/media-source/blob/codec-switching/codec-switching-explainer.md
+[Media Source Extensions]: https://developers.google.com/web/fundamentals/media/mse/basics
+[current version of MSE]: https://www.w3.org/TR/2016/REC-media-source-20161117/
+[bytestream formats]: https://www.w3.org/TR/mse-byte-stream-format-registry/
+[sample]: https://googlechrome.github.io/samples/media/sourcebuffer-changetype.html
+[Opus]: https://opus-codec.org/
+[Opus in ISO-BMFF]: https://people.xiph.org/~shobson/opus-codec.org/docs/opus_in_isobmff.html
+[official sample]: https://googlechrome.github.io/samples/media/opus-in-mp4-for-mse.html

--- a/site/en/blog/media-updates-in-chrome-70/index.md
+++ b/site/en/blog/media-updates-in-chrome-70/index.md
@@ -10,6 +10,7 @@ authors:
   - beaufortfrancois
 tags:
   - media
+  - chrome-70
 ---
 
 - Web developers can control [Picture-in-Picture for videos](#pip).

--- a/site/en/blog/media-updates-in-chrome-73/index.md
+++ b/site/en/blog/media-updates-in-chrome-73/index.md
@@ -1,0 +1,269 @@
+---
+title: Media updates in Chrome 73
+description: >
+  Hardware media keys support, HDCP policy check, Picture-in-Picture origin
+  trials, and more.
+layout: 'layouts/blog-post.njk'
+date: 2019-02-06
+updated: 2019-02-08
+authors:
+  - beaufortfrancois
+tags:
+  - media
+---
+
+In this article, I'll discuss Chrome 73 new media features which include:
+
+- [Hardware media keys](#media-keys) are now supported to control media playback
+  on desktop.
+- Web developers can [query whether a certain HDCP policy can be
+  enforced](#hdcp).
+- [Auto Picture-in-Picture](#auto-pip) in desktop PWAs and ["Skip Ad" in
+  Picture-in-Picture](#skipad) are coming to origin trials.
+- Desktop PWAs are granted [autoplay with sound](#autoplay-pwa).
+
+## Hardware Media Keys support {: #media-keys}
+
+Many keyboards nowadays have keys to control basic media playback functions such
+as play/pause, previous and next track. Headsets have them too. Until now,
+desktop users couldn't use these media keys to control audio and video playback
+in Chrome. This changes today!
+
+<figure>
+  {% Img src="image/vvhSqZboQoZZN9wBvoXq72wzGAf1/sHvqy6DFMuLJjkCRUrHF.jpeg", alt="Keyboard media keys", width="800", height="293" %}
+  <figcaption>
+    Keyboard media keys
+  </figcaption>
+</figure>
+
+If user presses the pause key, the active media element playing in Chrome will
+be paused and receive a "paused" media event. If the play key is pressed, the
+previously paused media element will be resumed and receive a "play" media
+event. It works whether Chrome is in foreground or background.
+
+In Chrome OS, Android apps using [audio focus] will now tell Chrome to pause and
+resume audio to create a seamless media experience between websites on Chrome,
+Chrome Apps and Android Apps. This is currently supported only on Chrome OS
+device running Android P.
+
+In short, it's a good practice to always listen to these media events and act
+accordingly.
+
+```js
+video.addEventListener('pause', function() {
+  // Video is now paused.
+  // TODO: Let's update UI accordingly.
+});
+
+video.addEventListener('play', function() {
+  // Video is now playing.
+  // TODO: Let's update UI accordingly.
+});
+```
+
+But wait, there's more! With the [Media Session API] now available on desktop
+(it was supported on mobile only before), web developers can handle media
+related events such as track changing that are triggered by media keys. The
+events `previoustrack` and `nexttrack` are currently supported.
+
+```js
+navigator.mediaSession.setActionHandler('previoustrack', function() {
+  // User hit "Previous Track" key.
+});
+
+navigator.mediaSession.setActionHandler('nexttrack', function() {
+  // User hit "Next Track" key.
+});
+```
+
+Play and pause keys are handled automatically by Chrome. However if the default
+behavior doesn't work out for you, you can still set some action handlers for
+"play" and "pause" to prevent this.
+
+```js
+navigator.mediaSession.setActionHandler('play', function() {
+  // User hit "Play" key.
+});
+
+navigator.mediaSession.setActionHandler('pause', function() {
+  // User hit "Pause" key.
+});
+```
+
+Hardware Media Keys support is available on Chrome OS, macOS, and Windows. Linux
+will come later.
+
+{% Aside %}
+Setting some media session metadata such as the title, artist, album name,
+and artwork with the Media Session API is available but not hooked up to desktop
+notifications yet. It will come in supported platforms later.
+{% endAside %}
+
+Check out our existing [developer documentation] and try out the [official Media
+Session samples].
+
+[Chromestatus Tracker](https://www.chromestatus.com/feature/5639924124483584) &#124;
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=497735)
+
+## Encrypted Media: HDCP Policy Check {: #hdcp }
+
+Thanks to the [HDCP Policy Check API], web developers can now query whether a
+specific policy, e.g. [HDCP] requirement, can be enforced **before** requesting
+Widevine licenses, and loading media.
+
+```js
+const status = await video.mediaKeys.getStatusForPolicy({ minHdcpVersion: '2.2' });
+
+if (status == 'usable')
+  console.log('HDCP 2.2 can be enforced.');
+```
+
+The API is available on all platforms. However, the actual policy checks might
+not be available on certain platforms. For example, HDCP policy check promise
+will reject with `NotSupportedError` on Android and Android WebView.
+
+Check out our [previous developer documentation] and give a try to the [official
+sample] to see all HDCP versions that are supported.
+
+[Intent to Ship](https://groups.google.com/a/chromium.org/forum/#!msg/blink-dev/w0jNaAhyTV0/3oDkR_ASAQAJ) &#124;
+[Chromestatus Tracker](https://www.chromestatus.com/feature/5652917147140096) &#124;
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=709348)
+
+## Origin Trial for Auto Picture-in-Picture for installed PWAs {: #auto-pip }
+
+Some pages may want to automatically enter and leave [Picture-in-Picture] for a
+video element; for example, video conferencing web apps would benefit from some
+automatic Picture-in-Picture behavior when user switches back and forth between
+the web app and other applications or tabs. This is sadly not possible with the
+[user gesture requirement]. So here comes Auto Picture-in-Picture!
+
+<video autoplay loop muted playsinline src="https://storage.googleapis.com/webfundamentals-assets/videos/pwa-auto-pip.mp4"></video>
+
+To support these tab and app switching, a new `autopictureinpicture` attribute
+is added to the `<video>` element.
+
+```html
+<video autopictureinpicture></video>
+```
+
+Here's roughly how it works:
+
+- When document becomes hidden, the video element whose `autopictureinpicture`
+  attribute was set most recently automatically enters Picture-in-Picture, if
+  allowed.
+- When document becomes visible, the video element in Picture-in-Picture
+  automatically leaves it.
+
+And that's it! Note that the Auto Picture-in-Picture feature applies only to
+[Progressive Web Apps] (PWAs) that users have installed on desktop.
+
+Check out the [spec] for more details and try out using the [official PWA
+sample].
+
+{% Aside %}
+To get feedback from web developers, the Auto Picture-in-Picture
+feature is available as an [Origin Trial] in Chrome 73 for desktop (Chrome OS,
+Linux, Mac, and Windows). You will need to [request a token], so that the
+feature is automatically enabled for your origin for a limited period of time.
+This will eliminate the need to enable the "Web Platform Features" flag.
+{% endAside %}
+
+[Intent to Experiment](https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/eFZ3h_A3VTY) &#124;
+[Chromestatus Tracker](https://www.chromestatus.com/feature/5317876315586560) &#124;
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=917303)
+
+## Origin Trial for Skip Ad in Picture-in-Picture window {: #skipad }
+
+The video advertisement model usually consists of pre-roll ads. Content
+providers often provide the ability to skip the ad after a few seconds. Sadly,
+as the Picture-in-Picture window is not interactive, users watching a video in
+Picture-in-Picture can't do this today.
+
+With the [Media Session API] now available on desktop (it was supported on
+mobile only before), a new `skipad` media session action may be used to offer this
+option in [Picture-in-Picture]. 
+
+<figure>
+  {% Img src="image/vvhSqZboQoZZN9wBvoXq72wzGAf1/LawyPY28acxZd6t4NQDS.png", alt="Skip Ad button in Picture-in-Picture window", width="668", height="416" %}
+  <figcaption>
+    "Skip Ad" button in Picture-in-Picture window
+  </figcaption>
+</figure>
+
+To provide this feature pass a function with `skipad` when calling
+`setActionHandler()`. To hide it pass `null`. As you can read below, it is
+pretty straightforward.
+
+```js
+try {
+  navigator.mediaSession.setActionHandler('skipad', null);
+  showSkipAdButton();
+} catch(error) {
+    // The "Skip Ad" media session action is not supported.
+}
+
+function showSkipAdButton() {
+  // The Picture-in-Picture window will show a "Skip Ad" button.
+  navigator.mediaSession.setActionHandler('skipad', onSkipAdButtonClick);
+}
+
+function onSkipAdButtonClick() {
+  // User clicked "Skip Ad" button, let's hide it now.
+  navigator.mediaSession.setActionHandler('skipad', null);
+
+  // TODO: Stop ad and play video.
+}
+```
+
+{% Aside 'caution' %}
+Media session action handlers will persist. I'd suggest always resetting them
+when media playback starts and ends to avoid showing an unexpected "Skip Ad"
+button.
+{% endAside %}
+
+Try out the [official "Skip Ad" sample] and [let us know] how this feature can
+be improved.
+
+{% Aside %}
+To get feedback from web developers, the Skip Ad in Picture-in-Picture
+window feature is available as an [Origin Trial] in Chrome 73 for desktop
+(Chrome OS, Linux, Mac, and Windows). You will need to [request a token], so
+that the feature is automatically enabled for your origin for a limited period
+of time. This will eliminate the need to enable the "Web Platform Features"
+flag.
+{% endAside %}
+
+[Intent to Experiment](https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/l6sW0G4jzhE) &#124;
+[Chromestatus Tracker](https://www.chromestatus.com/feature/4749278882824192) &#124;
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=910436)
+
+## Autoplay granted for Desktop PWAs {: #autoplay-pwa }
+
+Now that [Progressive Web Apps] (PWAs) are available on all desktop platforms,
+we are extending the rule that we had on mobile to desktop: [autoplay] with
+sound is now allowed for installed PWAs. Note that it only applies to pages in
+the [scope] of the web app manifest.
+
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=794874)
+
+<!-- lint disable definition-case -->
+
+[audio focus]: https://developer.android.com/guide/topics/media-apps/audio-focus
+[Media Session API]: https://w3c.github.io/mediasession/
+[developer documentation]: https://web.dev/media-session
+[official Media Session samples]: https://googlechrome.github.io/samples/media-session/
+[HDCP Policy Check API]: https://wicg.github.io/hdcp-detection/
+[HDCP]: https://en.wikipedia.org/wiki/High-bandwidth_Digital_Content_Protection
+[previous developer documentation]: /blog/media-updates-in-chrome-69#hdcp
+[official sample]: https://googlechrome.github.io/samples/hdcp-detection/
+[Picture-in-Picture]: https://developers.google.com/web/updates/2018/10/watch-video-using-picture-in-picture
+[user gesture requirement]: https://developers.google.com/web/updates/2018/10/watch-video-using-picture-in-picture#enter_picture-in-picture
+[Progressive Web Apps]: https://web.dev/progressive-web-apps/
+[spec]: https://wicg.github.io/picture-in-picture/#auto-pip
+[official PWA sample]: https://googlechrome.github.io/samples/auto-picture-in-picture/index.html
+[Origin Trial]: https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md
+[request a token]: https://developers.chrome.com/origintrials
+[official "Skip Ad" sample]: https://googlechrome.github.io/samples/picture-in-picture/skip-ad.html
+[let us know]: https://github.com/WICG/picture-in-picture/issues
+[autoplay]: /blog/autoplay/
+[scope]: https://web.dev/add-manifest/#scope

--- a/site/en/blog/media-updates-in-chrome-73/index.md
+++ b/site/en/blog/media-updates-in-chrome-73/index.md
@@ -163,7 +163,7 @@ sample].
 
 {% Aside %}
 To get feedback from web developers, the Auto Picture-in-Picture
-feature is available as an [Origin Trial] in Chrome 73 for desktop (Chrome OS,
+feature is available as an [origin trial] in Chrome 73 for desktop (Chrome OS,
 Linux, Mac, and Windows). You will need to [request a token], so that the
 feature is automatically enabled for your origin for a limited period of time.
 This will eliminate the need to enable the "Web Platform Features" flag.
@@ -227,7 +227,7 @@ be improved.
 
 {% Aside %}
 To get feedback from web developers, the Skip Ad in Picture-in-Picture
-window feature is available as an [Origin Trial] in Chrome 73 for desktop
+window feature is available as an [origin trial] in Chrome 73 for desktop
 (Chrome OS, Linux, Mac, and Windows). You will need to [request a token], so
 that the feature is automatically enabled for your origin for a limited period
 of time. This will eliminate the need to enable the "Web Platform Features"

--- a/site/en/blog/media-updates-in-chrome-73/index.md
+++ b/site/en/blog/media-updates-in-chrome-73/index.md
@@ -138,7 +138,13 @@ automatic Picture-in-Picture behavior when user switches back and forth between
 the web app and other applications or tabs. This is sadly not possible with the
 [user gesture requirement]. So here comes Auto Picture-in-Picture!
 
-<video autoplay loop muted playsinline src="https://storage.googleapis.com/webfundamentals-assets/videos/pwa-auto-pip.mp4"></video>
+{% Video
+  src="video/vvhSqZboQoZZN9wBvoXq72wzGAf1/QqD84WpfAAfk8UeSryF0.mp4",
+  autoplay=true,
+  loop=true,
+  muted=true,
+  playsinline=true
+%}
 
 To support these tab and app switching, a new `autopictureinpicture` attribute
 is added to the `<video>` element.

--- a/site/en/blog/media-updates-in-chrome-73/index.md
+++ b/site/en/blog/media-updates-in-chrome-73/index.md
@@ -10,6 +10,7 @@ authors:
   - beaufortfrancois
 tags:
   - media
+  - chrome-73
 ---
 
 In this article, I'll discuss Chrome 73 new media features which include:

--- a/site/en/blog/media-updates-in-chrome-75/index.md
+++ b/site/en/blog/media-updates-in-chrome-75/index.md
@@ -10,6 +10,7 @@ authors:
   - beaufortfrancois
 tags:
   - media
+  - chrome-75
 ---
 
 Chrome's media capabilities were updated in version 75. In this article, I'll

--- a/site/en/blog/media-updates-in-chrome-75/index.md
+++ b/site/en/blog/media-updates-in-chrome-75/index.md
@@ -118,7 +118,7 @@ if (bestConfig) {
 }
 ```
 
-Note that Decoding Info for encrypted media requires HTTPS.
+Note that decoding info for encrypted media requires HTTPS.
 
 Moreover, be aware that it may trigger a user prompt on Android and Chrome OS in
 the same way as `requestMediaKeySystemAccess()`. It won't show more prompts than
@@ -134,7 +134,7 @@ requiring more calls to setup encrypted media playback.
 
 {% Aside %}
 To get feedback from web developers, this feature is available as an
-[Origin Trial] in Chrome 75. You will need to [request a token], so that the
+[origin trial] in Chrome 75. You will need to [request a token], so that the
 feature is automatically enabled for your origin for a limited period
 of time. 
 {% endAside %}

--- a/site/en/blog/media-updates-in-chrome-75/index.md
+++ b/site/en/blog/media-updates-in-chrome-75/index.md
@@ -1,0 +1,175 @@
+---
+title: Media updates in Chrome 75
+description: >
+  Predicting whether playback will be smooth and power efficient for encrypted
+  media and support of the video element's "playsInline" attribute hint.
+layout: 'layouts/blog-post.njk'
+date: 2019-07-22
+updated: 2019-07-26
+authors:
+  - beaufortfrancois
+tags:
+  - media
+---
+
+Chrome's media capabilities were updated in version 75. In this article, I'll
+discuss those new features which include:
+
+- Predicting whether playback will be smooth and power efficient for encrypted
+  media.
+- Support of the video element's `playsInline` attribute hint.
+
+## Encrypted Media: Decoding Info  {: #encrypted-media}
+
+Since Chrome 66, web developers have been able to use [Decoding Info] to
+query the browser about the clear content decoding abilities of the device based
+on information such as the codecs, profile, resolution, bitrates, etc. It
+indicates whether the playback will be smooth (timely) and power efficient based
+on previous playback statistics recorded by the browser.
+
+The [Media Capabilities API] specification, defining Decoding Info, has since
+been updated to handle encrypted media configurations as well so that websites
+using encrypted media (EME) can select the optimal media streams.
+
+In a nutshell, here's how Decoding Info for EME works. Give a try to the
+[official sample].
+
+```js
+const encryptedMediaConfig = {
+  type: 'media-source', // or 'file'
+  video: {
+    contentType: 'video/webm; codecs="vp09.00.10.08"',
+    width: 1920,
+    height: 1080,
+    bitrate: 2646242, // number of bits used to encode a second of video
+    framerate: '25' // number of frames used in one second
+  },
+  keySystemConfiguration: {
+    keySystem: 'com.widevine.alpha',
+    videoRobustness: 'SW_SECURE_DECODE' // Widevine L3
+  }
+};
+
+navigator.mediaCapabilities.decodingInfo(encryptedMediaConfig).then(result => {
+  if (!result.supported) {
+    console.log('Argh! This encrypted media configuration is not supported.');
+    return;
+  }
+
+  if (!result.keySystemAccess) {
+    console.log('Argh! Encrypted media support is not available.')
+    return;
+  }
+
+  console.log('This encrypted media configuration is supported.');
+  console.log('Playback should be' +
+      (result.smooth ? '' : ' NOT') + ' smooth and' +
+      (result.powerEfficient ? '' : ' NOT') + ' power efficient.');
+
+  // TODO: Use `result.keySystemAccess.createMediaKeys()` to setup EME playback.
+});
+```
+
+EME playbacks have specialized decoding and rendering code paths, meaning
+different codec support and performance compared to clear playbacks. Hence a new
+`keySystemConfiguration` key must be set in the media configuration object
+passed to `navigator.mediaCapabilities.decodingInfo()`. The value of this key is
+a dictionary that holds a number of [well-known EME types]. This replicates the
+inputs provided to EME's `requestMediaKeySystemAccess()` with one major
+difference: sequences of inputs provided to `requestMediaKeySystemAccess()`
+are flattened to a single
+value wherever the intent of the sequence was to have `requestMediaKeySystemAccess()`
+choose a subset it supports.
+
+Decoding Info describes the quality (smoothness and power efficiency) of
+support for a single pair of audio and video streams without making a decision
+for the caller. Callers should still order media configurations as they do with
+`requestMediaKeySystemAccess()`. Only now they walk the list themselves.
+
+`navigator.mediaCapabilities.decodingInfo()` returns a promise that resolves
+asynchronously with an object containing three booleans: `supported`, `smooth`,
+and `powerEfficient`. However when a`keySystemConfiguration` key is set and
+`supported` is `true`, yet another `MediaKeySystemAccess` object named
+`keySystemAccess` is returned as well. It can be used to request some media keys
+and setup encrypted media playback. Here's an example:
+
+```js
+// Like rMSKA(), orderedMediaConfigs is ordered from most to least wanted.
+const capabilitiesPromises = orderedMediaConfigs.map(mediaConfig =>
+  navigator.mediaCapabilities.decodingInfo(mediaConfig)
+);
+
+// Assume this app wants a supported and smooth media playback.
+let bestConfig = null;
+for await (const result of capabilitiesPromises) {
+  if (result.supported && result.smooth) {
+    bestConfig = result;
+    break;
+  }
+}
+
+if (bestConfig) {
+  const mediaKeys = await bestConfig.keySystemAccess.createMediaKeys();
+  // TODO: rest of EME path as-is
+} else {
+  // Argh! No smooth configs found.
+  // TODO: Maybe choose the lowest resolution and framerate available.
+}
+```
+
+Note that Decoding Info for encrypted media requires HTTPS.
+
+Moreover, be aware that it may trigger a user prompt on Android and Chrome OS in
+the same way as `requestMediaKeySystemAccess()`. It won't show more prompts than
+`requestMediaKeySystemAccess()` though, in spite of
+requiring more calls to setup encrypted media playback.
+
+<figure>
+  {% Img src="image/vvhSqZboQoZZN9wBvoXq72wzGAf1/A8OGyLBIRDOqb6gxlWcj.jpeg", alt="ALT_TEXT_HERE", width="800", height="882" %}
+  <figcaption>
+    Protected content prompt
+  </figcaption>
+</figure>
+
+{% Aside %}
+To get feedback from web developers, this feature is available as an
+[Origin Trial] in Chrome 75. You will need to [request a token], so that the
+feature is automatically enabled for your origin for a limited period
+of time. 
+{% endAside %}
+
+[Intent to Experiment](https://groups.google.com/a/chromium.org/d/topic/blink-dev/eA9uG98td5U/discussion) &#124;
+[Chromestatus Tracker](https://www.chromestatus.com/feature/5765900795904000) &#124;
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=907909)
+
+## HTMLVideoElement.playsInline {: #playsinline}
+
+Chrome now supports the `playsInline` boolean attribute. If present, it hints to
+the browser that the video ought to be displayed "inline" in the document by
+default, constrained to the element's playback area.
+
+[Similarly] to Safari, where video elements on iPhone don't automatically enter
+fullscreen mode when playback begins, this hint allows some embedders to have an
+auto-fullscreen video playback experience. Web developers can use it to opt-out
+of this experience if needed.
+
+```html
+<video playsinline></video>
+```
+
+As Chrome on Android and Desktop don't implement auto-fullscreen, the
+`playsInline` video element attribute hint is not used.
+
+[Intent to Ship](https://groups.google.com/a/chromium.org/forum/#!msg/blink-dev/0TJyePKiegs/lgU0hLyyCwAJ) &#124;
+[Chromestatus Tracker](https://www.chromestatus.com/feature/5402804803862528) &#124;
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=943877)
+
+<!-- lint disable definition-case -->
+
+[Decoding Info]: /blog/media-updates-in-chrome-63-64#media-capabilities-decoding-info-api
+[Media Capabilities API]: https://wicg.github.io/media-capabilities
+[official sample]: https://googlechrome.github.io/samples/media-capabilities/decoding-info-eme
+[well-known EME types]: https://wicg.github.io/media-capabilities/#dictdef-mediacapabilitieskeysystemconfiguration
+[Origin Trial]: https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md
+[request a token]: https://developers.chrome.com/origintrials
+[Similarly]: https://webkit.org/blog/6784/new-video-policies-for-ios/


### PR DESCRIPTION
As discussed with @petele, this PR moves "Media updates in Chrome" posts from WebFundamentals found at https://developers.google.com/web/updates/tags/media to https://developer.chrome.com/blog/

I've checked all links in the articles and updated them when it made sense.

Once it's merged, I'll start a WebFundamentals PR to setup the automatic redirection so that https://developers.google.com/web/updates/2019/07/chrome-75-media-updates goes to https://developer.chrome.com/blog/media-updates-in-chrome-75/ and so on.