### PR TITLE
Fix digital-asset-links generator link

### DIFF
--- a/site/en/docs/android/trusted-web-activity/integration-guide/index.md
+++ b/site/en/docs/android/trusted-web-activity/integration-guide/index.md
@@ -315,7 +315,7 @@ Version: 3
 </pre>
 
 With both pieces of information at hand, head over to the [assetlinks
-generator](/digital-asset-links/tools/generator),
+generator](https://developers.google.com/digital-asset-links/tools/generator),
 fill-in the fields and hit _Generate Statement_. Copy the generated statement
 and serve it from your domain, from the URL `/.well-known/assetlinks.json`.
 


### PR DESCRIPTION
Fix digital-asset-links generator link (404 https://developer.chrome.com/digital-asset-links/tools/generator/ -> https://developers.google.com/digital-asset-links/tools/generator)