### PR TITLE
Upgrade to fetching chrome-types@latest, misc, fixes

### DIFF
--- a/external/build/lib/dts-parse-helper.js
+++ b/external/build/lib/dts-parse-helper.js
@@ -99,8 +99,12 @@ class InsertMissingTagsHelper {
     this.pendingUpdates.set(param, extraComment);
   }
 
-  onEnd() {
-    console.warn('Applying', this.pendingUpdates.size, 'extra comments');
+  /**
+   * @param {typedoc.Context} context
+   */
+  onEnd(context) {
+    context.logger.info(`Applying ${this.pendingUpdates.size} extra comments`);
+
     for (const [param, extraComment] of this.pendingUpdates) {
       // Skip call signatures, which TypeDoc correctly already annotates with comments.
       // Notably it annotates the _signatures_, not the top-level declaration, which is correct

--- a/external/build/lib/dts-parse-helper.js
+++ b/external/build/lib/dts-parse-helper.js
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const typedoc = require('typedoc');
+const ts = typedoc.TypeScript;
+
+/**
+ * TypeDoc, by default, ignores most JSDoc that exists prior to a parameter node. e.g.:
+ *
+ * ```js
+ * function foo(
+ *
+ *   /**
+ *    * Hello!
+ *    *
+ *    * @since Foo
+ *    *\/
+ *    bar: number,
+ *
+ * );
+ * ```
+ *
+ * This helper catches parameter creation and inserts the comments onto the
+ * {@link typedoc.ParameterReflection}. This is done in two passes: one listens for createParameter,
+ * and the other listens for the end step to apply the extra tags (otherwise TypeDoc can clobber
+ * us).
+ *
+ * Note that we do NOT apply to parameters which are call signatures, as TypeDoc handles these
+ * (and only these) properly.
+ */
+class InsertMissingTagsHelper {
+  /**
+   * @param {typedoc.Converter} converter
+   */
+  constructor(converter) {
+    converter.on(
+      typedoc.Converter.EVENT_CREATE_PARAMETER,
+      this.onCreateParameter.bind(this)
+    );
+    converter.on(typedoc.Converter.EVENT_END, this.onEnd.bind(this));
+
+    /** @type {Map<typedoc.ParameterReflection, typedoc.Comment>} */
+    this.pendingUpdates = new Map();
+  }
+
+  /**
+   * @param {typedoc.Context} _context
+   * @param {typedoc.ParameterReflection} param
+   * @param {typedoc.TypeScript.Node} node
+   */
+  onCreateParameter(_context, param, node) {
+    // We do a gross cast here as the `jsDoc` property does exist here but it's not obvious what
+    // type from TypeScript has it.
+    const {jsDoc} = /** @type {{jsDoc?: typedoc.TypeScript.JSDoc[]}} */ (
+      /** @type {any} */ (node)
+    );
+    if (!jsDoc?.length) {
+      return;
+    }
+
+    // This returns all jsDoc nodes _before_ this parameter. It's possible for this to be one or
+    // more, but we just care about the last one (closest to the node).
+    const jsDocNode = jsDoc[jsDoc.length - 1];
+
+    // Get all tags and convert to TypeDoc's CommentTag format.
+    const tags = Array.from(jsDocNode.tags ?? []).map(raw => {
+      return new typedoc.CommentTag(
+        raw.tagName.escapedText.toString(),
+        getParamNameFromTag(raw),
+        ts.getTextOfJSDocComment(raw.comment)
+      );
+    });
+
+    // Get the raw comment text.
+    // TODO(samthor): This isn't used. We just insert the tags.
+    ts.getTextOfJSDocComment(jsDocNode.comment);
+
+    // Don't add @param, since TypeDoc *can* do this on its own.
+    const tagsWithoutParam = tags.filter(tag => tag.tagName !== 'param');
+    if (!tagsWithoutParam.length) {
+      return;
+    }
+
+    const extraComment = new typedoc.Comment();
+    extraComment.tags = tagsWithoutParam;
+    this.pendingUpdates.set(param, extraComment);
+  }
+
+  onEnd() {
+    console.warn('Applying', this.pendingUpdates.size, 'extra comments');
+    for (const [param, extraComment] of this.pendingUpdates) {
+      // Skip call signatures, which TypeDoc correctly already annotates with comments.
+      // Notably it annotates the _signatures_, not the top-level declaration, which is correct
+      // (since the top-level represents 1-n signatures).
+      if (
+        param.type?.type === 'reflection' &&
+        param.type.declaration?.signatures
+      ) {
+        continue;
+      }
+
+      param.comment = mergeComment(param.comment, extraComment);
+    }
+    this.pendingUpdates.clear();
+  }
+}
+
+/**
+ * If this tag is a "@param" or "@property", then extract its name from `@param bar`.
+ *
+ * This does not extract its (optional) type, e.g., JSDoc like `@param {number} foo`.
+ *
+ * @param {typedoc.TypeScript.JSDocTag} tag
+ * @return {string|undefined}
+ */
+function getParamNameFromTag(tag) {
+  if (
+    tag.kind !== ts.SyntaxKind.JSDocParameterTag &&
+    tag.kind !== ts.SyntaxKind.JSDocPropertyTag
+  ) {
+    return undefined;
+  }
+
+  const paramTag = /** @type {typedoc.TypeScript.JSDocParameterTag} */ (tag);
+  if (paramTag.name.kind !== ts.SyntaxKind.Identifier) {
+    throw new Error(`got non-identifier for @param: ${paramTag}`);
+  }
+
+  const identifier = /** @type {typedoc.TypeScript.Identifier} */ (
+    paramTag.name
+  );
+  return identifier.escapedText.toString();
+}
+
+/**
+ * Merges two comments from typedoc. May return `a` or `b` unchanged.
+ *
+ * TODO: only returns the text from "a" if merging two nodes.
+ *
+ * @param {typedoc.Comment|undefined} a
+ * @param {typedoc.Comment|undefined} b
+ * @return {typedoc.Comment|undefined}
+ */
+function mergeComment(a, b) {
+  if (!a && !b) {
+    return undefined;
+  } else if (!a) {
+    return b;
+  } else if (!b) {
+    return a;
+  }
+
+  const merged = new typedoc.Comment();
+  merged.tags.push(...a.tags, ...b.tags);
+
+  // TODO: just grabs "a" comment
+  merged.shortText = a.shortText;
+  merged.text = a.text;
+
+  return merged;
+}
+
+module.exports = {
+  InsertMissingTagsHelper,
+};

--- a/external/build/lib/dts-parse.js
+++ b/external/build/lib/dts-parse.js
@@ -686,10 +686,10 @@ function declarationWith(node) {
 /**
  * Fetches and builds typedoc JSON for the given .d.ts source files.
  *
- * @param {...string} sources
+ * @param {{silent?: boolean, sources: string[] }} options
  * @return {Promise<{[id: string]: typedoc.JSONOutput.DeclarationReflection}>}
  */
-module.exports = async function parse(...sources) {
+module.exports = async function parse({silent, sources}) {
   const app = new typedoc.Application();
   app.options.addReader(new typedoc.TSConfigReader());
   app.bootstrap({
@@ -702,7 +702,9 @@ module.exports = async function parse(...sources) {
         case typedoc.LogLevel.Error:
           throw new Error(`failed to parse typedoc: ${message}`);
       }
-      console.warn(message);
+      if (!silent) {
+        console.warn(message);
+      }
     },
   });
 

--- a/external/build/lib/dts-parse.js
+++ b/external/build/lib/dts-parse.js
@@ -687,7 +687,7 @@ function declarationWith(node) {
  * Fetches and builds typedoc JSON for the given .d.ts source files.
  *
  * @param {{silent?: boolean, sources: string[] }} options
- * @return {Promise<{[id: string]: typedoc.JSONOutput.DeclarationReflection}>}
+ * @return {Promise<{[id: string]: ExtendedReflection}>}
  */
 module.exports = async function parse({silent, sources}) {
   const app = new typedoc.Application();

--- a/external/build/lib/dts-parse.js
+++ b/external/build/lib/dts-parse.js
@@ -24,6 +24,7 @@
  */
 
 const typedoc = require('typedoc');
+const {InsertMissingTagsHelper} = require('./dts-parse-helper');
 
 // matches "{@link ...}"
 const linkMatch = /{@link (\S+?)(|\s+.+?)}/g;
@@ -330,7 +331,6 @@ class Transform {
         for (const param of s.parameters ?? []) {
           if (!allParams.has(param.name) || param.flags.isOptional) {
             allParams.set(param.name, param);
-            this.upgradeParamWithParamSinceTags(param, s.comment?.tags ?? []);
           }
         }
 
@@ -369,15 +369,12 @@ class Transform {
           kind: typedoc.ReflectionKind.Parameter,
           flags: {},
           type: returnType,
+          comment: {
+            // Pull out tags that start with "@chrome-returns-extra" and put them here.
+            tags: this.extractReturnTags(returnSignatureComment?.tags ?? []),
+            shortText: nodeComment?.returns,
+          },
         };
-        if (nodeComment?.returns) {
-          virtualNode.comment = {shortText: nodeComment.returns};
-        }
-
-        this.upgradeReturnWithReturnSinceTags(
-          virtualNode,
-          returnSignatureComment?.tags ?? []
-        );
 
         extendedNode._method.return = virtualNode;
         if (returnType?.type === 'reference' && returnType.name === 'Promise') {
@@ -468,66 +465,29 @@ class Transform {
   }
 
   /**
-   * Given tags from a method signature, upgrade this param with standardized-looking tags.
+   * Given tags from a method signature, extract virtual comment tags. This just takes anything
+   * identified with "chrome-returns-extra" and extracts it, as there's otherwise no good way
+   * to annotate the return type (it's not a reflection that can have tags).
    *
-   * @param {typedoc.JSONOutput.ParameterReflection} param
    * @param {typedoc.JSONOutput.CommentTag[]} tags
+   * @return {typedoc.JSONOutput.CommentTag[]|undefined}
    */
-  upgradeParamWithParamSinceTags(param, tags) {
+  extractReturnTags(tags) {
     /** @type {typedoc.JSONOutput.CommentTag[]} */
     const virtualNodeTags = [];
-    const paramPrefix = param.name + ' ';
 
     for (const tag of tags) {
-      // These all look like "@chrome-param-deprecated-since paramName some text...", so only allow
-      // text that starts with "paramName ".
-      if (!tag.text.startsWith(paramPrefix)) {
+      if (tag.tag !== 'chrome-returns-extra') {
         continue;
       }
-      const text = tag.text.substr(paramPrefix.length);
 
-      if (tag.tag === 'chrome-param-since') {
-        virtualNodeTags.push({tag: 'since', text});
-      } else if (tag.tag === 'chrome-param-deprecated-since') {
-        virtualNodeTags.push({tag: 'chrome-deprecated-since', text});
-      } else if (tag.tag === 'chrome-param-deprecated') {
-        virtualNodeTags.push({tag: 'deprecated', text});
-      }
+      const tagName = tag.text.split(' ')[0];
+      const rest = tag.text.substr(tagName.length).trim();
+
+      virtualNodeTags.push({tag: tagName, text: rest});
     }
 
-    if (!param.comment) {
-      param.comment = {};
-    }
-    param.comment.tags = (param.comment.tags ?? []).concat(virtualNodeTags);
-  }
-
-  /**
-   * Given tags from a method signature, upgrade this virtual return declaration with
-   * standardized-looking tags.
-   *
-   * @param {typedoc.JSONOutput.ParameterReflection} param
-   * @param {typedoc.JSONOutput.CommentTag[]} tags
-   */
-  upgradeReturnWithReturnSinceTags(param, tags) {
-    /** @type {typedoc.JSONOutput.CommentTag[]} */
-    const virtualNodeTags = [];
-
-    for (const tag of tags) {
-      const text = tag.text;
-
-      if (tag.tag === 'chrome-returns-since') {
-        virtualNodeTags.push({tag: 'since', text});
-      } else if (tag.tag === 'chrome-returns-deprecated-since') {
-        virtualNodeTags.push({tag: 'chrome-deprecated-since', text});
-      } else if (tag.tag === 'chrome-returns-deprecated') {
-        virtualNodeTags.push({tag: 'deprecated', text});
-      }
-    }
-
-    if (!param.comment) {
-      param.comment = {};
-    }
-    param.comment.tags = (param.comment.tags ?? []).concat(virtualNodeTags);
+    return virtualNodeTags.length ? virtualNodeTags : undefined;
   }
 
   /**
@@ -733,10 +693,8 @@ module.exports = async function parse(...sources) {
   const app = new typedoc.Application();
   app.options.addReader(new typedoc.TSConfigReader());
   app.bootstrap({
-    // excludeExternals: true,
-    excludeInternal: true,
-    excludePrivate: true,
-    excludeProtected: true,
+    emit: 'none',
+    listInvalidSymbolLinks: true,
     entryPoints: sources,
     logger(message, level) {
       switch (level) {
@@ -744,14 +702,22 @@ module.exports = async function parse(...sources) {
         case typedoc.LogLevel.Error:
           throw new Error(`failed to parse typedoc: ${message}`);
       }
+      console.warn(message);
     },
   });
+
+  // nb. This doesn't need to be ref'ed, it just attaches to converter.
+  new InsertMissingTagsHelper(app.converter);
+
   app.options.setCompilerOptions(
     sources,
     {
       // TODO: for Workbox assume we're a webworker
       // lib: ['lib.webworker.d.ts'],
       declaration: true,
+      // lib: ['lib.esnext.full.d.ts'],
+      // target: typedoc.TypeScript.ScriptTarget.Latest,
+      // moduleResolution: typedoc.TypeScript.ModuleResolutionKind.NodeJs,
     },
     undefined
   );
@@ -759,6 +725,7 @@ module.exports = async function parse(...sources) {
   if (!reflection) {
     throw new Error(`failed to convert modules: ${sources}`);
   }
+
   const json = app.serializer.projectToObject(reflection);
   const t = new Transform(json);
 

--- a/external/build/types.js
+++ b/external/build/types.js
@@ -34,7 +34,7 @@ async function fetchAndPrepare(targetDir) {
  * @param {string} targetFile
  */
 async function parse(targetFile) {
-  const defs = await dtsParse(targetFile);
+  const defs = await dtsParse({sources: [targetFile]});
 
   const outputFile = path.join(__dirname, '../data/chrome-types.json');
   fs.writeFileSync(outputFile, JSON.stringify(defs, undefined, 2));

--- a/external/build/types.js
+++ b/external/build/types.js
@@ -8,21 +8,25 @@ const fs = require('fs');
 const path = require('path');
 const childProcess = require('child_process');
 
+const chromeTypesTag = 'latest';
+
 /**
  * @param {string} targetDir
  */
 async function fetchAndPrepare(targetDir) {
+  const packageName = `chrome-types@${chromeTypesTag}`;
+
   /** @type {childProcess.ExecFileSyncOptions} */
   const options = {cwd: targetDir, stdio: 'inherit'};
 
-  childProcess.execFileSync('npm', ['install', 'chrome-types@beta'], options);
+  childProcess.execFileSync('npm', ['install', packageName], options);
   const packageDir = path.join(targetDir, 'node_modules/chrome-types');
 
   /** @type {{version: string}} */
   const packageJson = JSON.parse(
     fs.readFileSync(path.join(packageDir, 'package.json'), 'utf-8')
   );
-  console.warn('fetched chrome-types@beta', targetDir, packageJson.version);
+  console.warn('fetched', packageName, targetDir, packageJson.version);
   return path.join(packageDir, '_all.d.ts');
 }
 

--- a/tests/external/types.js
+++ b/tests/external/types.js
@@ -23,7 +23,7 @@ async function parseVirtualTypes(source) {
   }
 }
 
-test('basic', async t => {
+test('chrome-like data', async t => {
   const source = `
 declare namespace chrome {
   export namespace purelyForTest {
@@ -59,4 +59,32 @@ declare namespace chrome {
     name: 'number',
     type: 'intrinsic',
   });
+});
+
+test('workbox-like data', async t => {
+  const source = `
+type HTTPMethod = 'GET';
+type Route = string;
+
+declare class Router {
+  private readonly _routes;
+  private _defaultHandler?;
+  private _catchHandler?;
+  /**
+   * Initializes a new Router.
+   */
+  constructor();
+  /**
+   * @return {Map<string, Array<module:workbox-routing.Route>>} routes A \`Map\` of HTTP
+   * method name ('GET', etc.) to an array of all the corresponding \`Route\`
+   * instances that are registered.
+   */
+  get routes(): Map<HTTPMethod, Route[]>;
+}
+export { Router };
+  `;
+
+  // TODO: We need to parse Workbox types differently and support top-level types.
+  const types = await parseVirtualTypes(source);
+  t.deepEqual(types, {});
 });

--- a/tests/external/types.js
+++ b/tests/external/types.js
@@ -40,4 +40,23 @@ declare namespace chrome {
 
   const types = await parseVirtualTypes(source);
   t.deepEqual(Object.keys(types), ['purelyForTest']);
+
+  // FIXME: types not inferring here
+
+  const fooNamespace = types['purelyForTest']?._type?.properties[0];
+  const helloProperty = fooNamespace?._type?.properties[0];
+
+  t.deepEqual(helloProperty._feature, {
+    channel: 'stable',
+    since: 'Chrome 42',
+  });
+
+  t.is(helloProperty._name, 'chrome.purelyForTest.Foo.hello');
+  t.is(helloProperty._pageHref, 'purelyForTest');
+  t.is(helloProperty._pageId, 'property-Foo-hello');
+
+  t.deepEqual(helloProperty.type, {
+    name: 'number',
+    type: 'intrinsic',
+  });
 });

--- a/tests/external/types.js
+++ b/tests/external/types.js
@@ -1,0 +1,43 @@
+/**
+ * @fileoverview Tests for TypeDoc / .d.ts parser.
+ */
+
+// eslint-disable-next-line ava/use-test
+const {default: test} = require('ava');
+const tmp = require('tmp');
+const fs = require('fs');
+const path = require('path');
+const dtsParse = require('../../external/build/lib/dts-parse.js');
+
+/**
+ * @param {string} source
+ */
+async function parseVirtualTypes(source) {
+  const t = tmp.dirSync();
+  const file = path.join(t.name, 'types.d.ts');
+  try {
+    fs.writeFileSync(file, source);
+    return await dtsParse({silent: true, sources: [file]});
+  } finally {
+    fs.rmSync(t.name, {recursive: true});
+  }
+}
+
+test('basic', async t => {
+  const source = `
+declare namespace chrome {
+  export namespace purelyForTest {
+    export interface Foo {
+
+      /**
+       * @since Chrome 42
+       */
+      hello: number;
+    }
+  }
+}
+  `;
+
+  const types = await parseVirtualTypes(source);
+  t.deepEqual(Object.keys(types), ['purelyForTest']);
+});


### PR DESCRIPTION
* Fetch chrome-types@latest, as during the update dance we were pointing at beta
* Support improved matching of @-style annotations on params from that source (TypeDoc misses some)
* Adds some tests for the data, including a stub/failed Workbox-like test