### PR TITLE
Add android:exported=true to TWA integration guide

### DIFF
--- a/site/en/docs/android/trusted-web-activity/integration-guide/index.md
+++ b/site/en/docs/android/trusted-web-activity/integration-guide/index.md
@@ -110,6 +110,7 @@ Add the Trusted Web Activity by inserting an `activity` tag into the `applicatio
 
     <application
         android:allowBackup="true"
+        android:exported="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"


### PR DESCRIPTION
See [Android doc on Behavior Changes in Android 12](https://developer.android.com/about/versions/12/behavior-changes-12#exported). A value for `android:exported` is required when targeting Android 12; true is required for the `LAUNCHER` category.