### PR TITLE
Changing CTA for PWA summit banner

### DIFF
--- a/site/_data/banner.yml
+++ b/site/_data/banner.yml
@@ -1,6 +1,6 @@
 type: info
-text: 'PWA Summit: a virtual conference to help everyone succeed with PWAs is on Oct 6 & 7.'
+text: 'PWA Summit: a virtual conference to help everyone succeed with PWAs is streaming today!'
 actions:
-  - text: Get your free ticket
-    href: https://pwasummit.org/register
+  - text: Join the live stream
+    href: https://www.youtube.com/watch?v=qbh_u2hvIjg
   - text: Dismiss


### PR DESCRIPTION
Updating the banner to point directly to the summit livestream.

This should be submitted sometime early October 7th, the livestream starts at 8:00am PT/ 11:00AM ET

I will have a PR ready to take down the banner at the end of day ~ 4:00PM PT