### PR TITLE
Disable Auto Dark Theme

### DIFF
--- a/site/_includes/partials/meta.njk
+++ b/site/_includes/partials/meta.njk
@@ -52,6 +52,8 @@
 <meta name="theme-color" content="#ffffff">
 
 {# [andreban] Origin Trial token for Auto Dark Theme. #}
+{#
 <meta 
   http-equiv="origin-trial"
   content="AqiW0xYMo4alAj4YT8WCj1HjZkdhGlDVapYAMWYhuQR86eWgMKmSA4plIz4EnIQNXnKuLIDoq95eUeA+saOstgwAAABaeyJvcmlnaW4iOiJodHRwczovL2RldmVsb3Blci5jaHJvbWUuY29tOjQ0MyIsImZlYXR1cmUiOiJBdXRvRGFya01vZGUiLCJleHBpcnkiOjE2NDU1NzQzOTl9" />
+#}


### PR DESCRIPTION
- Auto Dark Theme is being incorrectly applied by Chrome to light
users on Chrome for Android stable (https://crbug.com/1271517).
Disabling the OT while this is not fixed.
