### PR TITLE
Chrome label fixes

### DIFF
--- a/site/_data/i18n/common.yml
+++ b/site/_data/i18n/common.yml
@@ -134,7 +134,7 @@ current_release_label:
   en: 'Current stable version'
 
 pending_release_label:
-  en: 'Upcoming stable version'
+  en: 'Imminent stable version'
 
 future_release_label:
   en: 'Beta will promote to stable on'

--- a/site/_data/i18n/common.yml
+++ b/site/_data/i18n/common.yml
@@ -124,11 +124,17 @@ older_releases:
 current_release_description:
   en: 'The current stable version of Chrome is'
 
+pending_release_description:
+  en: 'The imminent stable version of Chrome is'
+
 future_release_description:
   en: 'The current beta version of Chrome is'
 
 current_release_label:
   en: 'Current stable version'
+
+pending_release_label:
+  en: 'Upcoming stable version'
 
 future_release_label:
   en: 'Beta will promote to stable on'
@@ -138,12 +144,6 @@ release_stable:
 
 release_beta:
   en: 'Beta'
-
-release_dev:
-  en: 'Dev'
-
-release_canary:
-  en: 'Canary'
 
 translated_to:
   en: 'Translated to:'

--- a/site/_includes/layouts/tags-landing.njk
+++ b/site/_includes/layouts/tags-landing.njk
@@ -21,13 +21,13 @@
   <div class="tag-card__header gap-bottom-600">
     <h2 class="type--label color-secondary-text case-upper">{{ 'i18n.nav.side_nav.releases' | i18n(locale) }}</h2>
     <ul role="list" class="pad-0 gap-top-300 gap-bottom-0">
-      {% for tag in namedChromeReleaseTags %}
+      {% for tag in currentChromeReleaseTags %}
         {{ renderTag(tag) }}
       {% endfor %}
       <select-loader>
         <select class="type--label gap-top-300 gap-bottom-300 color-primary">
           <option disabled selected>{{ 'i18n.common.older_releases' | i18n(locale) }}</option>
-          {% for tag in chromeReleaseTags %}
+          {% for tag in historicChromeReleaseTags %}
             <option href="{{ helpers.join('/', locale, 'tags', tag.key, '/') }}">{{ tag.title }}</option>
           {% endfor %}
         </select>

--- a/site/_includes/macros/cards/releases-card.njk
+++ b/site/_includes/macros/cards/releases-card.njk
@@ -20,6 +20,17 @@
         {{ 'i18n.common.current_release_label' | i18n(locale) }}
       </p>
     </div>
+    {% if chrome.channels.pending %}
+      <div class="flex-1 gap-300">
+        <div class="release-card__icon release-card__icon-pending">
+          <span class="visually-hidden">{{ 'i18n.common.pending_release_description' | i18n(locale) }}</span>
+          {{ chrome.channels.pending.mstone }}
+        </div>
+        <p class="type--caption text-align-center gap-top-300">
+          {{ 'i18n.common.pending_release_label' | i18n(locale) }}
+        </p>
+      </div>
+    {% endif %}
     <div class="flex-1 gap-300">
       <div class="release-card__icon release-card__icon-beta">
         <span class="visually-hidden">{{ 'i18n.common.future_release_description' | i18n(locale) }}</span>

--- a/site/_includes/macros/tag.njk
+++ b/site/_includes/macros/tag.njk
@@ -5,7 +5,6 @@
   "Chrome [version]".
 #}
 {% if item.startsWith('chrome-') %}
-  {% set item = 'chrome' %}
   {% set title = item | replace('-', ' ') | capitalize %}
 {% else %}
   {% set title = ('i18n.tags.' + item) | i18n(locale) %}

--- a/site/_scss/blocks/_release-card.scss
+++ b/site/_scss/blocks/_release-card.scss
@@ -17,6 +17,11 @@
   }
 }
 
