### PR TITLE
Remove browserAction (MV2 availability) from customize extension table on MV3 page

### DIFF
--- a/site/en/docs/extensions/mv3/devguide/index.md
+++ b/site/en/docs/extensions/mv3/devguide/index.md
@@ -16,10 +16,6 @@ functionality.
       <th colspan="2"><strong>Customize extension user interface</strong></th>
     </tr>
     <tr>
-      <td><a href="/docs/extensions/reference/browserAction">Browser&nbsp;Actions</a></td>
-      <td>Add an icon, tooltip, badge, and popup to the toolbar.</td>
-    </tr>
-    <tr>
       <td><a href="/docs/extensions/reference/commands">Commands</a></td>
       <td>Add keyboard shortcuts that trigger actions.</td>
     </tr>

--- a/site/en/docs/extensions/mv3/devguide/index.md
+++ b/site/en/docs/extensions/mv3/devguide/index.md
@@ -7,7 +7,7 @@ description: An overview of Chrome Extension capabilities and components.
 ---
 
 After reading the [Getting Started][1] tutorial and [Overview][2], use this guide as an outline to
-extension components and abilities. Developers are encouraged to explore and expand extension
+extension components and abilities with MV3 availability. Developers are encouraged to explore and expand extension
 functionality.
 
 <table class="width-full">


### PR DESCRIPTION
Cleanup for #1432

Changes proposed in this pull request:

- Removes `browserAction` from customize extension ui table
- Add note that the stuff on [mv3/devguide](https://developer.chrome.com/docs/extensions/mv3/devguide/) is all MV3 things. This can probably be cleaned up or moved to its own sentence, I just thought it sorta worked nicely in the existing sentence.

cc @samthor 