### PR TITLE
Tutorial for identifying a user using the Google OAuth2/OpenID endpoint

### DIFF
--- a/site/_includes/partials/extensions/reusing-prod-extension-id.md
+++ b/site/_includes/partials/extensions/reusing-prod-extension-id.md
@@ -1,0 +1,40 @@
+## Keep a consistent extension ID {: #keep-consistent-id }
+
+Preserving a single ID is essential during development. To keep a consistent id, follow these steps:
+
+### Upload extension to the developer dashboard {: #upload_to_dashboard }
+
+Package the extension directory into a `.zip` file and upload it to the [Chrome Developer
+Dashboard](https://chrome.google.com/webstore/developer/dashboard) without publishing it:
+
+1.  At the Developer Dashboard, click **Add new item**.
+2.  Click **Browse files**, select the `.zip` extension and upload it.
+3.  Go to the **Package** tab and click on **View public key**.
+
+{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/8j12N4AyvHyjCZaFghv8.png", alt="Developer Dashboard
+Package tab", width="296", height="121" %}
+
+From the popup, copy the public key and add it to the manifest inside the unzipped directory under
+the [`"key"`]([/docs/extensions/mv3/manifest/key/) field. This way the extension will maintain the
+same ID.
+
+```json
+{
+// manifest.json 
+
+  "manifest_version": 3,
+...
+  "key": "ThisKeyIsGoingToBeVeryLong/go8GGC2u3UD9WI3MkmBgyiDPP2OreImEQhPvwpliioUMJmERZK3zPAx72z8MDvGp7Fx7ZlzuZpL4yyp4zXBI+MUhFGoqEh32oYnm4qkS4JpjWva5Ktn4YpAWxd4pSCVs8I4MZms20+yx5OlnlmWQEwQiiIwPPwG1e1jRw0Ak5duPpE3uysVGZXkGhC5FyOFM+oVXwc1kMqrrKnQiMJ3lgh59LjkX4z1cDNX3MomyUMJ+I+DaWC2VdHggB74BNANSd+zkPQeNKg3o7FetlDJya1bk8ofdNBARxHFMBtMXu/ONfCT3Q2kCY9gZDRktmNRiHG/1cXhkIcN1RWrbsCkwIDAQAB"
+}
+```
+
+### Compare IDs {: #extension_management }
+
+Open the Extensions Management page at `chrome://extensions`, ensure developer mode is enabled and
+upload the unpackaged extension directory. Compare the extension ID on the extensions management
+page to the Item ID in the Developer Dashboard. They should match.
+
+{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/AGorME3hdXd2YeKot5Nc.png", 
+alt="The id of the
+extension match", width="356", height="352" %}
+

--- a/site/_includes/partials/extensions/reusing-prod-extension-id.md
+++ b/site/_includes/partials/extensions/reusing-prod-extension-id.md
@@ -19,12 +19,10 @@ the [`"key"`]([/docs/extensions/mv3/manifest/key/) field. This way the extension
 same ID.
 
 ```json
-{
-// manifest.json 
-
+{ // manifest.json 
   "manifest_version": 3,
 ...
-  "key": "ThisKeyIsGoingToBeVeryLong/go8GGC2u3UD9WI3MkmBgyiDPP2OreImEQhPvwpliioUMJmERZK3zPAx72z8MDvGp7Fx7ZlzuZpL4yyp4zXBI+MUhFGoqEh32oYnm4qkS4JpjWva5Ktn4YpAWxd4pSCVs8I4MZms20+yx5OlnlmWQEwQiiIwPPwG1e1jRw0Ak5duPpE3uysVGZXkGhC5FyOFM+oVXwc1kMqrrKnQiMJ3lgh59LjkX4z1cDNX3MomyUMJ+I+DaWC2VdHggB74BNANSd+zkPQeNKg3o7FetlDJya1bk8ofdNBARxHFMBtMXu/ONfCT3Q2kCY9gZDRktmNRiHG/1cXhkIcN1RWrbsCkwIDAQAB"
+  "key": "ThisKeyIsGoingToBeVeryLong/go8GGC2u3UD9WI3MkmBgyiDPP2OreImEQhPvwpliioUMJmERZK3zPAx72z8MDvGp7Fx7ZlzuZpL4yyp4zXBI+MUhFGoqEh32oYnm4qkS4JpjWva5Ktn4YpAWxd4pSCVs8I4MZms20+yx5OlnlmWQEwQiiIwPPwG1e1jRw0Ak5duPpE3uysVGZXkGhC5FyOFM+oVXwc1kMqrrKnQiMJ3lgh59LjkX4z1cDNX3MomyUMJ+I+DaWC2VdHggB74BNANSd+zkPQeNKg3o7FetlDJya1bk8ofdNBARxHFMBtMXu/ONfCT3Q2kCY9gZDRktmNRiHG/1cXhkIcN1RWrbsCkwIDAQAB",
 }
 ```
 

--- a/site/_includes/partials/extensions/reusing-prod-extension-id.md
+++ b/site/_includes/partials/extensions/reusing-prod-extension-id.md
@@ -1,15 +1,15 @@
 ## Keep a consistent extension ID {: #keep-consistent-id }
 
-Preserving a single ID is essential during development. To keep a consistent id, follow these steps:
+Preserving a single ID is essential during development. To keep a consistent ID, follow these steps:
 
 ### Upload extension to the developer dashboard {: #upload_to_dashboard }
 
 Package the extension directory into a `.zip` file and upload it to the [Chrome Developer
 Dashboard](https://chrome.google.com/webstore/developer/dashboard) without publishing it:
 
-1.  At the Developer Dashboard, click **Add new item**.
-2.  Click **Browse files**, select the `.zip` extension and upload it.
-3.  Go to the **Package** tab and click on **View public key**.
+1.  On the Developer Dashboard, click **Add new item**.
+2.  Click **Browse files**, select the `.zip` extension, and upload it.
+3.  Go to the **Package** tab and click **View public key**.
 
 {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/8j12N4AyvHyjCZaFghv8.png", alt="Developer Dashboard
 Package tab", width="296", height="121" %}
@@ -33,6 +33,6 @@ upload the unpackaged extension directory. Compare the extension ID on the exten
 page to the Item ID in the Developer Dashboard. They should match.
 
 {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/AGorME3hdXd2YeKot5Nc.png", 
-alt="The id of the
+alt="The ID of the
 extension match", width="356", height="352" %}
 

--- a/site/en/docs/webstore/identify_user/index.md
+++ b/site/en/docs/webstore/identify_user/index.md
@@ -19,11 +19,11 @@ To identify the user with Google OAuth2/OpenId, follow these steps:
 
 We'll go into detail about each step below.
 
-## Create your extension files
+## Create your extension files {: #create-extension-files}
 
 Begin by creating a directory and the following starter files.
 
-### manifest.json
+### manifest.json {: #manifest}
 
 Add the manifest by creating a file called `manifest.json` and include the following code.
 
@@ -38,11 +38,11 @@ Add the manifest by creating a file called `manifest.json` and include the follo
   },
   "background": {
     "service_worker": "background.js"
-  },
+  }
 }
 ```
 
-### background.js
+### background.js {: #background}
 
 Add the background service worker by creating a file called `background.js`. Include the following code.
 
@@ -54,13 +54,9 @@ chrome.action.onClicked.addListener(function () {
 })
 ```
 
-## Keep a consistent extension ID
-
 {% include 'partials/extensions/reusing-prod-extension-id.md' %}
 
-Add a generic partial with these steps and add to OAuth tutorial
-
-## Get the OAuth client ID
+## Get the OAuth client ID {: #get-client-id}
 
 Navigate to the [Google API Console][link] and create a new project. To get a OAuth client ID, follow these steps:
 
@@ -80,9 +76,9 @@ Navigate to the [Google API Console][link] and create a new project. To get a OA
 
 The console will provide an OAuth client ID. Keep this ID for later use.
 
-## Launch the Auth flow
+## Launch the Authorization flow {: #auth-flow}
 
-### Request the "identity" permission
+### Request the "identity" permission {: #identity-permission}
 
 To use the [Chrome Identity API][link], declare the `"identity"` permission in the `manifest.json`.
 
@@ -97,9 +93,12 @@ To use the [Chrome Identity API][link], declare the `"identity"` permission in t
 }
 ```
 
-### Construct the authorization URL
+### Construct the authorization URL {: #auth-url}
 
-Before the extension can make a request to [Google’s OAuth2 endpoint][link] using the Identity API, we need to construct an [authorization URL][link]. It must contain several request parameters including the client ID and redirect URI. In addition to the `openid` scope, you can request `profile` and/or `email` information. Update `background.js` to match the code below.
+Before the extension can make a request to [Google’s OAuth2 endpoint][link] using the Identity API,
+we need to construct an [authorization URL][link]. It must contain several request parameters
+including the client ID and redirect URI. In addition to the `openid` scope, you can request
+`profile` information and/or `email`. Update `background.js` to match the code below.
 
 ```javascript
 // background.js
@@ -125,7 +124,7 @@ chrome.action.onClicked.addListener(function () {
 
 Replace <CLIENT_ID> with the API key generated from the Google console. 
 
-### Add the Authentication flow
+### Retrieve a redirect URL {: #redirect-url}
 
 Now that the extension has the client ID, redirect URI, and OAuth URL, it can initiate Google's authentication flow. Use [`identity.launchWebAuthFlow`][link] to launch the web auth flow and retrieve a redirect URL. 
 
@@ -139,6 +138,7 @@ chrome.action.onClicked.addListener(function () {
   const authUrl = new URL('https://accounts.google.com/o/oauth2/v2/auth')
 
 ...
+
   chrome.identity.launchWebAuthFlow(
     {
       url: oauthUrl.href,
@@ -151,7 +151,7 @@ chrome.action.onClicked.addListener(function () {
         const params = new URLSearchParams(urlHash)
         const jwt = params.get('id_token')
 
-        // Parse the JWT
+        // Parse the JSON Web Token
         const base64Url = jwt.split('.')[1]
         const base64 = base64Url.replace('-', '+').replace('_', '/')
         const token = JSON.parse(atob(base64))
@@ -165,20 +165,21 @@ chrome.action.onClicked.addListener(function () {
 
 {% Aside %}
 
-The above code is not production ready. We strongly encourage validating and decoding the JWT before
+The above code is **not** production ready. We strongly encourage validating and decoding the JWT before
 the information it contains is trusted. See [how to handle credential
 responses][credential-responses]
 
 {% endAside %}
 
-## View the user information
+## View the user information {: #user-info}
 
 Click the extension action button to start the web authentication flow. Sign in with your Google
 Account. 
 
 <!-- SCREENSHOT GOES HERE -->
 
-Inspect the background service worker console to view the user identity information.
+Inspect the background service worker console to view the user identity information. **TODO: Add
+instructions how to inspect bg.**
 
 <!-- SCREENSHOT GOES HERE -->
 

--- a/site/en/docs/webstore/identify_user/index.md
+++ b/site/en/docs/webstore/identify_user/index.md
@@ -44,21 +44,23 @@ Add the manifest by creating a file called `manifest.json` and include the follo
 
 ### background.js {: #background}
 
-Add the background service worker by creating a file called `background.js`. Include the following code:
+Add the background service worker by creating a file called `background.js`. Include the following
+code:
 
 ```javascript
 // background.js
 
-chrome.action.onClicked.addListener(function () {
-  console.log('action clicked')
-})
+chrome.action.onClicked.addListener(function() {
+  console.log('action clicked');
+});
 ```
 
 {% include 'partials/extensions/reusing-prod-extension-id.md' %}
 
 ## Get the OAuth client ID {: #get-client-id}
 
-Navigate to the [Google API Console][google-console] and create a new project. To get a OAuth client ID, follow these steps:
+Navigate to the [Google API Console][google-console] and create a new project. To get a OAuth client
+ID, follow these steps:
 
 **1. Customize the consent screen and select scope.**
    - Click the **OAuth consent screen** menu item.
@@ -81,7 +83,8 @@ The console will provide an OAuth client ID. Keep this ID for later use.
 
 ### Request the "identity" permission {: #identity-permission}
 
-To use the [Chrome Identity API][identity-api], declare the `"identity"` permission in the `manifest.json`.
+To use the [Chrome Identity API][identity-api], declare the `"identity"` permission in the
+`manifest.json`.
 
 ```json
 {
@@ -96,9 +99,9 @@ To use the [Chrome Identity API][identity-api], declare the `"identity"` permiss
 
 ### Construct the authorization URL {: #auth-url}
 
-Before the extension can make a request to Google’s OAuth2 endpoint using the Identity API,
-you need to construct an [authorization URL][auth-url]. It must contain several request parameters
-including the client ID and redirect URI. In addition to the `openid` [scope][openid-scopes], you can request
+Before the extension can make a request to Google’s OAuth2 endpoint using the Identity API, you need
+to construct an [authorization URL][auth-url]. It must contain several request parameters including
+the client ID and redirect URI. In addition to the `openid` [scope][openid-scopes], you can request
 `profile` information and/or `email`. Update `background.js` to match the following code:
 
 ```javascript
@@ -108,20 +111,18 @@ let clientId = '<CLIENT_ID>'
 let redirectUri = `https://${chrome.runtime.id}.chromiumapp.org/`
 let nonce = Math.random().toString(36).substring(2, 15)
 
-chrome.action.onClicked.addListener(function () {
-  const authUrl = new URL('https://accounts.google.com/o/oauth2/v2/auth')
+chrome.action.onClicked.addListener(function() {
+  const authUrl = new URL('https://accounts.google.com/o/oauth2/v2/auth');
 
-  authUrl.searchParams.set('client_id', clientId)
-  authUrl.searchParams.set('response_type', 'id_token')
-  authUrl.searchParams.set('redirect_uri', redirectUri)
+  authUrl.searchParams.set('client_id', clientId);
+  authUrl.searchParams.set('response_type', 'id_token');
+  authUrl.searchParams.set('redirect_uri', redirectUri);
   // Add the OpenID scope. Scopes allow you to access the user’s information.
-  authUrl.searchParams.set('scope', 'openid profile email')
-  authUrl.searchParams.set('nonce', nonce)
-  // Show the consent screen after login
-  authUrl.searchParams.set('prompt', 'consent')
-
-})
-
+  authUrl.searchParams.set('scope', 'openid profile email');
+  authUrl.searchParams.set('nonce', nonce);
+  // Show the consent screen after login.
+  authUrl.searchParams.set('prompt', 'consent');
+});
 ```
 
 Replace `<CLIENT_ID>` with the API key generated from the Google console. 
@@ -129,8 +130,8 @@ Replace `<CLIENT_ID>` with the API key generated from the Google console.
 ### Retrieve a redirect URL {: #redirect-url}
 
 Now that the extension has the client ID, redirect URI, and OAuth URL, it can initiate Google's
-authentication flow. Call [`identity.launchWebAuthFlow()`][identity-webauthflow] to launch the web auth flow and
-retrieve a redirect URL. 
+authentication flow. Call [`identity.launchWebAuthFlow()`][identity-webauthflow] to launch the web
+auth flow and retrieve a redirect URL. 
 
 The redirect URL contains a JSON Web Token (JWT) that identifies the user. To view the requested
 user identity information, you'll need to parse the JWT into a plain JavaScript object. Update
@@ -138,11 +139,12 @@ user identity information, you'll need to parse the JWT into a plain JavaScript 
 
 ```javascript
 // background.js
-...
-
-chrome.action.onClicked.addListener(function () {
 
 ...
+
+chrome.action.onClicked.addListener(function() {
+
+  ...
 
   chrome.identity.launchWebAuthFlow(
       {
@@ -152,34 +154,34 @@ chrome.action.onClicked.addListener(function () {
       (redirectUrl) => {
         if (redirectUrl) {
           // The ID token is in the URL hash
-          const urlHash = redirectUrl.split('#')[1]
-          const params = new URLSearchParams(urlHash)
-          const jwt = params.get('id_token')
+          const urlHash = redirectUrl.split('#')[1];
+          const params = new URLSearchParams(urlHash);
+          const jwt = params.get('id_token');
 
           // Parse the JSON Web Token
-          const base64Url = jwt.split('.')[1]
-          const base64 = base64Url.replace('-', '+').replace('_', '/')
-          const token = JSON.parse(atob(base64))
+          const base64Url = jwt.split('.')[1];
+          const base64 = base64Url.replace('-', '+').replace('_', '/');
+          const token = JSON.parse(atob(base64));
 
-          console.log('token', token)
+          console.log('token', token);
         }
       },
-    )
-})
+    );
+});
 ```
 
 {% Aside %}
 
-The above code is **not** production ready. We strongly encourage validating and decoding the JWT before
-the information it contains is trusted. For more information, see [how to handle credential
+The above code is **not** production ready. We strongly encourage validating and decoding the JWT
+before the information it contains is trusted. For more information, see [how to handle credential
 responses][credential-responses].
 
 {% endAside %}
 
 ## View the user information {: #user-info}
 
-Reload and return to the extension. Click the extension action button to start the web authentication flow. Sign in with your Google
-Account, then press Enter. 
+Reload and return to the extension. Click the extension action button to start the web
+authentication flow. Sign in with your Google Account, then press Enter. 
 
 {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/CETlvMvFpe23QyIAq8Lx.png", alt="ALT_TEXT_HERE",
 width="358", height="428" %}

--- a/site/en/docs/webstore/identify_user/index.md
+++ b/site/en/docs/webstore/identify_user/index.md
@@ -173,15 +173,16 @@ responses][credential-responses]
 
 ## View the user information {: #user-info}
 
-Click the extension action button to start the web authentication flow. Sign in with your Google
-Account. 
+Reload and return to the extension. Click the extension action button to start the web authentication flow. Sign in with your Google
+Account. The extension should log the token containing the user information.
 
-<!-- SCREENSHOT GOES HERE -->
+{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/CETlvMvFpe23QyIAq8Lx.png", alt="ALT_TEXT_HERE",
+width="558", height="628" %}
 
-Inspect the background service worker console to view the user identity information. **TODO: Add
-instructions how to inspect bg.**
+To view the user identity information, click inspect the background service worker console.
 
-<!-- SCREENSHOT GOES HERE -->
+{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/450NKaekvVNpnAUXz7QJ.png", alt="ALT_TEXT_HERE",
+width="800", height="162" %}
 
 ## See also
 

--- a/site/en/docs/webstore/identify_user/index.md
+++ b/site/en/docs/webstore/identify_user/index.md
@@ -9,8 +9,8 @@ Supporting Google account sign-in can help provide a better user experience. Use
 
 This tutorial builds an extension using the [Google OAuth2/OpenID][google-openid] endpoint and the [Chrome
 Identity API][identity-api].  When the user clicks the [action][action], the extension will launch a consent
-screen. After the user signs in to their Google account; the background console will log their
-information.
+screen. After the user signs in to their Google account; the background will log their
+information in the console.
 
 To identify the user with Google OAuth2/OpenId, follow these steps:
 
@@ -133,7 +133,7 @@ authentication flow. Use the [`identity.launchWebAuthFlow`][identity-webauthflow
 retrieve a redirect URL. 
 
 The redirect URL contains a JSON Web Token (JWT) that identifies the user. To view the requested
-user identity information we can parse the JWT into a plain JavaScript object. Update
+user identity information, you'll need to parse the JWT into a plain JavaScript object. Update
 `background.js` to match the following code.
 
 ```javascript
@@ -143,7 +143,7 @@ user identity information we can parse the JWT into a plain JavaScript object. U
 chrome.action.onClicked.addListener(function () {
 
 ...
-// add from here on
+
   chrome.identity.launchWebAuthFlow(
       {
         url: authUrl.href,
@@ -179,7 +179,7 @@ responses][credential-responses]
 ## View the user information {: #user-info}
 
 Reload and return to the extension. Click the extension action button to start the web authentication flow. Sign in with your Google
-Account. 
+Account, then press Enter. 
 
 {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/CETlvMvFpe23QyIAq8Lx.png", alt="ALT_TEXT_HERE",
 width="358", height="428" %}
@@ -190,10 +190,12 @@ Inspect views. The extension should log the token containing the user informatio
 {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/450NKaekvVNpnAUXz7QJ.png", alt="ALT_TEXT_HERE",
 width="800", height="162" %}
 
-## See also
+## Additional resources {: #additional-resources }
 
-- [Extension tutorial that accesses a user's Google contacts][oauth-google-contacts].
-- [OpenID official documentation][google-openid].
+- See [OAuth2: Authenticate users with Google][oauth-google-contacts] for a guided tutorial on how
+  to access a user's Google contacts.
+- See [Google OpenID Connect][google-openid] to learn more about OAuth 2.0 implementation for
+  authentication.
 
 [action]: /docs/extensions/reference/action/
 [auth-url]: https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest

--- a/site/en/docs/webstore/identify_user/index.md
+++ b/site/en/docs/webstore/identify_user/index.md
@@ -5,84 +5,11 @@ date: 2017-08-30
 description: How to get the Google Account identity of a Chrome Web Store user.
 ---
 
-This page tells you how to get the Google Account identity of a user, using Google's OpenID
-endpoint. You can use this identity to manage user payments and licensing, or if you need a
-login system. Google Accounts can help you provide a better user experience, since users of the
-Chrome Web Store are likely to be logged in already, and they won't have to set up and remember yet
-another username and password.
+Supporting Google account sign-in can help provide a better user experience. Users of the Chrome Web Store are likely to be logged in to their Google account already, so they won't have to set up and remember yet another username and password.
 
-## When to support Google Accounts
-
-The following table summarizes when you should support Google Account logins using OpenID.
-
-<table>
-  <tbody>
-    <tr>
-      <th>App cost</th>
-      <th>Payment plan/system</th>
-      <th>Support for Google Accounts (using OpenID)</th>
-    </tr>
-    <tr>
-      <td>Paid</td>
-      <td>Custom payment solution</td>
-      <td>
-	<b>Recommended</b>
-	<br>Users from the Chrome Web Store will have a better experience if you support the Google Account that they're already logged into.
-      </td>
-    </tr>
-    <tr>
-      <td>Free</td>
-      <td>You <b>might charge</b> for the app in the future</td>
-      <td>
-	<b>Recommended</b>
-	<br>Supporting Google Accounts might make adding payments simpler.
-      </td>
-    </tr>
-    <tr>
-      <td>Free</td>
-      <td><b>No plans to charge</b> for the app in the future</td>
-      <td>
-	<b>Optional
-	</b>
-	<br>If you want to identify individual users, Google Accounts are a reasonable way to do so.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-## How to use OpenID with Google Accounts
-
-To get the user's OpenID URL, you query Google's OpenID service. If the user isn't already logged
-in, the user will be prompted to sign in with a Google-provided login page or popup.
-
-<div class="aside aside--note"><b>Note</b>: The OpenID URL is unique for a specific Google Account <em>and a specific app</em>. If you publish multiple apps, the same user will have a different OpenID URL for each app.</div>
-
-Here's what the login page looks like. Note that it has a Google URL, not a URL from the app's site:
-
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/yDxgjzMfnbRFJi9XlGyj.png", 
-       alt="The Google login page.", height="368", width="644" %}
-
-You can get the Google OpenID endpoint by sending a request
-to `https://www.google.com/accounts/o8/id`. See [Federated Login for Google Account Users][5] for
-details.
+This tutorial builds an extension using the [Google OAuth2/OpenID][link] endpoint and the [Chrome
+Identity API][link].  When the user clicks the [action][link], the extension will launch a consent
+screen. After the user signs in to their Google account; the background console will log their
+information.
 
 
-[1]: https://developers.google.com/appengine/docs/java/users/overview
-[2]: https://developers.google.com/appengine/docs/python/users/overview
-[3]: /docs/webstore/get_started
-[4]:
-  http://src.chromium.org/viewvc/chrome/trunk/src/chrome/common/extensions/docs/examples/apps/hello-java/HelloLicenseServlet.java
-[5]: https://developers.google.com/accounts/docs/OpenID
-[6]: https://developers.google.com/accounts/docs/OpenID#Parameters
-[7]: http://code.google.com/p/openid4java/
-[8]: http://code.google.com/p/google-app-engine-django-openid/
-[9]: http://gitorious.org/lightopenid
-[10]: http://rubyforge.org/projects/ruby-openid/
-[11]: http://github.com/josh/rack-openid
-[12]: http://www.janrain.com/openid-enabled
-[13]: http://openid.net/developers/libraries/
-[14]: /docs/webstore/authentication
-[15]: https://developers.google.com/accounts/docs/OpenID
-[16]: https://developers.google.com/appengine/articles/openid
-[17]: /docs/webstore/check_for_payment
-[18]: /docs/webstore/images

--- a/site/en/docs/webstore/identify_user/index.md
+++ b/site/en/docs/webstore/identify_user/index.md
@@ -8,8 +8,8 @@ description: How to get the Google Account identity of a Chrome Web Store user.
 Supporting Google account sign-in can help provide a better user experience. Users of the Chrome Web Store are likely to be logged in to their Google account already, so they won't have to set up and remember yet another username and password.
 
 This tutorial builds an extension using the [Google OAuth2/OpenID][google-openid] endpoint and the [Chrome
-Identity API][identity-api].  When the user clicks the [action][action], the extension will launch a consent
-screen. After the user signs in to their Google account; the background will log their
+Identity API][identity-api]. When the user clicks the [action][action], the extension will launch a consent
+screen. After the user signs in to their Google account, the background will log their
 information in the console.
 
 To identify the user with Google OAuth2/OpenId, follow these steps:
@@ -17,7 +17,7 @@ To identify the user with Google OAuth2/OpenId, follow these steps:
 1. TBD
 2. TBD
 
-We'll go into detail about each step below.
+We'll explain each step below.
 
 ## Create your extension files {: #create-extension-files}
 
@@ -25,7 +25,7 @@ Begin by creating a directory and the following starter files.
 
 ### manifest.json {: #manifest}
 
-Add the manifest by creating a file called `manifest.json` and include the following code.
+Add the manifest by creating a file called `manifest.json` and include the following code:
 
 ```json
 {
@@ -44,7 +44,7 @@ Add the manifest by creating a file called `manifest.json` and include the follo
 
 ### background.js {: #background}
 
-Add the background service worker by creating a file called `background.js`. Include the following code.
+Add the background service worker by creating a file called `background.js`. Include the following code:
 
 ```javascript
 // background.js
@@ -97,9 +97,9 @@ To use the [Chrome Identity API][identity-api], declare the `"identity"` permiss
 ### Construct the authorization URL {: #auth-url}
 
 Before the extension can make a request to Google’s OAuth2 endpoint using the Identity API,
-we need to construct an [authorization URL][auth-url]. It must contain several request parameters
+you need to construct an [authorization URL][auth-url]. It must contain several request parameters
 including the client ID and redirect URI. In addition to the `openid` [scope][openid-scopes], you can request
-`profile` information and/or `email`. Update `background.js` to match the following code.
+`profile` information and/or `email`. Update `background.js` to match the following code:
 
 ```javascript
 // background.js
@@ -124,17 +124,17 @@ chrome.action.onClicked.addListener(function () {
 
 ```
 
-Replace <CLIENT_ID> with the API key generated from the Google console. 
+Replace `<CLIENT_ID>` with the API key generated from the Google console. 
 
 ### Retrieve a redirect URL {: #redirect-url}
 
 Now that the extension has the client ID, redirect URI, and OAuth URL, it can initiate Google's
-authentication flow. Use the [`identity.launchWebAuthFlow`][identity-webauthflow] method to launch the web auth flow and
+authentication flow. Call [`identity.launchWebAuthFlow()`][identity-webauthflow] to launch the web auth flow and
 retrieve a redirect URL. 
 
 The redirect URL contains a JSON Web Token (JWT) that identifies the user. To view the requested
 user identity information, you'll need to parse the JWT into a plain JavaScript object. Update
-`background.js` to match the following code.
+`background.js` to match the following code:
 
 ```javascript
 // background.js
@@ -171,8 +171,8 @@ chrome.action.onClicked.addListener(function () {
 {% Aside %}
 
 The above code is **not** production ready. We strongly encourage validating and decoding the JWT before
-the information it contains is trusted. See [how to handle credential
-responses][credential-responses]
+the information it contains is trusted. For more information, see [how to handle credential
+responses][credential-responses].
 
 {% endAside %}
 
@@ -184,7 +184,7 @@ Account, then press Enter.
 {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/CETlvMvFpe23QyIAq8Lx.png", alt="ALT_TEXT_HERE",
 width="358", height="428" %}
 
-Go to the extension management page. Select the **service worker**  blue link next to
+Go to the extension management page. Select the **service worker** blue link next to
 Inspect views. The extension should log the token containing the user information.
 
 {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/450NKaekvVNpnAUXz7QJ.png", alt="ALT_TEXT_HERE",


### PR DESCRIPTION
Fixes #1719 

Changes proposed in this pull request:

- Provide tutorial on how to authenticate users using the Google OAuth2/OpenID endpoint.
- Add link to [OAuth2 extension tutorial](https://developer.chrome.com/docs/extensions/mv3/tut_oauth/)
- Add a partial for explaining how to keep an extension id consistent. Later it will be added to [OAuth2 tutorial](https://developer.chrome.com/docs/extensions/mv3/tut_oauth/)

NOTE: List of steps at the top are TBD until a final decision is made on section headers.

Staged links
[identifying user](https://deploy-preview-1757--developer-chrome-com.netlify.app/docs/webstore/identify_user/)