### PR TITLE
How to distribute an extension in the Chrome Web Store

### DIFF
--- a/site/en/docs/extensions/mv3/getstarted/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/index.md
@@ -39,7 +39,7 @@ following code.
 ### Load unpacked extension {: #unpacked }
 
 The directory holding the manifest file can be added as an extension in developer mode in its
-current state. To load an unpacked extension in developer mode, follow the next steps:
+current state. To load an unpacked extension in developer mode, follow these steps:
 
 1.  Open the Extension Management page by navigating to `chrome://extensions`.
     - Alternatively, open this page by clicking on the Extensions menu button and selecting **Manage

--- a/site/en/docs/extensions/mv3/getstarted/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/index.md
@@ -36,8 +36,10 @@ following code.
 }
 ```
 
+### Load unpacked extension {: #unpacked }
+
 The directory holding the manifest file can be added as an extension in developer mode in its
-current state.
+current state. To load an unpacked extension in developer mode, follow the next steps:
 
 1.  Open the Extension Management page by navigating to `chrome://extensions`.
     - Alternatively, open this page by clicking on the Extensions menu button and selecting **Manage

--- a/site/en/docs/extensions/mv3/getstarted/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/index.md
@@ -36,7 +36,7 @@ following code.
 }
 ```
 
-### Load unpacked extension {: #unpacked }
+### Load an unpacked extension {: #unpacked }
 
 The directory holding the manifest file can be added as an extension in developer mode in its
 current state. To load an unpacked extension in developer mode, follow these steps:

--- a/site/en/docs/extensions/mv3/hosting/index.md
+++ b/site/en/docs/extensions/mv3/hosting/index.md
@@ -9,7 +9,7 @@ description: >
 
 <!-- This docs has been changed to primarily explain 
      how to publish and update to the Chrome Web Store.
-     TODO: A rewrite should explore the reasoning behind
+     TODO: A rewrite should explore examples and use cases of
      each distribution options (locally unpacked, enterprise, 
      JSON preference file, personal server for Linux users). -->
 

--- a/site/en/docs/extensions/mv3/hosting/index.md
+++ b/site/en/docs/extensions/mv3/hosting/index.md
@@ -7,26 +7,45 @@ description: >
   How to publish and update your extension in the Chrome Web Store.
 ---
 
-Most extensions are hosted in the [Chrome Web Store][what-is-cws], an online marketplace where users can browse for Chrome
-extensions and themes.
+<!-- This docs has been changed to primarily explain 
+     how to publish and update to the Chrome Web Store.
+     TODO: A rewrite should explore the reasoning behind
+     each distribution options (locally unpacked, enterprise, 
+     JSON preference file, personal server for Linux users). -->
 
-## Hosting {: #hosting }
-
-All extensions are distributed to users as a special ZIP file with a `.crx` suffix. Extensions
-hosted in the [Chrome Web Store][cws-docs] are uploaded through the [Developer
-Dashboard][developer-console] as `.zip` files. The publishing process automatically converts the
-`.zip` into a `.crx` file. See [Publish in the Chrome Web Store][publish] to learn more. 
+Most extensions are hosted in the [Chrome Web Store][what-is-cws], an online marketplace where users
+can browse for Chrome extensions and themes.
 
 There are three exceptions to the Chrome Web Store hosting rule:
 
 1.  Extensions that are distributed through the [enterprise policy][enterprise-policy].
-2.  Unpacked extension directories from a local machine while in [developer mode][load-unpacked].
-3.  [Linux installation][linux-install].
+1.  Unpacked extension directories from a local machine while in [developer mode][load-unpacked].
+1.  Extensions hosted on a personal server for **Linux users only**. See [Linux
+    installation][linux-install].
+
+## Publishing {: #hosting }
+
+All extensions are distributed to users as a special ZIP file with a `.crx` suffix. Extensions
+hosted in the [Chrome Web Store][cws-docs] are uploaded through the [Developer
+Dashboard][developer-console] as `.zip` files. The publishing process automatically converts the
+`.zip` into a `.crx` file. 
+
+{% Aside %}
+
+See [Publish in the Chrome Web Store][publish] to learn more. 
+
+{% endAside%}
 
 ## Updating {: #updating }
 
 The Chrome Browser periodically checks for new versions of installed extensions and updates them
-without user intervention. See [Update your Chrome Web Store item][update] to learn more.
+without user intervention.
+
+{% Aside %}
+
+See [Update your Chrome Web Store item][update] to learn more.
+
+{% endAside%}
 
 [cws]: https://chrome.google.com/webstore/
 [cws-docs]: /docs/webstore

--- a/site/en/docs/extensions/mv3/hosting/index.md
+++ b/site/en/docs/extensions/mv3/hosting/index.md
@@ -30,22 +30,14 @@ hosted in the [Chrome Web Store][cws-docs] are uploaded through the [Developer
 Dashboard][developer-console] as `.zip` files. The publishing process automatically converts the
 `.zip` into a `.crx` file. 
 
-{% Aside %}
-
 See [Publish in the Chrome Web Store][publish] to learn more. 
-
-{% endAside%}
 
 ## Updating {: #updating }
 
 The Chrome Browser periodically checks for new versions of installed extensions and updates them
 without user intervention.
 
-{% Aside %}
-
 See [Update your Chrome Web Store item][update] to learn more.
-
-{% endAside%}
 
 [cws]: https://chrome.google.com/webstore/
 [cws-docs]: /docs/webstore

--- a/site/en/docs/extensions/mv3/hosting/index.md
+++ b/site/en/docs/extensions/mv3/hosting/index.md
@@ -2,13 +2,10 @@
 layout: "layouts/doc-post.njk"
 title: "Chrome Web Store"
 date: 2012-09-18
-updated: 2018-06-12
+updated: 2021-12-10
 description: >
-  How to host your extension in the Chrome Web Store and update an extension
-  that's hosted in the Chrome Web Store.
+  How to publish and update your extension in the Chrome Web Store.
 ---
-
-{% include 'partials/extensions/mv2page-in-mv3.md' %}
 
 Most extensions are hosted in the [Chrome Web Store][1] to best [protect users from malicious
 extensions][2].

--- a/site/en/docs/extensions/mv3/hosting/index.md
+++ b/site/en/docs/extensions/mv3/hosting/index.md
@@ -7,15 +7,15 @@ description: >
   How to publish and update your extension in the Chrome Web Store.
 ---
 
-Most extensions are hosted in the [Chrome Web Store][cws] to best [protect users from malicious
-extensions][2].
+Most extensions are hosted in the [Chrome Web Store][what-is-cws], an online marketplace where users can browse for Chrome
+extensions and themes.
 
 ## Hosting {: #hosting }
 
 All extensions are distributed to users as a special ZIP file with a `.crx` suffix. Extensions
-hosted in the [Chrome Web Store][cws-docs] are uploaded through the [Developer Dashboard][developer-console] as `.zip`
-files. The publishing process automatically converts the `.zip` into a `.crx` file. See [Publish in
-the Chrome Web Store][publish] to learn more. 
+hosted in the [Chrome Web Store][cws-docs] are uploaded through the [Developer
+Dashboard][developer-console] as `.zip` files. The publishing process automatically converts the
+`.zip` into a `.crx` file. See [Publish in the Chrome Web Store][publish] to learn more. 
 
 There are three exceptions to the Chrome Web Store hosting rule:
 
@@ -26,38 +26,15 @@ There are three exceptions to the Chrome Web Store hosting rule:
 ## Updating {: #updating }
 
 The Chrome Browser periodically checks for new versions of installed extensions and updates them
-without user intervention.
-
-To release an update to an extension, increase the number in the [`version`][version] field of the
-manifest.
-
-```json
-{
-  ...
-  "version": "1.5",
-  ...
-}
-```
-
-```json
-{
-  ...
-  "version": "1.6",
-  ...
-}
-```
-
-Convert the updated extension directory into a ZIP file and locate the old version in the [Developer
-Dashboard][developer-console]. Select **Edit**, upload the new package, and hit **Publish**. The browser will
-automatically update the extension for users after the new version is published.
+without user intervention. See [Update your Chrome Web Store item][update] to learn more.
 
 [cws]: https://chrome.google.com/webstore/
-[2]: http://blog.chromium.org/2015/05/continuing-to-protect-chrome-users-from.html
 [cws-docs]: /docs/webstore
 [developer-console]: https://chrome.google.com/webstore/developer/dashboard
 [publish]: /docs/webstore/publish
 [enterprise-policy]: /docs/webstore/cws-enterprise
 [load-unpacked]: /docs/extensions/mv3/getstarted#unpacked
 [linux-install]: /docs/extensions/mv3/linux_hosting
-[9]: /docs/extensions/mv2/hosting_changes
+[update]: /docs/webstore/update
 [version]: /docs/extensions/mv2/manifest/version/
+[what-is-cws]: /docs/webstore/about_webstore

--- a/site/en/docs/extensions/mv3/hosting/index.md
+++ b/site/en/docs/extensions/mv3/hosting/index.md
@@ -7,22 +7,21 @@ description: >
   How to publish and update your extension in the Chrome Web Store.
 ---
 
-Most extensions are hosted in the [Chrome Web Store][1] to best [protect users from malicious
+Most extensions are hosted in the [Chrome Web Store][cws] to best [protect users from malicious
 extensions][2].
 
 ## Hosting {: #hosting }
 
 All extensions are distributed to users as a special ZIP file with a `.crx` suffix. Extensions
-hosted in the [Chrome Web Store][3] are uploaded through the [Developer Dashboard][4] as `.zip`
-files. The [publishing][5] process automatically converts the `.zip` into a `.crx` file.
+hosted in the [Chrome Web Store][cws-docs] are uploaded through the [Developer Dashboard][developer-console] as `.zip`
+files. The publishing process automatically converts the `.zip` into a `.crx` file. See [Publish in
+the Chrome Web Store][publish] to learn more. 
 
 There are three exceptions to the Chrome Web Store hosting rule:
 
-1.  Extensions that are distributed through the [enterprise policy][6].
-2.  Unpacked extension directories from a local machine while in [developer mode][7].
-3.  [Linux installation][8].
-
-[Read more about the hosting policy][9].
+1.  Extensions that are distributed through the [enterprise policy][enterprise-policy].
+2.  Unpacked extension directories from a local machine while in [developer mode][load-unpacked].
+3.  [Linux installation][linux-install].
 
 ## Updating {: #updating }
 
@@ -49,18 +48,16 @@ manifest.
 ```
 
 Convert the updated extension directory into a ZIP file and locate the old version in the [Developer
-Dashboard][10]. Select **Edit**, upload the new package, and hit **Publish**. The browser will
+Dashboard][developer-console]. Select **Edit**, upload the new package, and hit **Publish**. The browser will
 automatically update the extension for users after the new version is published.
 
