### PR TITLE
Fix last updated date

### DIFF
--- a/site/en/docs/webstore/program_policies/index.md
+++ b/site/en/docs/webstore/program_policies/index.md
@@ -2,7 +2,7 @@
 layout: "layouts/doc-post.njk"
 title: "Developer Program Policies"
 date: 2014-02-28
-updated: 2021-06-29
+updated: 2021-09-28
 description: Chrome Web Store developer program policies.
 ---
 


### PR DESCRIPTION
The last update to the Chrome Web Store developer program policies was made in PR #1518. Unfortunately, we missed that this PR did not modify the page's "last updated" date in `site/en/docs/webstore/program_policies/index.md`'s frontmatter.

This PR changes the "last updated" date to reflect the date on which PR #1518 was merged.