### PR TITLE
Add missing URL for 'session cookies' link

### DIFF
--- a/site/en/docs/devtools/storage/cookies/index.md
+++ b/site/en/docs/devtools/storage/cookies/index.md
@@ -79,4 +79,5 @@ cookies.
 
 [1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies
 [2]: /docs/devtools/open
+[6]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_the_lifetime_of_a_cookie
 [10]: https://bugs.chromium.org/p/chromium/issues/detail?id=232693


### PR DESCRIPTION
Fixes #1384 

Changes proposed in this pull request:

- Adds url definition for [6] in template representing 'session cookies' 

Note: I wasn't entirely sure where the original link was pointing to, so I grabbed one I thought kinda worked and we can go from there, swapping it out for the correct link if need be.