### PR TITLE
Privacy Sandbox landing page, structure only

### DIFF
--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -35,13 +35,10 @@
         - url: /docs/privacy-sandbox/attribution-reporting
           title: i18n.docs.privacy-sandbox.attribution-reporting-overview
           description: i18n.docs.privacy-sandbox.attribution-reporting_description
-        - url: /docs/privacy-sandbox/attribution-reporting-event-guide
+        - url: /docs/privacy-sandbox/attribution-reporting-event-introduction/
           title: i18n.docs.privacy-sandbox.attribution-reporting-events
+        - url: /docs/privacy-sandbox/attribution-reporting-event-guide
+          title: i18n.docs.privacy-sandbox.attribution-reporting-events-api
 - title: i18n.docs.privacy-sandbox.fight-spam
   sections:
     - url: /docs/privacy-sandbox/trust-tokens
-- title: i18n.docs.privacy-sandbox.discuss
-  sections:
-    - url: https://github.com/GoogleChromeLabs/privacy-sandbox-dev-support
-      title: i18n.docs.privacy-sandbox.issues
-      description: i18n.docs.privacy-sandbox.issues_description

--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -1,11 +1,39 @@
-- url: /docs/privacy-sandbox/overview
-- url: /docs/privacy-sandbox/cds21-update
-- url: /docs/privacy-sandbox/status
-- url: /docs/privacy-sandbox/faq
-- url: /docs/privacy-sandbox/glossary
-- url: /docs/privacy-sandbox/trust-tokens
-- url: /docs/privacy-sandbox/first-party-sets
-- url: /docs/privacy-sandbox/attribution-reporting
-- url: /docs/privacy-sandbox/user-agent
-- url: /docs/privacy-sandbox/floc
-- url: /docs/privacy-sandbox/fledge
+# External URLs need an explicit title and description, otherwise
+# the toc won't know what to display.
+- title: i18n.docs.privacy-sandbox.overview
+  sections:
+    - url: /docs/privacy-sandbox/overview
+      title: i18n.docs.privacy-sandbox.overview-article
+    - url: /docs/privacy-sandbox/cds21-update
+    - url: /tags/privacy/
+      title: i18n.docs.privacy-sandbox.blog
+    - url: https://privacysandbox.com/timeline/
+      title: i18n.docs.privacy-sandbox.timeline
+- title: i18n.docs.privacy-sandbox.start
+  sections:
+    - url: /docs/privacy-sandbox/glossary
+    - url: /docs/privacy-sandbox/status
+    - url: /docs/privacy-sandbox/faq
+- title: i18n.docs.privacy-sandbox.apis
+  sections:
+    - url: /docs/privacy-sandbox/user-agent
+    - url: /docs/privacy-sandbox/first-party-sets
+    - url: /docs/privacy-sandbox/trust-tokens
+    - title: i18n.docs.privacy-sandbox.attribution-reporting
+      sections:
+        - url: /docs/privacy-sandbox/attribution-reporting
+          title: i18n.docs.privacy-sandbox.attribution-reporting-overview
+          description: i18n.docs.privacy-sandbox.attribution-reporting_description
+        - url: /docs/privacy-sandbox/attribution-reporting-event-guide
+          title: i18n.docs.privacy-sandbox.attribution-reporting-events
+        - url: /docs/privacy-sandbox/attribution-reporting-data-clearing
+          title: i18n.docs.privacy-sandbox.attribution-reporting-faqs
+    - url: /docs/privacy-sandbox/floc
+    - url: /docs/privacy-sandbox/fledge
+- title: i18n.docs.privacy-sandbox.discuss
+  sections:
+    - url: https://developer.chrome.com/feeds/privacy.xml
+      title: i18n.docs.privacy-sandbox.subscribe
+    - url: https://github.com/WICG/turtledove/issues
+      title: i18n.docs.privacy-sandbox.issues
+      description: i18n.docs.privacy-sandbox.issues_description

