### PR TITLE
MV2 support/sunset timeline and its introduction page

### DIFF
--- a/site/_data/authorsData.json
+++ b/site/_data/authorsData.json
@@ -285,6 +285,10 @@
     "country": "US",
     "image": "image/SHhb2PDKzXTggPGAYpv8JgR81pX2/kUhkXfBItc8GVTkWA2AB.jpg"
   },
+  "dsli": {
+    "country": "US",
+    "image": "image/SHhb2PDKzXTggPGAYpv8JgR81pX2/taqTgQ89EI2kdOtM7Zle.jpeg"
+  },
   "joycetoh": {
     "country": "US",
     "github": "joycetoh8",

--- a/site/_data/docs/extensions/toc.yml
+++ b/site/_data/docs/extensions/toc.yml
@@ -8,6 +8,7 @@
     - url: /docs/extensions/mv3/intro/mv3-overview
     - url: /docs/extensions/mv3/intro/mv3-migration
     - url: /docs/extensions/mv3/mv3-migration-checklist
+    - url: /docs/extensions/mv3/mv2-sunset
 - title: i18n.docs.extensions.overview
   sections:
     - url: /docs/extensions/mv3/overview

--- a/site/_data/i18n/authors.yaml
+++ b/site/_data/i18n/authors.yaml
@@ -244,6 +244,11 @@ ackermanb:
     en: 'Benjamin Ackerman'
   description:
     en: 'Lead Security Analyst, Chrome Trust & Safety Team'
+dsli:
+  title:
+    en: 'David Li'
+  description:
+    en: 'Product Manager, Chrome Extensions & Chrome Web Store'
 joycetoh:
   title:
     en: 'Joyce Toh'

--- a/site/en/blog/mv2-transition/index.md
+++ b/site/en/blog/mv2-transition/index.md
@@ -1,0 +1,59 @@
+---
+title: "The transition of Chrome extensions to Manifest V3"
+description: >
+  Sharing details about the plan to move extensions to Manifest V3
+layout: "layouts/blog-post.njk"
+authors:
+  - dsli
+date: 2021-09-23
+hero: image/WlD8wC6g8khYWPJUsQceQkhXSlv1/GoUHyuctM1Zs9wdy5a2s.png
+alt: Image of a butterfly
+tags:
+  - extensions
+
+---
+
+Earlier this year, for Chrome 88, we announced [the availability of a new manifest
+version](https://blog.chromium.org/2020/12/manifest-v3-now-available-on-m88-beta.html) for the
+Chrome extension ecosystem. Years in the making, Manifest V3 is more secure, performant, and
+privacy-preserving than its predecessor. It is an evolution of the extension platform that takes
+into consideration both the changing web landscape and the future of browser extensions.
+
+As we look to the future by continuing to iterate on and improve upon Manifest V3 functionality, we
+also want to share details about the plan to phase out Manifest V2 extensions.
+
+There are two key dates for the phase-out:
+
+*   **January 17, 2022**: New Manifest V2 extensions will no longer be accepted by the Chrome Web
+    Store. Developers may still push updates to existing Manifest V2 extensions, but no new Manifest
+    V2 items may be submitted.
+
+*   **January 2023**: The Chrome browser will no longer run Manifest V2 extensions. Developers may
+    no longer push updates to existing Manifest V2 extensions.
+
+As these dates draw closer, we will share more details around the Chrome version targeted for the
+change, as well as more information on how both extension developers and users may be affected.
+Refer to [this page](/docs/extensions/mv3/mv2-sunset/) for more granular timeline information, which
+will be kept up to date as more exact dates and milestone details are available.
+
+In the meantime, we will continue to add new capabilities to Manifest V3 based on the needs and
+voices of our developer community. Even in the last few months, there have been a number of exciting
+expansions of the extension platform. We introduced additional mechanisms to the new [Scripting
+API](/docs/extensions/reference/scripting/), and we expanded the
+[Declarative Net Request
+API](/docs/extensions/reference/declarativeNetRequest/) with support for
+multiple static rulesets, filtering based on tab ID, and session-scoped rules. 
+
+In the coming months, we'll also be launching support for dynamically configurable content scripts
+and an in-memory storage option, among other new capabilities. These changes were crafted with
+community feedback in mind, and we will continue to build more powerful extension API functionality
+as developers share more information about their migration challenges and business needs. Finally,
+we'll continue working with other browser vendors in the Web Extensions Community Group to iterate
+on the platform and pursue a common cross-browser extension model.
+
+If you have feedback on Manifest V3 or are encountering unique challenges with the migration
+process, please post to the
+[chromium-extensions](https://groups.google.com/a/chromium.org/g/chromium-extensions) Google Group.
+The earlier issues are raised and the earlier feedback is given, the more options the team has to
+address them prior to MV2 phase-out.
+

--- a/site/en/blog/mv2-transition/index.md
+++ b/site/en/blog/mv2-transition/index.md
@@ -7,7 +7,7 @@ authors:
   - dsli
 date: 2021-09-23
 hero: image/WlD8wC6g8khYWPJUsQceQkhXSlv1/GoUHyuctM1Zs9wdy5a2s.png
-alt: Image of a butterfly
+alt: Image with extensions logo and text saying Manifest V3 transition timeline
 tags:
   - extensions
 

--- a/site/en/docs/extensions/mv3/index.md
+++ b/site/en/docs/extensions/mv3/index.md
@@ -37,19 +37,16 @@ Beyond that, you might find useful entry points in these pages:
 * Pick something from the [samples page](https://github.com/GoogleChrome/chrome-extensions-samples), install it, and start hacking on it.
 * Look for answers in the [Extensions FAQ page](/docs/extensions/mv3/faq/)
 
-{% if process.env.HAS_MV3 %}
 {% Aside %}
 Now that Manifest V3 has launched, we've changed the default documentation to
 be for MV3. If you are maintaining a legacy Manifest V2 extension, see the [MV2
-documentation](/docs/extensions/mv2).	
+documentation](/docs/extensions/mv2).
 {% endAside %}
-{% else %}
-{% Aside %}
-With Manifest V3 launching soon, we've changed the default documentation
-experience to be for MV3. The [Manifest V2 documentation](/docs/extensions/mv2)
-is still available.
+
+{% Aside 'warning' %}
+As Manifest V3 approaches full feature parity with V2, we will be phasing out
+MV2. See [Manfest V2 sunset timeline](/docs/extensions/mv3/mv2-sunset) for details.
 {% endAside %}
-{% endif %}
 
 In addition to the documentation here, many developers find helpful community content at:
 

--- a/site/en/docs/extensions/mv3/index.md
+++ b/site/en/docs/extensions/mv3/index.md
@@ -45,7 +45,7 @@ documentation](/docs/extensions/mv2).
 
 {% Aside 'warning' %}
 As Manifest V3 approaches full feature parity with V2, we will be phasing out
-MV2. See [Manfest V2 sunset timeline](/docs/extensions/mv3/mv2-sunset) for details.
+MV2. See [Manfest V2 support timeline](/docs/extensions/mv3/mv2-sunset) for details.
 {% endAside %}
 
 In addition to the documentation here, many developers find helpful community content at:

--- a/site/en/docs/extensions/mv3/mv2-sunset/index.md
+++ b/site/en/docs/extensions/mv3/mv2-sunset/index.md
@@ -7,7 +7,7 @@ subhead: 'Understand when Manifest V2 will stop working for extensions'
 
 description: 'Details of the Manifest V2 phase-out and end of life.'
 
-date: 2021-09-20
+date: 2021-09-23
 
 ---
 

--- a/site/en/docs/extensions/mv3/mv2-sunset/index.md
+++ b/site/en/docs/extensions/mv3/mv2-sunset/index.md
@@ -1,0 +1,87 @@
+---
+layout: 'layouts/doc-post.njk'
+
+title: Manifest V2 support timeline
+
+subhead: 'Understand when Manifest V2 will stop working for extensions'
+
+description: 'Details of the Manifest V2 phase-out and end of life.'
+
+date: 2021-09-20
+
+---
+
+As MV3 approaches full feature parity with MV2, we'll be progressively phasing out MV2. This page
+specifies the timetable for this deprecation and describes the meaning of each milestone.
+
+{% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/zXdU3hdkj1K0Ks6tAfB4.png", alt="Diagram of MV2
+support timeline", width="800", height="270" %}
+
+{% Aside %}
+Check this page for any updates and for more specific dates as these milestones get closer.
+{% endAside %}
+
+<table>
+  <tr align="left" valign="top">
+   <td><!-- <strong>Date</strong> -->
+   </td>
+   <td><strong>Chrome Web Store<br>behavior changes</strong>
+   </td>
+   <td><strong>Chrome Browser<br>behavior changes</strong>
+   </td>
+  </tr>
+  <tr align="left" valign="top">
+   <td><strong>January&nbsp;17, 2022</strong>
+   </td>
+   <td><ul>
+
+<li>Chrome Web Store stops accepting new Manifest V2 extensions with visibility set to “Public" or "Unlisted”
+<li>Existing Manifest V2 extensions can no longer be changed from “Private” to "Public" or "Unlisted"</li></ul>
+
+   </td>
+   <td><i>no change</i>
+   </td>
+  </tr>
+  <tr align="left" valign="top">
+   <td><strong>June&nbsp;2022</strong>
+   </td>
+   <td><ul>
+
+<li>Chrome Web Store stops accepting new Manifest V2 extensions with visibility set to “Private”</li></ul>
+
+   </td>
+   <td><i>no change</i>
+   </td>
+  </tr>
+  <tr align="left" valign="top">
+   <td><strong>January&nbsp;2023</strong>
+   </td>
+   <td><ul>
+
+<li>Chrome Web Store stops accepting updates to existing Manifest V2 extensions</li></ul>
+
+   </td>
+   <td><ul>
+
+<li>Chrome stops running Manifest V2 extensions
+<li>Enterprise policy can let Manifest V2 extensions run on Chrome deployments
+<a href="https://support.google.com/chrome/a/answer/9296680?hl=en">within the organization</a>.
+</li></ul>
+
+   </td>
+  </tr>
+  <tr align="left" valign="top">
+   <td><strong>June&nbsp;2023</strong>
+   </td>
+   <td><i>no change</i>
+   </td>
+   <td><ul>
+
+<li>Manifest V2 extensions longer functions in Chrome even with the use of enterprise policy </li></ul>
+
+   </td>
+  </tr>
+</table>
+
+
+


### PR DESCRIPTION
Adds a blog post announcing the MV2 support timeline and transition to MV3, as well as a page with more detailed description of the dates and their impact.