### PR TITLE
Fix incorrect updated dates in CWS policy FAQs

### DIFF
--- a/site/en/docs/extensions/mv3/single_purpose/index.md
+++ b/site/en/docs/extensions/mv3/single_purpose/index.md
@@ -2,7 +2,7 @@
 layout: "layouts/doc-post.njk"
 title: "Extensions quality guidelines FAQ"
 date: 2014-05-09
-updated: 2017-05-09
+updated: 2021-07-22
 description: Frequently asked questions about the single purpose policy.
 ---
 

--- a/site/en/docs/webstore/spam-faq/index.md
+++ b/site/en/docs/webstore/spam-faq/index.md
@@ -2,7 +2,7 @@
 layout: "layouts/doc-post.njk"
 title: "Spam policy FAQ"
 date: 2020-05-01
-updated: 2021-08-25
+updated: 2021-09-28
 description: Frequently asked questions about Chrome Web Store's spam policy.
 ---
 
@@ -132,7 +132,7 @@ This depends on how relevant the keywords are in context, however, it's best to 
 specific keyword to under 5. Keywords must be relevant to the extension's purpose and not
 unnecessarily repeat in an unnatural way. Including more than 5 instances of a single keyword may
 result in increased scrutiny of your extensions, but will be allowed if its use is considered
-appropriate and relevant. 
+appropriate and relevant.
 
 When listing supported websites or brands in the description, do not list more than five. To provide
 a longer list of brands or websites, provide a link that users can refer to or embed the list in one

--- a/site/en/docs/webstore/terms/index.md
+++ b/site/en/docs/webstore/terms/index.md
@@ -2,7 +2,7 @@
 layout: "layouts/doc-post.njk"
 title: "Google Chrome Web Store Developer Agreement"
 date: 2014-02-28
-updated: 2021-05-04
+updated: 2021-06-29
 description: >
   The legal agreement governing the relationship between Chrome Web Store
   developers and the Chrome Web Store.
@@ -60,7 +60,7 @@ Agreement or use the Web Store on behalf of your employer or other entity.
 
 ## 3\. Pricing and Payments {: #pricing }
 
-3.1 You are responsible for any Taxes and must pay the Registration Fee without any reduction for Taxes. 
+3.1 You are responsible for any Taxes and must pay the Registration Fee without any reduction for Taxes.
 
 3.2 This Agreement covers both Products you choose to distribute for free and Products for which you charge a fee.
 If you charge a fee for your Product, you assume sole responsibility and liability for all related transactions and authentications, records, and taxes. Google will have no obligations with respect to such Products, including without limitation obligations to track and process payments, authenticate paid or previously paid downloads, maintain payment records, or pay, report, or charge taxes.
@@ -156,7 +156,7 @@ rated Products generally given better placement, subject to Google's right to ch
 Google's sole discretion. For new Developers without Product history, Google may use or publish
 performance measurements such as uninstall rates to identify or remove Products that are not meeting
 acceptable standards, as determined by Google. Google reserves the right to display Products to
-users in a manner that will be determined at Google's sole discretion.  
+users in a manner that will be determined at Google's sole discretion.
 Your Products may be subject to user ratings to which you may not agree. You may contact Google if
 you have any questions or concerns regarding such ratings at
 [http://groups.google.com/a/chromium.org/group/chromium-apps/][11].
@@ -325,9 +325,9 @@ below.
 10.2 If you want to terminate this Agreement, you must provide Google with thirty (30) days prior
 notice and cease your use of any relevant developer credentials.
 
-10.3 Google may at any time, terminate this Agreement with you if:  
-(A) you have breached any provision of this Agreement; or  
-(B) Google is required to do so by law; or  
+10.3 Google may at any time, terminate this Agreement with you if:
+(A) you have breached any provision of this Agreement; or
+(B) Google is required to do so by law; or
 (C) Google decides to no longer provide the Web Store.
 
 ## 11\. DISCLAIMER OF WARRANTIES {: #disclaimer }

--- a/site/en/docs/webstore/user_data/index.md
+++ b/site/en/docs/webstore/user_data/index.md
@@ -2,7 +2,7 @@
 layout: "layouts/doc-post.njk"
 title: "Updated Privacy Policy & Secure Handling Requirements"
 date: 2016-04-23
-updated: 2020-11-19
+updated: 2021-01-28
 description: Frequently asked questions about Chrome Web Store's user data policy.
 ---
 


### PR DESCRIPTION
The updated date on several CWS FAQ pages was not updated at the same time as the last meaningful content change. This PR addresses this oversight.