### PR TITLE
Expand on "Content Download" Network DevTools docs

### DIFF
--- a/site/en/docs/devtools/network/reference/index.md
+++ b/site/en/docs/devtools/network/reference/index.md
@@ -523,7 +523,7 @@ Here's more information about each of the phases you may see in the Timing tab:
 - **Waiting (TTFB)**. The browser is waiting for the first byte of a response. TTFB stands for Time
   To First Byte. This timing includes 1 round trip of latency and the time the server took to
   prepare the response.
-- **Content Download**. The browser is receiving the response.
+- **Content Download**. The browser is receiving the response, either directly from the network or from a service worker. This value is the total amount of time spent reading the response body. Larger than expected values could indicate a slow network, or that the browser is busy performing other work which delays the response from being read.
 - **Receiving Push**. The browser is receiving data for this response via HTTP/2 Server Push.
 - **Reading Push**. The browser is reading the local data previously received.
 


### PR DESCRIPTION
This change enhances the current definition of "Content Download" in the Network DevTools. It lets developers know that large values might be due to a slow network, or it might be due to the browser being busy with other work, preventing the response from being read as quickly as it would be otherwise.