### PR TITLE
Add supported language links for blog post

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -30,6 +30,7 @@ const {Columns, Column} = require('./site/_shortcodes/Columns');
 const {Compare, CompareCaption} = require('./site/_shortcodes/Compare');
 const {Aside} = require('./site/_shortcodes/Aside');
 const includeRaw = require('./site/_shortcodes/includeRaw');
+const {LanguageList} = require('./site/_shortcodes/LanguageList');
 
 // Transforms
 const {domTransformer} = require('./site/_transforms/dom-transformer-pool');
@@ -127,6 +128,7 @@ module.exports = eleventyConfig => {
   eleventyConfig.addPairedShortcode('Compare', Compare);
   eleventyConfig.addPairedShortcode('CompareCaption', CompareCaption);
   eleventyConfig.addPairedShortcode('Aside', Aside);
+  eleventyConfig.addShortcode('LanguageList', LanguageList);
 
   // Add transforms
   eleventyConfig.addTransform('domTransformer', domTransformer);

--- a/site/_filters/urls.js
+++ b/site/_filters/urls.js
@@ -15,7 +15,7 @@
  */
 
 const path = require('path');
-const {defaultLocale} = require('../_data/site.json');
+const {defaultLocale, locales} = require('../_data/site.json');
 
 const absolute = url => {
   if (!path.isAbsolute(url)) {
@@ -45,6 +45,21 @@ const stripDefaultLocale = url => {
   return url;
 };
 
+const stripLocale = (url, supportedLocales = locales) => {
+  if (typeof url !== 'string') {
+    return url; // shows up for `permalink: false`
+  }
+
+  const urlLocale = supportedLocales.find(locale =>
+    url.startsWith(`/${locale}/`)
+  );
+
+  if (urlLocale) {
+    url = url.substring(`/${urlLocale}`.length);
+  }
+  return url;
+};
+
 const getLocalizedPaths = (urlPath, locales) => {
   const urlParts = urlPath.split('/');
   return locales.map(locale => {
@@ -59,5 +74,6 @@ module.exports = {
   trailingSlash,
   leadingAndTrailingSlash,
   stripDefaultLocale,
+  stripLocale,
   getLocalizedPaths,
 };

--- a/site/_includes/partials/post-headline.njk
+++ b/site/_includes/partials/post-headline.njk
@@ -12,9 +12,8 @@
     <span>•</span>
     Updated on <time>{{ helpers.formatDateLong(updated, locale) }}</time>
   {% endif %}
-  </p>
-  <p class="type--caption language-list">
-    Translated to: {% LanguageList page.url, site.locales, collections, locale %}
+  <br>
+  {% LanguageList page.url, site, collections, locale %}
   </p>
 </div>
 {% endif %}

--- a/site/_includes/partials/post-headline.njk
+++ b/site/_includes/partials/post-headline.njk
@@ -5,15 +5,18 @@
 {% endif %}
 
 {% if date %}
-<div class="dates">
-  <p class="type--caption">
+  <p class="type--caption color-secondary-text">
     Published on <time>{{ helpers.formatDateLong(date, locale) }}</time>
-  {% if updated %}
+    {% if updated %}
     <span>•</span>
     Updated on <time>{{ helpers.formatDateLong(updated, locale) }}</time>
   {% endif %}
-  <br>
-  {% LanguageList page.url, site, collections, locale %}
   </p>
-</div>
+{% endif %}
+
+{% set languageListHtml %}{% LanguageList page.url, site, collections, locale %}{% endset %}
+{% if languageListHtml %}
+<p class="type--caption color-secondary-text">
+  {{ languageListHtml | safe }}
+</p>
 {% endif %}

--- a/site/_includes/partials/post-headline.njk
+++ b/site/_includes/partials/post-headline.njk
@@ -13,5 +13,8 @@
     Updated on <time>{{ helpers.formatDateLong(updated, locale) }}</time>
   {% endif %}
   </p>
+  <p class="type--caption language-list">
+    Translated to: {% LanguageList page.url, site.locales, collections, locale %}
+  </p>
 </div>
 {% endif %}

--- a/site/_includes/partials/updated.njk
+++ b/site/_includes/partials/updated.njk
@@ -1,13 +1,11 @@
-<div class="dates">
-  <p class="type--caption">
-    {% if updated %}
-      Last updated: <time>{{ helpers.formatDateLong(updated, locale) }}</time>
-    {% elif date %}
-      Last updated: <time>{{ helpers.formatDateLong(date, locale) }}</time>
-      <span>•</span>
-    {% endif %}
-    <a href="{{ page.inputPath | githubLink }}">
-      Improve article
-    </a>
-  </p>
-</div>
+<p class="color-secondary-text type--caption">
+  {% if updated %}
+    Last updated: <time>{{ helpers.formatDateLong(updated, locale) }}</time>
+  {% elif date %}
+    Last updated: <time>{{ helpers.formatDateLong(date, locale) }}</time>
+    <span>•</span>
+  {% endif %}
+  <a href="{{ page.inputPath | githubLink }}">
+    Improve article
+  </a>
+</p>

--- a/site/_scss/blocks/_dates.scss
+++ b/site/_scss/blocks/_dates.scss
@@ -1,3 +1,0 @@
-.dates {
-  color: var(--color-secondary-text);
-}

--- a/site/_scss/blocks/_language-list.scss
+++ b/site/_scss/blocks/_language-list.scss
@@ -1,4 +1,0 @@
-.language-list a {
-  color: var(--color-secondary-text);
-  margin-inline-start: 3px;
-}

--- a/site/_scss/blocks/_language-list.scss
+++ b/site/_scss/blocks/_language-list.scss
@@ -1,0 +1,4 @@
+.language-list a {
+  color: var(--color-secondary-text);
+  margin-inline-start: 3px;
+}

--- a/site/_scss/main.scss
+++ b/site/_scss/main.scss
@@ -30,7 +30,6 @@
 @import 'blocks/side-nav';
 @import 'blocks/post-authors';
 @import 'blocks/card-authors';
-@import 'blocks/dates';
 @import 'blocks/project-icon';
 @import 'blocks/project-hero';
 @import 'blocks/project-sections';

--- a/site/_scss/main.scss
+++ b/site/_scss/main.scss
@@ -70,7 +70,6 @@
 @import 'blocks/logo';
 @import 'blocks/devtools';
 @import 'blocks/select-loader';
-@import 'blocks/language-list';
 
 // Utilities
 @import 'utilities/center-margin';

--- a/site/_scss/main.scss
+++ b/site/_scss/main.scss
@@ -70,6 +70,7 @@
 @import 'blocks/logo';
 @import 'blocks/devtools';
 @import 'blocks/select-loader';
+@import 'blocks/language-list';
 
 // Utilities
 @import 'utilities/center-margin';

--- a/site/_shortcodes/LanguageList.js
+++ b/site/_shortcodes/LanguageList.js
@@ -1,12 +1,11 @@
 const {findByUrl} = require('../_data/lib/find');
 const {getLocalizedPaths} = require('../_filters/urls');
-const path = require('path');
 
 /**
  * A map of supported language codes to their full names.
  * @const
  */
- const languageNames = {
+const languageNames = {
   en: 'English',
   pl: 'Polski',
   es: 'Español',
@@ -21,8 +20,9 @@ const path = require('path');
  * Outputs a list of <link hreflang=""> tags with alternate language versions
  * for the given url.
  * @param {string} url Current page url
- * @param {object} site Site object from _data/site.json
+ * @param {object} locales Site supported locales
  * @param {EleventyCollectionObject} collections Eleventy collections object
+ * @param {string} locale current locale
  */
 function LanguageList(url, locales, collections, locale = 'en') {
   if (!url) {

--- a/site/_shortcodes/LanguageList.js
+++ b/site/_shortcodes/LanguageList.js
@@ -8,7 +8,6 @@ const path = require('path');
  */
 const languageNames = {
   en: 'English',
-  pl: 'Polski',
   es: 'Español',
   ko: '한국어',
   zh: '中文',

--- a/site/_shortcodes/LanguageList.js
+++ b/site/_shortcodes/LanguageList.js
@@ -37,8 +37,8 @@ function LanguageList(url, site, collections, locale = 'en') {
   const links = hreflangs
     // eslint-disable-next-line no-unused-vars
     .filter(([_, code]) => code !== locale)
-    .map(([path, code]) => {
-      return `<a href="${path.join(site.url, path)}">${languageNames[code]}
+    .map(([urlPath, code]) => {
+      return `<a href="${path.join(site.url, urlPath)}">${languageNames[code]}
         (${code})</a>`;
     });
 

--- a/site/_shortcodes/LanguageList.js
+++ b/site/_shortcodes/LanguageList.js
@@ -1,0 +1,44 @@
+const {findByUrl} = require('../_data/lib/find');
+const {getLocalizedPaths} = require('../_filters/urls');
+const path = require('path');
+
+/**
+ * A map of supported language codes to their full names.
+ * @const
+ */
+ const languageNames = {
+  en: 'English',
+  pl: 'Polski',
+  es: 'Español',
+  ko: '한국어',
+  zh: '中文',
+  ru: 'Pусский',
+  pt: 'Português',
+  ja: '日本語',
+};
+
+/**
+ * Outputs a list of <link hreflang=""> tags with alternate language versions
+ * for the given url.
+ * @param {string} url Current page url
+ * @param {object} site Site object from _data/site.json
+ * @param {EleventyCollectionObject} collections Eleventy collections object
+ */
+function LanguageList(url, locales, collections, locale = 'en') {
+  if (!url) {
+    return;
+  }
+  const hreflangs = getLocalizedPaths(url, locales).filter(hreflang =>
+    findByUrl(collections.all, hreflang[0])
+  );
+  const links = hreflangs
+    // eslint-disable-next-line no-unused-vars
+    .filter(([_, code]) => code !== locale)
+    .map(hreflang => {
+      return `<a href="${hreflang[0]}">${languageNames[hreflang[1]]}
+        (${hreflang[1]})</a>`;
+    });
+  return links.length > 1 ? links.join(',') : '';
+}
+
+module.exports = {LanguageList};

--- a/site/_shortcodes/LanguageList.js
+++ b/site/_shortcodes/LanguageList.js
@@ -17,7 +17,7 @@ const languageNames = {
 };
 
 /**
- * Outputs a list of <link hreflang=""> tags with alternate language versions
+ * Outputs a list of <a href> tags with alternate language versions
  * for the given url.
  * @param {string} url Current page url
  * @param {object} site Site object
@@ -30,22 +30,22 @@ function LanguageList(url, site, collections, locale = 'en') {
   }
 
   const cleanUrl = stripLocale(url);
-  const hreflangs = getLocalizedPaths(cleanUrl, site.locales).filter(hreflang =>
-    findByUrl(collections.all, hreflang[0])
+  const hreflangs = getLocalizedPaths(cleanUrl, site.locales).filter(
+    ([urlPath]) => findByUrl(collections.all, urlPath)
   );
   const links = hreflangs
-    // eslint-disable-next-line no-unused-vars
-    .filter(([_, code]) => code !== locale)
+    .filter(([, code]) => code !== locale)
     .map(([urlPath, code]) => {
-      return `<a href="${path.join(site.url, urlPath)}">${languageNames[code]}
-        (${code})</a>`;
+      return `<a translate="no" lang="${code}"
+        href="${path.join(site.url, urlPath)}">
+        ${languageNames[code]}</a>`;
     });
 
   let html = '';
 
   if (links.length) {
     html = `<span class="language-list">Translated to:
-    ${links.join(',')}</span>`;
+    ${links.join(', ')}</span>`;
   }
   return html;
 }

--- a/tests/site/_filters/urls.js
+++ b/tests/site/_filters/urls.js
@@ -52,3 +52,27 @@ test('getLocalizedPaths supports paths deeper than 2', t => {
   ];
   t.deepEqual(actual, expected);
 });
+
+test('stripLocale return url as is if no locale found', t => {
+  const path = '/someurl/someurl';
+  const locales = ['en', 'zh', 'de'];
+  const actual = urls.stripLocale(path, locales);
+  const expected = '/someurl/someurl';
+  t.assert(actual === expected);
+});
+
+test('stripLocale strip local if found', t => {
+  const path = '/zh/someurl';
+  const locales = ['en', 'zh', 'de'];
+  const actual = urls.stripLocale(path, locales);
+  const expected = '/someurl';
+  t.assert(actual === expected);
+});
+
+test('stripLocale strip only one locale if found', t => {
+  const path = '/zh/en/someurl';
+  const locales = ['en', 'zh', 'de'];
+  const actual = urls.stripLocale(path, locales);
+  const expected = '/en/someurl';
+  t.assert(actual === expected);
+});


### PR DESCRIPTION
Fixes #1358

There are a few points which I am not sure what is the best way to deal with it:
1. The current implement is using shortcode, but it could be a web component. The code is similar to `LanguageSelect` component in the `webdev-infra` project. Let me know if web component is preferred (locally in the project or put it in `webdev-infra`)
1. The supported language names are currently hardcoded in `webdev-infra/LanguageSelect`. I did the same now in my shortcode file. Ideally we should export it from the `webdev-infra` or put it in a global variable file... said `_data/site.json`?
1. For localized url that isn't english, I am not able to use relative path in href.  (e.g. if current locale = "es", this link`<a href="/ja/url">` will redirect to `/es/ja/url`. I am using absolute path now as a workaround. Any better option for this?

Test pages:
1. Page with no translation available: http://localhost:8080/blog/new-in-devtools-91/
2. English page with translation: http://localhost:8080/blog/new-in-devtools-93/
3. Translated page in Spanish: http://localhost:8080/es/blog/new-in-devtools-93/

<img width="1335" alt="Screen Shot 2021-09-10 at 4 20 50 PM" src="https://user-images.githubusercontent.com/5917927/132825981-37fcd33b-759e-4504-94d9-d72421e7a353.png">