-[1]: https://chrome.google.com/webstore/category/extensions
+[cws]: https://chrome.google.com/webstore/
 [2]: http://blog.chromium.org/2015/05/continuing-to-protect-chrome-users-from.html
-[3]: /docs/webstore
-[4]: https://chrome.google.com/webstore/developer/dashboard
-[5]: /docs/webstore/publish
-[6]: https://support.google.com/chrome/a/answer/7666985
-[7]: /docs/extensions/mv3/getstarted#unpacked
-[8]: /docs/extensions/mv3/linux_hosting
+[cws-docs]: /docs/webstore
+[developer-console]: https://chrome.google.com/webstore/developer/dashboard
+[publish]: /docs/webstore/publish
+[enterprise-policy]: /docs/webstore/cws-enterprise
+[load-unpacked]: /docs/extensions/mv3/getstarted#unpacked
+[linux-install]: /docs/extensions/mv3/linux_hosting
 [9]: /docs/extensions/mv2/hosting_changes
-[10]: https://chrome.google.com/webstore/developer/dashboard
-
 [version]: /docs/extensions/mv2/manifest/version/

--- a/site/en/docs/extensions/mv3/hosting/index.md
+++ b/site/en/docs/extensions/mv3/hosting/index.md
@@ -27,7 +27,7 @@ only two officially supported distribution mechanisms.
 : Chrome Web Store is an online marketplace for Chrome extensions and themes. Developers who
   register with the Chrome Web Store can publish their extensions and make them available to users
   across the world. Only extensions hosted on and signed by the Chrome Web Store can be directly
