### PR TITLE
feat(enable-docs): enable link to workbox on `/docs` page, fixes #1937

### DIFF
--- a/site/_data/docs/projects.yml
+++ b/site/_data/docs/projects.yml
@@ -1,7 +1,6 @@
 tools:
   - url: devtools
-# TODO: Uncomment when launched.
-#  - url: workbox
+  - url: workbox
 crx:
   - url: extensions
   - url: webstore


### PR DESCRIPTION
Fixes #1937

Changes proposed in this pull request:

- Uncomment workbox for docs
-
-