### PR TITLE
move to web-dev-uploads

### DIFF
--- a/site/_data/site.json
+++ b/site/_data/site.json
@@ -2,8 +2,8 @@
   "title": "Chrome Developers",
   "description": "Build the next generation of web experiences.",
   "url": "https://developer.chrome.com",
-  "imgixDomain": "developer-chrome-com.imgix.net",
-  "bucket": "chrome-gcs-uploader.appspot.com",
+  "imgixDomain": "wd.imgix.net",
+  "bucket": "web-dev-uploads",
   "repo": "https://github.com/GoogleChrome/developer.chrome.com/",
   "locales": [
     "en",

--- a/site/_data/tweets.js
+++ b/site/_data/tweets.js
@@ -2,6 +2,8 @@ require('dotenv').config();
 const CacheAsset = require('@11ty/eleventy-cache-assets');
 const escapeStringRegexp = require('escape-string-regexp');
 
+// nb. All images and uploaded assets are in the web-dev-uploads bucket, but tweets are still in
+// the default project bucket.
 const url =
   'https://storage.googleapis.com/chrome-gcs-uploader.appspot.com/tweets.json';
 

--- a/site/en/docs/extensions/mv2/getstarted/index.md
+++ b/site/en/docs/extensions/mv2/getstarted/index.md
@@ -434,7 +434,7 @@ What's next?
 [3]: /options
 [4]: /user_interface
 [5]: /docs/
-[6]: https://storage.googleapis.com/chrome-gcs-uploader.appspot.com/file/WlD8wC6g8khYWPJUsQceQkhXSlv1/n7V7IbH6D6gqNCV7Kp5t.zip "get_started_complete.zip"
+[6]: https://storage.googleapis.com/web-dev-uploads/file/WlD8wC6g8khYWPJUsQceQkhXSlv1/n7V7IbH6D6gqNCV7Kp5t.zip "get_started_complete.zip"
 [7]: /docs/extensions/mv2/manifest
 [9]: /background_pages
 [11]: /runtime#event-onInstalled
@@ -443,7 +443,7 @@ What's next?
 [14]: /user_interface
 [15]: /user_interface#popup
 [17]: /pageAction
-[18]: https://storage.googleapis.com/chrome-gcs-uploader.appspot.com/file/WlD8wC6g8khYWPJUsQceQkhXSlv1/qwlTyQ1ah3RmqsgDhRkL.zip "images.zip"
+[18]: https://storage.googleapis.com/web-dev-uploads/file/WlD8wC6g8khYWPJUsQceQkhXSlv1/qwlTyQ1ah3RmqsgDhRkL.zip "images.zip"
 [19]: /user_interface#icons
 [20]: /declarativeContent
 [21]: /declarativeContent

--- a/site/en/docs/extensions/mv2/overview/index.md
+++ b/site/en/docs/extensions/mv2/overview/index.md
@@ -124,7 +124,7 @@ or by pressing `Ctrl+Shift+F` on your keyboard.
 [6]: /docs/webstore
 [7]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/mv2-archive/tutorials/hello_extensions
 [8]: /docs/extensions/reference/browserAction
-[9]: https://storage.googleapis.com/chrome-gcs-uploader.appspot.com/image/WlD8wC6g8khYWPJUsQceQkhXSlv1/gmKIT88Ha1z8VBMJFOOH.png
+[9]: https://storage.googleapis.com/web-dev-uploads/image/WlD8wC6g8khYWPJUsQceQkhXSlv1/gmKIT88Ha1z8VBMJFOOH.png
 [10]: /docs/extensions/mv2/getstarted
 [11]: /docs/extensions/mv2/overview
 [12]: https://blog.chromium.org/

--- a/site/en/docs/extensions/mv2/tut_debugging/index.md
+++ b/site/en/docs/extensions/mv2/tut_debugging/index.md
@@ -196,7 +196,7 @@ For further information on debugging extensions, watch [Developing and Debugging
 about [Chrome Devtools][14] by reading the documentation.
 
 [1]: https://developers.google.com/web/tools/chrome-devtools/
-[2]: https://storage.googleapis.com/chrome-gcs-uploader.appspot.com/file/WlD8wC6g8khYWPJUsQceQkhXSlv1/KZdyzIighjOsDUPaibEn.zip "broken_background_color.zip"
+[2]: https://storage.googleapis.com/web-dev-uploads/file/WlD8wC6g8khYWPJUsQceQkhXSlv1/KZdyzIighjOsDUPaibEn.zip "broken_background_color.zip"
 [3]: /docs/extensions/reference/runtime#event-onInstalled
 [4]: /docs/extensions/reference/tabs#method-query
 [5]: /docs/extensions/mv2/override

--- a/site/en/docs/extensions/mv3/getstarted/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/index.md
@@ -447,13 +447,13 @@ What's next?
 [2]: /docs/extensions/mv3/content_scripts
 [3]: /docs/extensions/mv3/options
 [4]: /docs/extensions/mv3/user_interface
-[6]: https://storage.googleapis.com/chrome-gcs-uploader.appspot.com/file/WlD8wC6g8khYWPJUsQceQkhXSlv1/SVxMBoc5P3f6YV3O7Xbu.zip
+[6]: https://storage.googleapis.com/web-dev-uploads/file/WlD8wC6g8khYWPJUsQceQkhXSlv1/SVxMBoc5P3f6YV3O7Xbu.zip
 [7]: /docs/extensions/mv3/manifest
 [11]: /docs/extensions/reference/runtime#event-onInstalled
 [12]: /docs/extensions/reference/storage
 [15]: /docs/extensions/mv3/user_interface#popup
 [17]: /docs/extensions/reference/action
-[18]: https://storage.googleapis.com/chrome-gcs-uploader.appspot.com/file/WlD8wC6g8khYWPJUsQceQkhXSlv1/wy3lvPQdeJn4iqHmI0Rp.zip
+[18]: https://storage.googleapis.com/web-dev-uploads/file/WlD8wC6g8khYWPJUsQceQkhXSlv1/wy3lvPQdeJn4iqHmI0Rp.zip
 [19]: /docs/extensions/mv3/user_interface#icons
 [20]: /docs/extensions/reference/declarativeContent
 [24]: /docs/extensions/mv3/content_scripts/#programmatic

--- a/site/en/docs/extensions/mv3/overview/index.md
+++ b/site/en/docs/extensions/mv3/overview/index.md
@@ -194,6 +194,6 @@ or by pressing `Ctrl+Shift+F` on your keyboard.
 [extension samples]: https://github.com/GoogleChrome/chrome-extensions-samples
 [getstarted-tut]: /docs/extensions/mv3/getstarted
 [hello-sample]: /docs/extensions/mv3/samples#search:hello
-[hello-uploader]: https://storage.googleapis.com/chrome-gcs-uploader.appspot.com/image/WlD8wC6g8khYWPJUsQceQkhXSlv1/gmKIT88Ha1z8VBMJFOOH.png
+[hello-uploader]: https://storage.googleapis.com/web-dev-uploads/image/WlD8wC6g8khYWPJUsQceQkhXSlv1/gmKIT88Ha1z8VBMJFOOH.png
 [similar-pages-extension]: https://chrome.google.com/webstore/detail/google-similar-pages/pjnfggphgdjblhfjaphkjhfpiiekbbej
 [single purpose]: /docs/extensions/mv3/single_purpose

--- a/site/en/docs/handbook/how-to/add-media/index.md
+++ b/site/en/docs/handbook/how-to/add-media/index.md
@@ -8,14 +8,13 @@ updated: 2021-03-11
 
 ## Navigate to the media uploader
 
-Visit [the image uploader page](https://chrome-gcs-uploader.web.app/) and
+Visit [the image uploader page](https://web-dev-uploads.web.app/) and
 sign-in using your Google corporate account. Note that this page only allows
 Googlers access, so signing in with a personal account will fail.
 
 {% Aside 'caution' %}
-There are different uploaders for developer.chrome.com and web.dev:
-* [developer.chrome.com uploader](https://chrome-gcs-uploader.web.app/)
-* [web.dev uploader](https://web-dev-uploads.web.app/uploader)
+Prior to September 2021, there were different uploaders for developer.chrome.com and web.dev.
+Now, all assets are uploaded through the single uploader.
 {% endAside %}
 
 ## Choose a file

--- a/site/en/docs/handbook/how-to/add-media/index.md
+++ b/site/en/docs/handbook/how-to/add-media/index.md
@@ -12,9 +12,10 @@ Visit [the image uploader page](https://web-dev-uploads.web.app/) and
 sign-in using your Google corporate account. Note that this page only allows
 Googlers access, so signing in with a personal account will fail.
 
-{% Aside 'caution' %}
+{% Aside %}
 Prior to September 2021, there were different uploaders for developer.chrome.com and web.dev.
 Now, all assets are uploaded through the single uploader.
+This means you can migrate content between the sites and use the same sources.
 {% endAside %}
 
 ## Choose a file

--- a/site/en/docs/handbook/how-to/add-media/index.md
+++ b/site/en/docs/handbook/how-to/add-media/index.md
@@ -14,7 +14,7 @@ Googlers access, so signing in with a personal account will fail.
 
 {% Aside %}
 Prior to September 2021, there were different uploaders for developer.chrome.com and web.dev.
-Now, all assets are uploaded through the single uploader.
+Now, all assets are uploaded through a single uploader.
 This means you can migrate content between the sites and use the same sources.
 {% endAside %}
 

--- a/site/en/docs/webstore/branding/index.md
+++ b/site/en/docs/webstore/branding/index.md
@@ -137,14 +137,14 @@ Use of this trademark is subject to Google Permissions.
 [6]: /docs/webstore/terms/
 [7]: https://www.google.com/permissions/trademark/
 [8]: https://www.google.com/permissions/
-[10]: https://storage.googleapis.com/chrome-gcs-uploader.appspot.com/image/WlD8wC6g8khYWPJUsQceQkhXSlv1/tbyBjqi7Zu733AAKA5n4.png "ChromeWebStore_Badge_v2_206x58.png"
-[11]: https://storage.googleapis.com/chrome-gcs-uploader.appspot.com/image/WlD8wC6g8khYWPJUsQceQkhXSlv1/mPGKYBIR2uCP0ApchDXE.png "ChromeWebStore_Badge_v2_340x96.png"
-[12]: https://storage.googleapis.com/chrome-gcs-uploader.appspot.com/image/WlD8wC6g8khYWPJUsQceQkhXSlv1/YT2Grfi9vEBa2wAPzhWa.png "ChromeWebStore_Badge_v2_496x150.png"
-[13]: https://storage.googleapis.com/chrome-gcs-uploader.appspot.com/file/WlD8wC6g8khYWPJUsQceQkhXSlv1/xewneAQuXHkZbVSAEgiV.ai "ChromeWebStore_Badge.ai"
-[14]: https://storage.googleapis.com/chrome-gcs-uploader.appspot.com/image/WlD8wC6g8khYWPJUsQceQkhXSlv1/UV4C4ybeBTsZt43U4xis.png "ChromeWebStore_BadgeWBorder_v2_206x58.png"
-[15]: https://storage.googleapis.com/chrome-gcs-uploader.appspot.com/image/WlD8wC6g8khYWPJUsQceQkhXSlv1/iNEddTyWiMfLSwFD6qGq.png "ChromeWebStore_BadgeWBorder_v2_340x96.png"
-[16]: https://storage.googleapis.com/chrome-gcs-uploader.appspot.com/image/WlD8wC6g8khYWPJUsQceQkhXSlv1/HRs9MPufa1J1h5glNhut.png "ChromeWebStore_BadgeWBorder_v2_496x150.png"
-[17]: https://storage.googleapis.com/chrome-gcs-uploader.appspot.com/file/WlD8wC6g8khYWPJUsQceQkhXSlv1/YK7JoBOelVIK05uwEAEE.ai "ChromeWebStore_BadgeWBorder.ai"
+[10]: https://storage.googleapis.com/web-dev-uploads/image/WlD8wC6g8khYWPJUsQceQkhXSlv1/tbyBjqi7Zu733AAKA5n4.png "ChromeWebStore_Badge_v2_206x58.png"
+[11]: https://storage.googleapis.com/web-dev-uploads/image/WlD8wC6g8khYWPJUsQceQkhXSlv1/mPGKYBIR2uCP0ApchDXE.png "ChromeWebStore_Badge_v2_340x96.png"
+[12]: https://storage.googleapis.com/web-dev-uploads/image/WlD8wC6g8khYWPJUsQceQkhXSlv1/YT2Grfi9vEBa2wAPzhWa.png "ChromeWebStore_Badge_v2_496x150.png"
+[13]: https://storage.googleapis.com/web-dev-uploads/file/WlD8wC6g8khYWPJUsQceQkhXSlv1/xewneAQuXHkZbVSAEgiV.ai "ChromeWebStore_Badge.ai"
+[14]: https://storage.googleapis.com/web-dev-uploads/image/WlD8wC6g8khYWPJUsQceQkhXSlv1/UV4C4ybeBTsZt43U4xis.png "ChromeWebStore_BadgeWBorder_v2_206x58.png"
+[15]: https://storage.googleapis.com/web-dev-uploads/image/WlD8wC6g8khYWPJUsQceQkhXSlv1/iNEddTyWiMfLSwFD6qGq.png "ChromeWebStore_BadgeWBorder_v2_340x96.png"
+[16]: https://storage.googleapis.com/web-dev-uploads/image/WlD8wC6g8khYWPJUsQceQkhXSlv1/HRs9MPufa1J1h5glNhut.png "ChromeWebStore_BadgeWBorder_v2_496x150.png"
+[17]: https://storage.googleapis.com/web-dev-uploads/file/WlD8wC6g8khYWPJUsQceQkhXSlv1/YK7JoBOelVIK05uwEAEE.ai "ChromeWebStore_BadgeWBorder.ai"
 [19]: https://services.google.com/fb/forms/permissionsbrand/
 [20]: https://developers.google.com/youtube/branding
 [21]: https://checkout.google.com/seller/checkout_buttons.html

--- a/tests/site/_shortcodes/img.js
+++ b/tests/site/_shortcodes/img.js
@@ -11,18 +11,18 @@ test('Img shortcode generates img html', t => {
     Img.bind(thisToBind)({src, alt: 'hello', height: '100', width: '100'})
   );
   const expected = cheerio.load(html` <img
-    src="https://developer-chrome-com.imgix.net/image/foR0vJZKULb5AGJExlazy1xYDgI2/1600132969326.jpg?auto=format"
+    src="https://wd.imgix.net/image/foR0vJZKULb5AGJExlazy1xYDgI2/1600132969326.jpg?auto=format"
     srcset="
-      https://developer-chrome-com.imgix.net/image/foR0vJZKULb5AGJExlazy1xYDgI2/1600132969326.jpg?auto=format&w=100   100w,
-      https://developer-chrome-com.imgix.net/image/foR0vJZKULb5AGJExlazy1xYDgI2/1600132969326.jpg?auto=format&w=140   140w,
-      https://developer-chrome-com.imgix.net/image/foR0vJZKULb5AGJExlazy1xYDgI2/1600132969326.jpg?auto=format&w=196   196w,
-      https://developer-chrome-com.imgix.net/image/foR0vJZKULb5AGJExlazy1xYDgI2/1600132969326.jpg?auto=format&w=274   274w,
-      https://developer-chrome-com.imgix.net/image/foR0vJZKULb5AGJExlazy1xYDgI2/1600132969326.jpg?auto=format&w=384   384w,
-      https://developer-chrome-com.imgix.net/image/foR0vJZKULb5AGJExlazy1xYDgI2/1600132969326.jpg?auto=format&w=538   538w,
-      https://developer-chrome-com.imgix.net/image/foR0vJZKULb5AGJExlazy1xYDgI2/1600132969326.jpg?auto=format&w=752   752w,
-      https://developer-chrome-com.imgix.net/image/foR0vJZKULb5AGJExlazy1xYDgI2/1600132969326.jpg?auto=format&w=1054 1054w,
-      https://developer-chrome-com.imgix.net/image/foR0vJZKULb5AGJExlazy1xYDgI2/1600132969326.jpg?auto=format&w=1476 1476w,
-      https://developer-chrome-com.imgix.net/image/foR0vJZKULb5AGJExlazy1xYDgI2/1600132969326.jpg?auto=format&w=1600 1600w
+      https://wd.imgix.net/image/foR0vJZKULb5AGJExlazy1xYDgI2/1600132969326.jpg?auto=format&w=100   100w,
+      https://wd.imgix.net/image/foR0vJZKULb5AGJExlazy1xYDgI2/1600132969326.jpg?auto=format&w=140   140w,
+      https://wd.imgix.net/image/foR0vJZKULb5AGJExlazy1xYDgI2/1600132969326.jpg?auto=format&w=196   196w,
+      https://wd.imgix.net/image/foR0vJZKULb5AGJExlazy1xYDgI2/1600132969326.jpg?auto=format&w=274   274w,
+      https://wd.imgix.net/image/foR0vJZKULb5AGJExlazy1xYDgI2/1600132969326.jpg?auto=format&w=384   384w,
+      https://wd.imgix.net/image/foR0vJZKULb5AGJExlazy1xYDgI2/1600132969326.jpg?auto=format&w=538   538w,
+      https://wd.imgix.net/image/foR0vJZKULb5AGJExlazy1xYDgI2/1600132969326.jpg?auto=format&w=752   752w,
+      https://wd.imgix.net/image/foR0vJZKULb5AGJExlazy1xYDgI2/1600132969326.jpg?auto=format&w=1054 1054w,
+      https://wd.imgix.net/image/foR0vJZKULb5AGJExlazy1xYDgI2/1600132969326.jpg?auto=format&w=1476 1476w,
+      https://wd.imgix.net/image/foR0vJZKULb5AGJExlazy1xYDgI2/1600132969326.jpg?auto=format&w=1600 1600w
     "
     alt="hello"
     loading="lazy"

--- a/tests/site/_shortcodes/video.js
+++ b/tests/site/_shortcodes/video.js
@@ -11,7 +11,7 @@ test('Video shortcode generates video html', t => {
     html`
       <video controls>
         <source
-          src="https://storage.googleapis.com/chrome-gcs-uploader.appspot.com/video/tcFciHGuF3MxnTr1y5ue01OGLBn2/1601081394086.mp4"
+          src="https://storage.googleapis.com/web-dev-uploads/video/tcFciHGuF3MxnTr1y5ue01OGLBn2/1601081394086.mp4"
           type="video/mp4"
         />
       </video>
@@ -32,15 +32,15 @@ test('video shortcode generates multiple sources when provided', t => {
     html`
       <video controls>
         <source
-          src="https://storage.googleapis.com/chrome-gcs-uploader.appspot.com/video/tcFciHGuF3MxnTr1y5ue01OGLBn2/1601081394086.mp4"
+          src="https://storage.googleapis.com/web-dev-uploads/video/tcFciHGuF3MxnTr1y5ue01OGLBn2/1601081394086.mp4"
           type="video/mp4"
         />
         <source
-          src="https://storage.googleapis.com/chrome-gcs-uploader.appspot.com/video/tcFciHGuF3MxnTr1y5ue01OGLBn2/1601081394086.mov"
+          src="https://storage.googleapis.com/web-dev-uploads/video/tcFciHGuF3MxnTr1y5ue01OGLBn2/1601081394086.mov"
           type="video/mp4"
         />
         <source
-          src="https://storage.googleapis.com/chrome-gcs-uploader.appspot.com/video/tcFciHGuF3MxnTr1y5ue01OGLBn2/1601081394086.webm"
+          src="https://storage.googleapis.com/web-dev-uploads/video/tcFciHGuF3MxnTr1y5ue01OGLBn2/1601081394086.webm"
           type="video/webm"
         />
       </video>


### PR DESCRIPTION
Move all our asset references to web-dev-uploads (except tweets.json).

The new (short) imgix code is "wd.imgix.net".