-  installed by end users\*. See [Publish in the Chrome Web Store][cws-publish] and [Enterprise
+  installed by users. See [Publish in the Chrome Web Store][cws-publish] and [Enterprise
   publishing options][cws-enterprise] for more information about how to publish on Chrome Web Store.
 
 Self-hosting
@@ -43,8 +43,10 @@ and automatically updates them without user intervention.
 [Unpacked extensions][doc-load-unpacked] should only be used to load trusted code during the
 development process.
 
-*\*Linux users can manually install packed extensions that are not distributed or signed by Chrome
-Web Store.*
+{% Aside %}
+Linux users can manually install packed extensions that are not distributed or signed by Chrome
+Web Store.
+{% endAside %}
 
 [cws-about]: /docs/webstore/about_webstore
 [cws-enterprise]: /docs/webstore/cws-enterprise

--- a/site/en/docs/extensions/mv3/hosting/index.md
+++ b/site/en/docs/extensions/mv3/hosting/index.md
@@ -1,45 +1,54 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Extension Hosting"
+title: "Extension hosting"
 date: 2012-09-18
 updated: 2021-12-10
 description: >
   How to host your Chrome extension.
 ---
 
-Most extensions are hosted in the [Chrome Web Store][what-is-cws], an online marketplace where users
-can browse for Chrome extensions and themes.
+<!--
+Reframe this to focus explicitly on hosting.
 
-There are three exceptions to the Chrome Web Store hosting rule:
+2 options:
+- CWS
+- Self-hosting
 
-1.  Unpacked extension directories from a local machine while in [developer mode][load-unpacked].
-1.  Extensions that are distributed through the [enterprise policy][enterprise-policy].
-1.  Extensions hosted on a personal server for **Linux users only**. See [Linux
-    installation][linux-install].
+CWS is by far the most common
 
-## Publishing {: #hosting }
+note that during development you can also load unpacked.
+-->
 
-All extensions are distributed to users as a special ZIP file with a `.crx` suffix. Extensions
-hosted in the [Chrome Web Store][cws-docs] are uploaded through the [Developer
-Dashboard][developer-console] as `.zip` files. The publishing process automatically converts the
-`.zip` into a `.crx` file. 
+There are several different ways to initiate the installation of a Chrome extension, but there are
+only two officially supported distribution mechanisms.
 
-See [Publish in the Chrome Web Store][publish] to learn more. 
+[Chrome Web Store][cws-about]
 
-## Updating {: #updating }
+: Chrome Web Store is an online marketplace for Chrome extensions and themes. Developers who
+  register with the Chrome Web Store can publish their extensions and make them available to users
+  across the world. Only extensions hosted on and signed by the Chrome Web Store can be directly
+  installed by end users\*. See [Publish in the Chrome Web Store][cws-publish] and [Enterprise
+  publishing options][cws-enterprise] for more information about how to publish on Chrome Web Store.
 
-The Chrome Browser periodically checks for new versions of installed extensions and updates them
-without user intervention.
+Self-hosting
 
-See [Update your Chrome Web Store item][update] to learn more.
+: is the practice of hosting an extension outside of the Chrome Web Store. This option is used in
+  managed environments where system administrators control Chrome with [enterprise
+  policies][external-enterprise-policy]. See [Linux installation][doc-linux-hosting] for information
+  on how to host an extension on your own server.
 
-[cws]: https://chrome.google.com/webstore/
-[cws-docs]: /docs/webstore
-[developer-console]: https://chrome.google.com/webstore/developer/dashboard
-[publish]: /docs/webstore/publish
-[enterprise-policy]: /docs/webstore/cws-enterprise
-[load-unpacked]: /docs/extensions/mv3/getstarted#unpacked
-[linux-install]: /docs/extensions/mv3/linux_hosting
-[update]: /docs/webstore/update
-[version]: /docs/extensions/mv2/manifest/version/
-[what-is-cws]: /docs/webstore/about_webstore
+In both cases, Chrome periodically checks extension hosts for new versions of installed extensions
+and automatically updates them without user intervention.
+
+[Unpacked extensions][doc-load-unpacked] should only be used to load trusted code during the
+development process.
+
+*\*Linux users can manually install packed extensions that are not distributed or signed by Chrome
+Web Store.*
+
+[cws-about]: /docs/webstore/about_webstore
+[cws-enterprise]: /docs/webstore/cws-enterprise
+[cws-publish]: /docs/webstore/publish
+[doc-linux-hosting]: /docs/extensions/mv3/linux_hosting
+[doc-load-unpacked]: /docs/extensions/mv3/getstarted#unpacked
+[external-enterprise-policy]: https://chromeenterprise.google/policies/

--- a/site/en/docs/extensions/mv3/hosting/index.md
+++ b/site/en/docs/extensions/mv3/hosting/index.md
@@ -19,7 +19,7 @@ CWS is by far the most common
 note that during development you can also load unpacked.
 -->
 
-There are several different ways to initiate the installation of a Chrome extension, but there are
+There are multiple ways to install a Chrome extension, but there are
 only two officially supported distribution mechanisms.
 
 [Chrome Web Store][cws-about]
@@ -32,7 +32,7 @@ only two officially supported distribution mechanisms.
 
 Self-hosting
 
-: is the practice of hosting an extension outside of the Chrome Web Store. This option is used in
+: Self hosting is the practice of hosting an extension outside of the Chrome Web Store. This option is used in
   managed environments where system administrators control Chrome with [enterprise
   policies][external-enterprise-policy]. See [Linux installation][doc-linux-hosting] for information
   on how to host an extension on your own server.

--- a/site/en/docs/extensions/mv3/hosting/index.md
+++ b/site/en/docs/extensions/mv3/hosting/index.md
@@ -1,25 +1,19 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Chrome Web Store"
+title: "Extension Hosting"
 date: 2012-09-18
 updated: 2021-12-10
 description: >
-  How to publish and update your extension in the Chrome Web Store.
+  How to host your Chrome extension.
 ---
-
-<!-- This docs has been changed to primarily explain 
-     how to publish and update to the Chrome Web Store.
-     TODO: A rewrite should explore examples and use cases of
-     each distribution options (locally unpacked, enterprise, 
-     JSON preference file, personal server for Linux users). -->
 
 Most extensions are hosted in the [Chrome Web Store][what-is-cws], an online marketplace where users
 can browse for Chrome extensions and themes.
 
 There are three exceptions to the Chrome Web Store hosting rule:
 
-1.  Extensions that are distributed through the [enterprise policy][enterprise-policy].
 1.  Unpacked extension directories from a local machine while in [developer mode][load-unpacked].
+1.  Extensions that are distributed through the [enterprise policy][enterprise-policy].
 1.  Extensions hosted on a personal server for **Linux users only**. See [Linux
     installation][linux-install].
 

--- a/site/en/docs/extensions/mv3/linux_hosting/index.md
+++ b/site/en/docs/extensions/mv3/linux_hosting/index.md
@@ -3,20 +3,19 @@ layout: "layouts/doc-post.njk"
 title: "Installing extensions on Linux"
 date: 2017-12-14
 updated: 2018-03-23
-description: How to package, host, and update crx files from a personal server.
+description: How to package, host, and update crx files from a personal server for Linux users.
 ---
 
 {% include 'partials/extensions/mv2page-in-mv3.md' %}
 
-Extensions hosted outside of the [Chrome Web Store][1] can only be installed by Linux users. This
+Extensions hosted outside of the [Chrome Web Store][chrome-web-store] can only be installed by Linux users. This
 article describes how to package, host, and update `.crx` files from a personal server. If
-distributing an extension or theme solely through the [Chrome Web Store][2], consult [Webstore
-Hosting and Updating][3].
+distributing an extension or theme solely through the [Chrome Web Store][chrome-web-store], consult
+[Webstore Hosting and Updating][hosting-options].
 
 ## Packaging {: #packaging }
 
-Extensions and themes are served as `.crx` files. When uploading through the [Chrome Developer
-Dashboard][4] , the dashboard creates the `.crx` file automatically. If published on a personal
+Extensions and themes are served as `.crx` files. When uploading through the [Chrome Developer Dashboard][developer-dashboard], the dashboard creates the `.crx` file automatically. If published on a personal
 server, the `.crx` file will need to be created locally or downloaded from the Chrome Web Store.
 
 <!-- TODO this section's ID was previouly #create which is a duplicate of another section -->
@@ -34,10 +33,16 @@ The downloaded file can be hosted on a personal server. This is the most secure 
 extension locally as the contents of the extension will be signed by the Chrome Web Store. This
 helps detect potential attacks and tampering.
 
+{% Aside %}
+
+Read more about the [hosting policy][hosting-changes].
+
+{% endAside %}
+
 ### Create .crx locally {: #create }
 
 Extension directories are converted to `.crx` files at the Extensions Management Page. Navigate to
-`chrome://extensions/` in the ominibox, or click on the Chrome menu, hover over "More Tools" then
+`chrome://extensions/` in the omnibox, or click on the Chrome menu, hover over "More Tools" then
 select "Extensions".
 
 On the Extensions Management Page, enable Developer Mode by clicking the toggle switch next to
@@ -59,7 +64,7 @@ private key.
        alt="Packaged Extension Files", height="210", width="521" %}
 
 **Do not lose the private key!** Keep the `.pem` file in a secret and secure place; it will be
