### PR TITLE
Copy edit auto dark article.

### DIFF
--- a/site/en/blog/auto-dark-theme/index.md
+++ b/site/en/blog/auto-dark-theme/index.md
@@ -1,11 +1,12 @@
 ---
 title: "Auto Dark Theme"
 description: >
-  Chrome 96 introduces an Origin Trial for Auto Dark Mode on Android. 
+  Autogenerating a dark theme for light-themed sites.
 layout: 'layouts/blog-post.njk'
-authors: 
+authors:
   - andreban
 date: 2021-10-21
+updated: 2021-10-21
 hero: 'image/kheDArv5csY6rvQUJDbWRscckLr1/t98X06XyMtNI4rTmXyfZ.jpg'
 alt: >
   Lamp on a dark background.
@@ -13,18 +14,18 @@ tags:
   - origin-trials
 ---
 
-Chrome 96 introduces an [Origin Trial](https://developer.chrome.com/blog/origin-trials/) for Auto Dark Themes on Android. 
-With this feature, the browser applies an automatically generated dark theme to light themed sites, 
-when the user has opted into dark themes in the Operating System. 
+Chrome 96 introduces an [origin trial](https://developer.chrome.com/blog/origin-trials/) for Auto Dark Themes on Android.
+With this feature, the browser applies an automatically generated dark theme to light themed sites,
+when the user has opted into dark themes in the operating system.
 Users can opt-out of dark themes by either disabling the option on the OS level or in a specific setting in Chrome.
 
-## Sign-up for the Origin Trial
+## Sign-up for the origin trial
 
-You can also enable the darkening algorithm for your users, via an Origin Trial. 
-This will allow you to test how the Auto Dark Theme performs with regards to your KPIs.
+You can also enable the darkening algorithm for your users, via an origin trial.
+This allows you to test how the Auto Dark Theme performs with regards to your KPIs.
 
-Head over to the documentation to learn 
-[how to set up an Origin Trial](/blog/origin-trials/#how-to-register-for-an-origin-trial), 
+Head over to the documentation to learn
+[how to set up an origin trial](/blog/origin-trials/#how-to-register-for-an-origin-trial),
 then [sign-up for the AutoDarkMode origin trial](/origintrials/#/trials/active) to get a token.
 
 ## Test Auto Dark Theme on your device
@@ -33,7 +34,7 @@ then [sign-up for the AutoDarkMode origin trial](/origintrials/#/trials/active) 
 
 To enable Auto Dark Theme in DevTools:
 
-1. Click on the three dots menu.
+1. Click the three dots menu.
 1. Select **More Tools** then **Rendering**.
 1. Select **Enable** on the **Emulate auto dark mode** option.
 
@@ -41,31 +42,31 @@ To enable Auto Dark Theme in DevTools:
 
 To test Auto Dark Theme on your Android phone:
 
-1. Navigate to `chrome://flags` and enable the `#darken-websites-checkbox-in-theme-setting` experiment. 
-1. Then, tap on the 3 dots menu, select **Settings > Theme**, and check the box with **Apply Dark themes to sites, when possible**.
+1. Navigate to `chrome://flags` and enable the `#darken-websites-checkbox-in-theme-setting` experiment.
+1. Then, tap the three dots menu, select **Settings** then **Theme**, and check the box with **Apply Dark themes to sites, when possible**.
 
 Now, light pages will be darkened on the phone.
 
 ## Per-element customization
 
-Even though we aim for Auto Dark Theme to generate good results in all cases, 
-early conversations with developers suggested that they would like to tweak specific elements, 
+Even though we aim for Auto Dark Theme to generate good results in all cases,
+early conversations with developers suggested that they would like to tweak specific elements,
 to adapt better to their desired look and feel.
 
-In this initial Origin trial, 
+In this origin trial,
 those customizations are possible by using JavaScript to detect if the user is in Auto Dark Theme and then customizing the desired elements.
 
 {% Aside %}
-Using a `prefer-color-scheme: dark` media query to customize elements works when Auto Dark Theme is applied. 
-However, it would also be applied by other browsers that don't have Auto Dark Theme, 
+Using a `prefer-color-scheme: dark` media query to customize elements works when Auto Dark Theme is applied.
+However, it would also be applied by other browsers that don't have Auto Dark Theme,
 leading to a page that has a light theme, but with only parts of it darkened.
 {% endAside %}
 
 ### Detecting Auto Dark Theme
 
-To detect if the user is in Auto Dark Theme, 
-create an element with the `background-color` set to `canvas` and the color-scheme set to light. 
-If the computed color for the background is other than white (`rgb(255, 255, 255)`), 
+To detect if the user is in Auto Dark Theme,
+create an element with the `background-color` set to `canvas` and the color-scheme set to light.
+If the computed color for the background is other than white (`rgb(255, 255, 255)`),
 then we know that Auto Dark Theme is applied to the page.
 
 ```html
@@ -86,8 +87,8 @@ if (isAutoDark) {
 
 ### Customizing a large number of elements
 
-The solution above can be hard to scale if you need to customize a larger number of elements. 
-An alternative is to use the Auto Dark Theme detection to add a marker class to the page's body:
+The solution above can be hard to scale if you need to customize a larger number of elements.
+An alternative is to use Auto Dark Theme detection to add a marker class to the page's body:
 
 ```js
 function setAutoDarkClass() {
@@ -118,27 +119,27 @@ Then, use CSS to customize elements as needed:
   border-color: red;
 }
 ```
- 
-The per-element customization API is still in early development. 
-We're working with the standards teams to provide developers with a more expressive API for opt-out. 
+
+The per-element customization API is still in early development.
+We're working with the standards teams to provide developers with a more expressive API for opt-out.
 You follow the conversation on [this GitHub issue](https://github.com/w3c/csswg-drafts/issues/6664).
 
-## How to opt-out from Auto Dark Theme
+## How to opt-out of Auto Dark Theme
 
-Besides respecting the user's choice on their device, 
-dark themes provide benefits to users, such as battery life improvements and accessibility. 
-Instead of opting out of Auto Dark Theme, 
-we strongly recommend implementing your own curated dark theme instead, 
+Besides respecting the user's choice on their device,
+dark themes provide benefits to users such as battery life improvements and accessibility.
+Instead of opting out of Auto Dark Theme,
+we strongly recommend implementing your own curated dark theme instead,
 in order to respect the user's preference and keep those benefits.
 
-However, in the case where it's not viable to implement your own dark theme, 
-and the result generated by Auto Dark Theme is not satisfactory, 
+However, in the case where it's not viable to implement your own dark theme,
+and the result generated by Auto Dark Theme is not satisfactory,
 it is possible to opt out from the feature,
 
 ### Using a meta tag
 
-The first alternative for opting out from Auto Dark Theme is by adding the following meta tag to your page's header. 
-The advantage of using the meta tag is that it prevents Auto Dark Theme from being applied at all, 
+The first alternative for opting out of Auto Dark Theme is by adding the following meta tag to your page's header.
+The advantage of using the meta tag is that it prevents Auto Dark Theme from being applied at all,
 which could cause a "flash of darkened content".
 
 ```html
@@ -150,9 +151,9 @@ which could cause a "flash of darkened content".
 
 ### Per element opt-out
 
-A second alternative for opting out is setting the value of the [`color-scheme`](https://developer.mozilla.org/docs/Web/CSS/color-scheme) 
-CSS property to `only light`. 
-Even though the per-element opt-out can be used to opt-out the entire page from Auto Dark Mode, 
+A second alternative for opting out is setting the value of the [`color-scheme`](https://developer.mozilla.org/docs/Web/CSS/color-scheme)
+CSS property to `only light`.
+Even though the per-element opt-out can be used to opt-out the entire page from Auto Dark Mode,
 an advantage of this approach is that it allows only opting out specific parts of the page:
 
 ```css
@@ -171,13 +172,12 @@ It is still possible to use this approach to opt-out the entire page from Auto D
 
 ## Send us feedback!
 
-Auto Dark Theme is still being specified, 
-and we are looking for feedback across all areas of the implementation: 
+Auto Dark Theme is still being specified,
+and we are looking for feedback across all areas of the implementation:
 from the results of the darkening algorithm to the developer APIs for element customization and opt-out.
 
-You can send us feedback by filing a bug on the Chromium bugs, 
-using [this link](https://bugs.chromium.org/p/chromium/issues/list?q=component:Mobile%3EAutoDarkTheme) 
-or via the Origin Trial form. 
+You can send us feedback by filing a bug on the Chromium bugs,
+using [this link](https://bugs.chromium.org/p/chromium/issues/list?q=component:Mobile%3EAutoDarkTheme)
+or via the origin trial form.
 
 Photo by [Félix Besombes](https://unsplash.com/@druks?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText).
-  


### PR DESCRIPTION
This article was pushed without a copy edit because it had to be out before the beta release at ~11:00 am PDT.  This is the copy edit. There are a few things to note:

* Since this article will live into the feature's stable release, I've future-proofed the description against the day when it does  (Assuming it has a stable release. Not all origin trials do.) A best practice on OT articles is to try whenever possible to confine references to the trial to blocks of content dedicated to the origin trial phase. Then the work for updating such articles in s five-minute delete and submit instead of an hour long read and revise.
* Origin trial is lower case per the [handbook's word list](https://web.dev/handbook/word-list/) and the guy in charge of origin trials. The thinking is that origin trials are a class of things, making them common nouns.