### PR TITLE
Document script.executeScript() promise behavior

### DIFF
--- a/site/en/docs/extensions/reference/scripting/index.md
+++ b/site/en/docs/extensions/reference/scripting/index.md
@@ -198,6 +198,35 @@ chrome.scripting.executeScript(
 
 `scripting.insertCSS()` does not return any results.
 
+#### Promises
+
+If the resulting value of the script execution is a promise, Chrome will wait
+for the promise to settle and return the resulting value.
+
+```js
+async function addIframe() {
+  const iframe = document.createElement('iframe');
+  const loadComplete = new Promise((resolve) => {
+    iframe.addEventListener('load', resolve);
+  });
+  iframe.src = 'https://example.com';
+  document.body.appendChild(iframe);
+  await loadComplete;
+  return iframe.contentWindow.document.title;
+}
+
+const tabId = getTabId();
+chrome.scripting.executeScript(
+    {
+      target: {tabId: tabId, allFrames: true},
+      func: addIframe,
+    },
+    (injectionResults) => {
+      for (const frameResult of injectionResults)
+        console.log('Iframe Title: ' + frameResult.result);
+    });
+```
+
 [manifest]: /docs/extensions/mv3/manifest
 [contentscripts]: /docs/extensions/mv3/content_scripts
 [webnavigation]: /docs/extensions/reference/webNavigation

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -4,7 +4,7 @@ layout: 'layouts/doc-post.njk'
 title: What's new in Chrome extensions
 description: 'Recent changes to the Chrome extensions platform, documentation, and policy'
 date: 2021-02-25
-updated: 2021-11-10
+updated: 2021-11-24
 
 # Note: disabling the linter for duplicate headings because this isn't hierarchical and it needs
 # smaller font headings.
@@ -15,6 +15,12 @@ updated: 2021-11-10
 
 Check this page often to learn about changes to the Chrome extensions platform, its documentation,
 and related policy or other changes.
+
+### Chrome 98: Returning promises from scripting.executeScript()
+
+[`chrome.scripting.executeScript()`](/docs/extensions/reference/scripting/#method-executeScript)
+now supports returning promises. When a script evaluates to a promise, Chrome will wait for the
+promise to settle and return its resulting value.
 
 ### Chrome 96: Dynamic content scripts {: #m96-dynamic-content-scripts }
 


### PR DESCRIPTION
If the result of code injected with scripting.executeScript() is a
promise, Chrome will wait for the promise to resovle and return the
resulting value. Add documentation about this to the chrome.scripting
API reference page and the "What's New" page.