### PR TITLE
Remove commands that do appear in returned list from commands.getAll()

### DIFF
--- a/site/en/docs/extensions/reference/commands/index.md
+++ b/site/en/docs/extensions/reference/commands/index.md
@@ -273,7 +273,7 @@ experience by anticipating this possibility and checking for collisions at insta
 
 {% Aside %}
 
-`_execute_action`, `_execute_browser_action`, and `_execute_page_action` will not appear in the list
+`_execute_action` will not appear in the list
 of commands returned by `commands.getAll()`.
 
 {% endAside %}


### PR DESCRIPTION
Fixes #1537 (Cleanup)

Changes proposed in this pull request:

- Remove `_execute_browser_action` and `_execute_page_action` commands from blockquote as they are returned in the list from `chrome.commands.getAll()`


<img width="780" alt="Screen Shot 2021-10-05 at 10 24 04 PM" src="https://user-images.githubusercontent.com/48612525/136149753-1b945794-b324-4ec6-8bb8-69f7e0871eac.png">

cc @AmySteam