### PR TITLE
Postpone SAB deprecation trial to Chrome 103

### DIFF
--- a/site/en/blog/coep-credentialless-origin-trial/index.md
+++ b/site/en/blog/coep-credentialless-origin-trial/index.md
@@ -8,7 +8,7 @@ subhead: >
   headers. If they can be requested without credentials, now you can enable cross-origin
   isolation by marking them as such. 
 date: 2021-07-29
-updated: 2021-08-03
+updated: 2021-10-14
 authors:
   - agektmr
 tags:
@@ -179,12 +179,12 @@ cross-origin isolation:
 * [Anonymous
   iframes](https://github.com/camillelamy/explainers/blob/master/anonymous_iframes.md)
 
-Both of these changes are planned to land sometime in Q4 2021. Those who
-registered for [the Chrome origin trial to extend the SharedArrayBuffer
+Those who registered for [the Chrome origin trial to extend the
+SharedArrayBuffer
 change](https://developer.chrome.com/blog/enabling-shared-array-buffer/) due to
 the above obstacles might be wondering when it will be terminated. Originally we
-announced that it will be terminated in Chrome 96, but we will not do so until
-these updates are in place.
+announced that it will be terminated in Chrome 96, but we have decided to
+postpone this to Chrome 103.
 
 ## Resources
 

--- a/site/en/blog/enabling-shared-array-buffer/index.md
+++ b/site/en/blog/enabling-shared-array-buffer/index.md
@@ -24,7 +24,7 @@ alt: A collection of padlocks.
 To secure more time to introduce ways to relax the requirement to enable
 cross-origin isolation, we've decided to postpone the restriction on
 `SharedArrayBuffer` on desktop described in this article to Chrome 103
-(originally Chrome 96).
+(originally Chrome 96). You might need to update the token.
 
 {% endAside %}
 

--- a/site/en/blog/enabling-shared-array-buffer/index.md
+++ b/site/en/blog/enabling-shared-array-buffer/index.md
@@ -8,22 +8,23 @@ description: >
   SharedArrayBuffer will arrive in Android Chrome 88. It will only be available
   to pages that are cross-origin isolated. Starting in Desktop Chrome 92 it will
   also only be available to cross-origin isolated pages. You can register for an
-  origin trial to retain the current behavior until Desktop Chrome 96.
+  origin trial to retain the current behavior until Desktop Chrome 103.
 origin_trial:
   url: /origintrials/#/view_trial/303992974847508481
 date: 2021-01-18
-updated: 2021-05-13
+updated: 2021-10-14
 hero: image/CZmpGM8Eo1dFe0KNhEO9SGO8Ok23/tWnZEOnNmBeFcZxuR9Dx.jpg
 alt: A collection of padlocks.
 ---
 
 {% Aside %}
 
-**Update, May 2021**
+**Update, October 2021**
 
-Due to unexpected circumstances, the restriction on `SharedArrayBuffer` on
-desktop described in this article is postponed to Chrome 92 (originally Chrome
-91).
+To secure more time to introduce ways to relax the requirement to enable
+cross-origin isolation, we've decided to postpone the restriction on
+`SharedArrayBuffer` on desktop described in this article to Chrome 103
+(originally Chrome 96).
 
 {% endAside %}
 
@@ -37,8 +38,9 @@ web, but things are settling down. Here's what you need to know:
   isolated](#cross-origin-isolation).
 - `SharedArrayBuffer` is currently available in Desktop Chrome, but from Chrome
   92 it will be limited to cross-origin isolated pages. If you don't think you
-  can make this change in time, you can [register for an origin trial](#origin-trial) to retain
-  the current behavior until at least Chrome 96.
+  can make this change in time, you can [register for an origin
+  trial](#origin-trial) to retain the current behavior until at least Chrome
+  103.
 - If you intend to enable cross-origin isolation to continue using
   `SharedArrayBuffer` evaluate the impact this will have on other cross-origin
   elements on your website, such as ad placements. Check if `SharedArrayBuffer`
@@ -68,7 +70,7 @@ can gather data on requests that failed as a result of
 
 If you don't think you can make these changes in time for Chrome 92, you can
 [register for an origin trial](#origin-trial) to retain current Desktop Chrome
-behavior until at least Chrome 96.
+behavior until at least Chrome 103.
 
 {% Aside %}
 **Update, April 2021**
@@ -76,10 +78,10 @@ behavior until at least Chrome 96.
 We've been exploring ways to deploy `Cross-Origin-Resource-Policy` at scale, as
 cross-origin isolation requires all subresources to explicitly opt-in. And we
 have come up with the idea of going in the opposite direction: a new [COEP
-"credentialless" mode](https://github.com/mikewest/credentiallessness/) that
-allows loading resources without the CORP header by stripping all their
-credentials. We are figuring out the details of how it should work, but we hope
-this will lighten your burden of making sure the subresources are sending the
+"credentialless" mode](/blog/coep-credentialless-origin-trial/) that allows
+loading resources without the CORP header by stripping all their credentials. We
+are figuring out the details of how it should work, but we hope this will
+lighten your burden of making sure the subresources are sending the
 `Cross-Origin-Resource-Policy` header.
 
 Also, it's known that the `Cross-Origin-Opener-Policy: same-origin` header will
@@ -183,7 +185,7 @@ isolation.
 This is a temporary exception in the form of an 'origin trial' that gives folks
 more time to implement cross-origin isolated pages. It enables
 `SharedArrayBuffer` without requiring the page to be cross-origin isolated. The
-exception expires in Chrome 96, and the exception only applies to Desktop
+exception expires in Chrome 103, and the exception only applies to Desktop
 Chrome.
 
 1. [Request a token]({{origin_trial.url}}) for your origin.


### PR DESCRIPTION
Postpone SharedArrayBuffer deprecation trial to Chrome 103

cc: @lutzvahl