### PR TITLE
Typo in User-Agent reduction docs

### DIFF
--- a/site/en/docs/privacy-sandbox/user-agent/index.md
+++ b/site/en/docs/privacy-sandbox/user-agent/index.md
@@ -72,7 +72,7 @@ conditions in a way that can be audited.
 
 Further, the `User-Agent` string has grown longer and more complex, which led
 to error-prone string parsing. UA-CH provides structured and reliable data that
-is easier to understand. Existing code which parses the UA string shouldn’t
+is easier to interpret. Existing code which parses the UA string shouldn’t
 break (though it will return less data), and you’ll need to migrate to UA-CH
 if your site needs specific information for any
 [valid use cases](https://wicg.github.io/ua-client-hints/#use-cases).
@@ -111,7 +111,7 @@ experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints
 
 If you need a specific set of Client Hints on your initial request, refer to
 [Client Hints Reliability](https://github.com/WICG/client-hints-infrastructure/blob/main/reliability.md)
-to ensure Client Hints are available on site load and optimised.
+to ensure Client Hints are available on site load and optimized.
 
 ## Engage and share feedback
 

--- a/site/en/docs/privacy-sandbox/user-agent/index.md
+++ b/site/en/docs/privacy-sandbox/user-agent/index.md
@@ -2,10 +2,11 @@
 layout: 'layouts/doc-post.njk'
 title: 'User-Agent Reduction'
 subhead: >
-  Limit brower data shared to remove sensitive information and reduce fingerprinting.
+  Limit browser data shared to remove sensitive information and reduce fingerprinting.
 description: >
   The reduced User-Agent shares a limited set of data to improve user privacy and reduce opportunities for tracking. With User-Agent Client Hints, developers can request more details in a managed and audited process.
 date: 2021-11-09
+updated: 2021-12-28
 authors:
   - alexandrawhite
 ---

--- a/site/en/docs/privacy-sandbox/user-agent/index.md
+++ b/site/en/docs/privacy-sandbox/user-agent/index.md
@@ -18,7 +18,7 @@ authors:
 *  [Chrome DevTools integration](blog/new-in-devtools-89/#ua-ch)
 *  [Chrome Platform Status](https://chromestatus.com/feature/5995832180473856)
 
-## What is User-Agent Reduction?
+## What is User-Agent reduction?
 
 User-Agent (UA) reduction is the effort to minimize the identifying information
 shared in the User-Agent string which may be


### PR DESCRIPTION
Changes proposed in this pull request:

- "brower" should be "browser"
- sentence case caps for headers
- UK English -> US English for "optimized"
