### PR TITLE
[devtools-translate] Korean - What's new in DevTools (Chrome 97)

### DIFF
--- a/site/_includes/partials/devtools/ko/whats-new.md
+++ b/site/_includes/partials/devtools/ko/whats-new.md
@@ -1,12 +1,12 @@
 ## 더 많은 DevTools 기능 {: #whats-new }
 <a href="/tags/new-in-devtools/" translate="no">What's New In DevTools</a> 영어 버전을 참고하여 관련 기능의 전체 목록을 볼 수 있습니다. 아래 콘텐츠들은 한국어로 번역된 콘텐츠들입니다.
 
-<!-- ### Chrome 97 {: #chrome97 }
-* [Preview feature: New Recorder panel](/ko/blog/new-in-devtools-97/#recorder)
-* [Refresh device list in Device Mode](/ko/blog/new-in-devtools-97/#device)
-* [Autocomplete with Edit as HTML](/ko/blog/new-in-devtools-97/#code-completion)
-* [Improved code debugging experience](/ko/blog/new-in-devtools-97/#debugging)
-* [Syncing DevTools settings across devices](/ko/blog/new-in-devtools-97/#sync) -->
+### Chrome 97 {: #chrome97 }
+* [기능 미리보기: 신규 Recorder 패널](/ko/blog/new-in-devtools-97/#recorder)
+* [Device Mode 의 기기 목록 갱신](/ko/blog/new-in-devtools-97/#device)
+* [HTML로 수정에서 자동완성](/ko/blog/new-in-devtools-97/#code-completion)
+* [코드 디버깅 경험 개선](/ko/blog/new-in-devtools-97/#debugging)
+* [[실험적 기능] 여러 기기 사이의 DevTools 설정 동기화](/ko/blog/new-in-devtools-97/#sync)
 
 ### Chrome 96 {: #chrome96 }
 * [미리보기 기능: 새로운 CSS 개요 영역](/ko/blog/new-in-devtools-96/#css-overview)

--- a/site/_includes/partials/devtools/ko/whats-new.md
+++ b/site/_includes/partials/devtools/ko/whats-new.md
@@ -1,7 +1,9 @@
 ## 더 많은 DevTools 기능 {: #whats-new }
+
 <a href="/tags/new-in-devtools/" translate="no">What's New In DevTools</a> 영어 버전을 참고하여 관련 기능의 전체 목록을 볼 수 있습니다. 아래 콘텐츠들은 한국어로 번역된 콘텐츠들입니다.
 
 ### Chrome 97 {: #chrome97 }
+
 * [기능 미리보기: 신규 Recorder 패널](/ko/blog/new-in-devtools-97/#recorder)
 * [Device Mode 의 기기 목록 갱신](/ko/blog/new-in-devtools-97/#device)
 * [HTML로 수정에서 자동완성](/ko/blog/new-in-devtools-97/#code-completion)
@@ -9,6 +11,7 @@
 * [[실험적 기능] 여러 기기 사이의 DevTools 설정 동기화](/ko/blog/new-in-devtools-97/#sync)
 
 ### Chrome 96 {: #chrome96 }
+
 * [미리보기 기능: 새로운 CSS 개요 영역](/ko/blog/new-in-devtools-96/#css-overview)
 * [복원 및 개선된 CSS 길이 편집 및 복사 경험](/ko/blog/new-in-devtools-96/#length)
 * [CSS 의 prefers-contrast 미디어 기능 에뮬레이션](/ko/blog/new-in-devtools-96/#prefers-contrast)
@@ -24,6 +27,7 @@
 * [[실험실 기능] 애플리케이션 패널에 새롭게 추가된 Reporting API 영역](/ko/blog/new-in-devtools-96/#reporting-api)
 
 ### Chrome 95 {: #chrome95 }
+
 * [새 CSS 길이 작성 도구](/ko/blog/new-in-devtools-95/#length)
 * [문제 탭에서 문제 숨기기](/ko/blog/new-in-devtools-95/#hide-issues)
 * [속성 표시 개선](/ko/blog/new-in-devtools-95/#properties)

--- a/site/ko/blog/new-in-devtools-97/index.md
+++ b/site/ko/blog/new-in-devtools-97/index.md
@@ -6,7 +6,7 @@ authors:
 date: 2021-11-29
 updated: 2021-11-29
 description:
-  "New Recorder panel, refresh device list in Device Mode, and more."
+  "신규 Recorder 패널, Device Mode 의 기기 목록 갱신 등"
 hero: 'image/dPDCek3EhZgLQPGtEG3y0fTn4v82/4oKuqdeNrPY27y4pg3St.jpg'
 alt: ''
 tags:
@@ -16,82 +16,74 @@ tags:
 draft: true
 ---
 
-<!-- start: translation instructions -->
-<!-- 1. Remove the "draft: true" tag above when submitting PR -->
-<!-- 2. Provide translations under each of the English commented original content, do not delete English comment -->
-<!-- 3. Translate the "description" tag above -->
-<!-- 4. Translate all the <img> alt text -->
-<!-- 5. Update the whats-new.md file -->
-<!-- end: translation instructions -->
-
-*이 게시글의 번역에는 [최원영](https://www.linkedin.com/in/toruchoi)님이 참여하였으며, [도창욱](https://developers.google.com/community/experts/directory/profile/profile-changwook-doh)님과 리뷰를 맡아 주셨습니다.*
+*이 게시글의 번역에는 [조은](https://developers.google.com/community/experts/directory/profile/profile-eun-cho)님이 참여하였으며, [이지웅](https://bit.ly/JiwoongLeePortfolio)님과 [최원영](https://www.linkedin.com/in/toruchoi)님, 그리고 [도창욱](https://developers.google.com/community/experts/directory/profile/profile-changwook-doh)님이 리뷰를 맡아 주셨습니다.*
 
 {% include 'partials/devtools/ko/banner.md' %}
 
 
-<!-- ## Preview feature: New Recorder panel {: #recorder } -->
+## 기능 미리보기: 신규 Recorder 패널 {: #recorder }
 
-<!-- Use the new **Recorder** panel to record, replay and measure user flows.  -->
+새로 나온 **Recorder** 패널을 사용해서 사용자의 플로우를 녹화하여 다시 재생하고 측정해보세요
 
-<!-- [Open the **Recorder** panel](/docs/devtools/recorder/#open). Follow the instructions on screen to start a new recording.  -->
+[**Recorder** 패널 열기](/docs/devtools/recorder/#open). 화면의 지시에 따라 새 녹화를 시작합니다.
 
-<!-- For example, you can record the coffee checkout process with this [coffee ordering demo](https://coffee-cart.netlify.app/) application. After adding a coffee and filling out payment details, you can end the recording, replay the process or click on the **Measure performance** button to measure the user flow in the **Performance** panel. -->
+예를 들어 [커피 주문 데모](https://coffee-cart.netlify.app/) 애플리케이션에서 커피 구매 프로세스를 녹화해볼 수 있습니다. 커피를 추가한 뒤 주문 상세를 넣은 뒤, 녹화를 끝낼 수 있으며, 프로세스를 다시 재생하거나 **Measure performance** 버튼을 클릭하여 **Performance** 패널에서 사용자의 플로우를 측정할 수 있습니다.
 
-<!-- Go to the **Recorder** panel [documentation](/docs/devtools/recorder/) to learn more with the step-by-step tutorial! -->
+단계별 튜토리얼을 보려면 **Recorder** 패널 [문서](/docs/devtools/recorder/) 를 살펴보세요.
 
-<!-- The **Recorder** panel is a preview feature. Our team is still actively working on it and we are looking for your [feedback](https://goo.gle/recorder-feedback) for further enhancements. -->
+**Recorder** 패널은 기능 미리보기 상태입니다. Chrome 팀에서는 더 나은 개선을 위해 여러분의 [피드백](https://goo.gle/recorder-feedback)을 기대하고 있으며 열심히 작업하고 있습니다.
 
-{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/3EpVa15PtbhFwwszqyWF.png", alt="Recorder panel", width="800", height="540" %}
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/3EpVa15PtbhFwwszqyWF.png", alt="Recorder 패널", width="800", height="540" %}
 
 {# https://chromium.googlesource.com/devtools/devtools-frontend/+/ef26abc89035075bbdb08f1b26c1b8fd942ffc04 #}
 
 Chromium issue: [1257499](https://crbug.com/1257499)
 
+## Device Mode 의 기기 목록 갱신 {: #device }
 
-<!-- ## Refresh device list in Device Mode {: #device } -->
+[기기 툴바를 활성화](/docs/devtools/device-mode#viewport)하면 기기 목록에 더 많은 최신 기기가 추가됩니다. 치수를 시뮬레이션할 기기를 선택하세요.
 
-<!-- [Enabling the Device Toolbar](/docs/devtools/device-mode#viewport), more modern devices are now added in the device list. Select a device to simulate its dimensions. -->
-
-{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/Trx5NqE9RrqpWiN24iZ0.png", alt="Refresh device list in Device Mode", width="800", height="547" %}
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/Trx5NqE9RrqpWiN24iZ0.png", alt="Device Mode의 기기 목록 갱신", width="800", height="547" %}
 
 {# https://chromium.googlesource.com/devtools/devtools-frontend/+/ede4c59ac39f8281b3e372fa2e8f162c1a2a7ea2 #}
 
 Chromium issue: [1223525](https://crbug.com/1223525)
 
 
-<!-- ## Autocomplete with Edit as HTML {: #code-completion } -->
+## HTML로 수정에서 자동완성 {: #code-completion }
 
-<!-- The **Edit as HTML** UI now supports autocomplete and syntax highlights. In the **Elements** panel, right click on an element, and select  **Edit as HTML**. Try typing a DOM property (e.g. `id`, `aria`), the autocomplete should help you find the property name you're looking for. -->
+**HTML로 수정** UI 에서 자동 완성과 문법 강조를 지원합니다. **요소** 패널의 요소에서 우클릭한 뒤, **HTML로 수정** 을 선택하세요. DOM 속성 (예시: `id`, `aria`)을 작성해보세요, 자동 완성은 여러분이 찾고 있는 속성명을 찾는데 도움이 될 것입니다.
 
-{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/yWnmpCQXpsRjWbbRQ9Pi.png", alt="Autocomplete with Edit as HTML", width="800", height="472" %}
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/yWnmpCQXpsRjWbbRQ9Pi.png", alt="HTML로 수정에서 자동완성", width="800", height="472" %}
 
 {# https://chromium.googlesource.com/devtools/devtools-frontend/+/f467de3e756f998b0e9dd222ce286cb2b7cbaca0 #}
 
 Chromium issue: [1215072](https://crbug.com/1215072)
 
 
-<!-- ## Improved code debugging experience {: #debugging } -->
+## 코드 디버깅 경험 개선 {: #debugging }
 
-<!-- Column numbers are now included in the output error in the Console. Having easy access to the column number is essential for debugging especially with minified JavaScript. -->
+이제 열 번호가 Console의 출력 오류에 포함됩니다.
+특히 압축된 (minified) 자바스크립트로 디버깅하려면 열 번호에 쉽게 접근할 수 있어야 합니다.
 
-{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/mKAUxO94rwvBI9oyeiIB.png", alt="Column number in the output error", width="800", height="553" %}
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/mKAUxO94rwvBI9oyeiIB.png", alt="에러 출력에서 열 번호 노출", width="800", height="553" %}
 
 {# https://chromium.googlesource.com/devtools/devtools-frontend/+/277ee38b0701e6e5b36c9626d109b62b0361ced6 #}
 
 Chromium issue: [1073064](https://crbug.com/1073064)
 
 
-<!-- ## [Experimental] Syncing DevTools settings across devices {: #sync } -->
+## [실험적 기능] 여러 기기 사이의 DevTools 설정 동기화 {: #sync }
 
-<!-- Your DevTools settings are now synced across devices by default when you turn on Chrome profile sync. You can change the DevTools sync settings via **Settings** > **Sync** > **Enable settings sync**.  -->
+Chrome 프로필 동기화를 활성화하였을 때 DevTools 설정이 기본으로 여러 기기에서 동기화됩니다. DevTools 세팅은 **설정** > **동기화** > **설정 동기화 사용** 에서 변경 가능합니다.
 
-{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/LUwFNTDyP22L1euSGg73.png", alt="DevTools sync settings", width="800", height="654" %}
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/LUwFNTDyP22L1euSGg73.png", alt="DevTools 동기화 설정", width="800", height="654" %}
 
-<!-- This new setting makes it easier for you to work across devices. For example, the following appearance settings are synced so you have a consistent experience across devices and don’t need to re-define the same settings again. Learn more about the sync feature in [DevTools customization](/docs/devtools/customize/). -->
+이 신규 설정은 여러 기기에 걸쳐 작업하는 데 더 수월하게 해줄 것입니다.예를 들어, 다음과 같은 디자인 설정이 여러 기기에서 동기화되어 일관된 경험을 제공할 수 있으며 같은 세팅을 여러번 재정의할 필요가 없어집니다. 동기화 기능에 대한 더 자세한 내용은 [DevTools 커스터마이징](/docs/devtools/customize/) 에서 살펴보세요.
 
-{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/t8SQuZ4mE2xiLVxaZz11.png", alt="appearance settings", width="800", height="584" %}
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/t8SQuZ4mE2xiLVxaZz11.png", alt="디자인 설정", width="800", height="584" %}
 
-<!-- This feature is experimental at the moment, the team is still actively working on it. If you have any feedback, please share with us [here](https://crbug.com/1245541). -->
+이 기능은 현재 실험적 기능이며, Chrome 팀에서 해당 기능을 작업하고 있습니다. 어떤 피드백이 있다면 [여기](https://crbug.com/1245541) 에서 Chorme 팀에 공유해주세요.
 
 Chromium issue: [1245541](https://crbug.com/1245541)
 

--- a/site/ko/blog/new-in-devtools-97/index.md
+++ b/site/ko/blog/new-in-devtools-97/index.md
@@ -79,14 +79,13 @@ Chrome 프로필 동기화를 활성화하였을 때 DevTools 설정이 기본�
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/LUwFNTDyP22L1euSGg73.png", alt="DevTools 동기화 설정", width="800", height="654" %}
 
-이 새로운 설정은 여러 기기를 통해 작업하는 것을 더 수월하게 해줄 것입니다.예를 들어, 다음과 같은 디자인 설정이 여러 기기에서 동기화되어 일관된 경험을 제공할 수 있으며 같은 세팅을 여러번 재정의할 필요가 없어집니다. 동기화 기능에 대한 더 자세한 내용은 [DevTools 맞춤 설정](/docs/devtools/customize/) 에서 살펴보세요.
+이 새로운 설정은 여러 기기를 통해 작업하는 것을 더 수월하게 해줄 것입니다. 예를 들어, 다음과 같은 디자인 설정이 여러 기기에서 동기화되어 일관된 경험을 제공할 수 있으며 같은 세팅을 여러번 재정의할 필요가 없어집니다. 동기화 기능에 대한 더 자세한 내용은 [DevTools 맞춤 설정](/docs/devtools/customize/) 에서 살펴보세요.
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/t8SQuZ4mE2xiLVxaZz11.png", alt="디자인 설정", width="800", height="584" %}
 
-이 기능은 현재 실험실 기능이며, Chrome 팀에서 해당 기능을 작업하고 있습니다. 어떤 피드백이 있다면 [여기](https://crbug.com/1245541) 에서 Chorme 팀에 공유해주세요.
+이 기능은 현재 실험실 기능이며, Chrome 팀에서 해당 기능을 작업하고 있습니다. 피드백은 [여기](https://crbug.com/1245541) 를 통해 Chorme 팀에 공유해주세요.
 
 Chromium issue: [1245541](https://crbug.com/1245541)
-
 
 {% include 'partials/devtools/ko/reach-out.md' %}
 {% include 'partials/devtools/ko/whats-new.md' %}

--- a/site/ko/blog/new-in-devtools-97/index.md
+++ b/site/ko/blog/new-in-devtools-97/index.md
@@ -13,10 +13,9 @@ tags:
   - new-in-devtools
   - devtools
   - chrome-97
-draft: true
 ---
 
-*이 게시글의 번역에는 [조은](https://developers.google.com/community/experts/directory/profile/profile-eun-cho)님이 참여하였으며, [도창욱](https://developers.google.com/community/experts/directory/profile/profile-changwook-doh)님이 리뷰를 맡아 주셨습니다.*
+*이 게시글의 번역에는 [조은](https://developers.google.com/community/experts/directory/profile/profile-eun-cho)님이 참여하였으며, [최원영](https://www.linkedin.com/in/toruchoi)님과 [도창욱](https://developers.google.com/community/experts/directory/profile/profile-changwook-doh)님이 리뷰를 맡아 주셨습니다.*
 
 {% include 'partials/devtools/ko/banner.md' %}
 

--- a/site/ko/blog/new-in-devtools-97/index.md
+++ b/site/ko/blog/new-in-devtools-97/index.md
@@ -6,7 +6,7 @@ authors:
 date: 2021-11-29
 updated: 2021-11-29
 description:
-  "신규 Recorder 패널, Device Mode 의 기기 목록 갱신 등"
+  "새로운 Recorder 패널, Device Mode 의 기기 목록 갱신 등"
 hero: 'image/dPDCek3EhZgLQPGtEG3y0fTn4v82/4oKuqdeNrPY27y4pg3St.jpg'
 alt: ''
 tags:
@@ -16,12 +16,12 @@ tags:
 draft: true
 ---
 
-*이 게시글의 번역에는 [조은](https://developers.google.com/community/experts/directory/profile/profile-eun-cho)님이 참여하였으며, [이지웅](https://bit.ly/JiwoongLeePortfolio)님과 [최원영](https://www.linkedin.com/in/toruchoi)님, 그리고 [도창욱](https://developers.google.com/community/experts/directory/profile/profile-changwook-doh)님이 리뷰를 맡아 주셨습니다.*
+*이 게시글의 번역에는 [조은](https://developers.google.com/community/experts/directory/profile/profile-eun-cho)님이 참여하였으며, [도창욱](https://developers.google.com/community/experts/directory/profile/profile-changwook-doh)님이 리뷰를 맡아 주셨습니다.*
 
 {% include 'partials/devtools/ko/banner.md' %}
 
 
-## 기능 미리보기: 신규 Recorder 패널 {: #recorder }
+## 프리뷰 기능: 새로운 Recorder 패널 {: #recorder }
 
 새로 나온 **Recorder** 패널을 사용해서 사용자의 플로우를 녹화하여 다시 재생하고 측정해보세요
 
@@ -31,7 +31,7 @@ draft: true
 
 단계별 튜토리얼을 보려면 **Recorder** 패널 [문서](/docs/devtools/recorder/) 를 살펴보세요.
 
-**Recorder** 패널은 기능 미리보기 상태입니다. Chrome 팀에서는 더 나은 개선을 위해 여러분의 [피드백](https://goo.gle/recorder-feedback)을 기대하고 있으며 열심히 작업하고 있습니다.
+**Recorder** 패널은 프리뷰 기능입니다. Chrome 팀에서는 더 나은 개선을 위해 여러분의 [피드백](https://goo.gle/recorder-feedback)을 기대하고 있으며 열심히 작업하고 있습니다.
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/3EpVa15PtbhFwwszqyWF.png", alt="Recorder 패널", width="800", height="540" %}
 
@@ -41,7 +41,7 @@ Chromium issue: [1257499](https://crbug.com/1257499)
 
 ## Device Mode 의 기기 목록 갱신 {: #device }
 
-[기기 툴바를 활성화](/docs/devtools/device-mode#viewport)하면 기기 목록에 더 많은 최신 기기가 추가됩니다. 치수를 시뮬레이션할 기기를 선택하세요.
+[기기 툴바를 활성화](/docs/devtools/device-mode#viewport)하면 기기 목록에 더 많은 최신 기기가 추가됩니다. 해상도를 시뮬레이션할 기기를 선택하세요.
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/Trx5NqE9RrqpWiN24iZ0.png", alt="Device Mode의 기기 목록 갱신", width="800", height="547" %}
 
@@ -73,17 +73,17 @@ Chromium issue: [1215072](https://crbug.com/1215072)
 Chromium issue: [1073064](https://crbug.com/1073064)
 
 
-## [실험적 기능] 여러 기기 사이의 DevTools 설정 동기화 {: #sync }
+## [실험실 기능] 여러 기기 사이의 DevTools 설정 동기화 {: #sync }
 
-Chrome 프로필 동기화를 활성화하였을 때 DevTools 설정이 기본으로 여러 기기에서 동기화됩니다. DevTools 세팅은 **설정** > **동기화** > **설정 동기화 사용** 에서 변경 가능합니다.
+Chrome 프로필 동기화를 활성화하였을 때 DevTools 설정이 기본적으로 여러 기기에서 동기화됩니다. DevTools 동기화 설정은 **설정** > **동기화** > **설정 동기화 사용** 에서 변경 가능합니다.
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/LUwFNTDyP22L1euSGg73.png", alt="DevTools 동기화 설정", width="800", height="654" %}
 
-이 신규 설정은 여러 기기에 걸쳐 작업하는 데 더 수월하게 해줄 것입니다.예를 들어, 다음과 같은 디자인 설정이 여러 기기에서 동기화되어 일관된 경험을 제공할 수 있으며 같은 세팅을 여러번 재정의할 필요가 없어집니다. 동기화 기능에 대한 더 자세한 내용은 [DevTools 커스터마이징](/docs/devtools/customize/) 에서 살펴보세요.
+이 새로운 설정은 여러 기기를 통해 작업하는 것을 더 수월하게 해줄 것입니다.예를 들어, 다음과 같은 디자인 설정이 여러 기기에서 동기화되어 일관된 경험을 제공할 수 있으며 같은 세팅을 여러번 재정의할 필요가 없어집니다. 동기화 기능에 대한 더 자세한 내용은 [DevTools 맞춤 설정](/docs/devtools/customize/) 에서 살펴보세요.
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/t8SQuZ4mE2xiLVxaZz11.png", alt="디자인 설정", width="800", height="584" %}
 
-이 기능은 현재 실험적 기능이며, Chrome 팀에서 해당 기능을 작업하고 있습니다. 어떤 피드백이 있다면 [여기](https://crbug.com/1245541) 에서 Chorme 팀에 공유해주세요.
+이 기능은 현재 실험실 기능이며, Chrome 팀에서 해당 기능을 작업하고 있습니다. 어떤 피드백이 있다면 [여기](https://crbug.com/1245541) 에서 Chorme 팀에 공유해주세요.
 
 Chromium issue: [1245541](https://crbug.com/1245541)
 


### PR DESCRIPTION
Fixes #1781
Changes proposed in this pull request:

- Translate What's new in DevTools 97 into Korean