### PR TITLE
write site build version

### DIFF
--- a/gulp-tasks/write-version.js
+++ b/gulp-tasks/write-version.js
@@ -1,0 +1,25 @@
+/**
+ * Write the HEAD SHA to the `dist folder` on prod builds, plus the contents of `.hash` of the
+ * site's external data.
+ *
+ * This is used for Cloud Build to compare the currently deployed version of the site against
+ * what would be deployed.
+ *
+ * This matches web.dev's version, but:
+ *  - adds /external/data/.hash to the output.
+ *  - writes to "site-version", not "version""
+ */
+
+const fs = require('fs');
+
+const getVersion = require('../tools/version');
+
+const writeVersionInProd = async () => {
+  if (process.env.ELEVENTY_ENV === 'prod') {
+    const version = getVersion();
+    fs.mkdirSync('./dist', {recursive: true});
+    fs.writeFileSync('./dist/site-version', version);
+  }
+};
+
+module.exports = writeVersionInProd;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,6 +3,7 @@ const {parallel, watch} = require('gulp');
 // Pull in each task
 const sassTask = require('./gulp-tasks/sass.js');
 const staticTask = require('./gulp-tasks/static.js');
+const writeVersionTask = require('./gulp-tasks/write-version.js');
 
 // Set each directory and contents that we want to watch and
 // assign the relevant task. `ignoreInitial` set to true will
@@ -14,7 +15,7 @@ const watcher = () => {
 };
 
 // The default (if someone just runs `gulp`) is to run each task in parrallel
-exports.default = parallel(sassTask, staticTask);
+exports.default = parallel(sassTask, staticTask, writeVersionTask);
 
 // This is our watcher task that instructs gulp to watch directories and
 // act accordingly

--- a/tools/version/index.js
+++ b/tools/version/index.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const {execSync} = require('child_process');
+
+/**
+ * Gets the HEAD SHA of the git repo plus the contents of /external/data/.hash, either generated
+ * or synchronized from the external data repo.
+ */
+module.exports = () => {
+  const gitHash = execSync('git rev-parse HEAD').toString().trim();
+  let externalHash;
+  try {
+    externalHash = fs.readFileSync('external/data/.hash', 'utf-8').trim();
+  } catch (e) {
+    console.error(
+      'Could not load external/data/.hash: has "npm run sync-external" been run?'
+    );
+    throw e;
+  }
+
+  return `${gitHash}:${externalHash}`;
+};


### PR DESCRIPTION
First half of #1655. Writes version hash to distribution.

Once this is in and we're deploying, I'll set up the version checker build step.