### PR TITLE
Fix typo where the variable name was a keyword

### DIFF
--- a/site/en/docs/extensions/reference/runtime/index.md
+++ b/site/en/docs/extensions/reference/runtime/index.md
@@ -71,7 +71,7 @@ the page that the content script has been [injected][content-inject] into.
 //// content.js ////
 
 { // Block used to avoid setting global variables
-  let const = document.createElement('img');
+  const img = document.createElement('img');
   img.src = chrome.runtime.getURL('logo.png');
   document.body.append(img);
 }


### PR DESCRIPTION
Fixes #1429

Changes proposed in this pull request:

- Changes `let const = ..` to `const img = ..` (We could use `let img = ..`, i just reached for `const` first)