### PR TITLE
Fix typo in commands API usage on '/extensions/reference/commands/'

### DIFF
--- a/site/en/docs/extensions/reference/commands/index.md
+++ b/site/en/docs/extensions/reference/commands/index.md
@@ -274,7 +274,7 @@ experience by anticipating this possibility and checking for collisions at insta
 {% Aside %}
 
 `_execute_action`, `_execute_browser_action`, and `_execute_page_action` will not appear in the list
-of commands returned by `command.getAll()`.
+of commands returned by `commands.getAll()`.
 
 {% endAside %}
 


### PR DESCRIPTION
Fixes #1537

Changes proposed in this pull request:

- Changes `command.getAll()` to `commands.getAll()` to correct typo in commands API usage
- Todo: Fix language in blockquote to remove `_execute_browser_action` since it does appear in the list returned by `commands.getAll()`