### PR TITLE
Add chrome.action API to the customize extension user interface table

### DIFF
--- a/site/en/docs/extensions/mv3/devguide/index.md
+++ b/site/en/docs/extensions/mv3/devguide/index.md
@@ -16,6 +16,10 @@ functionality.
       <th colspan="2"><strong>Customize extension user interface</strong></th>
     </tr>
     <tr>
+      <td><a href="/docs/extensions/reference/action">Action</a></td>
+      <td>Control the display of an extension's icon in the toolbar.</td>
+    </tr>
+    <tr>
       <td><a href="/docs/extensions/reference/browserAction">Browser&nbsp;Actions</a></td>
       <td>Add an icon, tooltip, badge, and popup to the toolbar.</td>
     </tr>
@@ -34,10 +38,6 @@ functionality.
     <tr>
       <td><a href="/docs/extensions/mv3/override">Override&nbsp;Pages</a></td>
       <td>Create a version of the New Tab, Bookmark, or History page.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/action">Action</a></td>
-      <td>Control the display of an extension's icon in the toolbar.</td>
     </tr>
     <tr>
       <td><a href="/docs/extensions/reference/pageAction">Page&nbsp;Actions</a></td>

--- a/site/en/docs/extensions/mv3/devguide/index.md
+++ b/site/en/docs/extensions/mv3/devguide/index.md
@@ -36,6 +36,10 @@ functionality.
       <td>Create a version of the New Tab, Bookmark, or History page.</td>
     </tr>
     <tr>
+      <td><a href="/docs/extensions/reference/action">Action</a></td>
+      <td>Control the display of an extension's icon in the toolbar.</td>
+    </tr>
+    <tr>
       <td><a href="/docs/extensions/reference/pageAction">Page&nbsp;Actions</a></td>
       <td>Dynamically display icons in the toolbar.</td>
     </tr>


### PR DESCRIPTION
Fixes #1006

Changes proposed in this pull request:

- Add `action` to the "Customize extension user interface" table on https://developer.chrome.com/docs/extensions/mv3/devguide/
- Todo: Would be nice to clearly identify which APIs are MV2 like on API reference

The wording I used for the `action` description might need to be tweaked but hopefully this is a good start. As for identifying which APIs are MV2 etc, that can be added in this PR as well. Would it be preferred to keep the same styling as on [API reference](https://developer.chrome.com/docs/extensions/reference/), e.g.`<div class="reference-requirements"><span>MV3+</span></div>` representing the availability?

cc @AmySteam 