### PR TITLE
Feat/remove sass deprecation warnings

### DIFF
--- a/site/_scss/blocks/_navigation-rail.scss
+++ b/site/_scss/blocks/_navigation-rail.scss
@@ -46,7 +46,7 @@ navigation-rail {
         content: '';
         height: $hover-size;
         position: absolute;
-        top: -(($hover-size - 28px) / 2); // 28px is line-height
+        top: -(($hover-size - 28px) * 0.5); // 28px is line-height
         width: $hover-size;
         z-index: -1;
       }

--- a/site/_scss/globals/_functions.scss
+++ b/site/_scss/globals/_functions.scss
@@ -1,11 +1,13 @@
 // Global functions.
 
 // Pixels to ems.
+@use "sass:math";
+
 @function px-to-em($px) {
-  @return $px / $base-font-size * 1em;
+  @return math.div($px, $base-font-size) * 1em;
 }
 
 // Pixels to rems.
 @function px-to-rem($px) {
-  @return $px / $base-font-size * 1rem;
+  @return math.div($px, $base-font-size) * 1rem;
 }

--- a/site/_scss/globals/_functions.scss
+++ b/site/_scss/globals/_functions.scss
@@ -1,7 +1,7 @@
 // Global functions.
 
 // Pixels to ems.
-@use "sass:math";
+@use 'sass:math';
 
 @function px-to-em($px) {
   @return math.div($px, $base-font-size) * 1em;

--- a/site/_scss/globals/_mixins.scss
+++ b/site/_scss/globals/_mixins.scss
@@ -1,6 +1,8 @@
 // Global mixins.
 
 // Sets font styles.
+@use "sass:math";
+
 @mixin font-setup($size, $height, $weight: false, $rem: true) {
   @if $rem {
     font-size: px-to-rem($size);
@@ -8,7 +10,7 @@
     font-size: px-to-em($size);
   }
 
-  line-height: ($height / $size);
+  line-height: math.div($height, $size);
   @if $weight {
     font-weight: $weight;
   }
@@ -27,7 +29,7 @@
   @include font-setup(nth($md, 1), nth($md, 2), $weight);
 
   // Determine scaling factor so that the large font size is reached at 1024px
-  $font-scale: nth($lg, 1) / 10.24px * 1vw;
+  $font-scale: math.div(nth($lg, 1), 10.24px) * 1vw;
   // Set up clamp function
   $font-clamp: clamp(px-to-em(nth($sm, 1)), $font-scale, px-to-em(nth($lg, 1)));
 
@@ -36,7 +38,7 @@
     // Set font size to clamp
     font-size: $font-clamp;
     // Set line height to ratio of largest line height to font size (unitless number)
-    line-height: nth($lg, 2) / nth($lg, 1);
+    line-height: math.div(nth($lg, 2), nth($lg, 1));
   }
 }
 
