### PR TITLE
fix URL switcher links were being mangled

### DIFF
--- a/site/_data/i18n/common.yml
+++ b/site/_data/i18n/common.yml
@@ -144,3 +144,12 @@ release_dev:
 
 release_canary:
   en: 'Canary'
+
+translated_to:
+  en: 'Translated to:'
+
+published_on:
+  en: 'Published on'
+
+updated_on:
+  en: 'Updated on'

--- a/site/_filters/urls.js
+++ b/site/_filters/urls.js
@@ -45,6 +45,10 @@ const stripDefaultLocale = url => {
   return url;
 };
 
+/**
+ * @param {string} url
+ * @param {string[]} supportedLocales
+ */
 const stripLocale = (url, supportedLocales = locales) => {
   if (typeof url !== 'string') {
     return url; // shows up for `permalink: false`
@@ -60,6 +64,10 @@ const stripLocale = (url, supportedLocales = locales) => {
   return url;
 };
 
+/**
+ * @param {string} urlPath
+ * @param {string[]} locales
+ */
 const getLocalizedPaths = (urlPath, locales) => {
   const urlParts = urlPath.split('/');
   return locales.map(locale => {

--- a/site/_includes/partials/post-headline.njk
+++ b/site/_includes/partials/post-headline.njk
@@ -6,10 +6,12 @@
 
 {% if date %}
   <p class="type--caption color-secondary-text">
-    Published on <time>{{ helpers.formatDateLong(date, locale) }}</time>
+    {{ 'i18n.common.published_on' | i18n(locale) }}
+    <time>{{ helpers.formatDateLong(date, locale) }}</time>
     {% if updated %}
     <span>•</span>
-    Updated on <time>{{ helpers.formatDateLong(updated, locale) }}</time>
+    {{ 'i18n.common.updated_on' | i18n(locale) }}
+    <time>{{ helpers.formatDateLong(updated, locale) }}</time>
   {% endif %}
   </p>
 {% endif %}
@@ -17,6 +19,7 @@
 {% set languageListHtml %}{% LanguageList page.url, site, collections, locale %}{% endset %}
 {% if languageListHtml %}
 <p class="type--caption color-secondary-text">
+  {{ 'i18n.common.translated_to' | i18n(locale) }}
   {{ languageListHtml | safe }}
 </p>
 {% endif %}

--- a/site/_shortcodes/LanguageList.js
+++ b/site/_shortcodes/LanguageList.js
@@ -28,6 +28,8 @@ function LanguageList(url, site, collections, locale = 'en') {
     return;
   }
 
+  // getLocalizedPath also implicitly strips any locale prefix, but get the clean URL here first
+  // anyway: we want all options, and this makes it clearer to future readers.
   const cleanUrl = stripLocale(url);
   const hreflangs = getLocalizedPaths(cleanUrl, site.locales).filter(
     ([urlPath]) => findByUrl(collections.all, urlPath)

--- a/site/_shortcodes/LanguageList.js
+++ b/site/_shortcodes/LanguageList.js
@@ -1,6 +1,5 @@
 const {findByUrl} = require('../_data/lib/find');
 const {getLocalizedPaths, stripLocale} = require('../_filters/urls');
-const path = require('path');
 
 /**
  * A map of supported language codes to their full names.
@@ -36,18 +35,10 @@ function LanguageList(url, site, collections, locale = 'en') {
   const links = hreflangs
     .filter(([, code]) => code !== locale)
     .map(([urlPath, code]) => {
-      return `<a translate="no" lang="${code}"
-        href="${path.join(site.url, urlPath)}">
-        ${languageNames[code]}</a>`;
+      return `<a translate="no" lang="${code}" href="${urlPath}">${languageNames[code]}</a>`;
     });
 
-  let html = '';
-
-  if (links.length) {
-    html = `<span class="language-list">Translated to:
-    ${links.join(', ')}</span>`;
-  }
-  return html;
+  return links.join(', ');
 }
 
 module.exports = {LanguageList};

--- a/site/_transforms/pretty-urls.js
+++ b/site/_transforms/pretty-urls.js
@@ -69,6 +69,11 @@ const prettyUrls = ($, outputPath, locale) => {
   $links.each((_, elem) => {
     const $link = $(elem);
 
+    // This is a cross-language link, so don't try to "fix" it, which causes invalid URLs.
+    if ($link.attr('translate') === 'no') {
+      return;
+    }
+
     const href = $link.attr('href');
     if (!href && !$link.attr('id')) {
       console.warn(


### PR DESCRIPTION
The "Translated to:" links were being mangled in a few ways:
- They had a "developer.chrome.com" pathname prefix, which made no sense (the fallback redirect code took over)
- We tried to normalize language code links, disabled now for links marked with `translate="no"`

This also puts some meta strings up for translation ("Translated to:" and so on).