### PR TITLE
Add redirect from /summit to /devsummit/

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -48,6 +48,9 @@ redirects:
 - from: /docs/devtools/javascript/blackbox-chrome-extension-scripts/
   to: /docs/devtools/javascript/ignore-chrome-extension-scripts/
 
+- from: /summit
+  to: /devsummit/
+
 # Removal of /overview pages
 
 - from: /docs/android/custom-tabs/overview/


### PR DESCRIPTION
Changes proposed in this pull request:
- Adds a redirect from `/summit/` to the actual url `/devsummit/`

I've hit `/summit` more times then I care to count and forget that the URL is actually `/devsummit/`, let's just make it easy for devs to hit the right URL.