### PR TITLE
Add extension service worker docs to site TOC

### DIFF
--- a/site/_data/docs/extensions/toc.yml
+++ b/site/_data/docs/extensions/toc.yml
@@ -32,7 +32,7 @@
   sections:
     - url: /docs/extensions/mv3/messaging
     - url: /docs/extensions/mv3/content_scripts
-    - url: /docs/extensions/mv3/background_pages
+    - url: /docs/extensions/mv3/service_workers
     - url: /docs/extensions/mv3/match_patterns
     - url: /docs/extensions/mv3/promises
     - url: /docs/extensions/mv3/cross-origin-isolation


### PR DESCRIPTION
At some point in the past we accidentally dropped the extensions service worker page (previously the 'working with event pages' docs) from our table of contents. This minor fix resolves that missing page issue.