### PR TITLE
Update the UA reduction origin trial blog post

### DIFF
--- a/site/en/blog/user-agent-reduction-origin-trial/index.md
+++ b/site/en/blog/user-agent-reduction-origin-trial/index.md
@@ -11,7 +11,7 @@ authors:
   - arichiv
   - abeyad
 date: 2021-09-14
-updated: 2021-01-07
+updated: 2022-01-07
 tags:
   - privacy
   - origin-trials

--- a/site/en/blog/user-agent-reduction-origin-trial/index.md
+++ b/site/en/blog/user-agent-reduction-origin-trial/index.md
@@ -83,8 +83,8 @@ Hints](https://web.dev/migrate-to-ua-ch/).
 
 The User-Agent reduction plans do not currently include iOS and WebView, therefore
 those platforms will continue to get the full user agent string.  The primary
-reason is that these platforms currently do not implement
-[client hints](https://wicg.github.io/client-hints-infrastructure/).
+reason is that these platforms have not yet implemented User-Agent
+[Client Hints](https://web.dev/migrate-to-ua-ch/).
 
 ## How does this origin trial work?
 

--- a/site/en/blog/user-agent-reduction-origin-trial/index.md
+++ b/site/en/blog/user-agent-reduction-origin-trial/index.md
@@ -78,7 +78,12 @@ To receive more client information than what's shared by the reduced User-Agent,
 sites will need to migrate to the new User-Agent [Client
 Hints](https://web.dev/migrate-to-ua-ch/) API. For more details on migration
 strategies, see [Migrate to User-Agent Client
-Hints](https://web.dev/migrate-to-ua-ch/). 
+Hints](https://web.dev/migrate-to-ua-ch/).
+
+Note that the User-Agent reduction plans do not currently include iOS and WebView;
+those platforms will continue to get the full user agent string.  The primary
+reason is that these platforms currently do not implement
+[client hints](https://wicg.github.io/client-hints-infrastructure/).
 
 ## How does this origin trial work?
 

--- a/site/en/blog/user-agent-reduction-origin-trial/index.md
+++ b/site/en/blog/user-agent-reduction-origin-trial/index.md
@@ -11,6 +11,7 @@ authors:
   - arichiv
   - abeyad
 date: 2021-09-14
+updated: 2021-01-07
 tags:
   - privacy
   - origin-trials

--- a/site/en/blog/user-agent-reduction-origin-trial/index.md
+++ b/site/en/blog/user-agent-reduction-origin-trial/index.md
@@ -81,7 +81,7 @@ Hints](https://web.dev/migrate-to-ua-ch/) API. For more details on migration
 strategies, see [Migrate to User-Agent Client
 Hints](https://web.dev/migrate-to-ua-ch/).
 
-Note that the User-Agent reduction plans do not currently include iOS and WebView;
+The User-Agent reduction plans do not currently include iOS and WebView, therefore
 those platforms will continue to get the full user agent string.  The primary
 reason is that these platforms currently do not implement
 [client hints](https://wicg.github.io/client-hints-infrastructure/).


### PR DESCRIPTION
Includes a note that the origin trial does not apply to the WebView and iOS platforms.