### PR TITLE
Fix broken links on '/mv3/tut_oauth/' page

### DIFF
--- a/site/en/docs/extensions/mv3/tut_oauth/index.md
+++ b/site/en/docs/extensions/mv3/tut_oauth/index.md
@@ -2,7 +2,7 @@
 layout: "layouts/doc-post.njk"
 title: "OAuth2: Authenticate users with Google"
 date: 2012-09-18
-updated: 2018-05-01
+updated: 2021-09-17
 description: >
   Step-by-step instructions on how to build an extension that accesses
   a user's Google contacts via the Google People API, the Chrome Identity API,

--- a/site/en/docs/extensions/mv3/tut_oauth/index.md
+++ b/site/en/docs/extensions/mv3/tut_oauth/index.md
@@ -323,4 +323,4 @@ a block.
 [11]: /identity
 [12]: examples/tutorials/oauth_starter/oauth.js
 [13]: https://developers.google.com/people/
-[14]: https://developers.google.com/people/v1/read-people
+[14]: https://developers.google.com/people/api/rest/v1/contactGroups/get


### PR DESCRIPTION
Fixes #964 

Changes proposed in this pull request:

- Changes 'https://developers.google.com/people/v1/read-people' to 'https://developers.google.com/people/api/rest/v1/contactGroups/get'
- Todo: Find correct URLs to sample files within `GoogleChrome/samples` repo - download links for sample source files (should go to samples repo)

Broken sample file links (need to find matching file for these in `GoogleChrome/samples`):
- https://developer.chrome.com/docs/extensions/mv3/tut_oauth/examples/tutorials/oauth_starter/oauth.js
- https://developer.chrome.com/docs/extensions/mv3/tut_oauth/examples/tutorials/oauth_starter/index.html

I had a look at the [`samples`](https://github.com/GoogleChrome/samples) repository and couldn't find the files by the names used in their original links, I'm maybe thinking the filenames changed or maybe their location changed within `samples` (if they even exist)? @samthor 