### PR TITLE
feat(workbox-webpack-plugin): enable `workbox-webpack-plugin` type generation, fixes #1936

### DIFF
--- a/external/build/workbox-types.js
+++ b/external/build/workbox-types.js
@@ -25,7 +25,7 @@ const workboxPackages = [
   'workbox-routing',
   'workbox-strategies',
   'workbox-streams',
-  // 'workbox-webpack-plugin',
+  'workbox-webpack-plugin',
   'workbox-window',
 ];
 


### PR DESCRIPTION
Fixes #1936

Changes proposed in this pull request:

- enable `workbox-webpack-plugin` type generation
-
-

Pending GoogleChrome/workbox#2882