-needed to [update][5] the extension.
+needed to [update][header-updating] the extension.
 
 <!-- TODO duplicate ID (was previously #update) -->
 
@@ -85,7 +90,7 @@ Update an extension's `.crx` file by increasing the version number in `manifest.
 }
 ```
 
-Return to the [Extensions Management Page][6] and click the **PACK EXTENSION** button. Specify the
+Return to the [Extensions Management Page][load-locally] and click the **PACK EXTENSION** button. Specify the
 path to the extensions directory and the location of private key.
 
 {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/gcvNd3qR9hU7Pp0fQvhZ.png",
@@ -100,7 +105,7 @@ The page will provide the path for the updated packaged extension.
 
 ### Package through command line
 
-Package extensions in the command line by invoking [`chrome.exe`][7]. Use the `--pack-extension`
+Package extensions in the command line by invoking [`chrome.exe`][chromium-with-flags]. Use the `--pack-extension`
 flag to specify the location of the extension's folder and the `--pack-extension-key` flag to
 specify the location of the extension's private key file.
 
@@ -148,7 +153,7 @@ with the same private key as the currently installed version.
 ### Update URL {: #update_url }
 
 Extensions hosted on servers outside of the Chrome Webstore must include the `update_url` field in
-their [`manifest.json`][8] file.
+their [`manifest.json`][manifest] file.
 
 ```json
 {
@@ -172,7 +177,7 @@ The update manifest returned by the server should be an XML document.
 </gupdate>
 ```
 
-This XML format is borrowed from that used by [Omaha][9], Google's update infrastructure. The
+This XML format is borrowed from that used by [Omaha][omaha], Google's update infrastructure. The
 extensions system uses the following attributes for the `<app>` and `<updatecheck>` elements of the
 update manifest:
 
@@ -262,14 +267,13 @@ version, add the "prodversionmin" attribute to the <app> element in the update r
 This would ensure that users would autoupdate to version 2 only if they are running Google Chrome
 3.0.193.0 or greater.
 
-[1]: http://chrome.google.com/webstore
-[2]: http://chrome.google.com/webstore
-[3]: /docs/extensions/mv3/hosting
-[4]: https://chrome.google.com/webstore/developer/dashboard
-[5]: #update
-[6]: /packaging#extension_management
-[7]: https://www.chromium.org/developers/how-tos/run-chromium-with-flags
-[8]: /docs/extensions/mv3/tabs
-[9]: https://github.com/google/omaha
-[10]: /linux_hosting#packaging
-[11]: /linux_hosting#extension_management
+[chrome-web-store]: http://chrome.google.com/webstore
+[chromium-with-flags]: https://www.chromium.org/developers/how-tos/run-chromium-with-flags
+[developer-dashboard]: https://chrome.google.com/webstore/developer/dashboard
+[header-updating]: #update
+[hosting-changes]: /docs/extensions/mv2/hosting_changes/
+[hosting-options]: /docs/extensions/mv3/hosting
+[load-locally]: #create
+[manifest]: /docs/extensions/mv3/manifest/
+[omaha]: https://github.com/google/omaha
+

--- a/site/en/docs/extensions/mv3/linux_hosting/index.md
+++ b/site/en/docs/extensions/mv3/linux_hosting/index.md
@@ -9,16 +9,16 @@ description: How to package, host, and update crx files from a personal server f
 {% include 'partials/extensions/mv2page-in-mv3.md' %}
 
 Linux is the only platform where Chrome users can install extensions that are hosted outside of the
-[Chrome Web Store][chrome-web-store]. This article describes how to package, host, and update `.crx`
+[Chrome Web Store][chrome-web-store]. This article describes how to package, host, and update `crx`
 files from a general purpose web server. If you are distributing an extension or theme solely
-through the [Chrome Web Store][chrome-web-store], consult [Webstore Hosting and
-Updating][hosting-options].
+through the [Chrome Web Store][chrome-web-store], consult [Webstore hosting and
+updating][hosting-options].
 
 ## Packaging {: #packaging }
 
 Extensions and themes are served as `.crx` files. When uploading through the [Chrome Developer
-Dashboard][developer-dashboard], the dashboard creates the `.crx` file automatically. If published
-on a personal server, the `.crx` file will need to be created locally or downloaded from the Chrome
+Dashboard][developer-dashboard], the dashboard creates the `crx` file automatically. If published
+on a personal server, the `crx` file will need to be created locally or downloaded from the Chrome
 Web Store.
 
 <!-- TODO this section's ID was previouly #create which is a duplicate of another section -->

--- a/site/en/docs/extensions/mv3/linux_hosting/index.md
+++ b/site/en/docs/extensions/mv3/linux_hosting/index.md
@@ -8,15 +8,18 @@ description: How to package, host, and update crx files from a personal server f
 
 {% include 'partials/extensions/mv2page-in-mv3.md' %}
 
-Extensions hosted outside of the [Chrome Web Store][chrome-web-store] can only be installed by Linux users. This
-article describes how to package, host, and update `.crx` files from a personal server. If
-distributing an extension or theme solely through the [Chrome Web Store][chrome-web-store], consult
-[Webstore Hosting and Updating][hosting-options].
+Linux is the only platform where Chrome users can install extensions that are hosted outside of the
+[Chrome Web Store][chrome-web-store]. This article describes how to package, host, and update `.crx`
+files from a general purpose web server. If you are distributing an extension or theme solely
+through the [Chrome Web Store][chrome-web-store], consult [Webstore Hosting and
+Updating][hosting-options].
 
 ## Packaging {: #packaging }
 
-Extensions and themes are served as `.crx` files. When uploading through the [Chrome Developer Dashboard][developer-dashboard], the dashboard creates the `.crx` file automatically. If published on a personal
-server, the `.crx` file will need to be created locally or downloaded from the Chrome Web Store.
+Extensions and themes are served as `.crx` files. When uploading through the [Chrome Developer
+Dashboard][developer-dashboard], the dashboard creates the `.crx` file automatically. If published
+on a personal server, the `.crx` file will need to be created locally or downloaded from the Chrome
+Web Store.
 
 <!-- TODO this section's ID was previouly #create which is a duplicate of another section -->
 


### PR DESCRIPTION
This PR partially fixes #1826.

- [x] Remove broken links.
- [x] Match explanation to the description ([Chrome Web Store docs](https://developer.chrome.com/docs/extensions/mv3/hosting/)).
- [x] Add links to Chome Web Store publishing and updating docs.
- [x] Add section on [loading the extension locally](https://deploy-preview-1854--developer-chrome-com.netlify.app/docs/extensions/mv3/getstarted#unpacked)

**Staged Links**
[Chrome Web Store Hosting](https://deploy-preview-1854--developer-chrome-com.netlify.app/docs/extensions/mv3/hosting/)
