### PR TITLE
Link to the Chrome Web Store review process docs

### DIFF
--- a/site/en/docs/webstore/cws-dashboard-distribution/index.md
+++ b/site/en/docs/webstore/cws-dashboard-distribution/index.md
@@ -26,7 +26,7 @@ Use the **Visibility** settings to configure who can see your item in the Chrome
   typically used for testing before public launch of an item.
 
 {% Aside 'gotchas' %}
-All visibility settings have the same policy requirements and will go through the same review process.
+All visibility settings have the same policy requirements and will go through the same [review process][cws-review].
 {% endAside %}
 
 ### Private visibility: Trusted testers {: #private-visibility-trusted-testers }
@@ -115,10 +115,10 @@ see [Repetitive Content Spam Policy][repetitive-content].
 
 After filling out the [Listing][listing] tab and the [Privacy][privacy] tab, you can now [publish your item][publish].
 
-
-[private-google-groups]: #private-visibility-google-groups
+[cws-review]: /docs/webstore/review-process/
 [enterprise]: /docs/webstore/cws-enterprise/
 [listing]: /docs/webstore/cws-dashboard-listing/
-[publish]: /docs/webstore/publish/#publish-item
 [privacy]: /docs/webstore/cws-dashboard-privacy/
+[private-google-groups]: #private-visibility-google-groups
+[publish]: /docs/webstore/publish/#publish-item
 [repetitive-content]: /docs/webstore/spam-faq/#repetitive-content

--- a/site/en/docs/webstore/faq/index.md
+++ b/site/en/docs/webstore/faq/index.md
@@ -56,7 +56,7 @@ the standard [developer registration process][cws-register].
 All extensions go through an automated review process and in some cases, an extension will be published without
 further manual review. There may be some instances in which a manual review will be required before
 the extension is published based on our [program policies][program-policies]. In some cases, where sensitive permissions
-are requested, review times and/or [approval times may be longer][how-long-do-reviews-take].
+are requested, review times and/or [approval times may be longer][cws-review-times].
 
 ### What types of extensions are not allowed in the store? {: #faq-gen-22 }
 
