### PR TITLE
Adds token for the Auto Dark Origin Trial

### DIFF
--- a/site/_includes/partials/meta.njk
+++ b/site/_includes/partials/meta.njk
@@ -50,3 +50,8 @@
 <link rel="icon" type="image/png" sizes="32x32" href="/images/meta/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/images/meta/favicon-16x16.png">
 <meta name="theme-color" content="#ffffff">
+
+{# [andreban] Origin Trial token for Auto Dark Theme. #}
+<meta 
+  http-equiv="origin-trial"
+  content="AqiW0xYMo4alAj4YT8WCj1HjZkdhGlDVapYAMWYhuQR86eWgMKmSA4plIz4EnIQNXnKuLIDoq95eUeA+saOstgwAAABaeyJvcmlnaW4iOiJodHRwczovL2RldmVsb3Blci5jaHJvbWUuY29tOjQ0MyIsImZlYXR1cmUiOiJBdXRvRGFya01vZGUiLCJleHBpcnkiOjE2NDU1NzQzOTl9" />

--- a/site/_scss/blocks/_project-icon.scss
+++ b/site/_scss/blocks/_project-icon.scss
@@ -21,6 +21,7 @@
   background-size: contain;
   border-radius: 6px;
   color: var(--color-project-default);
+  color-scheme: only light;
   display: flex;
   height: 128px;
   justify-content: center;


### PR DESCRIPTION
- Added the token for the Auto Dark Origin Origin Trial.
- Check https://developer.chrome.com/blog/auto-dark-theme/ for
  details.

Fixes #1728 