### PR TITLE
Add note about weird RegEx implementation

### DIFF
--- a/site/en/docs/devtools/console/reference/index.md
+++ b/site/en/docs/devtools/console/reference/index.md
@@ -206,8 +206,8 @@ checkbox.
 
 ### Filter out messages that don't match a regular expression pattern {: #regex }
 
-Type a regular expression such as `/[gm][ta][mi]/` in the **Filter** text box to filter out any
-messages that don't match that pattern. DevTools checks if the pattern is found in the message text
+Type a regular expression such as `/[foo]\s[bar]/` in the **Filter** text box to filter out any
+messages that don't match that pattern. Spaces are not supported, use `\s` instead. DevTools checks if the pattern is found in the message text
 or the script that caused the message to be logged.
 
 {% Img src="image/admin/1FvJQi69s6J7nHtKUIDy.png", alt="Filtering out any messages that don't match /[gm][ta][mi]/.", width="800", height="512" %}


### PR DESCRIPTION
`-/Unrecognized feature:/` will not hide messages containing "Unrecognized feature". Unlike javascript, the console does not support spaces in regex.