--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -4,11 +4,11 @@
   sections:
     - url: /docs/privacy-sandbox/overview
       title: i18n.docs.privacy-sandbox.overview-article
-    - url: /docs/privacy-sandbox/cds21-update
     - url: /tags/privacy/
       title: i18n.docs.privacy-sandbox.blog
     - url: https://privacysandbox.com/timeline/
       title: i18n.docs.privacy-sandbox.timeline
+    - url: /docs/privacy-sandbox/cds21-update
 - title: i18n.docs.privacy-sandbox.start
   sections:
     - url: /docs/privacy-sandbox/glossary

--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -14,11 +14,22 @@
     - url: /docs/privacy-sandbox/glossary
     - url: /docs/privacy-sandbox/status
     - url: /docs/privacy-sandbox/faq
-- title: i18n.docs.privacy-sandbox.apis
+- title: i18n.docs.privacy-sandbox.strengthen-boundaries
+  sections:
+    - url: /docs/privacy-sandbox/first-party-sets
+    - url: https://github.com/WICG/CHIPS
+      title: i18n.docs.privacy-sandbox.chips
+    - url: https://github.com/WICG/FedCM
+      title: i18n.docs.privacy-sandbox.fedcm
+- title: i18n.docs.privacy-sandbox.tracking-prevention
   sections:
     - url: /docs/privacy-sandbox/user-agent
-    - url: /docs/privacy-sandbox/first-party-sets
-    - url: /docs/privacy-sandbox/trust-tokens
+- title: i18n.docs.privacy-sandbox.relevant
+  sections:
+    - url: /docs/privacy-sandbox/floc
+    - url: /docs/privacy-sandbox/fledge
+- title: i18n.docs.privacy-sandbox.measure
+  sections:
     - title: i18n.docs.privacy-sandbox.attribution-reporting
       sections:
         - url: /docs/privacy-sandbox/attribution-reporting
@@ -26,10 +37,9 @@
           description: i18n.docs.privacy-sandbox.attribution-reporting_description
         - url: /docs/privacy-sandbox/attribution-reporting-event-guide
           title: i18n.docs.privacy-sandbox.attribution-reporting-events
-        - url: /docs/privacy-sandbox/attribution-reporting-data-clearing
-          title: i18n.docs.privacy-sandbox.attribution-reporting-faqs
-    - url: /docs/privacy-sandbox/floc
-    - url: /docs/privacy-sandbox/fledge
+- title: i18n.docs.privacy-sandbox.fight-spam
+  sections:
+    - url: /docs/privacy-sandbox/trust-tokens
 - title: i18n.docs.privacy-sandbox.discuss
   sections:
     - url: https://github.com/GoogleChromeLabs/privacy-sandbox-dev-support

--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -32,8 +32,6 @@
     - url: /docs/privacy-sandbox/fledge
 - title: i18n.docs.privacy-sandbox.discuss
   sections:
-    - url: https://developer.chrome.com/feeds/privacy.xml
-      title: i18n.docs.privacy-sandbox.subscribe
-    - url: https://github.com/WICG/turtledove/issues
+    - url: https://github.com/GoogleChromeLabs/privacy-sandbox-dev-support
       title: i18n.docs.privacy-sandbox.issues
       description: i18n.docs.privacy-sandbox.issues_description

--- a/site/_data/i18n/docs/privacy-sandbox.yml
+++ b/site/_data/i18n/docs/privacy-sandbox.yml
@@ -18,8 +18,6 @@ trust-tokens:
   en: 'Trust Tokens'
 start:
   en: 'Get started'
-apis:
-  en: 'APIs'
 discuss:
   en: 'Discussion and updates'
 issues:
@@ -38,7 +36,25 @@ attribution-reporting-overview:
   en: 'Overview'
 attribution-reporting-events:
   en: 'Event-level reports'
+attribution-reporting-events-api:
+  en: 'Event-level reports API guide'
 attribution-reporting-faqs:
   en: 'User-initiated data clearing'
 attribution-reporting_description:
   en: 'Measure when user action leads to a conversion, without cross-site identifiers.'