@@ -171,7 +171,7 @@ extension. Do not upload a .crx file; the submission will fail.
 
 The item won't appear in the web store until it has successfully completed the review process.
 (Although the item's unique ID is generated as soon as you upload your first zip file.) For further
-details, see [How long will it take to review my item?][how-long-do-reviews-take].
+details, see [Chrome Web Store Review Times][cws-review-times].
 
 Extensions which are published to the same domain as the publisher address may be approved more
 quickly. Learn more about [enterprise publishing][enterprise].
@@ -243,8 +243,7 @@ to only users of the "en-GB" Chrome Web Store.
 ### My item's status says "pending review." What does this mean? {: #faq-listing-08 }
 
 This means that you've submitted your item for publishing and it is currently in the queue to be
-reviewed. The item will not appear in the store until it passes this review. (See also [How long
-will it take to review my item?][how-long-do-reviews-take])
+[reviewed][cws-review]. The item will not appear in the store until it passes this review. 
 
 ### How long will it take to review my item? {: #faq-listing-108 }
 
@@ -261,7 +260,7 @@ include:
 {% Aside %}
 
 Note that all item submissions—whether for a new item or an update to an existing one—are
-subject to the same review process.
+subject to the same [review process][cws-review].
 
 {% endAside %}
 
@@ -328,6 +327,8 @@ Business related issues by contacting [CWS support][cws-support].
 [cws-enterprise]: /docs/webstore/cws-dashboard-enterprise/
 [cws-images]: /docs/webstore/images/
 [cws-register]: /docs/webstore/register
+[cws-review]: /docs/webstore/review-process/
+[cws-review-times]: /docs/webstore/review-process/#review-time
 [cws-support]: https://support.google.com/chrome_webstore/contact/developer_support/
 [dev-channel-build]: https://www.chromium.org/getting-involved/dev-channel
 [dev-dashboard]: https://chrome.google.com/webstore/developer/dashboard
@@ -338,7 +339,6 @@ Business related issues by contacting [CWS support][cws-support].
 [extension-faq]: /docs/extensions/mv3/faq
 [google-groups]: https://groups.google.com
 [great-listing]: /docs/webstore/best_listing/
-[how-long-do-reviews-take]: #faq-listing-108
 [internationalize]: /docs/webstore/i18n
 [malware-policy]: https://www.google.com/about/company/unwanted-software-policy.html
 [manifest-version]: /docs/extensions/mv3/manifestVersion

--- a/site/en/docs/webstore/manage/index.md
+++ b/site/en/docs/webstore/manage/index.md
@@ -12,7 +12,7 @@ the Chrome Web Store.
 
 ## About the lifecycle of an item in the Chrome Web Store 
 
-All Chrome Web Store items go through an automated review process. In some instances a manual review
+All Chrome Web Store items go through an automated [review process][cws-review]. In some instances a manual review
 is required, especially when sensitive permissions are requested. For this reason review times
 and/or approval times can take longer. Since a Chrome Web Store item goes through several stages,
 it's important to keep track of your item's status. See the lifecycle diagram below:
@@ -53,7 +53,8 @@ can also find this information in the Status tab of your item.
 {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/C4wpnEeMriI9YeDAMDIr.png", alt="The Chrome Web Store
 Status Tab", width="700", height="276" %}
 
-If you have been informed about a violation and you do not rectify your item will be taken down. 
+If you have been informed about a violation and you do not rectify your item will be taken down. See
+[Violation enforcement][enforcement] for more details.
 
 {% Aside %} 
 
@@ -210,9 +211,11 @@ Analytics ID in the **Store listing Tab** under Additional fields.
 {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/nYdeRcgteYZL6pTyPQMA.png", alt="where to add google
 analytics id", width="787", height="121" %}
 
+[cws-review]: /docs/webstore/review-process/
 [cws-support]: https://support.google.com/chrome_webstore/contact/dev_account_transfer
 [dev-dashboard]: https://chrome.google.com/webstore/devconsole
 [dev-policies]: /docs/webstore/program_policies
+[enforcement]: /docs/webstore/review-process/#enforcement
 [support-tab]: #user-support-tab
 [troubleshooting]: /docs/webstore/troubleshooting/
 [whats-new]: /docs/extensions/whatsnew/

--- a/site/en/docs/webstore/publish/index.md
+++ b/site/en/docs/webstore/publish/index.md
@@ -23,11 +23,11 @@ intend.
 
 To publish your item to the Chrome Web Store, follow these steps:
 
-1.  Create your item's zip file
-2.  Create and setup a developer account
-3.  Upload your item
-4.  Add assets for your listing
-5.  Submit your item for publishing
+1.  Create your item's zip file.
+2.  Create and setup a developer account.
+3.  Upload your item.
+4.  Add assets for your listing.
+5.  Submit your item for publishing.
 
 We'll go into detail about each step below.
 
@@ -177,13 +177,22 @@ status", width="700", height="84" %}
 ### Review of submitted items {: #review-of-submitted-items }
 
 After you submit the item for review, it will undergo a review process. The time for this review
-depends on the nature of your item. See the [FAQ on review times][review-times] for more details.
+depends on the nature of your item. See [review times][review-times] for more details.
 
 There are important emails like take down or rejection notifications that are enabled by default. To receive an email notification when your item is published or staged, you can enable notifications in the Account page.
 
-{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/l27aRFGCN4MJURmpoCQN.png", alt="Screenshot of enable staged and reviewed items", width="709", height="238" %}
+{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/l27aRFGCN4MJURmpoCQN.png", alt="Screenshot of enable
+staged and reviewed items", width="709", height="238" %}
 
-[cws-support]: https://support.google.com/chrome_webstore/contact/dev_account_transfer
+## Additional resources
+
+- [Update your Chrome Web Store Item][update].
+- Learn how to [Manage your Chrome Web Store Item][cws-manage].
+- Understand the [Chrome Web Store Review Process][cws-review].
+
+[cws-manage]: /docs/webstore/manage/
+[cws-review]: /docs/webstore/review-process/
+[cws-support]: https://support.google.com/chrome_webstore/contact/one_stop_support
 [description]: /docs/apps/manifest/description/
 [dev-dashboard]: https://chrome.google.com/webstore/devconsole
 [distribution]: /docs/webstore/cws-dashboard-distribution
@@ -194,9 +203,9 @@ There are important emails like take down or rejection notifications that are en
 [name]: /docs/extensions/mv3/manifest/name
 [privacy]: /docs/webstore/cws-dashboard-privacy
 [register]: /docs/webstore/register
-[review-times]: /docs/webstore/faq#faq-listing-108
-[user-data]: /docs/webstore/user_data/
+[review-times]: /docs/webstore/review-process/#review-time
 [update]: /docs/webstore/update
+[user-data]: /docs/webstore/user_data/
 [verified-publisher]: /docs/webstore/cws-dashboard-listing/#displaying-your-verified-publisher-status
 [version]: /docs/extensions/mv3/manifest/version
 

--- a/site/en/docs/webstore/update/index.md
+++ b/site/en/docs/webstore/update/index.md
@@ -143,7 +143,7 @@ status", width="700", height="84" %}
 
 After you submit the item for review, it will undergo a review process. This is essentially the same
 review as new items receive; the time for this review depends on the nature of your item and the
-extent of your changes. See the [FAQ on review times][review-times] for more details.
+extent of your changes. See [review times][review-times] for more details.
 
 ## Update your percent rollout {: #update-rollout }
 
@@ -162,11 +162,18 @@ Changing the %rollout does *not* trigger a new review.
 
 {% endAside %}
 
+## Additional resources
+
+- Learn how to [Manage your Chrome Web Store Item][cws-manage].
+- Understand the [Chrome Web Store Review Process][cws-review].
+
+[cws-manage]: /docs/webstore/manage/
+[cws-review]: /docs/webstore/review-process/
 [cws-distribution]: /docs/webstore/cws-dashboard-distribution
 [cws-listing]: /docs/webstore/cws-dashboard-listing
 [cws-privacy]: /docs/webstore/cws-dashboard-privacy
 [dev-console]: https://chrome.google.com/webstore/devconsole
-[review-times]: /docs/webstore/faq#faq-listing-108
+[review-times]: /docs/webstore/review-process/#review-time
 [partial-rollout]: #partial-rollout
 [unpublish]: /docs/webstore/faq/#faq-listing-03
 [update-rollout]: #update-rollout


### PR DESCRIPTION
Changes proposed in this pull request:

Add links to [Chrome Web Store Review Process](https://developer.chrome.com/docs/webstore/review-process/) throughout the Chrome Web Store docs so that developers can find this information in several places.