### PR TITLE
Update footer to remove links to devweb firehose

### DIFF
--- a/site/_data/i18n/footer.yml
+++ b/site/_data/i18n/footer.yml
@@ -22,9 +22,6 @@ web_fundamentals:
 case_studies:
   en: Case studies
 
-content_firehose:
-  en: DevWeb Content Firehose
-
 podcasts:
   en: Podcasts
 

--- a/site/_includes/partials/footer.njk
+++ b/site/_includes/partials/footer.njk
@@ -53,11 +53,6 @@
             </a>
           </li>
           <li>
-            <a class="footer__link" href="https://devwebfeed.appspot.com/">
-              {{ 'i18n.footer.content_firehose' | i18n(locale) }}
-            </a>
-          </li>
-          <li>
             <a class="footer__link" href="https://web.dev/podcasts/">
               {{ 'i18n.footer.podcasts' | i18n(locale) }}
             </a>


### PR DESCRIPTION
Removes link to DevWeb Firehose (which has been removed).

@PaulKinlan fyi.