### PR TITLE
allow more varied release data from Chrome

### DIFF
--- a/site/_data/chrome.js
+++ b/site/_data/chrome.js
@@ -70,11 +70,11 @@ async function dataForVersion(channel, version) {
 /**
  * Generates Chrome version information.
  *
- * While there are many channels, we just care about 'stable' and 'beta', and this function is only
- * guaranteed to return 'stable' with optional 'beta'.
+ * While there are many channels, we just care about 'stable' and 'beta'. This method returns a
+ * value for both.
  *
- * Beta is not always stable+1, it can either be stable+0 or stable+2 depending on the point in the
- * release cycle.
+ * Beta is not always stable+1 in the underlying data, it can either be stable+0 or stable+2
+ * depending on the point in the release cycle.
  *
  * @return {!Promise<{channels: !Object<string, !Object>}>}
  */
@@ -109,14 +109,12 @@ module.exports = async function buildVersionInformation() {
     console.warn(raw);
     throw new Error('bad Chrome release data, no stable or beta < stable');
   }
-  if (!('beta' in raw)) {
+  if (!('beta' in raw) || raw['beta'] === raw['stable']) {
+    // pretend beta is stable+1 if it's not here or beta===stable
     raw['beta'] = raw['stable'] + 1;
   }
   const {beta, stable} = raw;
-  if (beta === stable) {
-    // beta is being released, just show stable
-    delete raw['beta'];
-  } else if (beta === stable + 1) {
+  if (beta === stable + 1) {
     // great
   } else if (beta === stable + 2) {
     // This can occur if Chrome does something weird with releases, basically the previous beta

--- a/site/_data/chrome.js
+++ b/site/_data/chrome.js
@@ -103,15 +103,18 @@ module.exports = async function buildVersionInformation() {
 
   // Sanity-check that we have 'stable', and if we have 'beta', that it's one or two higher.
   // Create the virtual 'pending' if it's two higher.
-  if (!('stable' in raw) || raw['beta'] <= raw['stable']) {
+  if (!('stable' in raw) || raw['beta'] < raw['stable']) {
     console.warn(raw);
-    throw new Error('bad Chrome release data');
+    throw new Error('bad Chrome release data, no stable or beta < stable');
   }
   if (!('beta' in raw)) {
     raw['beta'] = raw['stable'] + 1;
   }
   const {beta, stable} = raw;
-  if (beta === stable + 1) {
+  if (beta === stable) {
+    // beta is being released, just show stable
+    delete raw['beta'];
+  } else if (beta === stable + 1) {
     // great
   } else if (beta === stable + 2) {
     // This can occur if Chrome does something weird with releases, basically the previous beta

--- a/site/_data/chrome.js
+++ b/site/_data/chrome.js
@@ -70,9 +70,11 @@ async function dataForVersion(channel, version) {
 /**
  * Generates Chrome version information.
  *
- * While there are many channels, we just care about 'stable' and 'beta'. If we can't find beta, then
- * assume beta is stable+1. Beta is not always stable+1: it can be stable+2 if Chrome is
- * mid-release. We add a fake release 'pending' in this case.
+ * While there are many channels, we just care about 'stable' and 'beta', and this function is only
+ * guaranteed to return 'stable' with optional 'beta'.
+ *
+ * Beta is not always stable+1, it can either be stable+0 or stable+2 depending on the point in the
+ * release cycle.
  *
  * @return {!Promise<{channels: !Object<string, !Object>}>}
  */
@@ -140,5 +142,6 @@ module.exports = async function buildVersionInformation() {
   const channels = Object.fromEntries(
     await Promise.all(Object.entries(raw).map(fetchChannelData))
   );
+
   return {channels};
 };

--- a/site/_includes/layouts/releases-landing.njk
+++ b/site/_includes/layouts/releases-landing.njk
@@ -4,15 +4,17 @@
   {% for key, title in i18n.channels %}
 
   {% set release = chrome.channels[key] %}
+  {% if release %}
 
-  <h1 class="type--h1">{{ title }}</h1>
+    <h1 class="type--h1">{{ title }}</h1>
 
-  <dl>
-    <dt>{{ i18n.release_title }}</dt>
-    <dd>{{ release.mstone }}</dd>
-    <dt>{{ i18n.stabledate_title }}</dt>
-    <dd>{{ release.stableDate.toLocaleDateString(locale, {day: 'numeric', month: 'long', year: 'numeric'}) }}</dd>
-  </dl>
+    <dl>
+      <dt>{{ i18n.release_title }}</dt>
+      <dd>{{ release.mstone }}</dd>
+      <dt>{{ i18n.stabledate_title }}</dt>
+      <dd>{{ release.stableDate.toLocaleDateString(locale, {day: 'numeric', month: 'long', year: 'numeric'}) }}</dd>
+    </dl>
 
+  {% endif %}
   {% endfor %}
 {% endblock %}

--- a/site/_includes/macros/cards/releases-card.njk
+++ b/site/_includes/macros/cards/releases-card.njk
@@ -11,15 +11,17 @@
 
   <div class="display-flex direction-column md:direction-row justify-content-around gap-top-200">
 
-    <div class="flex-1 gap-300">
-      <div class="release-card__icon release-card__icon-stable">
-        <span class="visually-hidden">{{ 'i18n.common.current_release_description' | i18n(locale) }}</span>
-        {{ chrome.channels.stable.mstone }}
+    {% if chrome.channels.stable %}
+      <div class="flex-1 gap-300">
+        <div class="release-card__icon release-card__icon-stable">
+          <span class="visually-hidden">{{ 'i18n.common.current_release_description' | i18n(locale) }}</span>
+          {{ chrome.channels.stable.mstone }}
+        </div>
+        <p class="type--caption text-align-center gap-top-300">
+          {{ 'i18n.common.current_release_label' | i18n(locale) }}
+        </p>
       </div>
-      <p class="type--caption text-align-center gap-top-300">
-        {{ 'i18n.common.current_release_label' | i18n(locale) }}
-      </p>
-    </div>
+    {% endif %}
     {% if chrome.channels.pending %}
       <div class="flex-1 gap-300">
         <div class="release-card__icon release-card__icon-pending">
@@ -31,16 +33,18 @@
         </p>
       </div>
     {% endif %}
-    <div class="flex-1 gap-300">
-      <div class="release-card__icon release-card__icon-beta">
-        <span class="visually-hidden">{{ 'i18n.common.future_release_description' | i18n(locale) }}</span>
-        {{ chrome.channels.beta.mstone }}
+    {% if chrome.channels.beta %}
+      <div class="flex-1 gap-300">
+        <div class="release-card__icon release-card__icon-beta">
+          <span class="visually-hidden">{{ 'i18n.common.future_release_description' | i18n(locale) }}</span>
+          {{ chrome.channels.beta.mstone }}
+        </div>
+        <p class="type--caption text-align-center gap-top-300">
+          {{ 'i18n.common.future_release_label' | i18n(locale) }}
+          {{ chrome.channels.beta.stableDate.toLocaleDateString(locale, {day: 'numeric', month: 'long'}) }}
+        </p>
       </div>
-      <p class="type--caption text-align-center gap-top-300">
-        {{ 'i18n.common.future_release_label' | i18n(locale) }}
-        {{ chrome.channels.beta.stableDate.toLocaleDateString(locale, {day: 'numeric', month: 'long'}) }}
-      </p>
-    </div>
+    {% endif %}
 
   </div>
 

--- a/site/_utils/tags-11tydata.js
+++ b/site/_utils/tags-11tydata.js
@@ -61,7 +61,7 @@ module.exports = locale => ({
           // Only name 'stable' and 'beta' releases.
           if (rawChannels.stable.mstone === release) {
             title = i18n('i18n.common.release_stable', locale);
-          } else if (rawChannels.beta.mstone === release) {
+          } else if (rawChannels.beta?.mstone === release) {
             title = i18n('i18n.common.release_beta', locale);
           }
 


### PR DESCRIPTION
We now just assume the existence of 'stable'. If stable === beta, then pretend beta is stable+1.

Also is more permissive on the home page, if releases are missing don't render them.