### PR TITLE
correctly sync before check, throw on unhandled rejection

### DIFF
--- a/.cloudbuild/version-check.yaml
+++ b/.cloudbuild/version-check.yaml
@@ -13,3 +13,8 @@ steps:
     env:
     - 'PROJECT_ID=$PROJECT_ID'
     - 'NODE_ENV=production'
+
+options:
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'NODE_OPTIONS=--unhandled-rejections=strict'

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "start": "node ./server",
     "test:watch": "ava --watch",
     "test": "nyc ava",
-    "version-check": "node version-check.js",
+    "version-check": "npm run sync-external && node version-check.js",
     "build-external": "node ./external/build-external.js",
     "maybe-sync-external": "node ./external/maybe-sync-external.js",
     "sync-external": "node ./external/sync-external.js"


### PR DESCRIPTION
Fixes the version-check task, which was failing silently because
a) unhandled rejections don't throw in Node 14 by default
b) we weren't syncing external data to be able to calculate the hash.