### PR TITLE
Add 'Label' shortcode to render a filename for code snippets

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -24,6 +24,7 @@ const {IFrame} = require('./site/_shortcodes/IFrame');
 const {Glitch} = require('./site/_shortcodes/Glitch');
 const {Hreflang} = require('./site/_shortcodes/Hreflang');
 const {Img} = require('./site/_shortcodes/Img');
+const {Label} = require('./site/_shortcodes/Label');
 const {Video} = require('./site/_shortcodes/Video');
 const {YouTube} = require('./site/_shortcodes/YouTube');
 const {Columns, Column} = require('./site/_shortcodes/Columns');
@@ -128,6 +129,7 @@ module.exports = eleventyConfig => {
   eleventyConfig.addPairedShortcode('Compare', Compare);
   eleventyConfig.addPairedShortcode('CompareCaption', CompareCaption);
   eleventyConfig.addPairedShortcode('Aside', Aside);
+  eleventyConfig.addPairedShortcode('Label', Label);
   eleventyConfig.addShortcode('LanguageList', LanguageList);
 
   // Add transforms

--- a/site/_shortcodes/Label.js
+++ b/site/_shortcodes/Label.js
@@ -1,0 +1,8 @@
+/** Renders a filename associated with a code snippet.
+ * @param {string} filename A filename representing the code snippet
+ */
+function Label(filename) {
+  return `<div class="type--caption"><p class="code-label">${filename}</p></div>`;
+}
+
+module.exports = {Label};


### PR DESCRIPTION
Fixes #915

Changes proposed in this pull request:

- Defines `Label` function in the `./site/_shortcodes/` directory (Maybe we don't include the parent `<div class="type--caption">` and just use `<p class="code-label">` like web.dev does?)
- Registers `Label` as a paired shortcode (for consistency since web.dev does) in the eleventy config file
- Todo: Add styles to ensure margins look good between filename and code snippet e.g. `.code-label + pre { margin-top: get-size(200) }` where get-size(200) will be tinkered with until it looks good.

[Comments in original issue](https://github.com/GoogleChrome/developer.chrome.com/issues/915#issuecomment-868885621) by @robdodson 