### PR TITLE
Remove extra # from ids

### DIFF
--- a/site/_includes/macros/render-type.njk
+++ b/site/_includes/macros/render-type.njk
@@ -66,7 +66,7 @@
 
   <li class="stack">
     <div>
-      <div class="code-sections__label" id="#{{ node._pageId }}">{{ node.name }}</div>
+      <div class="code-sections__label" id="{{ node._pageId }}">{{ node.name }}</div>
       <div class="type--xsmall">{{ renderSingleIconType(node.type, node) }}</div>
     </div>
 
@@ -134,7 +134,7 @@
             <div>
               {# We need to disambiguate this from parameters, so include the name. #}
               {% if not isTopLevel %}
-                <div class="code-sections__label" id="#{{ node._pageId }}">returns</div>
+                <div class="code-sections__label" id="{{ node._pageId }}">returns</div>
               {% endif %}
               <div class="type--xsmall">{{ renderSingleIconType(node._method.return.type, node._method.return) }}</div>
             </div>


### PR DESCRIPTION
https://github.com/GoogleChrome/developer.chrome.com/pull/1622 introduced the `id=#{{...}}` attribute to this template. `id` attributes probably should not start with `#`, since the `#` is implicitly added to them when using them for in-page anchors via the hash part of a URL.

With the current template, https://developer.chrome.com/docs/extensions/reference/events/##method-Event-addListener is a valid in-page anchor URL, but https://developer.chrome.com/docs/extensions/reference/events/#method-Event-addListener isn't. This PR will make it so that the second URL, with the single `#`, works.

(I don't know whether there are any existing places in the docs that somehow rely on these `##` URLs—it's a hard string to search for, since `##` is used in a lot of other places for different purposes.)

CC: @tropicadri 