### PR TITLE
Add newline to Asides so markdown works

### DIFF
--- a/site/_shortcodes/Aside.js
+++ b/site/_shortcodes/Aside.js
@@ -53,6 +53,7 @@ function Aside(content, type = 'note') {
   // newline between it and the opening div or markdown-it will insert an extra
   // closing </div> if the Aside is used inside of a markdown definition list.
   return `<div class="aside aside--${type}">${ type !== 'note' ? `<div class="aside__label gap-bottom-300">${icons[type]}<span>${text}</span></div>` : ''}
+
 ${content}</div>`;
 }
 


### PR DESCRIPTION
Markdown links in Asides were not working, as reporting by our translation vendor. This fixes that by adding a new line after the opening div so the markdown parser will kick back in.