### PR TITLE
Fix URLPattern example error

### DIFF
--- a/site/en/blog/new-in-chrome-95/index.md
+++ b/site/en/blog/new-in-chrome-95/index.md
@@ -65,7 +65,7 @@ We'll specify the `kind` of file, the file `ID`, and what `mode` to open it in.
 Then to use the pattern, we can call either `test()`, or `exec()`.
 
 ```js
-const url = '/document/d/1s...5c/edit#heading=h.8...c';
+const url = 'https://docs.google.com/document/d/1s...5c/edit#heading=h.8...c';
 
 const pattern = new URLPattern({
   pathname: '/:kind/d/:fileID/:mode',


### PR DESCRIPTION
pattern.exec('/document/d/1s...5c/edit#heading=h.8...c') will return null. It should be:
1. pattern.exec('https://docs.google.com/document/d/1s5c/edit#heading=h.8...c');
2. pattern.exec('/document/d/1s5c/edit#heading=h.8...c', 'https://docs.google.com');

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

-
-
-