### PR TITLE
Article: Chrome will disable modifying `document.domain` to relax the same-origin policy

### DIFF
--- a/site/en/blog/immutable-document-domain/index.md
+++ b/site/en/blog/immutable-document-domain/index.md
@@ -101,9 +101,9 @@ security risk.
 
 ### Security concerns with `document.domain`
 
-Security concerns around `document.domain` have led to a change in the [specification that warns users to
-avoid
-using it](https://html.spec.whatwg.org/multipage/origin.html#relaxing-the-same-origin-restriction).
+Security concerns around `document.domain` have led to a change in the
+[specification that warns users to avoid using
+it](https://html.spec.whatwg.org/multipage/origin.html#relaxing-the-same-origin-restriction).
 The [current discussion with other browser
 vendors](https://github.com/w3ctag/design-reviews/issues/564) is moving in
 the same direction.
@@ -130,10 +130,13 @@ At this time, you have two options to replace `document.domain` for your website
 
 ### Use `postMessage()` or Channel Messaging API
 
-In most use cases, cross-origin [`postMessage()`
-](https://developer.mozilla.org/docs/Web/API/Window/postMessage) or [Channel
-Messaging API](https://developer.mozilla.org/docs/Web/API/Channel_Messaging_API)
-can replace `document.domain`. In the following example:
+In most use cases, cross-origin 
+[`postMessage()`](https://developer.mozilla.org/docs/Web/API/Window/postMessage)
+or [Channel Messaging API](https://developer.mozilla.org/docs/Web/API/Channel_Messaging_API)
+can replace `document.domain`.
+
+In the following example:
+
 1. `https://parent.example.com` requests `https://video.example.com` within an
    iframe to manipulate DOM by sending a message via `postMessage()`.
 2. `https://video.example.com` manipulates DOM as soon as it receives the
@@ -213,5 +216,7 @@ after it becomes immutable by default.
   `document.domain`](https://github.com/mikewest/deprecating-document-domain/)
 * [Deprecating `document.domain`. · Issue #564 ·
   w3ctag/design-reviews](https://github.com/w3ctag/design-reviews/issues/564)
+
+## Acknowledgements
 
 Photo by <a href="https://unsplash.com/@braydona">Braydon Anderson</a> on <a href="https://unsplash.com/">Unsplash</a>

--- a/site/en/blog/immutable-document-domain/index.md
+++ b/site/en/blog/immutable-document-domain/index.md
@@ -24,7 +24,7 @@ communication](#alternative-cross-origin-communication)
 
 {% endAside %}
 
-[`document.domain`](https://developer.mozilla.org/en-US/docs/Web/API/Document/domain)
+[`document.domain`](https://developer.mozilla.org/docs/Web/API/Document/domain)
 was designed to get or set the origin's hostname.
 
 Beginning with Chrome version 101, websites will be unable to set

--- a/site/en/blog/immutable-document-domain/index.md
+++ b/site/en/blog/immutable-document-domain/index.md
@@ -2,9 +2,9 @@
 layout: 'layouts/blog-post.njk'
 title: "Chrome 101 disables modifying `document.domain` to relax the same-origin policy"
 description: >
-  Websites will be unable to set `document.domain` on Chrome starting in version 101. If your website relies on setting `document.domain`, your action is required.
+  If your website relies on setting `document.domain`, your action is required.
 subhead: >
-  Beginning with Chrome version 101, websites will be unable to set `document.domain`.
+  If your website relies on setting `document.domain`, your action is required.
 date: 2022-01-06
 authors:
   - agektmr
@@ -29,11 +29,12 @@ was designed to get or set the origin's hostname.
 
 Beginning with Chrome version 101, websites will be unable to set
 `document.domain`. Websites will need to use alternative approaches such as
-`postMessage()` or Channel Messaging API to communicate cross-origin. If a
-website relies on same-origin policy relaxation via `document.domain` to
-function correctly, the site will need to send an `Origin-Agent-Cluster: ?0` header
-along with all documents that require that behavior (note that `document.domain`
-has no effect if only one document sets it).
+`postMessage()` or Channel Messaging API to communicate cross-origin.
+
+If your website relies on same-origin policy relaxation via `document.domain`
+to function correctly, the site will need to send an `Origin-Agent-Cluster: ?0`
+header, as will all other documents that require that behavior (note that
+`document.domain` has no effect if only one document sets it).
 
 ## Timeline
 
@@ -52,9 +53,9 @@ but cross-origin](https://web.dev/same-site-same-origin/) pages.
 
 {% Aside 'key-term' %}
 
-Sites which have the same
+Same-site but cross-origin sites have the same
 [eTLD+1](https://web.dev/same-site-same-origin/#:~:text=the%20whole%20site%20name%20is%20known%20as%20the%20etld%2B1)
-but different subdomains are considered "same-site but cross-origin".
+but different subdomains.
 
 {% endAside %}
 
@@ -68,10 +69,10 @@ with different subdomains. When both pages' `document.domain` is set to
 Set the `document.domain` for `https://parent.example.com`:
 
 ```js
-// confirm the current origin of "parent.example.com"
+// Confirm the current origin of "parent.example.com"
 console.log(document.domain);
 
-// set the document.domain
+// Set the document.domain
 document.domain = 'example.com';
 console.log(document.domain);
 ```
@@ -79,25 +80,24 @@ console.log(document.domain);
 Set the `document.domain` for `https://video.example.com`:
 
 ```js
-// confirm the current origin of "video.example.com"
+// Confirm the current origin of "video.example.com"
 console.log(document.domain);
 
-// set the document.domain
+// Set the document.domain
 document.domain = 'example.com';
 console.log(document.domain);
 ```
 
-You can now set a cross-origin DOM manipulation on `https://parent.example.com`
-against `https://video.example.com`.
+You could now create a cross-origin DOM manipulation on
+`https://parent.example.com` against `https://video.example.com`.
 
 Websites set `document.domain` to make it possible for same-site documents to
 communicate more easily. Because this change [relaxes the same-origin
 policy](https://html.spec.whatwg.org/multipage/origin.html#relaxing-the-same-origin-restriction),
-the parent page will be able to access the iframe's document and traverse the
+the parent page is able to access the iframe's document and traverse the
 DOM tree, and vice versa.
 
-This is a convenient technique, however it introduces a
-security risk.
+This is a convenient technique, however it introduces a security risk.
 
 ### Security concerns with `document.domain`
 
@@ -111,18 +111,18 @@ the same direction.
 For example, if a hosting service provides different subdomains per user, an
 attacker can set `document.domain` to pretend they are the same-origin
 as another user's page. Further, an attacker can host a website under a shared
-hosting service, which serves sites through the same IP address with different port
-numbers. In that case, the attacker can pretend to be on the same-site-but-same-origin as
-yours. This is possible because `document.domain` ignores the port number part
-of the domain.
+hosting service, which serves sites through the same IP address with different
+port numbers. In that case, the attacker can pretend to be on the same-site-but-same-origin
+as yours. This is possible because `document.domain` ignores the port number
+part of the domain.
 
 To learn more about the security implications of setting `document.domain`, read
 ["Document.domain" page on
 MDN](https://developer.mozilla.org/docs/Web/API/Document/domain#setter).
 
-Chrome will start displaying a warning in DevTools Console as soon as
-`document.domain` is set starting from Chrome 98. Chrome is planning to  make
-`document.domain` immutable starting from Chrome 101.
+Chrome will display a warning in DevTools Console as soon as `document.domain`
+is set, beginning in Chrome 98. Chrome plans to make `document.domain`
+immutable from Chrome 101.
 
 ## Alternative cross-origin communication
 
@@ -196,8 +196,8 @@ should be handled by the origin-keyed agent cluster or not. To learn more about
 `Origin-Agent-Cluster`, read [Requesting performance isolation with the
 `Origin-Agent-Cluster` header](https://web.dev/origin-agent-cluster/).
 
-When you send this header, the document can continue to set `document.domain` even
-after it becomes immutable by default.
+When you send this header, your document can continue to set `document.domain`
+even after it becomes immutable by default.
 
 ## Browser compatibility
 
@@ -210,7 +210,7 @@ after it becomes immutable by default.
 
 ## Resources
 
-* [Document.domain - Web APIs |
+* [`Document.domain` - Web APIs |
   MDN](https://developer.mozilla.org/docs/Web/API/Document/domain)
 * [Origin Isolation and Deprecating
   `document.domain`](https://github.com/mikewest/deprecating-document-domain/)

--- a/site/en/blog/immutable-document-domain/index.md
+++ b/site/en/blog/immutable-document-domain/index.md
@@ -1,6 +1,6 @@
 ---
 layout: 'layouts/blog-post.njk'
-title: "`document.domain` is becoming immutable"
+title: "Chrome 101 disables modifying `document.domain` to relax the same-origin policy"
 description: >
   Websites will be unable to set `document.domain` on Chrome starting in version 101. If your website relies on setting `document.domain`, your action is required.
 subhead: >
@@ -39,8 +39,10 @@ has no effect if only one document sets it).
 
 Here's the current timeline:
 
-* **Chrome 98:** When using `document.domain`, DevTools Console displays a warning message. `Origin-Agent-Cluster` header is available.
-* **Chrome 99:** Enterprise policy is in place to extend behavior.
+* **Chrome 98:** When using `document.domain`, DevTools Console displays a
+  warning message. `Origin-Agent-Cluster` header is available.
+* **Chrome 99:** Enterprise policy is offered to extend availability of
+  `document.domain`.
 * **Chrome 101:** `document.domain` is immutable.
 
 ## Why make `document.domain` immutable?
@@ -63,24 +65,30 @@ Let's say a page on `https://parent.example.com` embeds an iframe page from
 with different subdomains. When both pages' `document.domain` is set to
 `'example.com'`, the browser treats the two origins as if they are same-origin.
 
-On `https://parent.example.com`:
+Set the `document.domain` for `https://parent.example.com`:
 
 ```js
-console.log(document.domain); // "parent.example.com"
+// confirm the current origin of "parent.example.com"
+console.log(document.domain);
+
+// set the document.domain
 document.domain = 'example.com';
-console.log(document.domain); // "example.com"
+console.log(document.domain);
 ```
 
-On `https://video.example.com`:
+Set the `document.domain` for `https://video.example.com`:
 
 ```js
-console.log(document.domain); // "video.example.com"
+// confirm the current origin of "video.example.com"
+console.log(document.domain);
+
+// set the document.domain
 document.domain = 'example.com';
-console.log(document.domain); // "example.com"
+console.log(document.domain);
 ```
 
-On `https://parent.example.com`, do a cross origin DOM manipulation against
-`https://video.example.com`.
+You can now set a cross-origin DOM manipulation on `https://parent.example.com`
+against `https://video.example.com`.
 
 Websites set `document.domain` to make it possible for same-site documents to
 communicate more easily. Because this change [relaxes the same-origin
@@ -173,19 +181,19 @@ tag](https://stackoverflow.com/questions/tagged/document.domain).
 
 ### Send `Origin-Agent-Cluster: ?0` header to continue using `document.domain`
 
-If you have strong reasons to continue setting `document.domain`, you can send `Origin-Agent-Cluster: ?0` response header along with the target
-document.
+If you have strong reasons to continue setting `document.domain`, you can send
+`Origin-Agent-Cluster: ?0` response header along with the target document.
 
 ```http
 Origin-Agent-Cluster: ?0
 ```
 
-`Origin-Agent-Cluster` header instructs the browser whether the document should
-be handled by the origin-keyed agent cluster or not. To learn more about Origin
-Agent Cluster, read [Requesting performance isolation with the
-Origin-Agent-Cluster header](https://web.dev/origin-agent-cluster/).
+The `Origin-Agent-Cluster` header instructs the browser whether the document
+should be handled by the origin-keyed agent cluster or not. To learn more about
+`Origin-Agent-Cluster`, read [Requesting performance isolation with the
+`Origin-Agent-Cluster` header](https://web.dev/origin-agent-cluster/).
 
-By sending this header, the document can continue setting `document.domain` even
+When you send this header, the document can continue to set `document.domain` even
 after it becomes immutable by default.
 
 ## Browser compatibility

--- a/site/en/blog/immutable-document-domain/index.md
+++ b/site/en/blog/immutable-document-domain/index.md
@@ -1,0 +1,197 @@
+---
+layout: 'layouts/blog-post.njk'
+title: "`document.domain` is becoming immutable"
+description: >
+  Websites will be unable to set `document.domain` on Chrome starting in version 101. If your website relies on setting `document.domain`, your action is required.
+subhead: >
+  Beginning with Chrome version 101, websites will be unable to set `document.domain`.
+date: 2022-01-06
+authors:
+  - agektmr
+tags:
+  - security
+hero: 'image/YLflGBAPWecgtKJLqCJHSzHqe2J2/grGMzuhOjsGhN150dONe.jpg'
+alt: >
+  A dog in disguise.
+---
+
+**If your website relies on relaxing the same-origin policy via `document.domain`,
+your action is required.**
+
+Beginning with Chrome version 101, websites will be unable to set
+`document.domain`. Websites will need to use alternative approaches such as
+`postMessage()` or Channel Messaging API to communicate cross-origin. If a
+website relies on same-origin policy relaxation via `document.domain` to
+function correctly, it will need to send an `Origin-Agent-Cluster: ?0` header
+along with all documents that require that behavior (note that `document.domain`
+has no effect if only one document sets it).
+
+## Why make `document.domain` immutable?
+
+Many websites set `document.domain` to allow communication between [same-site
+but cross-origin](https://web.dev/same-site-same-origin/) pages. 
+
+{% Aside 'key-term' %}
+
+Sites which have the same
+[eTLD+1](https://web.dev/same-site-same-origin/#:~:text=the%20whole%20site%20name%20is%20known%20as%20the%20etld%2B1)
+but are different subdomains are considered "same-site but cross-origin".
+
+{% endAside %}
+
+Here's how it's used:
+
+Let's say a page on `https://parent.example.com` embeds an iframe page from
+`https://video.example.com`. These pages have the same eTLD+1 (`example.com`)
+with different subdomains. By setting both pages' `document.domain` to
+`'example.com'`, the two origins can be treated as if they are the same-origin
+by the browser.
+
+On `https://parent.example.com`:
+
+```js
+console.log(document.domain); // "parent.example.com"
+document.domain = 'example.com';
+console.log(document.domain); // "example.com"
+```
+
+On `https://video.example.com`:
+
+```js
+console.log(document.domain); // "video.example.com"
+document.domain = 'example.com';
+console.log(document.domain); // "example.com"
+```
+
+On `https://parent.example.com`, do a cross origin DOM manipulation against
+`https://video.example.com`.
+
+Websites set `document.domain` to make it possible for same-site documents to
+communicate more easily. Because this change [relaxes the same-origin
+policy](https://html.spec.whatwg.org/multipage/origin.html#relaxing-the-same-origin-restriction),
+the parent page will be able to access the iframe's document and traverse the
+DOM tree, and vice versa.
+
+At a glance, this is a convenient technique, but this actually introduces a
+security risk.
+
+### Security concerns with `document.domain`
+
+Security concerns have led to the spec for `document.domain` to [warn users to
+avoid
+usage](https://html.spec.whatwg.org/multipage/origin.html#relaxing-the-same-origin-restriction).
+The [current discussion with other browser
+vendors](https://github.com/w3ctag/design-reviews/issues/564) is moving toward
+the same direction.
+
+For example, if a hosting service provides different subdomains per user, an
+attacker can set `document.domain` to pretend as if they are the same-origin
+with another user's page. Further, an attacker can host a website under a shared
+hosting service, which serves through the same IP address with different port
+numbers, the attacker can pretend to be on the same-site-but-same-origin as
+yours. This is possible because `document.domain` ignores the port number part
+of the domain.
+
+To learn more about the security implications of setting `document.domain`, read
+["Document.domain" page on
+MDN](https://developer.mozilla.org/docs/Web/API/Document/domain#setter).
+
+Chrome will start displaying a warning in DevTools Console as soon as
+`document.domain` is set starting Chrome 98. Chrome is planning to  make
+`document.domain` immutable starting Chrome 101.
+
+## Alternative cross-domain communication
+
+### Use `postMessage()` or Channel Messaging API
+
+In most use cases, `document.domain` can be replaced by a cross-origin
+[`postMessage()`
+](https://developer.mozilla.org/docs/Web/API/Window/postMessage) or [Channel
+Messaging
+API](https://developer.mozilla.org/docs/Web/API/Channel_Messaging_API).
+
+On `https://parent.example.com`:
+
+```js
+// Send a message to https://video.example.com
+iframe.postMessage('Request DOM manipulation', 'https://video.example.com');
+
+// Receive messages
+iframe.addEventListener('message', (event) => {
+  // Reject all messages except ones from https://video.example.com
+  if (event.origin !== 'https://video.example.com') return;
+
+  // Filter success messages
+  if (event.data === 'succeeded') {
+    // DOM manipulation is succeeded
+  }
+});
+```
+
+On `https://video.example.com`:
+
+```js
+// Receive messages
+window.addEventListener('message', (event) => {
+  // Reject all messages except ones from https://parent.example.com
+  if (event.origin !== 'https://parent.example.com') return;
+
+  // Do a DOM manipulation on https://video.example.com.
+
+  // Send a success message to https://parent.example.com
+  event.source.postMessage('succeeded', event.origin);
+});
+```
+
+Try it and see if it works. If you have specific requirements that won't work
+with `postMessage()` or Channel Messaging API, please let us know on [Twitter
+via @ChromiumDev](https://twitter.com/ChromiumDev) or ask on Stack Overflow.
+
+### Send `Origin-Agent-Cluster: ?0` header to continue using `document.domain`
+
+If you have strong reasons to continue setting `document.domain`, you can do so
+by sending `Origin-Agent-Cluster: ?0` response header along with the target
+document.
+
+```http
+Origin-Agent-Cluster: ?0
+```
+
+`Origin-Agent-Cluster` header instructs the browser whether the document should
+be handled by the origin-keyed agent cluster or not. To learn more about Origin
+Agent Cluster, read [Requesting performance isolation with the
+Origin-Agent-Cluster header](https://web.dev/origin-agent-cluster/).
+
+By sending this header, the document can continue setting `document.domain` even
+after it becomes immutable by default.
+
+## Timeline
+
+Chrome will eventually make `document.domain` immutable. Here's the current
+timeline:
+
+* **Chrome 98:** Usage of `document.domain` displays a warning message in
+  DevTools Console. Also, `Origin-Agent-Cluster` header is available.
+* **Chrome 99:** Enterprise policy is in place to extend behavior.
+* **Chrome 101:** `document.domain` is immutable.
+
+## Browser compatibility
+
+* [In the Origin
+  spec](https://html.spec.whatwg.org/multipage/origin.html#:~:text=Because%20of%20these%20security%20pitfalls%2C%20this%20feature%20is%20in%20the%20process%20of%20being%20removed%20from%20the%20web%20platform),
+  it's clearly stated that the feature should be removed.
+* [WebKit indicated that they are moderately positive about deprecating
+  `document.domain`
+  setter](https://github.com/w3ctag/design-reviews/issues/564#issuecomment-768450217).
+
+## Resources
+
+* [Document.domain - Web APIs |
+  MDN](https://developer.mozilla.org/docs/Web/API/Document/domain)
+* [mikewest/deprecating-document-domain: `document.domain` intentionally weakens
+  the only security boundary we have. Perhaps we can dump
+  it?](https://github.com/mikewest/deprecating-document-domain/)
+* [Deprecating `document.domain`. · Issue #564 ·
+  w3ctag/design-reviews](https://github.com/w3ctag/design-reviews/issues/564)
+
+Photo by <a href="https://unsplash.com/@braydona?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Braydon Anderson</a> on <a href="https://unsplash.com/?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Unsplash</a>

--- a/site/en/blog/immutable-document-domain/index.md
+++ b/site/en/blog/immutable-document-domain/index.md
@@ -15,14 +15,20 @@ alt: >
   A dog in disguise.
 ---
 
-**If your website relies on relaxing the same-origin policy via `document.domain`,
-your action is required.**
+{% Banner 'warning' %}
+If your website relies on relaxing the same-origin policy via `document.domain`,
+your action is required. Continue to read more about why this is changing or skip to
+[alternative code for cross-domain communication](#alternative-cross-domain-communication)
+{% endBanner %}
+
+[`document.domain`](https://developer.mozilla.org/en-US/docs/Web/API/Document/domain)
+was designed to get or set the origin's hostname.
 
 Beginning with Chrome version 101, websites will be unable to set
 `document.domain`. Websites will need to use alternative approaches such as
 `postMessage()` or Channel Messaging API to communicate cross-origin. If a
 website relies on same-origin policy relaxation via `document.domain` to
-function correctly, it will need to send an `Origin-Agent-Cluster: ?0` header
+function correctly, the site will need to send an `Origin-Agent-Cluster: ?0` header
 along with all documents that require that behavior (note that `document.domain`
 has no effect if only one document sets it).
 
@@ -35,7 +41,7 @@ but cross-origin](https://web.dev/same-site-same-origin/) pages.
 
 Sites which have the same
 [eTLD+1](https://web.dev/same-site-same-origin/#:~:text=the%20whole%20site%20name%20is%20known%20as%20the%20etld%2B1)
-but are different subdomains are considered "same-site but cross-origin".
+but different subdomains are considered "same-site but cross-origin".
 
 {% endAside %}
 
@@ -43,9 +49,8 @@ Here's how it's used:
 
 Let's say a page on `https://parent.example.com` embeds an iframe page from
 `https://video.example.com`. These pages have the same eTLD+1 (`example.com`)
-with different subdomains. By setting both pages' `document.domain` to
-`'example.com'`, the two origins can be treated as if they are the same-origin
-by the browser.
+with different subdomains. When both pages' `document.domain` is set to
+`'example.com'`, the browser treats the two origins as if they are same-origin.
 
 On `https://parent.example.com`:
 
@@ -72,23 +77,23 @@ policy](https://html.spec.whatwg.org/multipage/origin.html#relaxing-the-same-ori
 the parent page will be able to access the iframe's document and traverse the
 DOM tree, and vice versa.
 
-At a glance, this is a convenient technique, but this actually introduces a
+This is a convenient technique, however it introduces a
 security risk.
 
 ### Security concerns with `document.domain`
 
-Security concerns have led to the spec for `document.domain` to [warn users to
+Security concerns around `document.domain` have led to a change in the [specification that warns users to
 avoid
-usage](https://html.spec.whatwg.org/multipage/origin.html#relaxing-the-same-origin-restriction).
+using it](https://html.spec.whatwg.org/multipage/origin.html#relaxing-the-same-origin-restriction).
 The [current discussion with other browser
-vendors](https://github.com/w3ctag/design-reviews/issues/564) is moving toward
+vendors](https://github.com/w3ctag/design-reviews/issues/564) is moving in
 the same direction.
 
 For example, if a hosting service provides different subdomains per user, an
-attacker can set `document.domain` to pretend as if they are the same-origin
-with another user's page. Further, an attacker can host a website under a shared
-hosting service, which serves through the same IP address with different port
-numbers, the attacker can pretend to be on the same-site-but-same-origin as
+attacker can set `document.domain` to pretend they are the same-origin
+as another user's page. Further, an attacker can host a website under a shared
+hosting service, which serves sites through the same IP address with different port
+numbers. In that case, the attacker can pretend to be on the same-site-but-same-origin as
 yours. This is possible because `document.domain` ignores the port number part
 of the domain.
 
@@ -97,18 +102,20 @@ To learn more about the security implications of setting `document.domain`, read
 MDN](https://developer.mozilla.org/docs/Web/API/Document/domain#setter).
 
 Chrome will start displaying a warning in DevTools Console as soon as
-`document.domain` is set starting Chrome 98. Chrome is planning to  make
-`document.domain` immutable starting Chrome 101.
+`document.domain` is set starting from Chrome 98. Chrome is planning to  make
+`document.domain` immutable starting from Chrome 101.
 
 ## Alternative cross-domain communication
 
+At this time, you have two options to replace `document.domain` for your website.
+
 ### Use `postMessage()` or Channel Messaging API
 
-In most use cases, `document.domain` can be replaced by a cross-origin
+In most use cases, cross-origin
 [`postMessage()`
 ](https://developer.mozilla.org/docs/Web/API/Window/postMessage) or [Channel
 Messaging
-API](https://developer.mozilla.org/docs/Web/API/Channel_Messaging_API).
+API](https://developer.mozilla.org/docs/Web/API/Channel_Messaging_API) can replace `document.domain`.
 
 On `https://parent.example.com`:
 
@@ -149,8 +156,7 @@ via @ChromiumDev](https://twitter.com/ChromiumDev) or ask on Stack Overflow.
 
 ### Send `Origin-Agent-Cluster: ?0` header to continue using `document.domain`
 
-If you have strong reasons to continue setting `document.domain`, you can do so
-by sending `Origin-Agent-Cluster: ?0` response header along with the target
+If you have strong reasons to continue setting `document.domain`, you can send `Origin-Agent-Cluster: ?0` response header along with the target
 document.
 
 ```http
@@ -170,16 +176,15 @@ after it becomes immutable by default.
 Chrome will eventually make `document.domain` immutable. Here's the current
 timeline:
 
-* **Chrome 98:** Usage of `document.domain` displays a warning message in
-  DevTools Console. Also, `Origin-Agent-Cluster` header is available.
+* **Chrome 98:** When using `document.domain`, DevTools Console displays a warning message. `Origin-Agent-Cluster` header is available.
 * **Chrome 99:** Enterprise policy is in place to extend behavior.
 * **Chrome 101:** `document.domain` is immutable.
 
 ## Browser compatibility
 
-* [In the Origin
-  spec](https://html.spec.whatwg.org/multipage/origin.html#:~:text=Because%20of%20these%20security%20pitfalls%2C%20this%20feature%20is%20in%20the%20process%20of%20being%20removed%20from%20the%20web%20platform),
-  it's clearly stated that the feature should be removed.
+* [The Origin
+  specification](https://html.spec.whatwg.org/multipage/origin.html#:~:text=Because%20of%20these%20security%20pitfalls%2C%20this%20feature%20is%20in%20the%20process%20of%20being%20removed%20from%20the%20web%20platform),
+  states that the feature should be removed.
 * [WebKit indicated that they are moderately positive about deprecating
   `document.domain`
   setter](https://github.com/w3ctag/design-reviews/issues/564#issuecomment-768450217).
@@ -194,4 +199,4 @@ timeline:
 * [Deprecating `document.domain`. · Issue #564 ·
   w3ctag/design-reviews](https://github.com/w3ctag/design-reviews/issues/564)
 
-Photo by <a href="https://unsplash.com/@braydona?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Braydon Anderson</a> on <a href="https://unsplash.com/?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Unsplash</a>
+Photo by <a href="https://unsplash.com/@braydona">Braydon Anderson</a> on <a href="https://unsplash.com/">Unsplash</a>

--- a/site/en/blog/immutable-document-domain/index.md
+++ b/site/en/blog/immutable-document-domain/index.md
@@ -15,11 +15,14 @@ alt: >
   A dog in disguise.
 ---
 
-{% Banner 'warning' %}
+{% Aside 'warning' %}
+
 If your website relies on relaxing the same-origin policy via `document.domain`,
-your action is required. Continue to read more about why this is changing or skip to
-[alternative code for cross-domain communication](#alternative-cross-domain-communication)
-{% endBanner %}
+your action is required. Continue to read more about why this is changing or
+skip to [alternative code for cross-origin
+communication](#alternative-cross-origin-communication)
+
+{% endAside %}
 
 [`document.domain`](https://developer.mozilla.org/en-US/docs/Web/API/Document/domain)
 was designed to get or set the origin's hostname.
@@ -31,6 +34,14 @@ website relies on same-origin policy relaxation via `document.domain` to
 function correctly, the site will need to send an `Origin-Agent-Cluster: ?0` header
 along with all documents that require that behavior (note that `document.domain`
 has no effect if only one document sets it).
+
+## Timeline
+
+Here's the current timeline:
+
+* **Chrome 98:** When using `document.domain`, DevTools Console displays a warning message. `Origin-Agent-Cluster` header is available.
+* **Chrome 99:** Enterprise policy is in place to extend behavior.
+* **Chrome 101:** `document.domain` is immutable.
 
 ## Why make `document.domain` immutable?
 
@@ -105,7 +116,7 @@ Chrome will start displaying a warning in DevTools Console as soon as
 `document.domain` is set starting from Chrome 98. Chrome is planning to  make
 `document.domain` immutable starting from Chrome 101.
 
-## Alternative cross-domain communication
+## Alternative cross-origin communication
 
 At this time, you have two options to replace `document.domain` for your website.
 
@@ -150,9 +161,10 @@ window.addEventListener('message', (event) => {
 });
 ```
 
-Try it and see if it works. If you have specific requirements that won't work
-with `postMessage()` or Channel Messaging API, please let us know on [Twitter
-via @ChromiumDev](https://twitter.com/ChromiumDev) or ask on Stack Overflow.
+Try it and see how it works. If you have specific requirements that won't work
+with `postMessage()` or Channel Messaging API, let us know on [Twitter via
+@ChromiumDev](https://twitter.com/ChromiumDev) or ask on Stack Overflow with a
+`document.domain` tag.
 
 ### Send `Origin-Agent-Cluster: ?0` header to continue using `document.domain`
 
@@ -171,15 +183,6 @@ Origin-Agent-Cluster header](https://web.dev/origin-agent-cluster/).
 By sending this header, the document can continue setting `document.domain` even
 after it becomes immutable by default.
 
-## Timeline
-
-Chrome will eventually make `document.domain` immutable. Here's the current
-timeline:
-
-* **Chrome 98:** When using `document.domain`, DevTools Console displays a warning message. `Origin-Agent-Cluster` header is available.
-* **Chrome 99:** Enterprise policy is in place to extend behavior.
-* **Chrome 101:** `document.domain` is immutable.
-
 ## Browser compatibility
 
 * [The Origin
@@ -193,9 +196,8 @@ timeline:
 
 * [Document.domain - Web APIs |
   MDN](https://developer.mozilla.org/docs/Web/API/Document/domain)
-* [mikewest/deprecating-document-domain: `document.domain` intentionally weakens
-  the only security boundary we have. Perhaps we can dump
-  it?](https://github.com/mikewest/deprecating-document-domain/)
+* [Origin Isolation and Deprecating
+  `document.domain`](https://github.com/mikewest/deprecating-document-domain/)
 * [Deprecating `document.domain`. · Issue #564 ·
   w3ctag/design-reviews](https://github.com/w3ctag/design-reviews/issues/564)
 

--- a/site/en/blog/immutable-document-domain/index.md
+++ b/site/en/blog/immutable-document-domain/index.md
@@ -122,11 +122,15 @@ At this time, you have two options to replace `document.domain` for your website
 
 ### Use `postMessage()` or Channel Messaging API
 
-In most use cases, cross-origin
-[`postMessage()`
+In most use cases, cross-origin [`postMessage()`
 ](https://developer.mozilla.org/docs/Web/API/Window/postMessage) or [Channel
-Messaging
-API](https://developer.mozilla.org/docs/Web/API/Channel_Messaging_API) can replace `document.domain`.
+Messaging API](https://developer.mozilla.org/docs/Web/API/Channel_Messaging_API)
+can replace `document.domain`. In the following example:
+1. `https://parent.example.com` requests `https://video.example.com` within an
+   iframe to manipulate DOM by sending a message via `postMessage()`.
+2. `https://video.example.com` manipulates DOM as soon as it receives the
+   message and notify the success back to the parent.
+3. `https://parent.example.com` acknowledges the success.
 
 On `https://parent.example.com`:
 
@@ -163,8 +167,9 @@ window.addEventListener('message', (event) => {
 
 Try it and see how it works. If you have specific requirements that won't work
 with `postMessage()` or Channel Messaging API, let us know on [Twitter via
-@ChromiumDev](https://twitter.com/ChromiumDev) or ask on Stack Overflow with a
-`document.domain` tag.
+@ChromiumDev](https://twitter.com/ChromiumDev) or ask on Stack Overflow with [a
+`document.domain`
+tag](https://stackoverflow.com/questions/tagged/document.domain).
 
 ### Send `Origin-Agent-Cluster: ?0` header to continue using `document.domain`
 

--- a/site/en/blog/immutable-document-domain/index.md
+++ b/site/en/blog/immutable-document-domain/index.md
@@ -29,8 +29,8 @@ was designed to get or set the origin's hostname.
 
 On Chrome, websites will be unable to set `document.domain`. They will need to
 use alternative approaches such as `postMessage()` or Channel Messaging API to
-communicate cross-origin. We are targeting Chrome 101 to ship this change the
-earliest depending on the response to the [Intent to
+communicate cross-origin. We're targeting Chrome 101 to ship this change at the
+earliest, but this is dependent on the response to the [Intent to
 Ship](https://groups.google.com/a/chromium.org/g/blink-dev/c/_oRc19PjpFo/).
 
 If your website relies on same-origin policy relaxation via `document.domain`

--- a/site/en/blog/immutable-document-domain/index.md
+++ b/site/en/blog/immutable-document-domain/index.md
@@ -1,11 +1,11 @@
 ---
 layout: 'layouts/blog-post.njk'
-title: "Chrome 101 disables modifying `document.domain` to relax the same-origin policy"
+title: "Chrome will disable modifying `document.domain` to relax the same-origin policy"
 description: >
   If your website relies on setting `document.domain`, your action is required.
 subhead: >
   If your website relies on setting `document.domain`, your action is required.
-date: 2022-01-06
+date: 2022-01-11
 authors:
   - agektmr
 tags:
@@ -27,9 +27,11 @@ communication](#alternative-cross-origin-communication)
 [`document.domain`](https://developer.mozilla.org/docs/Web/API/Document/domain)
 was designed to get or set the origin's hostname.
 
-Beginning with Chrome version 101, websites will be unable to set
-`document.domain`. Websites will need to use alternative approaches such as
-`postMessage()` or Channel Messaging API to communicate cross-origin.
+On Chrome, websites will be unable to set `document.domain`. They will need to
+use alternative approaches such as `postMessage()` or Channel Messaging API to
+communicate cross-origin. We are targeting Chrome 101 to ship this change the
+earliest depending on the response to the [Intent to
+Ship](https://groups.google.com/a/chromium.org/g/blink-dev/c/_oRc19PjpFo/).
 
 If your website relies on same-origin policy relaxation via `document.domain`
 to function correctly, the site will need to send an `Origin-Agent-Cluster: ?0`
@@ -44,7 +46,10 @@ Here's the current timeline:
   warning message. `Origin-Agent-Cluster` header is available.
 * **Chrome 99:** Enterprise policy is offered to extend availability of
   `document.domain`.
-* **Chrome 101:** `document.domain` is immutable.
+* **Chrome 101:** `document.domain` is immutable. Depending on the feedback to
+  [Intent to
+  Ship](https://groups.google.com/a/chromium.org/g/blink-dev/c/_oRc19PjpFo/),
+  this may be delayed.
 
 ## Why make `document.domain` immutable?
 


### PR DESCRIPTION
Fixes #1828

This is a continuation of #1896 and #1908 

cc: @jpmedley @mihajlija @heyawhite @lutzvahl