### PR TITLE
always use reference layout

### DIFF
--- a/site/en/docs/extensions/reference/reference.11tydata.js
+++ b/site/en/docs/extensions/reference/reference.11tydata.js
@@ -29,11 +29,13 @@ function namespaceForData(data) {
   }
 
   if (api in chromeApiNamespaces) {
+    console.warn('found API :party:', api);
     return chromeApiNamespaces[api];
   }
 
   // This can be called several times by Eleventy. The first time it's called it's unlikely that
   // the namespace data is available yet, so we can't warn here if it's missing.
+  console.warn('failed to find API', api);
   return undefined;
 }
 
@@ -68,11 +70,11 @@ module.exports = {
       }
 
       // Otherwise, if we're a namespace, use a predefined layout.
-      const namespace = namespaceForData(data);
-      if (namespace) {
+      if (data.api) {
         return 'layouts/namespace-reference.njk';
       }
-      return data.layout;
+
+      throw new Error(`API reference page has no data.layout: ${data.layout}`);
     },
 
     /**

--- a/site/en/docs/extensions/reference/reference.11tydata.js
+++ b/site/en/docs/extensions/reference/reference.11tydata.js
@@ -69,6 +69,8 @@ module.exports = {
         return 'layouts/namespace-reference.njk';
       }
 
+      // Every item in this folder should either be displaying an API (and have `data.api` set) or
+      // have a specific layout override, so throw otherwise.
       throw new Error(`API reference page has no data.layout: ${data.layout}`);
     },
 

--- a/site/en/docs/extensions/reference/reference.11tydata.js
+++ b/site/en/docs/extensions/reference/reference.11tydata.js
@@ -28,15 +28,10 @@ function namespaceForData(data) {
     return undefined;
   }
 
-  if (api in chromeApiNamespaces) {
-    console.warn('found API :party:', api);
-    return chromeApiNamespaces[api];
-  }
-
-  // This can be called several times by Eleventy. The first time it's called it's unlikely that
-  // the namespace data is available yet, so we can't warn here if it's missing.
-  console.warn('failed to find API', api);
-  return undefined;
+  // This can be called several times by Eleventy because the data gets resolved in an odd order.
+  // It's fine to return undefined here, and we don't want to log (since it'll be spammy), and
+  // we'll be called again if we previously returned undefined.
+  return chromeApiNamespaces[api];
 }
 
 module.exports = {


### PR DESCRIPTION
Fixes a race condition which caused some pages to often have no layout.

Pages should have a layout. If they don't, throw an error.