### PR TITLE
[devtools-translate] Russian - What's New in DevTools (Chrome 97)

### DIFF
--- a/site/_includes/partials/devtools/ru/whats-new.md
+++ b/site/_includes/partials/devtools/ru/whats-new.md
@@ -11,6 +11,7 @@
 * [Syncing DevTools settings across devices](/ru/blog/new-in-devtools-97/#sync) -->
 
 ### Chrome 97 {: #chrome97 }
+
 * [Ранний доступ: новая панель Recorder](/ru/blog/new-in-devtools-97/#recorder)
 * [Обновлён список устройств в панели инструментов устройства (Device Mode)](/ru/blog/new-in-devtools-97/#device)
 * [Автодополнение в режиме Редактировать как HTML (Edit as HTML)](/ru/blog/new-in-devtools-97/#code-completion)
@@ -18,6 +19,7 @@
 * [Синхронизация настроек DevTools между устройствами](/ru/blog/new-in-devtools-97/#sync)
 
 ### Chrome 96 {: #chrome96 }
+
 * [Ранний доступ: Новая вкладка Обзор CSS](/ru/blog/new-in-devtools-96/#css-overview)
 * [Восстановлен и улучшен опыт редактирования и копирования длины в CSS](/ru/blog/new-in-devtools-966/#length)
 * [Эмуляция CSS-медиафункции prefers-contrast](/ru/blog/new-in-devtools-96/#prefers-contrast)
@@ -33,6 +35,7 @@
 * [[Эксперимент] Новая панель Reporting API на вкладке Приложение](/ru/blog/new-in-devtools-96/#reporting-api)
 
 ### Chrome 95 {: #chrome95 }
+
 * [Новый инструмент выбора единиц измерения длины в CSS](/blog/new-in-devtools-95/#length)
 * [Скрытие задач во вкладке Проблемы (Issues)](/blog/new-in-devtools-95/#hide-issues)
 * [Улучшенное отображение свойств](/blog/new-in-devtools-95/#properties)

--- a/site/_includes/partials/devtools/ru/whats-new.md
+++ b/site/_includes/partials/devtools/ru/whats-new.md
@@ -12,7 +12,7 @@
 
 ### Chrome 97 {: #chrome97 }
 
-* [Ранний доступ: новая панель Recorder](/ru/blog/new-in-devtools-97/#recorder)
+* [Ранний доступ: новая вкладка Recorder](/ru/blog/new-in-devtools-97/#recorder)
 * [Обновлён список устройств в панели инструментов устройства (Device Mode)](/ru/blog/new-in-devtools-97/#device)
 * [Автодополнение в режиме Редактировать как HTML (Edit as HTML)](/ru/blog/new-in-devtools-97/#code-completion)
 * [Улучшен процесс отладки кода](/ru/blog/new-in-devtools-97/#debugging)

--- a/site/_includes/partials/devtools/ru/whats-new.md
+++ b/site/_includes/partials/devtools/ru/whats-new.md
@@ -10,6 +10,13 @@
 * [Improved code debugging experience](/ru/blog/new-in-devtools-97/#debugging)
 * [Syncing DevTools settings across devices](/ru/blog/new-in-devtools-97/#sync) -->
 
+### Chrome 97 {: #chrome97 }
+* [Ранний доступ: новая панель Recorder](/ru/blog/new-in-devtools-97/#recorder)
+* [Обновлён список устройств в панели инструментов устройства (Device Mode)](/ru/blog/new-in-devtools-97/#device)
+* [Автодополнение в режиме Редактировать как HTML (Edit as HTML)](/ru/blog/new-in-devtools-97/#code-completion)
+* [Улучшен процесс отладки кода](/ru/blog/new-in-devtools-97/#debugging)
+* [Синхронизация настроек DevTools между устройствами](/ru/blog/new-in-devtools-97/#sync)
+
 ### Chrome 96 {: #chrome96 }
 * [Ранний доступ: Новая вкладка Обзор CSS](/ru/blog/new-in-devtools-96/#css-overview)
 * [Восстановлен и улучшен опыт редактирования и копирования длины в CSS](/ru/blog/new-in-devtools-966/#length)

--- a/site/ru/blog/new-in-devtools-97/index.md
+++ b/site/ru/blog/new-in-devtools-97/index.md
@@ -36,7 +36,7 @@ tags:
 пользовательские сценарии.
 
 <!-- [Open the **Recorder** panel](/docs/devtools/recorder/#open). Follow the instructions on screen to start a new recording.  -->
-[Откройте панель **Recorder**](/docs/devtools/recorder/#open). Следуйте инструкциям на
+[Откройте вкладку **Recorder**](/docs/devtools/recorder/#open). Следуйте инструкциям на
 экране, чтобы начать новую запись.
 
 <!-- For example, you can record the coffee checkout process with this [coffee ordering demo](https://coffee-cart.netlify.app/) application. After adding a coffee and filling out payment details, you can end the recording, replay the process or click on the **Measure performance** button to measure the user flow in the **Performance** panel. -->
@@ -92,7 +92,7 @@ tags:
 
 <!-- Column numbers are now included in the output error in the Console. Having easy access to the column number is essential for debugging especially with minified JavaScript. -->
 В вывод ошибки в Консоли (Console) добавлены номера колонок. Простой доступ к номеру колонки
-критичен для отладки кода, особенно в случае с минифицированным кодом JavaScript.
+критичен для отладки кода, особенно в случае с минифицированным JavaScript.
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/mKAUxO94rwvBI9oyeiIB.png", alt="Номера колонок добавлены в вывод ошибки", width="800", height="553" %}
 
@@ -105,7 +105,7 @@ tags:
 ## [Эксперимент] Синхронизация настроек DevTools между устройствами {: #sync }
 
 <!-- Your DevTools settings are now synced across devices by default when you turn on Chrome profile sync. You can change the DevTools sync settings via **Settings** > **Sync** > **Enable settings sync**.  -->
-Ваши настройки DevTools теперь синхронизируются между устройствами когда вы включаете синхронизацию
+Ваши настройки DevTools теперь синхронизируются между устройствами, когда вы включаете синхронизацию
 профиля Chrome. Вы можете изменить настройки синхронизации зайдя в **Настройки** (Settings) >
 **Синхронизация** (Sync)  > **Включить синхронизацию настроек** (Enable settings sync).
 

--- a/site/ru/blog/new-in-devtools-97/index.md
+++ b/site/ru/blog/new-in-devtools-97/index.md
@@ -13,15 +13,14 @@ tags:
   - new-in-devtools
   - devtools
   - chrome-97
-draft: true
 ---
 
 <!-- start: translation instructions -->
-<!-- 1. Remove the "draft: true" tag above when submitting PR -->
-<!-- 2. Provide translations under each of the English commented original content, do not delete English comment -->
-<!-- 3. Translate the "description" tag above -->
-<!-- 4. Translate all the <img> alt text -->
-<!-- 5. Update the whats-new.md file -->
+<!-- + 1. Remove the "draft: true" tag above when submitting PR -->
+<!-- + 2. Provide translations under each of the English commented original content, do not delete English comment -->
+<!-- + 3. Translate the "description" tag above -->
+<!-- + 4. Translate all the <img> alt text -->
+<!-- + 5. Update the whats-new.md file -->
 <!-- end: translation instructions -->
 
 *Переводы предоставлены [Alena Batitskaya](https://twitter.com/ABatickaya). Редактор — [Maxim Salnikov](https://twitter.com/webmaxru).*
@@ -30,70 +29,101 @@ draft: true
 
 
 <!-- ## Preview feature: New Recorder panel {: #recorder } -->
+## Ранний доступ: новая панель Recorder  {: #recorder }
 
 <!-- Use the new **Recorder** panel to record, replay and measure user flows.  -->
+Используйте новую панель **Recorder** чтобы записать, проиграть или измерить
+пользовательские сценарии.
 
 <!-- [Open the **Recorder** panel](/docs/devtools/recorder/#open). Follow the instructions on screen to start a new recording.  -->
+[Откройте панель **Recorder**](/docs/devtools/recorder/#open). Следуйте инструкциям на
+экране чтобы начать новую запись.
 
 <!-- For example, you can record the coffee checkout process with this [coffee ordering demo](https://coffee-cart.netlify.app/) application. After adding a coffee and filling out payment details, you can end the recording, replay the process or click on the **Measure performance** button to measure the user flow in the **Performance** panel. -->
+Например, вы можете записать процесс заказа кофе с помощью этого [демо приложения по заказу
+кофе](https://coffee-cart.netlify.app/). После выбора кофе и ввода платёжных данных вы можете
+закончить запись, проиграть её с начала или кликнуть на кнопку **Measure performance** для просмотра пользовательских данных в панели **Производительность** (Performance).
 
 <!-- Go to the **Recorder** panel [documentation](/docs/devtools/recorder/) to learn more with the step-by-step tutorial! -->
+Обратитесь к [документации](/docs/devtools/recorder/) по панели **Recorder** чтобы узнать больше с пошаговыми туториалами.
 
 <!-- The **Recorder** panel is a preview feature. Our team is still actively working on it and we are looking for your [feedback](https://goo.gle/recorder-feedback) for further enhancements. -->
+Функция **Recorder** находится в раннем доступе. Наша команда все ещё активно работает над ней, и мы ждем [ваши отзывы](https://goo.gle/recorder-feedback) для дальнейших улучшений.
 
-{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/3EpVa15PtbhFwwszqyWF.png", alt="Recorder panel", width="800", height="540" %}
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/3EpVa15PtbhFwwszqyWF.png", alt="Панель Recorder", width="800", height="540" %}
 
 {# https://chromium.googlesource.com/devtools/devtools-frontend/+/ef26abc89035075bbdb08f1b26c1b8fd942ffc04 #}
 
-Chromium issue: [1257499](https://crbug.com/1257499)
+Задача в трекере Chromium: [1257499](https://crbug.com/1257499)
 
 
 <!-- ## Refresh device list in Device Mode {: #device } -->
+## Обновлён список устройств в панели инструментов устройства (Device Mode) {: #device }
 
 <!-- [Enabling the Device Toolbar](/docs/devtools/device-mode#viewport), more modern devices are now added in the device list. Select a device to simulate its dimensions. -->
+[Включая функцию выбора устройства](/docs/devtools/device-mode#viewport) вы увидите больше современных
+устройств, добавленных в список. Выберите устройство для симуляции размеров его экрана.
 
-{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/Trx5NqE9RrqpWiN24iZ0.png", alt="Refresh device list in Device Mode", width="800", height="547" %}
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/Trx5NqE9RrqpWiN24iZ0.png", alt="Обновлён список устройств в панели инструментов устройства", width="800", height="547" %}
 
 {# https://chromium.googlesource.com/devtools/devtools-frontend/+/ede4c59ac39f8281b3e372fa2e8f162c1a2a7ea2 #}
 
-Chromium issue: [1223525](https://crbug.com/1223525)
+Задача в трекере Chromium: [1223525](https://crbug.com/1223525)
 
 
 <!-- ## Autocomplete with Edit as HTML {: #code-completion } -->
+## Автодополнение в режиме Редактировать как HTML (Edit as HTML)  {: #code-completion }
 
 <!-- The **Edit as HTML** UI now supports autocomplete and syntax highlights. In the **Elements** panel, right click on an element, and select  **Edit as HTML**. Try typing a DOM property (e.g. `id`, `aria`), the autocomplete should help you find the property name you're looking for. -->
+Интерфейс функции **Редактировать как HTML** (Edit as HTML) теперь поддерживает автодополнение и
+подсветку синтаксиса. Во вкладке **Элементы** (Elements) кликните правой кнопкой мыши на элементе и
+выберите **Редактировать как HTML** (Edit as HTML). Начните печатать свойство DOM (`id`, `aria` и
+т.д.) и автодополнение поможет вам найти нужное имя свойства.
 
-{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/yWnmpCQXpsRjWbbRQ9Pi.png", alt="Autocomplete with Edit as HTML", width="800", height="472" %}
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/yWnmpCQXpsRjWbbRQ9Pi.png", alt="Автодополнение в режиме Редактировать как HTML", width="800", height="472" %}
 
 {# https://chromium.googlesource.com/devtools/devtools-frontend/+/f467de3e756f998b0e9dd222ce286cb2b7cbaca0 #}
 
-Chromium issue: [1215072](https://crbug.com/1215072)
+Задача в трекере Chromium: [1215072](https://crbug.com/1215072)
 
 
 <!-- ## Improved code debugging experience {: #debugging } -->
+## Улучшен процесс отладки кода {: #debugging }
 
 <!-- Column numbers are now included in the output error in the Console. Having easy access to the column number is essential for debugging especially with minified JavaScript. -->
+Номера колонок добавлены в вывод ошибки в Консоли (Console). Простой доступ к номеру колонки
+критичен для отладки кода, особенно в случае с минифицированным кодом JavaScript.
 
-{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/mKAUxO94rwvBI9oyeiIB.png", alt="Column number in the output error", width="800", height="553" %}
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/mKAUxO94rwvBI9oyeiIB.png", alt="Номера колонок добавлены в вывод ошибки", width="800", height="553" %}
 
 {# https://chromium.googlesource.com/devtools/devtools-frontend/+/277ee38b0701e6e5b36c9626d109b62b0361ced6 #}
 
-Chromium issue: [1073064](https://crbug.com/1073064)
+Задача в трекере Chromium: [1073064](https://crbug.com/1073064)
 
 
 <!-- ## [Experimental] Syncing DevTools settings across devices {: #sync } -->
+## [Эксперимент] Синхронизация настроек DevTools между устройствами {: #sync }
 
 <!-- Your DevTools settings are now synced across devices by default when you turn on Chrome profile sync. You can change the DevTools sync settings via **Settings** > **Sync** > **Enable settings sync**.  -->
+Ваши настройки DevTools теперь синхронизируются между устройствами когда вы включаете синхронизацию
+профиля Chrome. Вы можете изменить настройки синхронизации зайдя в **Настройки** (Settings) >
+**Синхронизация** (Sync)  > **Включить синхронизацию настроек** (Enable settings sync).
 
-{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/LUwFNTDyP22L1euSGg73.png", alt="DevTools sync settings", width="800", height="654" %}
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/LUwFNTDyP22L1euSGg73.png", alt="Настройки
+синхронизации DevTools", width="800", height="654" %}
 
 <!-- This new setting makes it easier for you to work across devices. For example, the following appearance settings are synced so you have a consistent experience across devices and don’t need to re-define the same settings again. Learn more about the sync feature in [DevTools customization](/docs/devtools/customize/). -->
+Эта настройка облегчает работу на разных устройствах. Например, следующие настройки внешнего вида
+синхронизированы и ваш пользовательский опыт на разных устройствах будет консистентным, вам не нужно
+заново настраивать те же настройки.
 
-{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/t8SQuZ4mE2xiLVxaZz11.png", alt="appearance settings", width="800", height="584" %}
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/t8SQuZ4mE2xiLVxaZz11.png", alt="Настройки внешнего вида", width="800", height="584" %}
 
 <!-- This feature is experimental at the moment, the team is still actively working on it. If you have any feedback, please share with us [here](https://crbug.com/1245541). -->
+В данный момент это экспериментальная функция, наша команда все ещё активно работает над ней.
+Пожалуйста, поделитесь с нами любым фидбэком [здесь](https://crbug.com/1245541).
 
-Chromium issue: [1245541](https://crbug.com/1245541)
+Задача в трекере Chromium: [1245541](https://crbug.com/1245541)
 
 {% include 'partials/devtools/ru/reach-out.md' %}
 {% include 'partials/devtools/ru/whats-new.md' %}

--- a/site/ru/blog/new-in-devtools-97/index.md
+++ b/site/ru/blog/new-in-devtools-97/index.md
@@ -32,25 +32,25 @@ tags:
 ## Ранний доступ: новая панель Recorder  {: #recorder }
 
 <!-- Use the new **Recorder** panel to record, replay and measure user flows.  -->
-Используйте новую панель **Recorder** чтобы записать, проиграть или измерить
+Используйте новую панель **Recorder**, чтобы записать, воспроизвести или измерить
 пользовательские сценарии.
 
 <!-- [Open the **Recorder** panel](/docs/devtools/recorder/#open). Follow the instructions on screen to start a new recording.  -->
 [Откройте панель **Recorder**](/docs/devtools/recorder/#open). Следуйте инструкциям на
-экране чтобы начать новую запись.
+экране, чтобы начать новую запись.
 
 <!-- For example, you can record the coffee checkout process with this [coffee ordering demo](https://coffee-cart.netlify.app/) application. After adding a coffee and filling out payment details, you can end the recording, replay the process or click on the **Measure performance** button to measure the user flow in the **Performance** panel. -->
-Например, вы можете записать процесс заказа кофе с помощью этого [демо приложения по заказу
-кофе](https://coffee-cart.netlify.app/). После выбора кофе и ввода платёжных данных вы можете
-закончить запись, проиграть её с начала или кликнуть на кнопку **Measure performance** для просмотра пользовательских данных в панели **Производительность** (Performance).
+Например, вы можете записать процесс заказа кофе с помощью этого [демо приложения
+](https://coffee-cart.netlify.app/). После выбора кофе и ввода платёжных данных вы можете
+закончить запись, воспроизвести её сначала или кликнуть на кнопку **Measure performance** для просмотра пользовательских данных в панели **Производительность** (Performance).
 
 <!-- Go to the **Recorder** panel [documentation](/docs/devtools/recorder/) to learn more with the step-by-step tutorial! -->
-Обратитесь к [документации](/docs/devtools/recorder/) по панели **Recorder** чтобы узнать больше с пошаговыми туториалами.
+Обратитесь к [документации](/docs/devtools/recorder/) по панели **Recorder**, чтобы узнать больше из пошагового руководства.
 
 <!-- The **Recorder** panel is a preview feature. Our team is still actively working on it and we are looking for your [feedback](https://goo.gle/recorder-feedback) for further enhancements. -->
-Функция **Recorder** находится в раннем доступе. Наша команда все ещё активно работает над ней, и мы ждем [ваши отзывы](https://goo.gle/recorder-feedback) для дальнейших улучшений.
+Вкладка **Recorder** находится в раннем доступе. Наша команда все ещё активно работает над ней, и мы ждем [ваши отзывы](https://goo.gle/recorder-feedback) для дальнейших улучшений.
 
-{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/3EpVa15PtbhFwwszqyWF.png", alt="Панель Recorder", width="800", height="540" %}
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/3EpVa15PtbhFwwszqyWF.png", alt="Вкладка Recorder", width="800", height="540" %}
 
 {# https://chromium.googlesource.com/devtools/devtools-frontend/+/ef26abc89035075bbdb08f1b26c1b8fd942ffc04 #}
 
@@ -61,8 +61,8 @@ tags:
 ## Обновлён список устройств в панели инструментов устройства (Device Mode) {: #device }
 
 <!-- [Enabling the Device Toolbar](/docs/devtools/device-mode#viewport), more modern devices are now added in the device list. Select a device to simulate its dimensions. -->
-[Включая функцию выбора устройства](/docs/devtools/device-mode#viewport) вы увидите больше современных
-устройств, добавленных в список. Выберите устройство для симуляции размеров его экрана.
+[При выборе устройства](/docs/devtools/device-mode#viewport) теперь вы увидите больше современных
+моделей в списке. Выберите устройство для симуляции размеров его экрана.
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/Trx5NqE9RrqpWiN24iZ0.png", alt="Обновлён список устройств в панели инструментов устройства", width="800", height="547" %}
 
@@ -78,7 +78,7 @@ tags:
 Интерфейс функции **Редактировать как HTML** (Edit as HTML) теперь поддерживает автодополнение и
 подсветку синтаксиса. Во вкладке **Элементы** (Elements) кликните правой кнопкой мыши на элементе и
 выберите **Редактировать как HTML** (Edit as HTML). Начните печатать свойство DOM (`id`, `aria` и
-т.д.) и автодополнение поможет вам найти нужное имя свойства.
+т.д.) и автодополнение поможет вам найти нужное название свойства.
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/yWnmpCQXpsRjWbbRQ9Pi.png", alt="Автодополнение в режиме Редактировать как HTML", width="800", height="472" %}
 
@@ -91,7 +91,7 @@ tags:
 ## Улучшен процесс отладки кода {: #debugging }
 
 <!-- Column numbers are now included in the output error in the Console. Having easy access to the column number is essential for debugging especially with minified JavaScript. -->
-Номера колонок добавлены в вывод ошибки в Консоли (Console). Простой доступ к номеру колонки
+В вывод ошибки в Консоли (Console) добавлены номера колонок. Простой доступ к номеру колонки
 критичен для отладки кода, особенно в случае с минифицированным кодом JavaScript.
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/mKAUxO94rwvBI9oyeiIB.png", alt="Номера колонок добавлены в вывод ошибки", width="800", height="553" %}
@@ -113,15 +113,15 @@ tags:
 синхронизации DevTools", width="800", height="654" %}
 
 <!-- This new setting makes it easier for you to work across devices. For example, the following appearance settings are synced so you have a consistent experience across devices and don’t need to re-define the same settings again. Learn more about the sync feature in [DevTools customization](/docs/devtools/customize/). -->
-Эта настройка облегчает работу на разных устройствах. Например, следующие настройки внешнего вида
-синхронизированы и ваш пользовательский опыт на разных устройствах будет консистентным, вам не нужно
-заново настраивать те же настройки.
+Эта функция облегчает работу на разных устройствах. Например, следующие настройки внешнего вида
+могут быть синхронизированы, так что ваш пользовательский опыт на разных устройствах будет консистентным без необходимости
+настраивать эти параметры заново.
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/t8SQuZ4mE2xiLVxaZz11.png", alt="Настройки внешнего вида", width="800", height="584" %}
 
 <!-- This feature is experimental at the moment, the team is still actively working on it. If you have any feedback, please share with us [here](https://crbug.com/1245541). -->
 В данный момент это экспериментальная функция, наша команда все ещё активно работает над ней.
-Пожалуйста, поделитесь с нами любым фидбэком [здесь](https://crbug.com/1245541).
+Ждем ваши отзывы [здесь](https://crbug.com/1245541).
 
 Задача в трекере Chromium: [1245541](https://crbug.com/1245541)
 

--- a/site/ru/blog/new-in-devtools-97/index.md
+++ b/site/ru/blog/new-in-devtools-97/index.md
@@ -29,10 +29,10 @@ tags:
 
 
 <!-- ## Preview feature: New Recorder panel {: #recorder } -->
-## Ранний доступ: новая панель Recorder  {: #recorder }
+## Ранний доступ: новая вкладка Recorder  {: #recorder }
 
 <!-- Use the new **Recorder** panel to record, replay and measure user flows.  -->
-Используйте новую панель **Recorder**, чтобы записать, воспроизвести или измерить
+Используйте новую вкладку **Recorder**, чтобы записать, воспроизвести или измерить
 пользовательские сценарии.
 
 <!-- [Open the **Recorder** panel](/docs/devtools/recorder/#open). Follow the instructions on screen to start a new recording.  -->
@@ -42,10 +42,10 @@ tags:
 <!-- For example, you can record the coffee checkout process with this [coffee ordering demo](https://coffee-cart.netlify.app/) application. After adding a coffee and filling out payment details, you can end the recording, replay the process or click on the **Measure performance** button to measure the user flow in the **Performance** panel. -->
 Например, вы можете записать процесс заказа кофе с помощью этого [демо приложения
 ](https://coffee-cart.netlify.app/). После выбора кофе и ввода платёжных данных вы можете
-закончить запись, воспроизвести её сначала или кликнуть на кнопку **Measure performance** для просмотра пользовательских данных в панели **Производительность** (Performance).
+закончить запись, воспроизвести её сначала или кликнуть на кнопку **Measure performance** для просмотра пользовательских данных во вкладке **Производительность** (Performance).
 
 <!-- Go to the **Recorder** panel [documentation](/docs/devtools/recorder/) to learn more with the step-by-step tutorial! -->
-Обратитесь к [документации](/docs/devtools/recorder/) по панели **Recorder**, чтобы узнать больше из пошагового руководства.
+Обратитесь к [документации](/docs/devtools/recorder/) по вкладке **Recorder**, чтобы узнать больше из пошагового руководства.
 
 <!-- The **Recorder** panel is a preview feature. Our team is still actively working on it and we are looking for your [feedback](https://goo.gle/recorder-feedback) for further enhancements. -->
 Вкладка **Recorder** находится в раннем доступе. Наша команда все ещё активно работает над ней, и мы ждем [ваши отзывы](https://goo.gle/recorder-feedback) для дальнейших улучшений.


### PR DESCRIPTION
Fixes #1783 

Hi! 

@kateryna-prokopenko @webmaxru notes for you:
- Recorder panel don't have Russian translation right now in DevTools. So I didn't translate this name for now.
- Is «автокомплит» fairly self-explanatory term already? Or do we still have to use «автодополнение»?
- I use «панели инструментов устройства» as translation for Device Mode. This phrase is used in DevTools right now. May be you have more elegant shape =)