### PR TITLE
Provide User Support section

### DIFF
--- a/site/en/docs/webstore/cws-dashboard-listing/index.md
+++ b/site/en/docs/webstore/cws-dashboard-listing/index.md
@@ -91,10 +91,11 @@ To explain how your extension works in more detail, you can provide a direct lin
 
 ### Providing a support URL {: #support-url }
 
-The CWS provides a [built in user support][support-tab] experience under your items' **Support tab**, but you can use
+The Chrome Web Store provides a [built in user support][support-tab] experience under your items' **Support tab**, but you can use
 a [dedicated support site][support-site] by including a link in the **Support URL**. 
 
 ## You are almost ready to publish this item! 
+
 If you haven't done so yet, complete your listing by 
 -  Filling out your [privacy practices][privacy] 
 -  Providing your [distribution preferences][distribution].

--- a/site/en/docs/webstore/cws-dashboard-listing/index.md
+++ b/site/en/docs/webstore/cws-dashboard-listing/index.md
@@ -91,9 +91,8 @@ To explain how your extension works in more detail, you can provide a direct lin
 
 ### Providing a support URL {: #support-url }
 
-The CWS provides a built in user support system under your items' "Support tab", but you can use your own support page by including a link in the **Support URL**. Note that first you must activate "Enable User Feedback" in the Account settings page. 
-
-{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/ArMfJztL1OlP6UektUwb.png", alt="Enable User Feedback Support tab", width="800", height="185" %}
+The CWS provides a [built in user support][support-tab] experience under your items' **Support tab**, but you can use
+a [dedicated support site][support-site] by including a link in the **Support URL**. 
 
 ## You are almost ready to publish this item! 
 If you haven't done so yet, complete your listing by 
@@ -107,4 +106,6 @@ If you haven't done so yet, complete your listing by
 [distribution]: /docs/webstore/cws-dashboard-distribution
 [keyword-spam]: /docs/webstore/spam-faq/#keyword-spam
 [privacy]: /docs/webstore/cws-dashboard-privacy
+[support-tab]: /docs/webstore/manage/#user-support-tab
+[support-site]: /docs/webstore/manage/#dedicated-support-site
 [verify-owner]: https://support.google.com/webmasters/answer/9008080

--- a/site/en/docs/webstore/manage/index.md
+++ b/site/en/docs/webstore/manage/index.md
@@ -2,7 +2,7 @@
 layout: "layouts/doc-post.njk"
 title: "Manage your Chrome Web Store Item"
 date: 2021-08-17
-updated: 2021-10-01
+updated: 2021-10-05
 description: >
   How to manage an extension or theme ("item") in the Chrome Web Store.
 ---

--- a/site/en/docs/webstore/manage/index.md
+++ b/site/en/docs/webstore/manage/index.md
@@ -106,18 +106,21 @@ store item by adding `/reviews` at the end of your item’s URL:
 ## Provide user support
 
 To ensure the best user experience and build a great extension it's important to
-collect, evaluate, and follow-up on user feedback. You can do so by enabling user feedback in the
-CWS dashboard Account setting page.
+collect, evaluate, and follow-up on user feedback. You can manage your extension's user feedback in
+two ways:
 
-{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/ArMfJztL1OlP6UektUwb.png", alt="Enable User Feedback Support tab", width="800", height="185" %}
+- By using the built in CWS User Support tab, or
+- By using a dedicated support site.
 
-Users will be able to ask questions, request features and report bugs in the **Support** Tab of your store item.
+Users will be able to communicate with you using the **Support** Tab of your store item.
 
 {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/OBDYk7n5dBcaqs3z1HtL.png", alt="Store item Support tab", width="800", height="121" %}
 
-There are two ways in which you can manage your extension's user feedback.
+### Using the User Support tab {: #user-support-tab }
 
-### Using the User Support tab
+First, you must enable user feedback in the developer console Account setting page.
+
+{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/ArMfJztL1OlP6UektUwb.png", alt="Enable User Feedback Support tab", width="800", height="185" %}
 
 In the **User Support** Tab of the developer console you can view, respond and manage user feedback. Use the **Type**
 dropdown to filter user input by
@@ -136,18 +139,25 @@ Currently, this feature does not provide notifications:
 
 {% endAside %}
 
-### Using a dedicated support site
+### Using a dedicated support site {: #dedicated-support-site }
 
 You can set up a dedicated support site for your users, so that the support link goes there instead of the default forum experience. This site can be anything you like, such as:
 
-* A discussion group using Google Groups or some similar service.
-* A form-handling site that lets users submit feedback or support tickets.
-* A public information site with your product road map or other details.
+- A discussion group using Google Groups or some similar service.
+- A form-handling site that lets users submit feedback or support tickets.
+- A public information site with your product road map or other details.
 
-Once you set up the site, go to the **Store Listing** tab and add the link to the **Support URL** field. Your support link will then take users to your dedicated site.
+Once you set up the site, go to the **Store Listing** tab of the developer console and add the link to the **Support URL**
+field. Your support link will then take users to your dedicated site.
 
 {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/7R8GYtBJjjRy1ih20dGd.png", alt="Store Listing Support
 URL field", width="514", height="283" %}
+
+{% Aside %}
+
+Make sure you **turn off** the [User Feedback][support-tab] in the dashboard Account settings to disable the default support experience.
+
+{% endAside %}
 
 ## Track your store listing performance
 
@@ -203,5 +213,6 @@ analytics id", width="787", height="121" %}
 [cws-support]: https://support.google.com/chrome_webstore/contact/dev_account_transfer
 [dev-dashboard]: https://chrome.google.com/webstore/devconsole
 [dev-policies]: /docs/webstore/program_policies
+[support-tab]: #user-support-tab
 [troubleshooting]: /docs/webstore/troubleshooting/
 [whats-new]: /docs/extensions/whatsnew/

--- a/site/en/docs/webstore/manage/index.md
+++ b/site/en/docs/webstore/manage/index.md
@@ -111,7 +111,7 @@ CWS dashboard Account setting page.
 
 {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/ArMfJztL1OlP6UektUwb.png", alt="Enable User Feedback Support tab", width="800", height="185" %}
 
-Users will be able to ask questions, request features and report bugs in the **Support Tab** of your store item.
+Users will be able to ask questions, request features and report bugs in the **Support** Tab of your store item.
 
 {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/OBDYk7n5dBcaqs3z1HtL.png", alt="Store item Support tab", width="800", height="121" %}
 
@@ -119,9 +119,9 @@ There are two ways in which you can manage your extension's user feedback.
 
 ### Using the User Support tab
 
-In the **User Support Tab** of your item you can view, respond and manage user feedback. Use the *Type*
+In the **User Support** Tab of the developer console you can view, respond and manage user feedback. Use the **Type**
 dropdown to filter user input by
-feature request, bug report or question. You can assign a status to each request and respond to each inquiry. Each ticket includes the extension
+feature request, bug report or question. You can assign a status to each request, and can respond to each inquiry. Each ticket includes the extension
 version, browser type and operating system to help you reproduce bugs
 more efficiently.
 
@@ -129,7 +129,7 @@ more efficiently.
 Support Tab", width="800", height="269" %}
 
 {% Aside %}
-Currently, there are no notifications for this feature:
+Currently, this feature does not provide notifications:
 
 - You will not be notified when a user posts a new request.
 - The user will not be notified when you post a response.
@@ -140,8 +140,8 @@ Currently, there are no notifications for this feature:
 
 You can set up a dedicated support site for your users, so that the support link goes there instead of the default forum experience. This site can be anything you like, such as:
 
-* A discussion group using Google Groups or some similar service
-* A form-handling site that lets users submit feedback or support tickets
+* A discussion group using Google Groups or some similar service.
+* A form-handling site that lets users submit feedback or support tickets.
 * A public information site with your product road map or other details.
 
 Once you set up the site, go to the **Store Listing** tab and add the link to the **Support URL** field. Your support link will then take users to your dedicated site.

--- a/site/en/docs/webstore/manage/index.md
+++ b/site/en/docs/webstore/manage/index.md
@@ -106,13 +106,13 @@ store item by adding `/reviews` at the end of your item’s URL:
 ## Provide user support
 
 To ensure the best user experience and build a great extension it's important to
-collect, evaluate, and follow-up on user feedback. You can manage your extension's user feedback in
+collect, evaluate, and follow up on user feedback. You can manage your extension's user feedback in
 two ways:
 
 - By using the built in CWS User Support tab, or
 - By using a dedicated support site.
 
-Users will be able to communicate with you using the **Support** Tab of your store item.
+Users will be able to communicate with you using the **Support** tab of your store item.
 
 {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/OBDYk7n5dBcaqs3z1HtL.png", alt="Store item Support tab", width="800", height="121" %}
 
@@ -122,7 +122,7 @@ First, you must enable user feedback in the developer console Account setting pa
 
 {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/ArMfJztL1OlP6UektUwb.png", alt="Enable User Feedback Support tab", width="800", height="185" %}
 
-In the **User Support** Tab of the developer console you can view, respond and manage user feedback. Use the **Type**
+In the **User Support** tab of the developer console you can view, respond and manage user feedback. Use the **Type**
 dropdown to filter user input by
 feature request, bug report or question. You can assign a status to each request, and can respond to each inquiry. Each ticket includes the extension
 version, browser type and operating system to help you reproduce bugs

--- a/site/en/docs/webstore/manage/index.md
+++ b/site/en/docs/webstore/manage/index.md
@@ -2,7 +2,7 @@
 layout: "layouts/doc-post.njk"
 title: "Manage your Chrome Web Store Item"
 date: 2021-08-17
-updated: 2021-09-15
+updated: 2021-10-01
 description: >
   How to manage an extension or theme ("item") in the Chrome Web Store.
 ---
@@ -102,6 +102,52 @@ store item by adding `/reviews` at the end of your item’s URL:
 `https://chrome.google.com/webstore/detail/{your-item-id}/reviews`
 
 {% endAside %}
+
+## Provide user support
+
+To ensure the best user experience and build a great extension it's important to
+collect, evaluate, and follow-up on user feedback. You can do so by enabling user feedback in the
+CWS dashboard Account setting page.
+
+{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/ArMfJztL1OlP6UektUwb.png", alt="Enable User Feedback Support tab", width="800", height="185" %}
+
+Users will be able to ask questions, request features and report bugs in the **Support Tab** of your store item.
+
+{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/OBDYk7n5dBcaqs3z1HtL.png", alt="Store item Support tab", width="800", height="121" %}
+
+There are two ways in which you can manage your extension's user feedback.
+
+### Using the User Support tab
+
+In the **User Support Tab** of your item you can view, respond and manage user feedback. Use the *Type*
+dropdown to filter user input by
+feature request, bug report or question. You can assign a status to each request and respond to each inquiry. Each ticket includes the extension
+version, browser type and operating system to help you reproduce bugs
+more efficiently.
+
+{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/VvJFAHdrcMnUivTLm0kK.png", alt="Dashboard User
+Support Tab", width="800", height="269" %}
+
+{% Aside %}
+Currently, there are no notifications for this feature:
+
+- You will not be notified when a user posts a new request.
+- The user will not be notified when you post a response.
+
+{% endAside %}
+
+### Using a dedicated support site
+
+You can set up a dedicated support site for your users, so that the support link goes there instead of the default forum experience. This site can be anything you like, such as:
+
+* A discussion group using Google Groups or some similar service
+* A form-handling site that lets users submit feedback or support tickets
+* A public information site with your product road map or other details.
+
+Once you set up the site, go to the **Store Listing** tab and add the link to the **Support URL** field. Your support link will then take users to your dedicated site.
+
+{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/7R8GYtBJjjRy1ih20dGd.png", alt="Store Listing Support
+URL field", width="514", height="283" %}
 
 ## Track your store listing performance
 


### PR DESCRIPTION
Fixes #1491 

CC: @CharyCh 

Changes proposed in this pull request:

- Add "Provide User Support" section to [Manage your CWS item](https://developer.chrome.com/docs/webstore/manage/) 

Staged Link

[Provide User Support](https://deploy-preview-1536--developer-chrome-com.netlify.app/docs/webstore/manage/#provide-user-support)

[Store Listing Support URL](https://deploy-preview-1536--developer-chrome-com.netlify.app/docs/webstore/cws-dashboard-listing/#support-url)