### PR TITLE
Fix typo in Tooltip (title) section of chrome.action reference page

### DIFF
--- a/site/en/docs/extensions/reference/action/index.md
+++ b/site/en/docs/extensions/reference/action/index.md
@@ -81,7 +81,7 @@ Unpacked extensions must use images in the PNG format.
 
 ### Tooltip (title)
 
-The tooltip, or title, appears when the user hovers the mouse of the extension's icon in the
+The tooltip, or title, appears when the user hovers the mouse on the extension's icon in the
 toolbar. It is also included in the accessible text spoken by screenreaders when the button gets
 focus.
 


### PR DESCRIPTION
Fixes #1434 

Changes proposed in this pull request:

- Changes 'of' to 'on' in the first sentence of the [Tooltip (title)](https://developer.chrome.com/docs/extensions/reference/action/#tooltip-title) section on chrome.action API reference page.