### PR TITLE
feat(project-landing): allow for embedded project landing pages by using `project_key` property in frontmatter, fixes #1809

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -8,6 +8,7 @@ const {
   leadingAndTrailingSlash,
   stripDefaultLocale,
 } = require('./site/_filters/urls');
+const embededDoc = require('./site/_filters/docs');
 const {i18n} = require('./site/_filters/i18n');
 const {githubLink} = require('./site/_filters/github-link');
 const {namespaceToPath} = require('./site/_filters/namespace');
@@ -102,6 +103,7 @@ module.exports = eleventyConfig => {
 
   // Add filters
   eleventyConfig.addFilter('absolute', absolute);
+  eleventyConfig.addFilter('embededDoc', embededDoc);
   eleventyConfig.addFilter('trailingSlash', trailingSlash);
   eleventyConfig.addFilter('leadingAndTrailingSlash', leadingAndTrailingSlash);
   eleventyConfig.addFilter('stripDefaultLocale', stripDefaultLocale);

--- a/site/_filters/docs.js
+++ b/site/_filters/docs.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Returns the docs object for a given object.
+ *
+ * @param {string} projectKey The docs project key (aka path).
+ * @param {TODO} docs Docs data object to search.
+ * @return {import("webdev-infra/types").TODOObject}
+ */
+const embededDoc = (projectKey, docs = {}) => {
+  return projectKey
+    .split('-')
+    .reduce((prev, curr) => (prev ? prev[curr] : null), docs);
+};
+
+module.exports = embededDoc;

--- a/site/_includes/layouts/project-landing.njk
+++ b/site/_includes/layouts/project-landing.njk
@@ -1,4 +1,4 @@
-{# 
+{#
   This page grabs data from _data/docs/${project_key}/toc.yml. (The `page.fileSlug` value will also
   work, as the URL for this page looks like "/en/docs/{project_key}".)
   For each page in the set of links, it fetches the page's frontmatter and uses that to render the
@@ -34,12 +34,11 @@
         card=>{{ card }}
       {% endfor %}
     {% endif %}
-
     {# Render nested sections. #}
     {% import 'macros/project-sections.njk' as macros with context %}
     <div class="project-sections gap-top-800">
       {# toc defines the table of contents that appears to the left of the documentation. #}
-      {% set toc = docs[project_key].toc %}
+      {% set toc = (project_key | embededDoc(docs)).toc %}
       {{ macros.projectSections(toc) }}
     </div>
   </div>

--- a/site/_includes/macros/project-icon.njk
+++ b/site/_includes/macros/project-icon.njk
@@ -2,7 +2,7 @@
 
 {% macro projectIcon(project_key) %}
   <div class="project-icon">
-    {% set styles = docs[project_key].styles %}
+    {% set styles = (project_key | embededDoc(docs)).styles %}
     {% set color = styles.project_icon_color %}
     <div class="project-icon__cover"{% if color %} style="color: var(--{{color}})"{% endif %}>
       {# svg() looks in "_includes", so find the project image in the parent directory #}

--- a/site/site.11tydata.js
+++ b/site/site.11tydata.js
@@ -20,6 +20,10 @@ module.exports = {
     },
     // Give some pages a project_key.
     project_key: data => {
+      if (data.project_key) {
+        return data.project_key;
+      }
+
       const {url} = data.page;
       if (!url) {
         return;


### PR DESCRIPTION
Fixes #1809

Changes proposed in this pull request:

- Allow for `project_key` to be manually assigned in front matter.
- Add `embededDoc` filter which takes `project_key`  and splits it to find embedded objects in `data.docs`
- Use `embededDoc` filter in `project-icon` and `project-landing` macros.