### PR TITLE
implement "up-to-date" build design

### DIFF
--- a/.cloudbuild/external.yaml
+++ b/.cloudbuild/external.yaml
@@ -1,0 +1,31 @@
+# This builds external data, and if the site passes a basic build, writes the data to
+# Cloud Storage.
+
+steps:
+  - name: node:14
+    id: 'Install dependencies'
+    entrypoint: npm
+    args: ['ci']
+
+  - name: node:14
+    id: 'Build external data'
+    entrypoint: npm
+    args: ['run', 'build-external']
+    env:
+    - 'PROJECT_ID=$PROJECT_ID'
+    - 'NODE_ENV=production'
+
+  - name: node:14
+    id: 'Build eleventy to confirm'
+    entrypoint: npm
+    args: ['run', 'eleventy']
+    env:
+    - 'NODE_ENV=production'
+
+  - name: 'gcr.io/cloud-builders/gcloud'
+    id: 'Synchronize content to external-dcc-data bucket'
+    entrypoint: bash
+    args:
+    - '-c'
+    - |
+      gsutil rsync external/data/ gs://external-dcc-data

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -61,6 +61,9 @@ module.exports = eleventyConfig => {
   // to use it for its build.
   eleventyConfig.setUseGitIgnore(false);
 
+  // Watch our external data in case it is synchronized or rebuilt.
+  eleventyConfig.addWatchTarget('./external/data/');
+
   // Merge eleventy's data cascade. This means directory data files will
   // cascade down to any child directories.
   eleventyConfig.setDataDeepMerge(true);

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ dist
 
 # External source files
 external/data/
+external/local-build-flag

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ dist
 # Eleventy
 # We generate our own .eleventyignore file dynamically during builds
 .eleventyignore
+
+# External source files
+external/data/

--- a/external/README.md
+++ b/external/README.md
@@ -1,0 +1,3 @@
+This folder contains the system that deals with external data for developer.chrome.com, that is, data that regularly changes to publish the site.
+
+- "fallback" contains checked-in data that is used for CI builds, and is overlaid over the site's actual data

--- a/external/build-external.js
+++ b/external/build-external.js
@@ -1,0 +1,70 @@
+/**
+ * @fileoverview Builds all external sources. This clears the data/ folder here
+ * and allows all scripts in build/ to write new files there.
+ *
+ * This is intended for use by Cloud Build, or by site devs doing local work.
+ */
+
+// nb. This is important; we load dotenv here and pass environment down.
+// It's safe to call this inside the build scripts too, but we run them with
+// cwd=data/, so it can't find the env.
+require('dotenv').config();
+
+const fs = require('fs');
+const path = require('path');
+const glob = require('glob');
+const childProcess = require('child_process');
+const crypto = require('crypto');
+
+async function run() {
+  let errors = 0;
+
+  const scripts = glob.sync('build/*.js', {cwd: __dirname});
+  scripts.sort(); // run in alphabetical order
+
+  const dataTarget = path.join(__dirname, 'data');
+  fs.rmSync(dataTarget, {recursive: true});
+  fs.mkdirSync(dataTarget, {recursive: true});
+
+  /** @type {childProcess.CommonExecOptions} */
+  const options = {cwd: dataTarget};
+
+  for (const script of scripts) {
+    const r = path.join(__dirname, script);
+    console.info('> Running', r);
+    try {
+      childProcess.execFileSync('node', [r], options);
+    } catch (e) {
+      // We don't log the error here, as we're already getting STDERR piped above.
+      console.warn(`! Failed to execute "${script}" (${e.status})`);
+      ++errors;
+    }
+  }
+
+  // Determine the hash for everything in data/.
+  const h = crypto.createHash('sha256');
+  const allFiles = glob.sync('data/**/*', {cwd: __dirname});
+  if (!allFiles.length) {
+    throw new Error('no files generated, cowardly refusing to hash');
+  }
+
+  // Sort allFiles, in case glob.sync is inconsistent.
+  allFiles.sort();
+
+  for (const f of allFiles) {
+    const p = path.join(__dirname, f);
+    const bytes = fs.readFileSync(p);
+    h.update(bytes);
+  }
+  const digest = h.digest('hex');
+  console.info(`@ Generated digest=${digest} for ${allFiles.length} files`);
+  fs.writeFileSync(path.join(__dirname, 'data/.hash'), digest);
+
+  // If there were any errors, return with a non-zero status code anyway.
+  if (errors) {
+    // eslint-disable-next-line no-process-exit
+    process.exit(1);
+  }
+}
+
+run();

--- a/external/build-external.js
+++ b/external/build-external.js
@@ -27,7 +27,7 @@ async function run() {
   fs.mkdirSync(dataTarget, {recursive: true});
 
   /** @type {childProcess.CommonExecOptions} */
-  const options = {cwd: dataTarget};
+  const options = {cwd: dataTarget, stdio: 'inherit'};
 
   for (const script of scripts) {
     const r = path.join(__dirname, script);
@@ -65,6 +65,12 @@ async function run() {
     // eslint-disable-next-line no-process-exit
     process.exit(1);
   }
+
+  // Mark this local environment as being build-only, so it won't automatically sync.
+  const payload =
+    '// This file blocks synchronizing local data, because you ran `npm run build-external`.\n' +
+    '// Delete it to bring back automatic sync when you run `npm run dev`.';
+  fs.writeFileSync(path.join(__dirname, 'local-build-flag'), payload);
 }
 
 run();

--- a/external/build/tweets.js
+++ b/external/build/tweets.js
@@ -1,0 +1,32 @@
+const fetch = require('node-fetch');
+const fs = require('fs');
+
+const tweetCount = 1;
+const url = `https://api.twitter.com/1.1/statuses/user_timeline.json?user_id=113713261&count=${tweetCount}&include_rts=false&exclude_replies=true&tweet_mode=extended&include_ext_alt_text=true`;
+
+async function run() {
+  if (!process.env.TWITTER_BEARER) {
+    throw new Error('No `TWITTER_BEARER` environment var for production');
+  }
+
+  const r = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${process.env.TWITTER_BEARER}`,
+    },
+  });
+
+  if (!r.ok) {
+    throw new Error(`Could not fetch tweets, status: ${r.status}`);
+  }
+
+  const json = await r.json();
+
+  if (json['errors']) {
+    const error = json['errors'][0];
+    throw new Error(`${error.code}: ${error.message}`);
+  }
+
+  fs.writeFileSync('tweets.json', JSON.stringify(json));
+}
+
+run();

--- a/external/fallback/tweets.json
+++ b/external/fallback/tweets.json
@@ -1,0 +1,324 @@
+[
+  {
+    "created_at": "Wed Dec 02 21:27:11 +0000 2020",
+    "id": 1334247765883367400,
+    "id_str": "1334247765883367424",
+    "full_text": "🎧  New episode of the #CSSPodcast just went live.\n\n🎨 This one is all about worklets and the Houdini Painting API!\n\nPaint worklets can be used all over CSS as:\n- backgrounds\n- masks\n- borders\n- etc!\n\n➡️ Learn more, including how to write your own today!\n\nhttps://t.co/PtKpp75VxK",
+    "truncated": false,
+    "display_text_range": [
+      0,
+      277
+    ],
+    "entities": {
+      "hashtags": [
+        {
+          "text": "CSSPodcast",
+          "indices": [
+            22,
+            33
+          ]
+        }
+      ],
+      "symbols": [],
+      "user_mentions": [],
+      "urls": [
+        {
+          "url": "https://t.co/PtKpp75VxK",
+          "expanded_url": "https://pod.link/thecsspodcast/episode/NTYzZTljNWUtNjQ2ZC00OWJjLWExOTgtZTY0M2VjYjBhYmU0",
+          "display_url": "pod.link/thecsspodcast/…",
+          "indices": [
+            254,
+            277
+          ]
+        }
+      ]
+    },
+    "source": "<a href=\"https://about.twitter.com/products/tweetdeck\" rel=\"nofollow\">TweetDeck</a>",
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 113713261,
+      "id_str": "113713261",
+      "name": "Chrome Developers",
+      "screen_name": "ChromiumDev",
+      "location": "Mountain View, CA",
+      "description": "News & guidance for developers from the Google Chrome Developer Relations team.",
+      "url": "https://t.co/b9JgHDUd68",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "https://t.co/b9JgHDUd68",
+              "expanded_url": "https://web.dev",
+              "display_url": "web.dev",
+              "indices": [
+                0,
+                23
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 341222,
+      "friends_count": 70,
+      "listed_count": 5411,
+      "created_at": "Fri Feb 12 19:48:38 +0000 2010",
+      "favourites_count": 1388,
+      "utc_offset": null,
+      "time_zone": null,
+      "geo_enabled": false,
+      "verified": true,
+      "statuses_count": 8659,
+      "lang": null,
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "ECF0F5",
+      "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+      "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+      "profile_background_tile": false,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/1316430904806440960/i47iiwIk_normal.jpg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/1316430904806440960/i47iiwIk_normal.jpg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/113713261/1602696263",
+      "profile_image_extensions_alt_text": null,
+      "profile_banner_extensions_alt_text": null,
+      "profile_link_color": "2A4C8A",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "AAB7D0",
+      "profile_text_color": "333333",
+      "profile_use_background_image": true,
+      "has_extended_profile": false,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": null,
+      "follow_request_sent": null,
+      "notifications": null,
+      "translator_type": "none"
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "is_quote_status": false,
+    "retweet_count": 8,
+    "favorite_count": 32,
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Wed Dec 02 17:04:07 +0000 2020",
+    "id": 1334181565874671600,
+    "id_str": "1334181565874671616",
+    "full_text": "🎺 Introducing CDS Adventure! 🎺\n\n💻 Create your own avatar, play together, and interact with the community and Googlers! Immerse yourself in our virtual world at #ChromeDevSummit.\n\n🗺 Your journey begins at 9:30am PT on December 9th! → https://t.co/iZ2Kee0SdP https://t.co/ryFaPeRWU1",
+    "truncated": false,
+    "display_text_range": [
+      0,
+      256
+    ],
+    "entities": {
+      "hashtags": [
+        {
+          "text": "ChromeDevSummit",
+          "indices": [
+            160,
+            176
+          ]
+        }
+      ],
+      "symbols": [],
+      "user_mentions": [],
+      "urls": [
+        {
+          "url": "https://t.co/iZ2Kee0SdP",
+          "expanded_url": "http://goo.gle/cds-adventure",
+          "display_url": "goo.gle/cds-adventure",
+          "indices": [
+            233,
+            256
+          ]
+        }
+      ],
+      "media": [
+        {
+          "id": 1334181499839545300,
+          "id_str": "1334181499839545345",
+          "indices": [
+            257,
+            280
+          ],
+          "media_url": "http://pbs.twimg.com/tweet_video_thumb/EoP3AVvVgAEcT6F.jpg",
+          "media_url_https": "https://pbs.twimg.com/tweet_video_thumb/EoP3AVvVgAEcT6F.jpg",
+          "url": "https://t.co/ryFaPeRWU1",
+          "display_url": "pic.twitter.com/ryFaPeRWU1",
+          "expanded_url": "https://twitter.com/ChromiumDev/status/1334181565874671616/photo/1",
+          "type": "photo",
+          "sizes": {
+            "thumb": {
+              "w": 150,
+              "h": 150,
+              "resize": "crop"
+            },
+            "small": {
+              "w": 680,
+              "h": 680,
+              "resize": "fit"
+            },
+            "medium": {
+              "w": 720,
+              "h": 720,
+              "resize": "fit"
+            },
+            "large": {
+              "w": 720,
+              "h": 720,
+              "resize": "fit"
+            }
+          }
+        }
+      ]
+    },
+    "extended_entities": {
+      "media": [
+        {
+          "id": 1334181499839545300,
+          "id_str": "1334181499839545345",
+          "indices": [
+            257,
+            280
+          ],
+          "media_url": "http://pbs.twimg.com/tweet_video_thumb/EoP3AVvVgAEcT6F.jpg",
+          "media_url_https": "https://pbs.twimg.com/tweet_video_thumb/EoP3AVvVgAEcT6F.jpg",
+          "url": "https://t.co/ryFaPeRWU1",
+          "display_url": "pic.twitter.com/ryFaPeRWU1",
+          "expanded_url": "https://twitter.com/ChromiumDev/status/1334181565874671616/photo/1",
+          "type": "animated_gif",
+          "sizes": {
+            "thumb": {
+              "w": 150,
+              "h": 150,
+              "resize": "crop"
+            },
+            "small": {
+              "w": 680,
+              "h": 680,
+              "resize": "fit"
+            },
+            "medium": {
+              "w": 720,
+              "h": 720,
+              "resize": "fit"
+            },
+            "large": {
+              "w": 720,
+              "h": 720,
+              "resize": "fit"
+            }
+          },
+          "video_info": {
+            "aspect_ratio": [
+              1,
+              1
+            ],
+            "variants": [
+              {
+                "bitrate": 0,
+                "content_type": "video/mp4",
+                "url": "https://video.twimg.com/tweet_video/EoP3AVvVgAEcT6F.mp4"
+              }
+            ]
+          },
+          "ext_alt_text": null
+        }
+      ]
+    },
+    "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 113713261,
+      "id_str": "113713261",
+      "name": "Chrome Developers",
+      "screen_name": "ChromiumDev",
+      "location": "Mountain View, CA",
+      "description": "News & guidance for developers from the Google Chrome Developer Relations team.",
+      "url": "https://t.co/b9JgHDUd68",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "https://t.co/b9JgHDUd68",
+              "expanded_url": "https://web.dev",
+              "display_url": "web.dev",
+              "indices": [
+                0,
+                23
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 341222,
+      "friends_count": 70,
+      "listed_count": 5411,
+      "created_at": "Fri Feb 12 19:48:38 +0000 2010",
+      "favourites_count": 1388,
+      "utc_offset": null,
+      "time_zone": null,
+      "geo_enabled": false,
+      "verified": true,
+      "statuses_count": 8659,
+      "lang": null,
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "ECF0F5",
+      "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+      "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+      "profile_background_tile": false,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/1316430904806440960/i47iiwIk_normal.jpg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/1316430904806440960/i47iiwIk_normal.jpg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/113713261/1602696263",
+      "profile_image_extensions_alt_text": null,
+      "profile_banner_extensions_alt_text": null,
+      "profile_link_color": "2A4C8A",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "AAB7D0",
+      "profile_text_color": "333333",
+      "profile_use_background_image": true,
+      "has_extended_profile": false,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": null,
+      "follow_request_sent": null,
+      "notifications": null,
+      "translator_type": "none"
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "is_quote_status": false,
+    "retweet_count": 44,
+    "favorite_count": 167,
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  }
+]

--- a/external/maybe-sync-external.js
+++ b/external/maybe-sync-external.js
@@ -1,0 +1,41 @@
+/**
+ * @fileoverview
+ */
+
+const fs = require('fs');
+const path = require('path');
+const childProcess = require('child_process');
+
+// Synchronize remote data at most once every 12 hours.
+const syncThresholdMs = 12 * 60 * 60 * 1000;
+
+async function run() {
+  if (fs.existsSync(path.join(__dirname, 'local-build-flag'))) {
+    console.info(
+      '! Not synchronizing external data, previous local build found.' +
+        'Run `npm run sync-external` to clear it.'
+    );
+    return;
+  }
+
+  try {
+    const stat = fs.statSync(path.join(__dirname, 'data'));
+    const since = +new Date() - stat.mtimeMs;
+    if (since < syncThresholdMs) {
+      // Don't log at all, just don't synchronize.
+      return;
+    }
+  } catch (e) {
+    // The folder probably doesn't exist. Sync.
+  }
+
+  const out = childProcess.spawnSync('npm run sync-external', {
+    shell: true,
+    stdio: 'inherit',
+  });
+  if (out.status) {
+    throw new Error(`could not sync, non-zero status: ${out.status}`);
+  }
+}
+
+run();

--- a/external/sync-external.js
+++ b/external/sync-external.js
@@ -1,0 +1,80 @@
+/**
+ * @fileoverview Synchronizes the last known good state from shared storage.
+ */
+
+const storageApi = require('@google-cloud/storage');
+const fs = require('fs');
+const path = require('path');
+const stream = require('stream');
+
+// This uses Application Default Credentials, but we just use it for synchronizing a public
+// bucket so it shouldn't need any special permissions.
+const storage = new storageApi.Storage();
+
+/**
+ * Write the contents of the specified bucket to the target folder. Clobbers existing files but
+ * does not clear existing unmatched files.
+ *
+ * @param {string} bucketName
+ * @param {string} target
+ * @return {Promise<string[]>}
+ */
+async function syncBucket(bucketName, target) {
+  const bucket = storage.bucket(bucketName);
+  fs.mkdirSync(target, {recursive: true});
+
+  /** @type {Promise<string>[]} */
+  const work = [];
+
+  /** @type {(file: storageApi.File) => void} */
+  const handleFile = file => {
+    const {name} = file;
+    const targetFile = path.join(target, name);
+
+    // Create the target folder, in case the data is nested.
+    fs.mkdirSync(path.dirname(targetFile), {recursive: true});
+
+    work.push(
+      // TODO: can we not sync a file if its timestamp is the same?
+      new Promise((resolve, reject) => {
+        const readable = file.createReadStream();
+        stream.pipeline(readable, fs.createWriteStream(targetFile), e => {
+          e ? reject(e) : resolve(name);
+        });
+      })
+    );
+  };
+
+  /** @type {Promise<void>} */
+  const streamPromise = new Promise((resolve, reject) => {
+    bucket
+      .getFilesStream()
+      .on('error', reject)
+      .on('data', handleFile)
+      .on('end', resolve);
+  });
+
+  await streamPromise;
+  const filenames = await Promise.all(work);
+  return filenames;
+}
+
+async function run() {
+  const target = path.join(__dirname, 'data');
+
+  const filenames = await syncBucket('external-dcc-data', target);
+  console.info('Synchronized external state:', filenames);
+
+  // If this is a CI build, we clobber synchronized data with anything found in "fallback/".
+  if (process.env.CI) {
+    // TODO(samthor): Just top-level files for now.
+    const fallbackTarget = path.join(__dirname, 'fallback');
+    const all = fs.readdirSync(fallbackTarget);
+    for (const f of all) {
+      fs.copyFileSync(path.join(fallbackTarget, f), path.join(target, f));
+    }
+    console.info('Preparing CI run, copied:', all);
+  }
+}
+
+run();

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@11ty/eleventy": "^0.11.1",
         "@11ty/eleventy-cache-assets": "^2.0.3",
         "@11ty/eleventy-plugin-rss": "^1.0.9",
+        "@google-cloud/storage": "^5.14.4",
         "@lhci/cli": "^0.7.2",
         "@rollup/plugin-node-resolve": "^8.4.0",
         "algoliasearch": "^4.6.0",
@@ -1084,6 +1085,99 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/@google-cloud/common": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-3.7.2.tgz",
+      "integrity": "sha512-5Q9f74IbZaY6xAwJSNFy5SrGwbm1j7mpv+6A/r+K2dymjsXBH5UauB0tziaMwWoVVaMq1IQnZF9lgtfqqvxcUg==",
+      "dependencies": {
+        "@google-cloud/projectify": "^2.0.0",
+        "@google-cloud/promisify": "^2.0.0",
+        "arrify": "^2.0.1",
+        "duplexify": "^4.1.1",
+        "ent": "^2.2.0",
+        "extend": "^3.0.2",
+        "google-auth-library": "^7.0.2",
+        "retry-request": "^4.2.2",
+        "teeny-request": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/duplexify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/google-auth-library": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.10.0.tgz",
+      "integrity": "sha512-ICsqaU+lxMHVlDUzMrfVIEqnARw2AwBiZ/2KnNM6BcTf9Nott+Af87DTIzmlnW865p3REUP2MVL0xkPC3a61aQ==",
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^4.0.0",
+        "gcp-metadata": "^4.2.0",
+        "gtoken": "^5.0.4",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/@google-cloud/paginator": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-3.0.6.tgz",
+      "integrity": "sha512-XCTm/GfQIlc1ZxpNtTSs/mnZxC2cePNhxU3X8EzHXKIJ2JFncmJj2Fcd2IP+gbmZaSZnY0juFxbUCkIeuu/2eQ==",
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@google-cloud/projectify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-2.1.1.tgz",
+      "integrity": "sha512-+rssMZHnlh0twl122gXY4/aCrk0G1acBqkHFfYddtsqpYXGxA29nj9V5V9SfC+GyOG00l650f6lG9KL+EpFEWQ==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@google-cloud/promisify": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-2.0.4.tgz",
+      "integrity": "sha512-j8yRSSqswWi1QqUGKVEKOG03Q7qOoZP6/h2zN2YO+F5h2+DHU0bSrHCK9Y7lo2DI9fBd8qGAw795sf+3Jva4yA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@google-cloud/secret-manager": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@google-cloud/secret-manager/-/secret-manager-3.2.2.tgz",
@@ -1094,6 +1188,101 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@google-cloud/storage": {
+      "version": "5.14.4",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.14.4.tgz",
+      "integrity": "sha512-CjpGuk+ZZB7b3yMXPQrPb0TMIhXqbDzrGxngeSl2S2fItFp2pZDnYhvFuB0/8S73cA2T/4x3g1tl6PB1OuuaoQ==",
+      "dependencies": {
+        "@google-cloud/common": "^3.7.0",
+        "@google-cloud/paginator": "^3.0.0",
+        "@google-cloud/promisify": "^2.0.0",
+        "arrify": "^2.0.0",
+        "async-retry": "^1.3.1",
+        "compressible": "^2.0.12",
+        "date-and-time": "^2.0.0",
+        "duplexify": "^4.0.0",
+        "extend": "^3.0.2",
+        "gcs-resumable-upload": "^3.3.0",
+        "get-stream": "^6.0.0",
+        "hash-stream-validation": "^0.2.2",
+        "mime": "^2.2.0",
+        "mime-types": "^2.0.8",
+        "p-limit": "^3.0.1",
+        "pumpify": "^2.0.0",
+        "snakeize": "^0.1.0",
+        "stream-events": "^1.0.1",
+        "xdg-basedir": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/duplexify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/mime": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+      "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/pumpify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
+      "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
+      "dependencies": {
+        "duplexify": "^4.1.1",
+        "inherits": "^2.0.3",
+        "pump": "^3.0.0"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -2976,6 +3165,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@types/babel-types": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.9.tgz",
@@ -3479,7 +3676,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -4082,6 +4278,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
     },
     "node_modules/async-settle": {
       "version": "1.0.0",
@@ -4926,7 +5130,6 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
       "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
-      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -5748,8 +5951,7 @@
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
-      "dev": true
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "node_modules/buffer-fill": {
       "version": "1.0.0",
@@ -7846,6 +8048,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/date-and-time": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-2.0.0.tgz",
+      "integrity": "sha512-HJSzj25iPm8E01nt+rSmCIlwjsmjvKfUivG/kXBglpymcHF1FolWAqWwTEV4FvN1Lx5UjPf0J1W4H8yQsVBfFg=="
+    },
     "node_modules/date-fns": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.15.0.tgz",
@@ -8620,7 +8827,6 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -8866,6 +9072,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/ent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
+      "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0="
     },
     "node_modules/entities": {
       "version": "2.0.3",
@@ -9677,7 +9888,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -10353,8 +10563,7 @@
     "node_modules/fast-text-encoding": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
-      "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig==",
-      "dev": true
+      "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig=="
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.12",
@@ -11113,7 +11322,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.0.1.tgz",
       "integrity": "sha512-jOin8xRZ/UytQeBpSXFqIzqU7Fi5TqgPNLlUsSB8kjJ76+FiGBfImF8KJu++c6J4jOldfJUtt0YmkRj2ZpSHTQ==",
-      "dev": true,
       "dependencies": {
         "abort-controller": "^3.0.0",
         "extend": "^3.0.2",
@@ -11129,7 +11337,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "dependencies": {
         "debug": "4"
       },
@@ -11141,7 +11348,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-      "dev": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -11154,7 +11360,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
       "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -11163,7 +11368,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.2.1.tgz",
       "integrity": "sha512-tSk+REe5iq/N+K+SK1XjZJUrFPuDqGZVzCy2vocIHIGmPlTGsa8owXMJwGkrXr73NO0AzhPW4MF2DEHz7P2AVw==",
-      "dev": true,
       "dependencies": {
         "gaxios": "^4.0.0",
         "json-bigint": "^1.0.0"
@@ -11171,6 +11375,91 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/gcs-resumable-upload": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-3.3.1.tgz",
+      "integrity": "sha512-WyC0i4VkslIdrdmeM5PNuGzANALLXTG5RoHb08OE30gYT+FEvCDPiA8KOjV2s1wOu9ngEW4+IuzBjtP/ni7UdQ==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "configstore": "^5.0.0",
+        "extend": "^3.0.2",
+        "gaxios": "^4.0.0",
+        "google-auth-library": "^7.0.0",
+        "pumpify": "^2.0.0",
+        "stream-events": "^1.0.4"
+      },
+      "bin": {
+        "gcs-upload": "build/src/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gcs-resumable-upload/node_modules/duplexify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/gcs-resumable-upload/node_modules/google-auth-library": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.10.0.tgz",
+      "integrity": "sha512-ICsqaU+lxMHVlDUzMrfVIEqnARw2AwBiZ/2KnNM6BcTf9Nott+Af87DTIzmlnW865p3REUP2MVL0xkPC3a61aQ==",
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^4.0.0",
+        "gcp-metadata": "^4.2.0",
+        "gtoken": "^5.0.4",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gcs-resumable-upload/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gcs-resumable-upload/node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/gcs-resumable-upload/node_modules/pumpify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
+      "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
+      "dependencies": {
+        "duplexify": "^4.1.1",
+        "inherits": "^2.0.3",
+        "pump": "^3.0.0"
+      }
+    },
+    "node_modules/gcs-resumable-upload/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/generic-pool": {
       "version": "3.7.1",
@@ -12092,7 +12381,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.3.tgz",
       "integrity": "sha512-wS0ek4ZtFx/ACKYF3JhyGe5kzH7pgiQ7J5otlumqR9psmWMYc+U9cErKlCYVYHoUaidXHdZ2xbo34kB+S+24hA==",
-      "dev": true,
       "dependencies": {
         "node-forge": "^0.10.0"
       },
@@ -12107,7 +12395,6 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
       "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
-      "dev": true,
       "engines": {
         "node": ">= 6.0.0"
       }
@@ -12207,7 +12494,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.1.0.tgz",
       "integrity": "sha512-4d8N6Lk8TEAHl9vVoRVMh9BNOKWVgl2DdNtr3428O75r3QFrF/a5MMu851VmK0AA8+iSvbwRv69k5XnMLURGhg==",
-      "dev": true,
       "dependencies": {
         "gaxios": "^4.0.0",
         "google-p12-pem": "^3.0.3",
@@ -12222,7 +12508,6 @@
       "version": "2.4.6",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
       "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
-      "dev": true,
       "bin": {
         "mime": "cli.js"
       },
@@ -13396,6 +13681,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/hash-stream-validation": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/hash-stream-validation/-/hash-stream-validation-0.2.4.tgz",
+      "integrity": "sha512-Gjzu0Xn7IagXVkSu9cSFuK1fqzwtLwFhNhVL8IFJijRNMgUttFbBSIAzKuSIrsFMO1+g1RlsoN49zPIbwPDMGQ=="
+    },
     "node_modules/hash-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/hash-string/-/hash-string-1.0.0.tgz",
@@ -13571,6 +13861,30 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/http-signature": {
@@ -15385,7 +15699,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-      "dev": true,
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
@@ -15610,7 +15923,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
       "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
-      "dev": true,
       "dependencies": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -15621,7 +15933,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
       "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
-      "dev": true,
       "dependencies": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
@@ -23625,6 +23936,14 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/retry-axios": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-1.0.2.tgz",
@@ -23638,12 +23957,12 @@
       }
     },
     "node_modules/retry-request": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.1.3.tgz",
-      "integrity": "sha512-QnRZUpuPNgX0+D1xVxul6DbJ9slvo4Rm6iV/dn63e048MvGbUZiKySVt6Tenp04JqmchxjiLltGerOJys7kJYQ==",
-      "dev": true,
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.2.2.tgz",
+      "integrity": "sha512-xA93uxUD/rogV7BV59agW/JHPGXeREMWiZc9jhcwY4YdZ7QOtC7qbomYg0n4wyk2lJhggjvKvhNX8wln/Aldhg==",
       "dependencies": {
-        "debug": "^4.1.1"
+        "debug": "^4.1.1",
+        "extend": "^3.0.2"
       },
       "engines": {
         "node": ">=8.10.0"
@@ -24359,6 +24678,11 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/snakeize": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/snakeize/-/snakeize-0.1.0.tgz",
+      "integrity": "sha1-EMCI2LWOsHazIpu1oE4jLOEmQi0="
+    },
     "node_modules/snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -25032,6 +25356,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "dependencies": {
+        "stubs": "^3.0.0"
+      }
+    },
     "node_modules/stream-exhaust": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
@@ -25301,6 +25633,11 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/striptags/-/striptags-3.1.1.tgz",
       "integrity": "sha1-yMPn/db7S7OjKjt1LltePjgJPr0="
+    },
+    "node_modules/stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls="
     },
     "node_modules/style-search": {
       "version": "0.1.0",
@@ -26243,6 +26580,52 @@
       "optional": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/teeny-request": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.1.3.tgz",
+      "integrity": "sha512-Ew3aoFzgQEatLA5OBIjdr1DWJUaC1xardG+qbPPo5k/y/3fMwXLxpjh5UB5dVfElktLaQbbMs80chkz53ByvSg==",
+      "dependencies": {
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "stream-events": "^1.0.5",
+        "uuid": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/teeny-request/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/teeny-request/node_modules/https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/teeny-request/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/temp-dir": {
@@ -28772,7 +29155,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -29614,6 +29996,83 @@
         }
       }
     },
+    "@google-cloud/common": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-3.7.2.tgz",
+      "integrity": "sha512-5Q9f74IbZaY6xAwJSNFy5SrGwbm1j7mpv+6A/r+K2dymjsXBH5UauB0tziaMwWoVVaMq1IQnZF9lgtfqqvxcUg==",
+      "requires": {
+        "@google-cloud/projectify": "^2.0.0",
+        "@google-cloud/promisify": "^2.0.0",
+        "arrify": "^2.0.1",
+        "duplexify": "^4.1.1",
+        "ent": "^2.2.0",
+        "extend": "^3.0.2",
+        "google-auth-library": "^7.0.2",
+        "retry-request": "^4.2.2",
+        "teeny-request": "^7.0.0"
+      },
+      "dependencies": {
+        "duplexify": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+          "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+          "requires": {
+            "end-of-stream": "^1.4.1",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "google-auth-library": {
+          "version": "7.10.0",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.10.0.tgz",
+          "integrity": "sha512-ICsqaU+lxMHVlDUzMrfVIEqnARw2AwBiZ/2KnNM6BcTf9Nott+Af87DTIzmlnW865p3REUP2MVL0xkPC3a61aQ==",
+          "requires": {
+            "arrify": "^2.0.0",
+            "base64-js": "^1.3.0",
+            "ecdsa-sig-formatter": "^1.0.11",
+            "fast-text-encoding": "^1.0.0",
+            "gaxios": "^4.0.0",
+            "gcp-metadata": "^4.2.0",
+            "gtoken": "^5.0.4",
+            "jws": "^4.0.0",
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "@google-cloud/paginator": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-3.0.6.tgz",
+      "integrity": "sha512-XCTm/GfQIlc1ZxpNtTSs/mnZxC2cePNhxU3X8EzHXKIJ2JFncmJj2Fcd2IP+gbmZaSZnY0juFxbUCkIeuu/2eQ==",
+      "requires": {
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2"
+      }
+    },
+    "@google-cloud/projectify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-2.1.1.tgz",
+      "integrity": "sha512-+rssMZHnlh0twl122gXY4/aCrk0G1acBqkHFfYddtsqpYXGxA29nj9V5V9SfC+GyOG00l650f6lG9KL+EpFEWQ=="
+    },
+    "@google-cloud/promisify": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-2.0.4.tgz",
+      "integrity": "sha512-j8yRSSqswWi1QqUGKVEKOG03Q7qOoZP6/h2zN2YO+F5h2+DHU0bSrHCK9Y7lo2DI9fBd8qGAw795sf+3Jva4yA=="
+    },
     "@google-cloud/secret-manager": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@google-cloud/secret-manager/-/secret-manager-3.2.2.tgz",
@@ -29621,6 +30080,82 @@
       "dev": true,
       "requires": {
         "google-gax": "^2.9.2"
+      }
+    },
+    "@google-cloud/storage": {
+      "version": "5.14.4",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.14.4.tgz",
+      "integrity": "sha512-CjpGuk+ZZB7b3yMXPQrPb0TMIhXqbDzrGxngeSl2S2fItFp2pZDnYhvFuB0/8S73cA2T/4x3g1tl6PB1OuuaoQ==",
+      "requires": {
+        "@google-cloud/common": "^3.7.0",
+        "@google-cloud/paginator": "^3.0.0",
+        "@google-cloud/promisify": "^2.0.0",
+        "arrify": "^2.0.0",
+        "async-retry": "^1.3.1",
+        "compressible": "^2.0.12",
+        "date-and-time": "^2.0.0",
+        "duplexify": "^4.0.0",
+        "extend": "^3.0.2",
+        "gcs-resumable-upload": "^3.3.0",
+        "get-stream": "^6.0.0",
+        "hash-stream-validation": "^0.2.2",
+        "mime": "^2.2.0",
+        "mime-types": "^2.0.8",
+        "p-limit": "^3.0.1",
+        "pumpify": "^2.0.0",
+        "snakeize": "^0.1.0",
+        "stream-events": "^1.0.1",
+        "xdg-basedir": "^4.0.0"
+      },
+      "dependencies": {
+        "duplexify": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+          "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+          "requires": {
+            "end-of-stream": "^1.4.1",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+          "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
+        },
+        "mime": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+          "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg=="
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "pumpify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
+          "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
+          "requires": {
+            "duplexify": "^4.1.1",
+            "inherits": "^2.0.3",
+            "pump": "^3.0.0"
+          }
+        }
       }
     },
     "@grpc/grpc-js": {
@@ -31089,6 +31624,11 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
+    },
     "@types/babel-types": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.9.tgz",
@@ -31489,7 +32029,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
       "requires": {
         "event-target-shim": "^5.0.0"
       }
@@ -31937,6 +32476,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+    },
+    "async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "requires": {
+        "retry": "0.13.1"
+      }
     },
     "async-settle": {
       "version": "1.0.0",
@@ -32600,8 +33147,7 @@
     "bignumber.js": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
-      "dev": true
+      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
     },
     "bin-build": {
       "version": "3.0.0",
@@ -33286,8 +33832,7 @@
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
-      "dev": true
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-fill": {
       "version": "1.0.0",
@@ -35003,6 +35548,11 @@
         "whatwg-url": "^8.0.0"
       }
     },
+    "date-and-time": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-2.0.0.tgz",
+      "integrity": "sha512-HJSzj25iPm8E01nt+rSmCIlwjsmjvKfUivG/kXBglpymcHF1FolWAqWwTEV4FvN1Lx5UjPf0J1W4H8yQsVBfFg=="
+    },
     "date-fns": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.15.0.tgz",
@@ -35632,7 +36182,6 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -35852,6 +36401,11 @@
           "dev": true
         }
       }
+    },
+    "ent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
+      "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0="
     },
     "entities": {
       "version": "2.0.3",
@@ -36451,8 +37005,7 @@
     "event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "eventemitter3": {
       "version": "4.0.4",
@@ -37009,8 +37562,7 @@
     "fast-text-encoding": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
-      "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig==",
-      "dev": true
+      "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig=="
     },
     "fastest-levenshtein": {
       "version": "1.0.12",
@@ -37623,7 +38175,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.0.1.tgz",
       "integrity": "sha512-jOin8xRZ/UytQeBpSXFqIzqU7Fi5TqgPNLlUsSB8kjJ76+FiGBfImF8KJu++c6J4jOldfJUtt0YmkRj2ZpSHTQ==",
-      "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
         "extend": "^3.0.2",
@@ -37636,7 +38187,6 @@
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
           "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-          "dev": true,
           "requires": {
             "debug": "4"
           }
@@ -37645,7 +38195,6 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
           "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-          "dev": true,
           "requires": {
             "agent-base": "6",
             "debug": "4"
@@ -37654,8 +38203,7 @@
         "is-stream": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-          "dev": true
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
         }
       }
     },
@@ -37663,10 +38211,84 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.2.1.tgz",
       "integrity": "sha512-tSk+REe5iq/N+K+SK1XjZJUrFPuDqGZVzCy2vocIHIGmPlTGsa8owXMJwGkrXr73NO0AzhPW4MF2DEHz7P2AVw==",
-      "dev": true,
       "requires": {
         "gaxios": "^4.0.0",
         "json-bigint": "^1.0.0"
+      }
+    },
+    "gcs-resumable-upload": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-3.3.1.tgz",
+      "integrity": "sha512-WyC0i4VkslIdrdmeM5PNuGzANALLXTG5RoHb08OE30gYT+FEvCDPiA8KOjV2s1wOu9ngEW4+IuzBjtP/ni7UdQ==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "configstore": "^5.0.0",
+        "extend": "^3.0.2",
+        "gaxios": "^4.0.0",
+        "google-auth-library": "^7.0.0",
+        "pumpify": "^2.0.0",
+        "stream-events": "^1.0.4"
+      },
+      "dependencies": {
+        "duplexify": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+          "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+          "requires": {
+            "end-of-stream": "^1.4.1",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "google-auth-library": {
+          "version": "7.10.0",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.10.0.tgz",
+          "integrity": "sha512-ICsqaU+lxMHVlDUzMrfVIEqnARw2AwBiZ/2KnNM6BcTf9Nott+Af87DTIzmlnW865p3REUP2MVL0xkPC3a61aQ==",
+          "requires": {
+            "arrify": "^2.0.0",
+            "base64-js": "^1.3.0",
+            "ecdsa-sig-formatter": "^1.0.11",
+            "fast-text-encoding": "^1.0.0",
+            "gaxios": "^4.0.0",
+            "gcp-metadata": "^4.2.0",
+            "gtoken": "^5.0.4",
+            "jws": "^4.0.0",
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "pumpify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
+          "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
+          "requires": {
+            "duplexify": "^4.1.1",
+            "inherits": "^2.0.3",
+            "pump": "^3.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
       }
     },
     "generic-pool": {
@@ -38409,7 +39031,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.3.tgz",
       "integrity": "sha512-wS0ek4ZtFx/ACKYF3JhyGe5kzH7pgiQ7J5otlumqR9psmWMYc+U9cErKlCYVYHoUaidXHdZ2xbo34kB+S+24hA==",
-      "dev": true,
       "requires": {
         "node-forge": "^0.10.0"
       },
@@ -38417,8 +39038,7 @@
         "node-forge": {
           "version": "0.10.0",
           "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-          "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
-          "dev": true
+          "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
         }
       }
     },
@@ -38506,7 +39126,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.1.0.tgz",
       "integrity": "sha512-4d8N6Lk8TEAHl9vVoRVMh9BNOKWVgl2DdNtr3428O75r3QFrF/a5MMu851VmK0AA8+iSvbwRv69k5XnMLURGhg==",
-      "dev": true,
       "requires": {
         "gaxios": "^4.0.0",
         "google-p12-pem": "^3.0.3",
@@ -38517,8 +39136,7 @@
         "mime": {
           "version": "2.4.6",
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
-          "dev": true
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
         }
       }
     },
@@ -39373,6 +39991,11 @@
       "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
       "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw=="
     },
+    "hash-stream-validation": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/hash-stream-validation/-/hash-stream-validation-0.2.4.tgz",
+      "integrity": "sha512-Gjzu0Xn7IagXVkSu9cSFuK1fqzwtLwFhNhVL8IFJijRNMgUttFbBSIAzKuSIrsFMO1+g1RlsoN49zPIbwPDMGQ=="
+    },
     "hash-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/hash-string/-/hash-string-1.0.0.tgz",
@@ -39518,6 +40141,26 @@
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
         "requires-port": "^1.0.0"
+      }
+    },
+    "http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "requires": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+          "requires": {
+            "debug": "4"
+          }
+        }
       }
     },
     "http-signature": {
@@ -40861,7 +41504,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-      "dev": true,
       "requires": {
         "bignumber.js": "^9.0.0"
       }
@@ -41044,7 +41686,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
       "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
-      "dev": true,
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -41055,7 +41696,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
       "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
-      "dev": true,
       "requires": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
@@ -47360,6 +48000,11 @@
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
+    "retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
+    },
     "retry-axios": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-1.0.2.tgz",
@@ -47368,12 +48013,12 @@
       "requires": {}
     },
     "retry-request": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.1.3.tgz",
-      "integrity": "sha512-QnRZUpuPNgX0+D1xVxul6DbJ9slvo4Rm6iV/dn63e048MvGbUZiKySVt6Tenp04JqmchxjiLltGerOJys7kJYQ==",
-      "dev": true,
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.2.2.tgz",
+      "integrity": "sha512-xA93uxUD/rogV7BV59agW/JHPGXeREMWiZc9jhcwY4YdZ7QOtC7qbomYg0n4wyk2lJhggjvKvhNX8wln/Aldhg==",
       "requires": {
-        "debug": "^4.1.1"
+        "debug": "^4.1.1",
+        "extend": "^3.0.2"
       }
     },
     "reusify": {
@@ -47963,6 +48608,11 @@
       "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.6.tgz",
       "integrity": "sha512-ZdJIgv9gdrYwhXqxsH9pv7nXxjUEyQ6nqhngRxoAAOlmMGA28FDq5O4/5US4G2/Nod7d1ovNcgURQJ7kHq50KQ=="
     },
+    "snakeize": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/snakeize/-/snakeize-0.1.0.tgz",
+      "integrity": "sha1-EMCI2LWOsHazIpu1oE4jLOEmQi0="
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -48549,6 +49199,14 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
+    "stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "requires": {
+        "stubs": "^3.0.0"
+      }
+    },
     "stream-exhaust": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
@@ -48740,6 +49398,11 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/striptags/-/striptags-3.1.1.tgz",
       "integrity": "sha1-yMPn/db7S7OjKjt1LltePjgJPr0="
+    },
+    "stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls="
     },
     "style-search": {
       "version": "0.1.0",
@@ -49485,6 +50148,42 @@
           "requires": {
             "safe-buffer": "~5.1.0"
           }
+        }
+      }
+    },
+    "teeny-request": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.1.3.tgz",
+      "integrity": "sha512-Ew3aoFzgQEatLA5OBIjdr1DWJUaC1xardG+qbPPo5k/y/3fMwXLxpjh5UB5dVfElktLaQbbMs80chkz53ByvSg==",
+      "requires": {
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "stream-events": "^1.0.5",
+        "uuid": "^8.0.0"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+          "requires": {
+            "debug": "4"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
+          }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         }
       }
     },
@@ -51499,8 +52198,7 @@
     "yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@11ty/eleventy": "^0.11.1",
     "@11ty/eleventy-cache-assets": "^2.0.3",
     "@11ty/eleventy-plugin-rss": "^1.0.9",
+    "@google-cloud/storage": "^5.14.4",
     "@lhci/cli": "^0.7.2",
     "@rollup/plugin-node-resolve": "^8.4.0",
     "algoliasearch": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "algolia": "node ./algolia.js",
     "clean": "rimraf dist",
     "cloud-secrets": "node ./cloud-secrets.js",
-    "dev": "npm-run-all clean ignore gulp rollup --parallel --race gulp:watch rollup:watch eleventy:watch start",
+    "dev": "npm-run-all clean ignore gulp rollup maybe-sync-external --parallel --race gulp:watch rollup:watch eleventy:watch start",
     "eleventy:debug": "node --inspect ./node_modules/.bin/eleventy",
     "eleventy:watch": "npx eleventy --quiet --watch",
     "eleventy": "npx eleventy",
@@ -23,7 +23,7 @@
     "lint:scss": "stylelint **/*.scss",
     "lint:types": "tsc --noEmit",
     "lint": "npm-run-all lint:js lint:scss lint:md lint:types",
-    "production": "NODE_ENV=production npm-run-all clean ignore gulp rollup eleventy",
+    "production": "NODE_ENV=production npm-run-all clean maybe-sync-external ignore gulp rollup eleventy",
     "snapshots": "percy snapshot dist/en",
     "percy": "ELEVENTY_IGNORE_NACL=true npm-run-all production snapshots",
     "rollup:watch": "chokidar \"site/**/*.js\" -c \"npx rollup -c\"",
@@ -32,7 +32,10 @@
     "stage": "NODE_ENV=production npm run production && gcloud app deploy --project=chrome-apps-doc-staging-2020 --quiet",
     "start": "node ./server",
     "test:watch": "ava --watch",
-    "test": "nyc ava"
+    "test": "nyc ava",
+    "build-external": "node ./external/build-external.js",
+    "maybe-sync-external": "node ./external/maybe-sync-external.js",
+    "sync-external": "node ./external/sync-external.js"
   },
   "license": "Apache 2.0",
   "dependencies": {

--- a/site/_data/tweets.js
+++ b/site/_data/tweets.js
@@ -1,11 +1,4 @@
-require('dotenv').config();
-const CacheAsset = require('@11ty/eleventy-cache-assets');
 const escapeStringRegexp = require('escape-string-regexp');
-
-// nb. All images and uploaded assets are in the web-dev-uploads bucket, but tweets are still in
-// the default project bucket.
-const url =
-  'https://storage.googleapis.com/chrome-gcs-uploader.appspot.com/tweets.json';
 
 /**
  * Insert media (images/videos) into a tweet.
@@ -134,19 +127,11 @@ const formatEntities = tweet => {
  * @return {Promise<TwitterTweet[]>}
  */
 module.exports = async () => {
-  let tweets = process.env.CI
-    ? require('./tweets-sample.json')
-    : await CacheAsset(url, {
-        duration: '1h',
-        type: 'json',
-      }).catch(e => {
-        console.warn(e);
-        if (process.env.NODE_ENV === 'production') {
-          return undefined;
-        } else {
-          return require('./tweets-sample.json');
-        }
-      });
+  // We have to cast this to unknown first as Typescript gets very literal about the underlying type
+  // of the JSON.
+  let tweets = /** @type {TwitterTweet[]} */ (
+    /** @type {unknown} */ (require('../../external/data/tweets.json'))
+  );
 
   // Remove polls
   tweets = tweets.filter(tweet => !tweet.entities.polls);


### PR DESCRIPTION
This is a major PR changing the way we pull in external data to the site. It mostly implements the internal named design doc.

- We have a subfolder named external/ which itself contains data/ (dynamically fetched), build/ (run to build data/) and fallback/ (provides consistent data for CI).
- The Cloud Build task will be run every ~hour, and populates a Cloud Storage bucket with external data on success
- Normal users of the site, as part of `npm run dev`, will have this folder synchronized to external/data/
- If you want to instead test external data or change its build, you can run `npm run build-external`; this will also prevent sync until you later run `npm run sync-external` to clear a boolean

The idea is that external data breakages, while important (and will alert the team, because we alert on Cloud Build failures of any type), shouldn't stop regular deploy for our authors. They'll always get a "last known good" during local dev, or as part of our regular site deploy.