### PR TITLE
feat(types): get defaut values from `@default` tag

### DIFF
--- a/external/build/lib/dts-parse.js
+++ b/external/build/lib/dts-parse.js
@@ -712,6 +712,9 @@ class Transform {
       text = text.trim(); // some show up with extra \n
 
       switch (tag) {
+        case 'default':
+          out.default = text;
+          break;
         case 'chrome-platform-apps':
           out.platformAppsOnly = true;
           break;

--- a/site/_includes/macros/render-type.njk
+++ b/site/_includes/macros/render-type.njk
@@ -155,8 +155,8 @@
 
   {% elif node._event %}
     {# This is a declarative event without a method. #}
-    {{ renderIconTypesArray(node._event.conditions, 'Conditions', prop) }}
-    {{ renderIconTypesArray(node._event.actions, 'Actions', prop) }}
+    {{ renderIconTypesArray(node._event.conditions, 'Conditions') }}
+    {{ renderIconTypesArray(node._event.actions, 'Actions') }}
 
   {% endif %}
 
@@ -202,12 +202,15 @@
   {% endif %}
 
   {# Note that we avoid whitespace below, and instead set margins in CSS. #}
-  <span class="code-sections__icon code-sections__icon--{{ iconType }}">{{ renderSingleType(type, node) | trim | safe }}
+  <p class="code-sections__icon code-sections__icon--{{ iconType }}">{{ renderSingleType(type, node) | trim | safe }}
     {%- if node.flags.isOptional -%}
       &nbsp;<span class="code-sections__optional">optional</span>
     {%- endif -%}
-  </span>
+  </p>
 
+  {%- if node._feature.default -%}
+    <p>Default value is: <span class="code-sections__optional">{{ node._feature.default }}</span></p>
+  {%- endif -%}
 {% endmacro %}
 
 

--- a/types/site/_data/types.d.ts
+++ b/types/site/_data/types.d.ts
@@ -31,6 +31,10 @@ declare global {
   }
 
   export interface FeatureInfo {
+    /**
+     * Default value of a attribute.
+     */
+    default?: string;
     platformAppsOnly?: true;
     disallowServiceWorkers?: true;
     deprecated?: {


### PR DESCRIPTION
Changes proposed in this pull request:

- Add `switch` case to `external/build/lib/dts-parse.js` to store the value of `@default` to `node._feautre`.
- Render `node._feature.default` when rendering single icon type.