### PR TITLE
Adds links to the Workbox ToC for the API Reference and modules.

### DIFF
--- a/site/_data/docs/workbox/toc.yml
+++ b/site/_data/docs/workbox/toc.yml
@@ -30,3 +30,9 @@
     - url: /docs/workbox/managing-fallback-responses
     - url: /docs/workbox/handling-service-worker-updates
     - url: /docs/workbox/retrying-requests-when-back-online
+- url: /docs/workbox/modules
+  title: i18n.docs.workbox.modules
+  description: i18n.docs.workbox.modules_description
+- url: /docs/workbox/reference
+  title: i18n.docs.workbox.reference
+  description: i18n.docs.workbox.reference_description

--- a/site/_data/i18n/docs/workbox.yml
+++ b/site/_data/i18n/docs/workbox.yml
@@ -18,3 +18,13 @@ uses:
 uses_description:
   en: |
     To do.
+modules:
+  en: "Workbox Modules"
+modules_description:
+  en: |
+    Dig deeper into specific Workbox modules.
+reference:
+  en: "API Reference"
+reference_description:
+  en: |
+    Browse the API reference to get information on available methods in the Workbox API, broken down by module.


### PR DESCRIPTION
Changes proposed in this pull request:

- This adds links to the [modules documentation](https://developer.chrome.com/docs/workbox/modules) and the [API reference](https://developer.chrome.com/docs/workbox/reference) to the [documentation ToC](https://developer.chrome.com/docs/workbox/).