### PR TITLE
fix(landing): identify landing pages by `/` rather than `-`, fixes #1840

### DIFF
--- a/site/_filters/docs.js
+++ b/site/_filters/docs.js
@@ -23,8 +23,8 @@
  */
 const embededDoc = (projectKey, docs = {}) => {
   return projectKey
-    .split('-')
-    .reduce((prev, curr) => (prev ? prev[curr] : null), docs);
+    .split('/')
+    .reduce((prev, curr) => (prev && prev[curr] ? prev[curr] : prev), docs);
 };
 
 module.exports = embededDoc;

--- a/site/_includes/macros/project-icon.njk
+++ b/site/_includes/macros/project-icon.njk
@@ -6,7 +6,7 @@
     {% set color = styles.project_icon_color %}
     <div class="project-icon__cover"{% if color %} style="color: var(--{{color}})"{% endif %}>
       {# svg() looks in "_includes", so find the project image in the parent directory #}
-      {{ svg('../_static/images/project/' + project_key + '.svg', {hidden: true}) }}
+      {{ svg('../_static/images/project/' + project_key | replace("/", "-") + '.svg', {hidden: true}) }}
     </div>
   </div>
 {% endmacro %}

--- a/site/en/docs/workbox/modules/index.md
+++ b/site/en/docs/workbox/modules/index.md
@@ -2,4 +2,5 @@
 layout: 'layouts/project-landing.njk'
 title: 'Workbox Modules'
 description: 'Tooling! Workbox! Stuff!'
+project_key: workbox/modules
 ---

--- a/site/en/docs/workbox/modules/index.md
+++ b/site/en/docs/workbox/modules/index.md
@@ -2,5 +2,4 @@
 layout: 'layouts/project-landing.njk'
 title: 'Workbox Modules'
 description: 'Tooling! Workbox! Stuff!'
-project_key: workbox-modules
 ---

--- a/site/site.11tydata.js
+++ b/site/site.11tydata.js
@@ -1,5 +1,5 @@
-// Matches e.g. "/es/docs/blah/", "/en/docs/foo-bar_zing/", or "/en/docs/foo-bar/zing/".
-const projectKeyRe = /\/\w{2,}\/docs\/(.*)\/$/;
+// Matches e.g. "/es/docs/blah/" or "/en/docs/foo-bar_zing/".
+const projectKeyRe = /\/\w{2,}\/docs\/([_-\w]+)\//;
 
 module.exports = {
   eleventyComputed: {

--- a/site/site.11tydata.js
+++ b/site/site.11tydata.js
@@ -1,5 +1,5 @@
-// Matches e.g. "/es/docs/blah/" or "/en/docs/foo-bar_zing/".
-const projectKeyRe = /\/\w{2,}\/docs\/([_-\w]+)\//;
+// Matches e.g. "/es/docs/blah/", "/en/docs/foo-bar_zing/", or "/en/docs/foo-bar/zing/".
+const projectKeyRe = /\/\w{2,}\/docs\/(.*)\/$/;
 
 module.exports = {
   eleventyComputed: {


### PR DESCRIPTION
Fixes #1840

Changes proposed in this pull request:

- search data object by splitting `projectKey` by `/`
- replace `/` with `-` for image asset