### PR TITLE
Add UA Reduction Testing Methods to landing page

### DIFF
--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -24,6 +24,7 @@
 - title: i18n.docs.privacy-sandbox.tracking-prevention
   sections:
     - url: /docs/privacy-sandbox/user-agent
+    - url: /docs/privacy-sandbox/user-agent/snippets
 - title: i18n.docs.privacy-sandbox.relevant
   sections:
     - url: /docs/privacy-sandbox/floc

--- a/site/en/docs/privacy-sandbox/user-agent/index.md
+++ b/site/en/docs/privacy-sandbox/user-agent/index.md
@@ -6,7 +6,7 @@ subhead: >
 description: >
   The reduced User-Agent shares a limited set of data to improve user privacy and reduce opportunities for tracking. With User-Agent Client Hints, developers can request more details in a managed and audited process.
 date: 2021-11-09
-updated: 2021-12-28
+updated: 2022-01-12
 authors:
   - alexandrawhite
 ---
@@ -21,10 +21,10 @@ authors:
 ## What is User-Agent reduction?
 
 User-Agent (UA) reduction is the effort to minimize the identifying information
-shared in the User-Agent string which may be
-[used for passive fingerprinting](https://www.w3.org/2001/tag/doc/unsanctioned-tracking/#unsanctioned-tracking-tracking-without-user-control).
-As these
-[changes are rolled out](https://blog.chromium.org/2021/09/user-agent-reduction-origin-trial-and-dates.html), 
+shared in the User-Agent string which may be [used for passive
+fingerprinting](https://www.w3.org/2001/tag/doc/unsanctioned-tracking/#unsanctioned-tracking-tracking-without-user-control).
+As these [changes are rolled
+out](https://blog.chromium.org/2021/09/user-agent-reduction-origin-trial-and-dates.html), 
 all resource requests will have a reduced `User-Agent` header. As a result,
 the returns from certain `Navigator` interfaces will be reduced, including:
 `navigator.userAgent`, `navigator.appVersion`, and `navigator.platform`.

--- a/site/en/docs/privacy-sandbox/user-agent/index.md
+++ b/site/en/docs/privacy-sandbox/user-agent/index.md
@@ -29,12 +29,10 @@ all resource requests will have a reduced `User-Agent` header. As a result,
 the returns from certain `Navigator` interfaces will be reduced, including:
 `navigator.userAgent`, `navigator.appVersion`, and `navigator.platform`.
 
-Web developers should
-[review site code](https://web.dev/migrate-to-ua-ch/#audit-collection-and-use-of-user-agent-data)
-for instances and uses of the `User-Agent` string. If your site relies on
-parsing the `User-Agent` string to read the device model, platform version, or
-full browser version, you'll need to
-[implement the User-Agent Client Hints API](https://web.dev/migrate-to-ua-ch/). 
+Web developers should [prepare for the reduced User-Agent string](#) by reviewing their site code for instances and uses of the User-Agent string. If your site relies on parsing the User-Agent string to read the device model, platform version, or full browser version, you’ll need to [implement the User-Agent Client Hints API](https://web.dev/migrate-to-ua-ch/).
+
+[Review the latest timeline](https://www.chromium.org/updates/ua-reduction) for
+User-Agent reduction.
 
 {% Aside 'key-term' %}
 The [`User-Agent` string](https://developer.mozilla.org/docs/Web/HTTP/Headers/User-Agent)
@@ -112,6 +110,57 @@ experience with User-Agent Client Hints](https://web.dev/user-agent-client-hints
 If you need a specific set of Client Hints on your initial request, refer to
 [Client Hints Reliability](https://github.com/WICG/client-hints-infrastructure/blob/main/reliability.md)
 to ensure Client Hints are available on site load and optimized.
+
+## How do I prepare for reduced UA?
+
+As we get closer to the reduced User-Agent string launch, [review your site
+code](https://web.dev/migrate-to-ua-ch/#audit-collection-and-use-of-user-agent-data)
+for instances and uses of the User-Agent string. If your site relies on parsing
+the User-Agent string to read the device model, platform version, or full
+browser version, you’ll need to
+[implement the UA-CH API](https://web.dev/migrate-to-ua-ch/).
+
+Once you’ve updated to the UA-CH API, you should test to ensure you get the
+data you expect from the User-Agent. There are three ways to test, each
+increasing in complexity.
+
+### Test the string locally
+
+There are a couple of methods to test the reduced User-Agent locally:
+
+* Enable the `chrome://flags/#reduce-user-agent` flag.
+    * This will set your local browser to receive just the reduced `user-agent`
+      string for all sites, before it becomes the default setting.
+* Configure an emulated device in DevTools with the right user-agent string
+  and client hints.
+    * In DevTools under ⚙️ Settings → Devices → Add custom device...
+      you can configure an emulated device with any combination of
+      `user-agent` string and user-agent client hints values you need. 
+    * Use the 📱 Toggle device toolbar button to select an emulated device.
+* Launch Chrome with the `--user-agent="Custom string here"`.
+    * Use the command line flag to start Chrome with a custom user-agent string.
+
+### Transform the string in your site’s code
+
+If you process the existing Chrome `user-agent` string in your client-side or
+server-side code, you can transform that string to the new format to test
+compatibility. You can test by either by overriding and replacing the string,
+or generate the new version and test side-by-side.
+
+Review these
+[User-Agent reduction snippets](/docs/privacy-sandbox/user-agent/snippets/) for
+example regular expressions.
+
+### Test on real user traffic with an  origin trial
+
+[Register for the Chrome origin trial](/origintrials/#/view_trial/-7123568710593282047)
+to test the reduced User-Agent with your platform on real user traffic.
+
+If you work with embedded content, you can participate in a [third-party origin
+trial](/blog/third-party-origin-trials/) and test this change across multiple
+sites. When you register for the Chrome origin trial, select the "third-party
+matching" option to allow the script to be injected when your site is embedded
+on third-parties.
 
 ## Engage and share feedback
 

--- a/site/en/docs/privacy-sandbox/user-agent/index.md
+++ b/site/en/docs/privacy-sandbox/user-agent/index.md
@@ -29,7 +29,12 @@ all resource requests will have a reduced `User-Agent` header. As a result,
 the returns from certain `Navigator` interfaces will be reduced, including:
 `navigator.userAgent`, `navigator.appVersion`, and `navigator.platform`.
 
-Web developers should [prepare for the reduced User-Agent string](#) by reviewing their site code for instances and uses of the User-Agent string. If your site relies on parsing the User-Agent string to read the device model, platform version, or full browser version, you’ll need to [implement the User-Agent Client Hints API](https://web.dev/migrate-to-ua-ch/).
+Web developers should [prepare for the reduced User-Agent
+string](#prepare-and-test) by reviewing their site code for instances and uses
+of the User-Agent string. If your site relies on parsing the User-Agent string
+to read the device model, platform version, or full browser version, you'll
+need to [implement the User-Agent Client Hints
+API](https://web.dev/migrate-to-ua-ch/).
 
 [Review the latest timeline](https://www.chromium.org/updates/ua-reduction) for
 User-Agent reduction.
@@ -111,7 +116,7 @@ If you need a specific set of Client Hints on your initial request, refer to
 [Client Hints Reliability](https://github.com/WICG/client-hints-infrastructure/blob/main/reliability.md)
 to ensure Client Hints are available on site load and optimized.
 
-## How do I prepare for reduced UA?
+## How do I prepare for reduced UA? {: #prepare-and-test}
 
 As we get closer to the reduced User-Agent string launch, [review your site
 code](https://web.dev/migrate-to-ua-ch/#audit-collection-and-use-of-user-agent-data)
@@ -124,7 +129,7 @@ Once you’ve updated to the UA-CH API, you should test to ensure you get the
 data you expect from the User-Agent. There are three ways to test, each
 increasing in complexity.
 
-### Test the string locally
+### Test the string locally {: #test-locally}
 
 There are a couple of methods to test the reduced User-Agent locally:
 

--- a/site/en/docs/privacy-sandbox/user-agent/index.md
+++ b/site/en/docs/privacy-sandbox/user-agent/index.md
@@ -118,7 +118,8 @@ to ensure Client Hints are available on site load and optimized.
 
 ## How do I prepare for reduced UA? {: #prepare-and-test}
 
-As we get closer to the reduced User-Agent string launch, [review your site
+As we get closer to the rollout of the reduced User-Agent string in Chrome
+Stable, [review your site
 code](https://web.dev/migrate-to-ua-ch/#audit-collection-and-use-of-user-agent-data)
 for instances and uses of the User-Agent string. If your site relies on parsing
 the User-Agent string to read the device model, platform version, or full
@@ -136,14 +137,16 @@ There are a couple of methods to test the reduced User-Agent locally:
 * Enable the `chrome://flags/#reduce-user-agent` flag.
     * This will set your local browser to receive just the reduced `user-agent`
       string for all sites, before it becomes the default setting.
-* Configure an emulated device in DevTools with the right user-agent string
+* Configure an emulated device in DevTools with the right `user-agent` string
   and client hints.
     * In DevTools under ⚙️ Settings → Devices → Add custom device...
       you can configure an emulated device with any combination of
-      `user-agent` string and user-agent client hints values you need. 
+      `user-agent` string and User-Agent Client Hints values you need. 
     * Use the 📱 Toggle device toolbar button to select an emulated device.
 * Launch Chrome with the `--user-agent="Custom string here"`.
-    * Use the command line flag to start Chrome with a custom user-agent string.
+    * Use this [command line
+      flag](https://www.chromium.org/developers/how-tos/run-chromium-with-flags)
+      to run Chrome with a custom user-agent string.
 
 ### Transform the string in your site’s code
 

--- a/site/en/docs/privacy-sandbox/user-agent/index.md
+++ b/site/en/docs/privacy-sandbox/user-agent/index.md
@@ -155,9 +155,9 @@ server-side code, you can transform that string to the new format to test
 compatibility. You can test by either by overriding and replacing the string,
 or generate the new version and test side-by-side.
 
-Review these
-[User-Agent reduction snippets](/docs/privacy-sandbox/user-agent/snippets/) for
-example regular expressions.
+Review these [User-Agent reduction
+snippets](/docs/privacy-sandbox/user-agent/snippets/) for example regular
+expressions.
 
 ### Test on real user traffic with an  origin trial
 

--- a/site/en/docs/privacy-sandbox/user-agent/snippets/index.md
+++ b/site/en/docs/privacy-sandbox/user-agent/snippets/index.md
@@ -36,30 +36,17 @@ AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.<span style="background:
 
 ## How to override the user-agent in your code
 
-### Local testing methods
-
-- Enable the `chrome://flags/#reduce-user-agent` flag.
-  - This will enable the new behavior and use the reduced format for the
-    user-agent string for all sites.
-- Configure an emulated device in DevTools with the right user-agent string and
-  client hints.
-  - In DevTools under ⚙️ **Settings → Devices → Add custom device…** you can
-    configure an emulated device with any combination of user-agent string and
-    user-agent client hints values you need. Use the 📱 **Toggle device
-    toolbar** button to select an emulated device.
-- Launch Chrome with the `--user-agent="Custom string here"`.
-  - Use the command line flag to start Chrome with a custom user-agent string.
+You can [test the string locally](/docs/privacy-sandbox/user-agent/#test-locally)
+with the help of regular expressions.
 
 {% Aside %}
-
-You can also [enroll your own sites in the origin
+[Enroll your sites in the origin
 trial](/blog/user-agent-reduction-origin-trial/) to
 enable Chrome browsers visiting your site to send the reduced version of the
-user-agent.
-
+`user-agent`.
 {% endAside %}
 
-As the format for the reduced user-agent string is available, this means you can
+As the format for the reduced `user-agent` string is available, this means you can
 transform and test the new string against your own code—either by overriding and
 replacing it, or by generating the new version and testing side-by-side.
 
@@ -74,7 +61,6 @@ matching against Chrome and doing with relatively cheap checks.
 
 ```text
 /^Mozilla\/5\.0 \(((?<platform>Lin|Win|Mac|X11; C|X11; L)+[^\)]+)\) AppleWebKit\/537.36 \(KHTML, like Gecko\) Chrome\/(?<major>\d+)[\d\.]+(?<mobile>[ Mobile]*) Safari\/537\.36$/
-
 ```
 
 The expression captures the following values:


### PR DESCRIPTION
Fixes #1888

Changes proposed in this pull request:

- Add section "How do I prepare for reduced UA?"
- Move directions to test locally from snippets to preparation section
- Expose snippets doc in main dcc landing page

