### PR TITLE
fix post breadcrumbs for 'es'

### DIFF
--- a/site/_data/i18n/tags.yml
+++ b/site/_data/i18n/tags.yml
@@ -87,6 +87,7 @@ devtools:
 
 new-in-devtools:
   en: What's New in DevTools
+  es: Qué hay de nuevo en DevTools
 
 devtools-engineering:
   en: DevTools Engineering

--- a/site/es/blog/blog.11tydata.js
+++ b/site/es/blog/blog.11tydata.js
@@ -1,0 +1,3 @@
+module.exports = {
+  type: 'blogPost',
+};

--- a/site/es/blog/index.md
+++ b/site/es/blog/index.md
@@ -5,6 +5,6 @@ permalink: '{{locale}}/blog/{% if pagination.pageNumber > 0 %}{{ pagination.page
 layout: 'layouts/blog-landing.njk'
 type: landing
 pagination:
-  data: collections.blog-en
+  data: collections.blog-es
   size: 24
 ---

--- a/site/es/tags/index.md
+++ b/site/es/tags/index.md
@@ -1,0 +1,6 @@
+---
+title: 'Tags'
+description: 'Find blog posts tagged to a certain feature'
+permalink: '{{locale}}/tags/index.html'
+layout: 'layouts/tags-landing.njk'
+---

--- a/site/es/tags/tag/index.md
+++ b/site/es/tags/tag/index.md
@@ -1,0 +1,10 @@
+---
+title: 'Tags'
+permalink: '{{paged.permalink}}'
+layout: 'layouts/tag-landing.njk'
+pagination:
+  data: collections.tags
+  size: 1
+  alias: paged
+  resolve: values
+---

--- a/site/es/tags/tag/tag.11tydata.js
+++ b/site/es/tags/tag/tag.11tydata.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const {locale} = require('../../es.11tydata');
+const tag11tyData = require('../../../_utils/tag-11tydata');
+
+module.exports = tag11tyData(locale);

--- a/site/es/tags/tags.11tydata.js
+++ b/site/es/tags/tags.11tydata.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const {locale} = require('../es.11tydata');
+const tags11tyData = require('../../_utils/tags-11tydata');
+
+module.exports = tags11tyData(locale);

--- a/tests/site/_data/lib/breadcrumbs.js
+++ b/tests/site/_data/lib/breadcrumbs.js
@@ -17,6 +17,11 @@ function virtualItem(title, project_key) {
   };
 }
 
+/**
+ * @param {(path: string) => EleventyCollectionItem|undefined} callback
+ * @param {string} url
+ * @param {AllProjectIndex} index
+ */
 function run(callback, url, index) {
   const builder = new BreadcrumbBuilder(url => {
     url = path.join(url, '/');
@@ -25,6 +30,21 @@ function run(callback, url, index) {
   buildAllBreadcrumbs(url, builder, index);
   return builder.build(url);
 }
+
+test('i18n URLs', t => {
+  const lookup = url => {
+    switch (url) {
+      case '/en/':
+        return virtualItem('Top');
+      case '/pt/blog/':
+        return virtualItem('Blog');
+      case '/pt/blog/article/':
+        return virtualItem('Article');
+    }
+  };
+
+  t.deepEqual(run(lookup, '/pt/blog/article'), [{title: 'Blog', url: '..'}]);
+});
 
 test('real URLs only', t => {
   const lookup = url => {


### PR DESCRIPTION
Technically fixes #1393 for 'es', but not in the general case.

This will create "/es/tags" and "/es/blog", but not for all languages (just did 'es' as a demo). There's some open questions here:

- 11ty doesn't allow us to programatically generate these pages: we have to just add this for every supported lang, is that fine? (cc @devnook who has worked on i18n content on web.dev)
- should the blog/tags include all posts, even untranslated ones? (cc @chybie and @MichaelSolati who have opinions)
- the feed links are broken (we only generate feeds for English)—is this important?

In general I'm of the view that we will never have full coverage, so it's responsible of us to basically show English fallback content wherever possible.