+tracking-prevention:
+  en: 'Prevent covert tracking'
+strengthen-boundaries:
+  en: 'Strengthen cross-site privacy boundaries'
+relevant:
+  en: 'Show relevant content'
+fight-spam:
+  en: 'Fight spam and fraud'
+measure:
+  en: 'Measure digital ads'
+chips:
+  en: 'Cookies Having Independent Partitioned State (CHIPS)'
+fedcm:
+  en: 'Federated Credentials Management (FedCM)'
+  
+  

--- a/site/_data/i18n/docs/privacy-sandbox.yml
+++ b/site/_data/i18n/docs/privacy-sandbox.yml
@@ -18,20 +18,10 @@ trust-tokens:
   en: 'Trust Tokens'
 start:
   en: 'Get started'
-discuss:
-  en: 'Discussion and updates'
-issues:
-  en: 'File an issue'
-issues_description:
-  en: 'Read the proposal, raise questions, and follow discussion.'
 timeline:
   en: 'Timeline'
-timeline-descrition:
-  en: 'Discover when we expect new APIs and technologies to be ready for adoption.'
 blog:
   en: 'Blog'
-subscribe:
-  en: 'Subscribe to RSS'
 attribution-reporting-overview:
   en: 'Overview'
 attribution-reporting-events:

--- a/site/_data/i18n/docs/privacy-sandbox.yml
+++ b/site/_data/i18n/docs/privacy-sandbox.yml
@@ -45,7 +45,7 @@ attribution-reporting_description:
 tracking-prevention:
   en: 'Prevent covert tracking'
 strengthen-boundaries:
-  en: 'Strengthen cross-site privacy boundaries'
+  en: 'Strengthen privacy boundaries'
 relevant:
   en: 'Show relevant content'
 fight-spam:

--- a/site/_data/i18n/docs/privacy-sandbox.yml
+++ b/site/_data/i18n/docs/privacy-sandbox.yml
@@ -28,8 +28,6 @@ attribution-reporting-events:
   en: 'Event-level reports'
 attribution-reporting-events-api:
   en: 'Event-level reports API guide'
-attribution-reporting-faqs:
-  en: 'User-initiated data clearing'
 attribution-reporting_description:
   en: 'Measure when user action leads to a conversion, without cross-site identifiers.'
 tracking-prevention:

--- a/site/_data/i18n/docs/privacy-sandbox.yml
+++ b/site/_data/i18n/docs/privacy-sandbox.yml
@@ -10,7 +10,35 @@ guiding-principles:
   en: 'Guiding principles'
 overview:
   en: 'What is the Privacy Sandbox?'
+overview-article:
+  en: 'Introduction'
 status:
   en: 'Is it ready yet?'
 trust-tokens:
   en: 'Trust Tokens'
+start:
+  en: 'Get started'
+apis:
+  en: 'APIs'
+discuss:
+  en: 'Discussion and updates'
+issues:
+  en: 'File an issue'
+issues_description:
+  en: 'Read the proposal, raise questions, and follow discussion.'
+timeline:
+  en: 'Timeline'
+timeline-descrition:
+  en: 'Discover when we expect new APIs and technologies to be ready for adoption.'
+blog:
+  en: 'Blog'
+subscribe:
+  en: 'Subscribe to RSS'
+attribution-reporting-overview:
+  en: 'Overview'
+attribution-reporting-events:
+  en: 'Event-level reports'
+attribution-reporting-faqs:
+  en: 'User-initiated data clearing'
+attribution-reporting_description:
+  en: 'Measure when user action leads to a conversion, without cross-site identifiers.'


### PR DESCRIPTION
Changes proposed in this pull request:

- Re-organizing the Privacy Sandbox doc pages into groups

Not covered in this pull request:

- Updates to the API descriptions to ensure brevity and clarity. 

Preview: https://deploy-preview-1843--developer-chrome-com.netlify.app/docs/privacy-sandbox/