@@ -100,8 +102,8 @@
   &::-webkit-scrollbar-thumb {
     background: $thumbColor;
     background-clip: padding-box;
-    border: ($size / 4) solid $trackColor;
-    border-radius: ($size / 2);
+    border: ($size * 0.25) solid $trackColor;
+    border-radius: ($size * 0.5);
   }
 
   &::-webkit-scrollbar-thumb:hover {

--- a/site/_scss/globals/_mixins.scss
+++ b/site/_scss/globals/_mixins.scss
@@ -1,7 +1,7 @@
 // Global mixins.
 
 // Sets font styles.
-@use "sass:math";
+@use 'sass:math';
 
 @mixin font-setup($size, $height, $weight: false, $rem: true) {
   @if $rem {

--- a/site/_scss/globals/extends/_type.scss
+++ b/site/_scss/globals/extends/_type.scss
@@ -2,6 +2,8 @@
 // These placeholders are safer to use with @extend as they don't get included
 // in the final CSS output and help us avoid duplication.
 
+@use "sass:math";
+
 @mixin list-styles($margin) {
   $list-margin: px-to-rem($margin);
   list-style: none;
@@ -226,8 +228,8 @@
       flex-shrink: 0;
       height: $bullet-size;
       justify-content: center;
-      margin-left: -#{$bullet-size * 5/3};
-      margin-right: $bullet-size * 2/3;
+      margin-left: -#{math.div($bullet-size * 5, 3)};
+      margin-right: math.div($bullet-size * 2, 3);
       position: absolute;
       transform: translateY(px-to-rem(3px));
       width: $bullet-size;

--- a/site/_scss/globals/extends/_type.scss
+++ b/site/_scss/globals/extends/_type.scss
@@ -2,7 +2,7 @@
 // These placeholders are safer to use with @extend as they don't get included
 // in the final CSS output and help us avoid duplication.
 
-@use "sass:math";
+@use 'sass:math';
 
 @mixin list-styles($margin) {
   $list-margin: px-to-rem($margin);

--- a/site/_scss/globals/gorko/_config.scss
+++ b/site/_scss/globals/gorko/_config.scss
@@ -7,6 +7,8 @@
  * you keep it at 1rem because that is the root font size. You
  * can set it to whatever you like and whatever unit you like.
  */
+@use "sass:math";
+
 $gorko-base-size: 1rem;
 
 /**
@@ -172,9 +174,9 @@ $gorko-config: (
   'height': (
     'items': map-merge($gorko-size-scale, (
       'full': '100%',
-      'half': percentage(1/2),
-      'quarter': percentage(1/4),
-      'third': percentage(1/3)
+      'half': percentage(1*0.5),
+      'quarter': percentage(1*0.25),
+      'third': percentage(math.div(1, 3))
     )),
     'output': 'responsive',
     'property': 'height'
@@ -332,9 +334,9 @@ $gorko-config: (
   'width': (
     'items': map-merge($gorko-size-scale, (
       'full': '100%',
-      'half': percentage(1/2),
-      'quarter': percentage(1/4),
-      'third': percentage(1/3)
+      'half': percentage(1*0.5),
+      'quarter': percentage(1*0.25),
+      'third': percentage(math.div(1, 3))
     )),
     'output': 'responsive',
     'property': 'width'

--- a/site/_scss/globals/gorko/_config.scss
+++ b/site/_scss/globals/gorko/_config.scss
@@ -7,7 +7,7 @@
  * you keep it at 1rem because that is the root font size. You
  * can set it to whatever you like and whatever unit you like.
  */
-@use "sass:math";
+@use 'sass:math';
 
 $gorko-base-size: 1rem;
 


### PR DESCRIPTION
**Remove Deprecation Warnings for SASS compilations.**

Using `/` for division will be deprecated and we should use instead Math.div or multiply. So we remove noise warnings during the compilation.

Example of list of warnings that will be removed:
```
DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($px, $base-font-size)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
10 │   @return $px / $base-font-size * 1rem;
   │           ^^^^^^^^^^^^^^^^^^^^^
   ╵
    site/_scss/globals/_functions.scss 10:11  px-to-rem()
    site/_scss/globals/_vars.scss 8:21        @import
    site/_scss/main.scss 4:9                  root stylesheet

DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(1, 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

    ╷
175 │       'half': percentage(1/2),
    │                          ^^^
    ╵
    site/_scss/globals/gorko/_config.scss 175:26  @import
    site/_scss/globals/_gorko.scss 3:9            @import
    site/_scss/main.scss 6:9                      root stylesheet

DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(1, 4)

More info and automated migrator: https://sass-lang.com/d/slash-div

    ╷
176 │       'quarter': percentage(1/4),
    │                             ^^^
    ╵
    site/_scss/globals/gorko/_config.scss 176:29  @import
    site/_scss/globals/_gorko.scss 3:9            @import
    site/_scss/main.scss 6:9                      root stylesheet

DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(1, 3)

More info and automated migrator: https://sass-lang.com/d/slash-div

    ╷
177 │       'third': percentage(1/3)
    │                           ^^^
    ╵
    site/_scss/globals/gorko/_config.scss 177:27  @import
    site/_scss/globals/_gorko.scss 3:9            @import
    site/_scss/main.scss 6:9                      root stylesheet

DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(1, 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

    ╷
335 │       'half': percentage(1/2),
    │                          ^^^
    ╵
    site/_scss/globals/gorko/_config.scss 335:26  @import
    site/_scss/globals/_gorko.scss 3:9            @import
    site/_scss/main.scss 6:9                      root stylesheet

WARNING: 11 repetitive deprecation warnings omitted.
```