### PR TITLE
Adding pwa summit registration banner

### DIFF
--- a/site/_data/banner.yml
+++ b/site/_data/banner.yml
@@ -1,0 +1,6 @@
+type: info
+text: 'PWA Summit: a virtual conference to help everyone succeed with PWAs is on Oct 6 & 7.'
+actions:
+  - text: Get your free ticket
+    href: https://pwasummit.org/register
+  - text: Dismiss


### PR DESCRIPTION
Changes proposed in this pull request:

- Adding a PWA banner with a link to the registration

My idea is to have this banner until Oct 7, when I'll change the banner to link to the livestream, so people can join directly, and I'll remove the banner by EOD oct 7th.