### PR TITLE
Add note about cloning underneath 'Clone the repo' heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Version Manager (nvm)](https://github.com/nvm-sh/nvm).
 
 ### Clone the repo
 
+⚠️ If you'd like to contribute (and you're not a member of the core team), be sure to fork the repo first, and clone the fork.
+
 ```bash
 git clone https://github.com/GoogleChrome/developer.chrome.com.git
 ```


### PR DESCRIPTION
Fixes #1385 

Changes proposed in this pull request:

- Add note under "Clone the repo" heading in README.md