### PR TITLE
[devtools-translate] Japanese - What's New in DevTools (Chrome 97)

### DIFF
--- a/site/_includes/partials/devtools/ja/whats-new.md
+++ b/site/_includes/partials/devtools/ja/whats-new.md
@@ -6,7 +6,7 @@
 
 * [プレビュー機能: 新しい Recorder パネル](/ja/blog/new-in-devtools-97/#recorder)
 * [デバイスモードでのデバイス一覧の更新](/ja/blog/new-in-devtools-97/#device)
-* [Edit as HTML での自動補完](/ja/blog/new-in-devtools-97/#code-completion)
+* [Edit as HTML でのオートコンプリート](/ja/blog/new-in-devtools-97/#code-completion)
 * [改善されたコードデバッグ体験](/ja/blog/new-in-devtools-97/#debugging)
 * [[実験的] デバイスを横断した DevTools 設定の同期](/ja/blog/new-in-devtools-97/#sync)
 

--- a/site/_includes/partials/devtools/ja/whats-new.md
+++ b/site/_includes/partials/devtools/ja/whats-new.md
@@ -3,12 +3,14 @@
 関連する機能の完全なリストは、<a href="/tags/new-in-devtools/" translate="no">What's New In DevTools</a> の英語版を参照してください。以下は、日本語に翻訳された内容の一部です。
 
 ### Chrome 97 {: #chrome97 }
+
 * [プレビュー機能: 新しい Recorder パネル](/ja/blog/new-in-devtools-97/#recorder)
 * [デバイスモードでのデバイス一覧の更新](/ja/blog/new-in-devtools-97/#device)
 * [Edit as HTML での自動補完](/ja/blog/new-in-devtools-97/#code-completion)
 * [改善されたコードデバッグ体験](/ja/blog/new-in-devtools-97/#debugging)
 
 ### Chrome 96 {: #chrome96 }
+
 * [プレビュー機能: 新しい CSS Overview パネル](/ja/blog/new-in-devtools-96/#css-overview)
 <!-- * [Restored and improved CSS length edit and copy experince](/ja/blog/new-in-devtools-966/#length) -->
 * [CSS の prefers-contrast メディア機能のエミュレート](/ja/blog/new-in-devtools-96/#prefers-contrast)
@@ -24,6 +26,7 @@
 * [[実験的] Application パネルの新しい Reporting API ペイン](/ja/blog/new-in-devtools-96/#reporting-api)
 
 ### Chrome 95 {: #chrome95 }
+
 * [新しいCSSの長さ編集ツール](/ja//blog/new-in-devtools-95/#length)
 * [Issues タブで問題を隠す](/ja/blog/new-in-devtools-95/#hide-issues)
 * [プロパティの表示の改善](/ja/blog/new-in-devtools-95/#properties)

--- a/site/_includes/partials/devtools/ja/whats-new.md
+++ b/site/_includes/partials/devtools/ja/whats-new.md
@@ -2,11 +2,11 @@
 
 関連する機能の完全なリストは、<a href="/tags/new-in-devtools/" translate="no">What's New In DevTools</a> の英語版を参照してください。以下は、日本語に翻訳された内容の一部です。
 
-<!-- ### Chrome 97 {: #chrome97 }
-* [Preview feature: New Recorder panel](/ja/blog/new-in-devtools-97/#recorder)
-* [Refresh device list in Device Mode](/ja/blog/new-in-devtools-97/#device)
-* [Autocomplete with Edit as HTML](/ja/blog/new-in-devtools-97/#code-completion)
-* [Improved code debugging experience](/ja/blog/new-in-devtools-97/#debugging) -->
+### Chrome 97 {: #chrome97 }
+* [プレビュー機能: 新しい Recorder パネル](/ja/blog/new-in-devtools-97/#recorder)
+* [デバイスモードでのデバイス一覧の更新](/ja/blog/new-in-devtools-97/#device)
+* [Edit as HTML での自動補完](/ja/blog/new-in-devtools-97/#code-completion)
+* [改善されたコードデバッグ体験](/ja/blog/new-in-devtools-97/#debugging)
 
 ### Chrome 96 {: #chrome96 }
 * [プレビュー機能: 新しい CSS Overview パネル](/ja/blog/new-in-devtools-96/#css-overview)

--- a/site/_includes/partials/devtools/ja/whats-new.md
+++ b/site/_includes/partials/devtools/ja/whats-new.md
@@ -8,7 +8,7 @@
 * [デバイスモードでのデバイス一覧の更新](/ja/blog/new-in-devtools-97/#device)
 * [Edit as HTML でのオートコンプリート](/ja/blog/new-in-devtools-97/#code-completion)
 * [改善されたコードデバッグ体験](/ja/blog/new-in-devtools-97/#debugging)
-* [[実験的] デバイスを横断した DevTools 設定の同期](/ja/blog/new-in-devtools-97/#sync)
+* [デバイスを横断した DevTools 設定の同期](/ja/blog/new-in-devtools-97/#sync)
 
 ### Chrome 96 {: #chrome96 }
 

--- a/site/ja/blog/new-in-devtools-97/index.md
+++ b/site/ja/blog/new-in-devtools-97/index.md
@@ -36,7 +36,7 @@ tags:
 **Recorder** パネルの [ドキュメント](/docs/devtools/recorder/) に行って、ステップバイステップなチュートリアルにて詳細を学びましょう！
 
 <!-- The **Recorder** panel is a preview feature. Our team is still actively working on it and we are looking for your [feedback](https://goo.gle/recorder-feedback) for further enhancements. -->
-**Recorder** パネルは、プレビュー機能です。私たちのチームは活発に開発を進めています。更なる改善のために、あなたからの [フィードバック](https://goo.gle/recorder-feedback) をお待ちしております。
+**Recorder** パネルは、プレビュー機能です。私たちのチームは活発に開発を進めています。更なる改善のために、皆さんからの [フィードバック](https://goo.gle/recorder-feedback) をお待ちしております。
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/3EpVa15PtbhFwwszqyWF.png", alt="Recorder パネル", width="800", height="540" %}
 

--- a/site/ja/blog/new-in-devtools-97/index.md
+++ b/site/ja/blog/new-in-devtools-97/index.md
@@ -24,7 +24,7 @@ tags:
 ## プレビュー機能: 新しい Recorder パネル {: #decorder }
 
 <!-- Use the new **Recorder** panel to record, replay and measure user flows.  -->
-ユーザフローを記録、再生、そして計測するために、新しい **Recorder** パネルを使ってください。
+新しい **Recorder** パネルを使用すると、ユーザフローを記録、再生、そして計測できます。
 
 <!-- [Open the **Recorder** panel](/docs/devtools/recorder/#open). Follow the instructions on screen to start a new recording.  -->
 [**Recorder** パネルを開きます](/docs/devtools/recorder/#open)。新規に記録を開始するために、画面の指示に従ってください。
@@ -49,7 +49,7 @@ Chromium issue: [1257499](https://crbug.com/1257499)
 ## デバイスモードでのデバイス一覧の更新 {: #device }
 
 <!-- [Enabling the Device Toolbar](/docs/devtools/device-mode#viewport), more modern devices are now added in the device list. Select a device to simulate its dimensions. -->
-[デバイスツールバーを有効にする](/docs/devtools/device-mode#viewport) と、より新しいデバイスがデバイス一覧に追加されているのがわかります。寸法をシミュレートするデバイスを選択しましょう。
+[デバイスツールバーを有効にする](/docs/devtools/device-mode#viewport) と、より新しいデバイスがデバイス一覧に追加されているのがわかります。画面サイズをシミュレートするデバイスを選択しましょう。
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/Trx5NqE9RrqpWiN24iZ0.png", alt="デバイスモードでのデバイス一覧の更新", width="800", height="547" %}
 
@@ -62,7 +62,7 @@ Chromium issue: [1223525](https://crbug.com/1223525)
 ## Edit as HTML でのオートコンプリート {: #code-completion }
 
 <!-- The **Edit as HTML** UI now supports autocomplete and syntax highlights. In the **Elements** panel, right click on an element, and select  **Edit as HTML**. Try typing a DOM property (e.g. `id`, `aria`), the autocomplete should help you find the property name you're looking for. -->
-**Edit as HTML** はオートコンプリートとシンタックスハイライトをサポートするようになります。**Elements** パネルにて、要素を右クリックして、**Edit as HTML** を選択してください。DOM プロパティ（例: `id`, `aria`）をタイプすることで、期待しているプロパティ名を探すことをオートコンプリート機能が手伝ってくれるはずです。
+**Edit as HTML** はオートコンプリートとシンタックスハイライトをサポートするようになります。**Elements** パネルにて、要素を右クリックして、**Edit as HTML** を選択してください。DOM プロパティ（例: `id`, `aria`）をタイプしてみましょう。期待しているプロパティ名を探すことをオートコンプリート機能が手伝ってくれるはずです。
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/yWnmpCQXpsRjWbbRQ9Pi.png", alt="Edit as HTML でのオートコンプリート", width="800", height="472" %}
 

--- a/site/ja/blog/new-in-devtools-97/index.md
+++ b/site/ja/blog/new-in-devtools-97/index.md
@@ -59,12 +59,12 @@ Chromium issue: [1223525](https://crbug.com/1223525)
 
 
 <!-- ## Autocomplete with Edit as HTML {: #code-completion } -->
-## Edit as HTML での自動補完 {: #code-completion }
+## Edit as HTML でのオートコンプリート {: #code-completion }
 
 <!-- The **Edit as HTML** UI now supports autocomplete and syntax highlights. In the **Elements** panel, right click on an element, and select  **Edit as HTML**. Try typing a DOM property (e.g. `id`, `aria`), the autocomplete should help you find the property name you're looking for. -->
-**Edit as HTML** は自動補完とシンタックスハイライトをサポートするようになります。**Elements** パネルにて、要素を右クリックして、**Edit as HTML** を選択してください。DOM プロパティ（例: `id`, `aria`）をタイプすることで、期待しているプロパティ名を探すことを自動補完が手伝ってくれるはずです。
+**Edit as HTML** はオートコンプリートとシンタックスハイライトをサポートするようになります。**Elements** パネルにて、要素を右クリックして、**Edit as HTML** を選択してください。DOM プロパティ（例: `id`, `aria`）をタイプすることで、期待しているプロパティ名を探すことをオートコンプリート機能が手伝ってくれるはずです。
 
-{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/yWnmpCQXpsRjWbbRQ9Pi.png", alt="Edit as HTML での自動補完", width="800", height="472" %}
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/yWnmpCQXpsRjWbbRQ9Pi.png", alt="Edit as HTML でのオートコンプリート", width="800", height="472" %}
 
 {# https://chromium.googlesource.com/devtools/devtools-frontend/+/f467de3e756f998b0e9dd222ce286cb2b7cbaca0 #}
 

--- a/site/ja/blog/new-in-devtools-97/index.md
+++ b/site/ja/blog/new-in-devtools-97/index.md
@@ -6,42 +6,39 @@ authors:
 date: 2021-11-29
 updated: 2021-11-29
 description:
-  "New Recorder panel, refresh device list in Device Mode, and more."
+  "新しい Recorder パネル、デバイスモードでのデバイス一覧の更新など"
 hero: 'image/dPDCek3EhZgLQPGtEG3y0fTn4v82/Z4Fm456SsBm1MYylRhzA.jpg'
 alt: ''
 tags:
   - new-in-devtools
   - devtools
   - chrome-97
-draft: true
 ---
 
-<!-- start: translation instructions -->
-<!-- 1. Remove the "draft: true" tag above when submitting PR -->
-<!-- 2. Provide translations under each of the English commented original content -->
-<!-- 3. Translate the "description" tag above -->
-<!-- 4. Translate all the <img> alt text -->
-<!-- 5. Update the whats-new.md file -->
-<!-- end: translation instructions -->
-
-*翻訳者の [technohippy](https://github.com/technohippy) さん、レビュアーの [lacolaco](https://github.com/lacolaco) さんと [yoichiro](https://github.com/yoichiro) さんに感謝いたします。*
+*翻訳者の [yoichiro](https://github.com/yoichiro) さん、レビュアーの [lacolaco](https://github.com/lacolaco) さんと [technohippy](https://github.com/technohippy) さんに感謝いたします。*
 
 {% include 'partials/devtools/ja/banner.md' %}
 
 
 <!-- ## Preview feature: New Recorder panel {: #recorder } -->
+## プレビュー機能: 新しい Recorder パネル {: #decorder }
 
 <!-- Use the new **Recorder** panel to record, replay and measure user flows.  -->
+ユーザフローを記録、再生、そして計測するために、新しい **Recorder** パネルを使ってください。
 
 <!-- [Open the **Recorder** panel](/docs/devtools/recorder/#open). Follow the instructions on screen to start a new recording.  -->
+[**Recorder** パネルを開きます](/docs/devtools/recorder/#open)。新規に記録を開始するために、画面の指示に従ってください。
 
 <!-- For example, you can record the coffee checkout process with this [coffee ordering demo](https://coffee-cart.netlify.app/) application. After adding a coffee and filling out payment details, you can end the recording, replay the process or click on the **Measure performance** button to measure the user flow in the **Performance** panel. -->
+例えば、この [コーヒー注文のデモ](https://coffee-cart.netlify.app/) を使って、コーヒーをチェックアウトする処理を記録することができます。コーヒーを追加して決済のための詳細情報を入力した後、記録を終えて処理を再生したり、**Performance** パネルにて **Measure performance** ボタンをクリックしてユーザフローの計測を行うことが可能です。
 
 <!-- Go to the **Recorder** panel [documentation](/docs/devtools/recorder/) to learn more with the step-by-step tutorial! -->
+**Recorder** パネルの [ドキュメント](/docs/devtools/recorder/) に行って、ステップバイステップなチュートリアルにて詳細を学びましょう！
 
 <!-- The **Recorder** panel is a preview feature. Our team is still actively working on it and we are looking for your [feedback](https://goo.gle/recorder-feedback) for further enhancements. -->
+**Recorder** パネルは、プレビュー機能です。私たちのチームは活発に開発を進めています。更なる改善のために、あなたからの [フィードバック](https://goo.gle/recorder-feedback) をお待ちしております。
 
-{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/3EpVa15PtbhFwwszqyWF.png", alt="Recorder panel", width="800", height="540" %}
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/3EpVa15PtbhFwwszqyWF.png", alt="Recorder パネル", width="800", height="540" %}
 
 {# https://chromium.googlesource.com/devtools/devtools-frontend/+/ef26abc89035075bbdb08f1b26c1b8fd942ffc04 #}
 
@@ -49,10 +46,12 @@ Chromium issue: [1257499](https://crbug.com/1257499)
 
 
 <!-- ## Refresh device list in Device Mode {: #device } -->
+## デバイスモードでのデバイス一覧の更新 {: #device }
 
 <!-- [Enabling the Device Toolbar](/docs/devtools/device-mode#viewport), more modern devices are now added in the device list. Select a device to simulate its dimensions. -->
+[デバイスツールバーを有効にする](/docs/devtools/device-mode#viewport) と、より新しいデバイスがデバイス一覧に追加されているのがわかります。寸法をシミュレートするデバイスを選択しましょう。
 
-{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/Trx5NqE9RrqpWiN24iZ0.png", alt="Refresh device list in Device Mode", width="800", height="547" %}
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/Trx5NqE9RrqpWiN24iZ0.png", alt="デバイスモードでのデバイス一覧の更新", width="800", height="547" %}
 
 {# https://chromium.googlesource.com/devtools/devtools-frontend/+/ede4c59ac39f8281b3e372fa2e8f162c1a2a7ea2 #}
 
@@ -60,10 +59,12 @@ Chromium issue: [1223525](https://crbug.com/1223525)
 
 
 <!-- ## Autocomplete with Edit as HTML {: #code-completion } -->
+## Edit as HTML での自動補完 {: #code-completion }
 
 <!-- The **Edit as HTML** UI now supports autocomplete and syntax highlights. In the **Elements** panel, right click on an element, and select  **Edit as HTML**. Try typing a DOM property (e.g. `id`, `aria`), the autocomplete should help you find the property name you're looking for. -->
+**Edit as HTML** は自動補完とシンタックスハイライトをサポートするようになります。**Elements** パネルにて、要素を右クリックして、**Edit as HTML** を選択してください。DOM プロパティ（例: `id`, `aria`）をタイプすることで、期待しているプロパティ名を探すことを自動補完が手伝ってくれるはずです。
 
-{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/yWnmpCQXpsRjWbbRQ9Pi.png", alt="Autocomplete with Edit as HTML", width="800", height="472" %}
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/yWnmpCQXpsRjWbbRQ9Pi.png", alt="Edit as HTML での自動補完", width="800", height="472" %}
 
 {# https://chromium.googlesource.com/devtools/devtools-frontend/+/f467de3e756f998b0e9dd222ce286cb2b7cbaca0 #}
 
@@ -71,10 +72,12 @@ Chromium issue: [1215072](https://crbug.com/1215072)
 
 
 <!-- ## Improved code debugging experience {: #debugging } -->
+## 改善されたコードデバッグ体験 {: debugging }
 
 <!-- Column numbers are now included in the output error in the Console. Having easy access to the column number is essential for debugging especially with minified JavaScript. -->
+Console 内のエラー出力に、列番号が含まれるようになります。特に Minify された JavaScript に対するデバッグでは、列番号に簡単にアクセスできることが不可欠です。
 
-{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/mKAUxO94rwvBI9oyeiIB.png", alt="Column number in the output error", width="800", height="553" %}
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/mKAUxO94rwvBI9oyeiIB.png", alt="エラー出力での列番号", width="800", height="553" %}
 
 {# https://chromium.googlesource.com/devtools/devtools-frontend/+/277ee38b0701e6e5b36c9626d109b62b0361ced6 #}
 
@@ -82,22 +85,27 @@ Chromium issue: [1073064](https://crbug.com/1073064)
 
 
 <!-- ## [Experimental] Syncing DevTools settings across devices {: #sync } -->
+## [実験的] デバイスを横断した DevTools 設定の同期 {: #sync }
 
 <!-- Your DevTools settings are now synced across devices by default when you turn on Chrome profile sync. You can change the DevTools sync settings via **Settings** > **Sync** > **Enable settings sync**. -->
+Chrome プロファイル同期を有効にしている際は、DevTools 設定はデバイスを横断してデフォルトで同期されるようになります。**Settings** > **Sync** > **Enable settings sync** から DevTools の同期設定を変更することが可能です。
 
-{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/yhIipqtEvDuy6ygB677t.png", alt="Chrome profile sync", width="300", height="434" %}
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/yhIipqtEvDuy6ygB677t.png", alt="Chrome プロファイル同期", width="300", height="434" %}
 
-{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/LUwFNTDyP22L1euSGg73.png", alt="DevTools sync settings", width="800", height="654" %}
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/LUwFNTDyP22L1euSGg73.png", alt="DevTools 同期設定", width="800", height="654" %}
 
 <!-- This new setting makes it easier for you to work across devices. For example, the following appearance settings are synced so you have a consistent experience across devices and don’t need to re-define the same settings again.  -->
+この新しい設定は、デバイスを横断して作業を行うことを簡単にしてくれます。例えば、以下の表示設定が同期されることで、一貫した体験をデバイスを横断して得ることができ、同じ設定を何度も再定義する必要がなくなります。
 
-{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/t8SQuZ4mE2xiLVxaZz11.png", alt="appearance settings", width="800", height="584" %}
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/t8SQuZ4mE2xiLVxaZz11.png", alt="表示設定", width="800", height="584" %}
 
 <!-- However, not all the settings are sync. For example, the dock settings isn’t synced because developers have different dock preferences when debugging on different devices.  -->
+しかしながら、全ての設定が同期されるわけではありません。例えば、異なるデバイスでデバッグする際に開発者は異なるドック設定を行っていることもあるため、ドック設定は同期されません。
 
-{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/jWv8rwkF4q6SwTQbSNpp.png", alt="dock", width="426", height="134" %}
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/jWv8rwkF4q6SwTQbSNpp.png", alt="ドック", width="426", height="134" %}
 
 <!-- This feature is experimental at the moment, the team is still actively working on it. If you have any feedback, please share with us [here](https://crbug.com/1245541) -->
+この機能は現在実験的であり、チームは活発に作業を続けています。もし何かフィードバックがあれば、ぜひ [ここ](https://crbug.com/1245541) から私達に共有してください。
 
 Chromium issue: [1245541](https://crbug.com/1245541)
 

--- a/site/ja/blog/new-in-devtools-97/index.md
+++ b/site/ja/blog/new-in-devtools-97/index.md
@@ -98,7 +98,7 @@ Chrome プロファイル同期を有効にしている際は、DevTools 設定�
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/t8SQuZ4mE2xiLVxaZz11.png", alt="表示設定", width="800", height="584" %}
 
 <!-- This feature is experimental at the moment, the team is still actively working on it. If you have any feedback, please share with us [here](https://crbug.com/1245541) -->
-この機能は現在実験的であり、チームは活発に作業を続けています。もし何かフィードバックがあれば、ぜひ [ここ](https://crbug.com/1245541) から私達に共有してください。
+この機能は現在実験的であり、チームは活発に作業を続けています。もし何かフィードバックがあれば、ぜひ [こちら](https://crbug.com/1245541) から私たちに共有してください。
 
 Chromium issue: [1245541](https://crbug.com/1245541)
 

--- a/site/ja/blog/new-in-devtools-97/index.md
+++ b/site/ja/blog/new-in-devtools-97/index.md
@@ -93,7 +93,7 @@ Chrome プロファイル同期を有効にしている際は、DevTools 設定�
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/LUwFNTDyP22L1euSGg73.png", alt="DevTools 同期設定", width="800", height="654" %}
 
 <!-- This new setting makes it easier for you to work across devices. For example, the following appearance settings are synced so you have a consistent experience across devices and don’t need to re-define the same settings again. Learn more about the sync feature in [DevTools customization](/docs/devtools/customize/).  -->
-この新しい設定は、デバイスを横断して作業を行うことを簡単にしてくれます。例えば、以下の表示設定が同期されることで、一貫した体験をデバイスを横断して得ることができ、同じ設定を何度も再定義する必要がなくなります。この[ドキュメント](/docs/devtools/customize/)で同期設定の詳細をご覧ください。
+この新しい設定は、デバイスを横断して作業を行うことを簡単にしてくれます。例えば、以下の表示設定が同期されることで、一貫した体験をデバイスを横断して得ることができ、同じ設定を何度も再定義する必要がなくなります。[DevTools カスタマイズ](/docs/devtools/customize/) にて、同期機能の詳細をご覧ください。
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/t8SQuZ4mE2xiLVxaZz11.png", alt="表示設定", width="800", height="584" %}
 


### PR DESCRIPTION
Fixes #1779 

Changes proposed in this pull request:

Translated "What's New in DevTools 97" into Japanese.