### PR TITLE
Updated snippet: executeScript prop name from function to func in the given example

### DIFF
--- a/site/en/docs/extensions/mv3/getstarted/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/index.md
@@ -292,7 +292,7 @@ changeColor.addEventListener("click", async () => {
 
   chrome.scripting.executeScript({
     target: { tabId: tab.id },
-    function: setPageBackgroundColor,
+    func: setPageBackgroundColor,
   });
 });
 


### PR DESCRIPTION
Fixes #1875

### Changes proposed in this pull request:
While following the existing getting started article (https://developer.chrome.com/docs/extensions/mv3/getstarted/), it occurred that the updation of the background color of a tab example is not working. Digging up a little in detail, found from https://developer.chrome.com/docs/extensions/reference/scripting/#runtime-functions. The proposed prop name is func. Whereas in the snippet of this getting started page we are maintaining prop name function.
https://developer.chrome.com/docs/extensions/mv3/getstarted/#logic

### Expected result:
![Screenshot 2021-12-25 at 6 14 31 PM](https://user-images.githubusercontent.com/12895563/147385054-61195887-a18d-44a6-9be9-c0d5d8df308a.png)