### PR TITLE
Add Auto Dark opt-out for the Chrome logo 

### DIFF
--- a/site/_scss/blocks/_top-nav.scss
+++ b/site/_scss/blocks/_top-nav.scss
@@ -16,10 +16,11 @@ top-nav {
     }
   }
 
+  // Per-element opt-out for Auto Dark Theme. See https://crbug.com/1271390.
   .top-nav__logo {
-      svg {
-        color-scheme: only light;
-      }      
+    svg {
+      color-scheme: only light;
+    }      
   }
 }
 

--- a/site/_scss/blocks/_top-nav.scss
+++ b/site/_scss/blocks/_top-nav.scss
@@ -15,6 +15,12 @@ top-nav {
       grid-template-columns: 1fr 2fr 1fr;
     }
   }
+
+  .top-nav__logo {
+      svg {
+        color-scheme: only light;
+      }      
+  }
 }
 
 top-nav[data-search-active] {


### PR DESCRIPTION
- Adds an auto dark per-element opt-out for the Chrome logo.
- See https://crbug.com/1271390