### PR TITLE
Fix version link in Minimum Chrome Version

### DIFF
--- a/site/en/docs/extensions/mv3/manifest/minimum_chrome_version/index.md
+++ b/site/en/docs/extensions/mv3/manifest/minimum_chrome_version/index.md
@@ -7,6 +7,6 @@ description: Reference documentation for the minimum_chrome_version property of 
 ---
 
 The version of Chrome that your extension, app, or theme requires, if any. The format for this
-string is the same as for the [version][1] field.
+string is the same as for the [version][version] field.
 
-[1] /docs/extensions/mv3/tabs#version
+[version]: /docs/extensions/mv3/manifest/version/


### PR DESCRIPTION
Found this broken link issue in [extension-samples](https://github.com/GoogleChrome/chrome-extensions-samples/issues/633)

Changes proposed in this pull request:

- Fix broken link