### PR TITLE
fix changelog link and h2 title in lighthouse post

### DIFF
--- a/site/en/blog/lighthouse-8-4/index.md
+++ b/site/en/blog/lighthouse-8-4/index.md
@@ -23,7 +23,11 @@ npm install -g lighthouse
 lighthouse https://www.example.com --view
 ```
 
-## Don't lazy-load Largest Contentful Paint images {: #new-audit-lazy-lcp }
+See the full list of changes in the [8.4 changelog](https://github.com/GoogleChrome/lighthouse/releases/tag/v8.4.0).
+
+## New audits
+
+### Don't lazy-load Largest Contentful Paint images {: #new-audit-lazy-lcp }
 
 Lazy-loading images can be an effective way to defer offscreen images so they don't interfere with loading the content that is [above the fold](https://web-dev.imgix.net/image/admin/t3Kkvh265zi6naTBga41.png?auto=format&w=845).
 


### PR DESCRIPTION
fixes some issues introduced by the Github suggestion UI messing up https://github.com/GoogleChrome/developer.chrome.com/pull/1367#discussion_r706051221. If you edit the comment to see the full suggestion you'll see the changelog and "New audits" heading are still in there, but the three backticks prematurely closed the suggestion and so those got cut off.

This fixes the h2/h3 nesting issue noticed in #1405 (and fixed a different way in #1406) and adds back the link to the full lighthouse changelog.