### PR TITLE
fix typo in What's new in Lighthouse 8.4

### DIFF
--- a/site/en/blog/lighthouse-8-4/index.md
+++ b/site/en/blog/lighthouse-8-4/index.md
@@ -21,6 +21,7 @@ To try the Lighthouse Node CLI, use the following commands:
 ```text
 npm install -g lighthouse
 lighthouse https://www.example.com --view
+```
 
 ### Don't lazy-load Largest Contentful Paint images {: #new-audit-lazy-lcp }
 


### PR DESCRIPTION
a codeblock wasn't closed in the change added in https://github.com/GoogleChrome/developer.chrome.com/pull/1367#pullrequestreview-751242211

sorry, should have caught this before submitting!