### PR TITLE
Adds table of contents to blog posts

### DIFF
--- a/site/_includes/layouts/blog-post.njk
+++ b/site/_includes/layouts/blog-post.njk
@@ -44,4 +44,6 @@
     {% include 'partials/tags.njk' %}
     {% include 'partials/updated.njk' %}
   </article>
+  
+  {% include 'partials/toc-side.njk' %} 
 {% endblock %}

--- a/site/_includes/layouts/blog-post.njk
+++ b/site/_includes/layouts/blog-post.njk
@@ -5,6 +5,10 @@
   {% include 'partials/breadcrumbs.njk' %}
 {% endblock %}
 
+{% set tocContents %}
+  {{- content | toc | safe -}}
+{% endset %}
+
 {% block content %}
   {% if hero %}
     <div class="display-flex justify-content-center lg:pad-left-400 lg:pad-right-400">
@@ -30,6 +34,7 @@
       </div>
     {% endif %}
 
+    {% include 'partials/toc-inner.njk' %}
     {% include 'partials/draft.njk' %}
 
     <div class="stack stack--block type center-images">


### PR DESCRIPTION
Fixes #1521 

Changes proposed in this pull request:

- Adds ToC to the base blog posts template `blog-post.njk` (Similar to how `doc-post.njk` generates a ToC)