### PR TITLE
Update AndroidX Browser Dependency in Custom Tabs Guide to 1.4.0

### DIFF
--- a/site/en/docs/android/custom-tabs/integration-guide/index.md
+++ b/site/en/docs/android/custom-tabs/integration-guide/index.md
@@ -18,7 +18,7 @@ project. Open the `app/build.gradle` file and add the browser library to the dep
 ```groovy
 dependencies {
     ...
-    implementation "androidx.browser:browser:1.3.0"
+    implementation "androidx.browser:browser:1.4.0"
 }
 ```
 


### PR DESCRIPTION
Updates the version here to the latest version of AndroidX Browser which you'll want to use if you are targeting Android 12 :)