### PR TITLE
Fix EN typos in KR translation

### DIFF
--- a/site/_includes/partials/devtools/en/whats-new.md
+++ b/site/_includes/partials/devtools/en/whats-new.md
@@ -1,7 +1,9 @@
 ## What's New in DevTools {: #whats-new }
+
 A list of everything that has been covered in the [What's New In DevTools](/tags/new-in-devtools/) series.
 
 ### Chrome 96 {: #chrome96 }
+
 * [Preview feature: New CSS Overview panel](/blog/new-in-devtools-96/#css-overview)
 * [Restored and improved CSS length edit and copy experince](/blog/new-in-devtools-96/#length)
 * [Emulate the CSS prefers-contrast media feature](/blog/new-in-devtools-96/#prefers-contrast)
@@ -18,6 +20,7 @@ A list of everything that has been covered in the [What's New In DevTools](/tags
 
 
 ### Chrome 95 {: #chrome95 }
+
 * [New CSS length authoring tools](/blog/new-in-devtools-95/#length)
 * [Hide issues in the Issues tab](/blog/new-in-devtools-95/#hide-issues)
 * [Improved the display of properties](/blog/new-in-devtools-95/#properties)

--- a/site/_includes/partials/devtools/ko/whats-new.md
+++ b/site/_includes/partials/devtools/ko/whats-new.md
@@ -4,7 +4,7 @@
 ### Chrome 96 {: #chrome96 }
 * [미리보기 기능: 새로운 CSS 개요 영역](/ko/blog/new-in-devtools-96/#css-overview)
 * [복원 및 개선된 CSS 길이 편집 및 복사 경험](/ko/blog/new-in-devtools-96/#length)
-* [CSS 의 prefers-constrast 미디어 기능 에뮬레이션](/ko/blog/new-in-devtools-96/#prefers-contrast)
+* [CSS 의 prefers-contrast 미디어 기능 에뮬레이션](/ko/blog/new-in-devtools-96/#prefers-contrast)
 * [크롬의 자동 어두운 테마 기능 에뮬레이션](/ko/blog/new-in-devtools-96/#auto-dark-mode)
 * [스타일 영역에서 선언을 자바스크립트로 복사하기](/ko/blog/new-in-devtools-96/#copy-as-js)
 * [네트워크 패널의 새로운 페이로드 탭](/ko/blog/new-in-devtools-96/#payload)

--- a/site/ko/blog/new-in-devtools-96/index.md
+++ b/site/ko/blog/new-in-devtools-96/index.md
@@ -48,6 +48,7 @@ Chromium issue: [1254557](https://crbug.com/1254557)
 
 
 ## 복원 및 개선된 CSS 길이 편집 및 복사 기능 {: #length }
+
 이전 배포판에서 중단되었던 길이를 갖는 CSS 요소에 대한 **CSS 복사하기**와 **텍스트로 편집하기** 기능이 복구되었습니다.
 
 {% Video src="video/dPDCek3EhZgLQPGtEG3y0fTn4v82/3zxmVrRNd767L9zPDvU8.mp4", autoplay="true", muted="true", loop="true", class="screenshot" %}
@@ -67,6 +68,7 @@ Chromium issues: [1259088](https://crbug.com/1259088), [1172993](https://crbug.c
 
 
 ## 렌더링 탭의 업데이트 
+
 ### CSS 의 prefers-contrast 미디어 기능 에뮬레이션 {: #prefers-contrast }
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/47fsHvVLiVC9J0eWY9wD.png", alt="Emulate the CSS prefers-contrast media feature", width="800", height="483" %}

--- a/site/ko/blog/new-in-devtools-96/index.md
+++ b/site/ko/blog/new-in-devtools-96/index.md
@@ -6,7 +6,7 @@ authors:
 date: 2021-10-25
 updated: 2021-10-25
 description:
-  "새로운 CSS 개요 영역, CSS 의 prefers-constrast 미디어 기능 에뮬레이션, 크롬의 자동 어두운 테마 기능 에뮬레이션 및 다른 새로운 기능들."
+  "새로운 CSS 개요 영역, CSS 의 prefers-contrast 미디어 기능 에뮬레이션, 크롬의 자동 어두운 테마 기능 에뮬레이션 및 다른 새로운 기능들."
 hero: 'image/dPDCek3EhZgLQPGtEG3y0fTn4v82/61LuaWeAzEc2dbdFjnWm.jpg'
 alt: ''
 tags:
@@ -67,7 +67,7 @@ Chromium issues: [1259088](https://crbug.com/1259088), [1172993](https://crbug.c
 
 
 ## 렌더링 탭의 업데이트 
-### CSS 의 prefers-constrast 미디어 기능 에뮬레이션 {: #prefers-contrast }
+### CSS 의 prefers-contrast 미디어 기능 에뮬레이션 {: #prefers-contrast }
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/47fsHvVLiVC9J0eWY9wD.png", alt="Emulate the CSS prefers-contrast media feature", width="800", height="483" %}
 


### PR DESCRIPTION
Fixes typo `prefers-constrast` to `prefers-contrast` in 🇰🇷  [What's New in DevTools (Chrome 96)](https://developer.chrome.com/ko/blog/new-in-devtools-96/) 

Changes proposed in this pull request:

- Change `prefers-constrast` → `prefers-contrast` in article and description


I noticed this typo also appears in the [Chrome DevTools Twitter graphic](https://twitter.com/ChromeDevTools/status/1460761698621530116). As I'm unauthorized to post a corrected version, I'd like to propose an amended repost by the account maintainer.  

![Graphic Typo](https://user-images.githubusercontent.com/46656072/142343386-94a2a949-5f1a-461f-a798-6bd345d6243b.jpeg)

Thank you!