+.release-card__icon-pending {
+  background: var(--color-yellow-lighter);
+  color: var(--color-yellow-darkest);
+}
+
 .release-card__icon-beta {
   background: var(--color-blue-lighter);
   color: var(--color-blue-darkest);

--- a/site/_utils/tags-11tydata.js
+++ b/site/_utils/tags-11tydata.js
@@ -27,68 +27,56 @@ const {i18n} = require('../_filters/i18n');
  */
 module.exports = locale => ({
   eleventyComputed: {
-    /**
-     * Generates tags for the current named releases: Stable, Beta, and so on. Ordered by earliest
-     * release first (i.e., 'Stable' > 'Beta' > 'Dev' > 'Canary').
-     */
-    namedChromeReleaseTags: data => {
+    releaseTags: data => {
+      /** @type {{[name: string]: ChromeReleaseData}} */
       const rawChannels = data.chrome.channels;
 
       /** @type {Tags} */
       const rawTags = data.collections.tags;
 
-      const all = [];
-
-      for (const [name, data] of Object.entries(rawChannels)) {
-        // name = 'stable', 'beta' etc
-        const release = data.mstone;
-        if (typeof release !== 'number') {
-          throw new Error(`exepected release number, was: ${release}`);
-        }
-
-        // If there's no posts for this named release, skip.
-        const key = `chrome-${release}`;
-        const tag = rawTags[key];
-        if (!tag?.posts[locale].length) {
-          continue;
-        }
-
-        all.push({
-          key: `chrome-${release}`,
-          posts: tag.posts[locale],
-          title: i18n('i18n.common.release_' + name, locale),
-          release,
-        });
-      }
-
-      // Sort lowest release first.
-      all.sort(({release: a}, {release: b}) => a - b);
-
-      return all;
-    },
-
-    chromeReleaseTags: data => {
-      /** @type {Tags} */
-      const rawTags = data.collections.tags;
-
       // Create an array of tags releated to releases.
-      const all = Object.values(rawTags)
+      const out = Object.values(rawTags)
         .filter(tag => tag.release)
         .map(tag => {
           const release = /** @type {number} */ (tag.release);
+          let title = `Chrome ${release}`;
+
+          if (rawChannels.stable.mstone === release) {
+            title = i18n('i18n.common.release_stable', locale);
+          } else if (rawChannels.beta.mstone === release) {
+            title = i18n('i18n.common.release_stable', locale);
+          }
+
           return {
             key: tag.key,
             posts: tag.posts[locale] ?? [],
-            title: `Chrome ${release}`,
+            title,
             release,
+            isCurrent: release >= rawChannels.stable.mstone,
           };
         });
 
       // Sort highest release first.
-      all.sort(({release: a}, {release: b}) => b - a);
+      out.sort(({release: a}, {release: b}) => b - a);
 
-      // Only return if there's locale-valid posts.
-      return all.filter(tag => tag.posts.length);
+      return out;
+    },
+
+    /**
+     * Generates tags for the stable release and higher. Ordered by earliest release first (i.e.,
+     * 'Stable' > 'Beta' > 'Dev' > 'Canary'). Only names 'Stable' and 'Beta'.
+     */
+    currentChromeReleaseTags: data => {
+      const out = (data.releaseTags || []).filter(({isCurrent}) => isCurrent);
+      out.reverse();
+      return out;
+    },
+
+    /**
+     * Return tag information for any Chrome release prior to the current stable.
+     */
+    historicChromeReleaseTags: data => {
+      return (data.releaseTags || []).filter(({isCurrent}) => !isCurrent);
     },
 
     displayTags: data => {

--- a/site/_utils/tags-11tydata.js
+++ b/site/_utils/tags-11tydata.js
@@ -41,10 +41,11 @@ module.exports = locale => ({
           const release = /** @type {number} */ (tag.release);
           let title = `Chrome ${release}`;
 
+          // Only name 'stable' and 'beta' releases.
           if (rawChannels.stable.mstone === release) {
             title = i18n('i18n.common.release_stable', locale);
           } else if (rawChannels.beta.mstone === release) {
-            title = i18n('i18n.common.release_stable', locale);
+            title = i18n('i18n.common.release_beta', locale);
           }
 
           return {

--- a/site/_utils/tags-11tydata.js
+++ b/site/_utils/tags-11tydata.js
@@ -27,6 +27,23 @@ const {i18n} = require('../_filters/i18n');
  */
 module.exports = locale => ({
   eleventyComputed: {
+    /**
+     * Generates tags for the stable release and higher. Ordered by earliest release first (i.e.,
+     * 'Stable' > 'Beta' > 'Dev' > 'Canary'). Only names 'Stable' and 'Beta'.
+     */
+    currentChromeReleaseTags: data => {
+      const out = (data.releaseTags || []).filter(({isCurrent}) => isCurrent);
+      out.reverse();
+      return out;
+    },
+
+    /**
+     * Return tag information for any Chrome release prior to the current stable.
+     */
+    historicChromeReleaseTags: data => {
+      return (data.releaseTags || []).filter(({isCurrent}) => !isCurrent);
+    },
+
     releaseTags: data => {
       /** @type {{[name: string]: ChromeReleaseData}} */
       const rawChannels = data.chrome.channels;
@@ -61,23 +78,6 @@ module.exports = locale => ({
       out.sort(({release: a}, {release: b}) => b - a);
 
       return out;
-    },
-
-    /**
-     * Generates tags for the stable release and higher. Ordered by earliest release first (i.e.,
-     * 'Stable' > 'Beta' > 'Dev' > 'Canary'). Only names 'Stable' and 'Beta'.
-     */
-    currentChromeReleaseTags: data => {
-      const out = (data.releaseTags || []).filter(({isCurrent}) => isCurrent);
-      out.reverse();
-      return out;
-    },
-
-    /**
-     * Return tag information for any Chrome release prior to the current stable.
-     */
-    historicChromeReleaseTags: data => {
-      return (data.releaseTags || []).filter(({isCurrent}) => !isCurrent);
     },
 
     displayTags: data => {

--- a/site/en/releases/index.md
+++ b/site/en/releases/index.md
@@ -9,8 +9,6 @@ i18n:
   channels:
     stable: Stable
     beta: Beta
-    canary: Canary
-    dev: Dev
   channel_title: Channel
   release_title: Release
   stabledate_title: Stable Date

--- a/tests/site/_data/chrome.js
+++ b/tests/site/_data/chrome.js
@@ -15,15 +15,6 @@ const testOmahaProxyData = [
       },
     ],
   },
-  {
-    os: 'linux',
-    versions: [
-      {
-        channel: 'beta',
-        version: '43.1.1234.8',
-      },
-    ],
-  },
 ];
 
 test.before(() => {
@@ -54,7 +45,14 @@ test('returns version information', async t => {
 
   setCacheForTest(
     'https://chromiumdash.appspot.com/fetch_milestone_schedule?mstone=43',
-    {} // set an empty value for 43, discarded by client
+    {
+      mstones: [
+        {
+          mstone: 43,
+          stable_date: '2020-02-01T00:00:00',
+        },
+      ],
+    }
   );
 
   const actual = await buildVersionInformation();
@@ -64,6 +62,11 @@ test('returns version information', async t => {
         key: 'stable',
         mstone: 42,
         stableDate: new Date('2020-01-01T00:00:00'),
+      },
+      beta: {
+        key: 'beta',
+        mstone: 43,
+        stableDate: new Date('2020-02-01T00:00:00'),
       },
     },
   };


### PR DESCRIPTION
Fixes #1380.

Also, makes sure that we show any "imminent" release that occurs while `beta == stable + 2`, which happened recently because of the release schedule shift, but could happen again.