### PR TITLE
Add storage permissions to options page example

### DIFF
--- a/site/en/docs/extensions/mv3/options/index.md
+++ b/site/en/docs/extensions/mv3/options/index.md
@@ -79,9 +79,9 @@ document.getElementById('save').addEventListener('click',
     save_options);
 ```
 
-For this to work, you must add in the `manifest.json`:
+Finally, add the `"storage"` permission to the extension's `manifest.json`:
 
-```json/3
+```json/4
 {
   "name": "My extension",
   ...

--- a/site/en/docs/extensions/mv3/options/index.md
+++ b/site/en/docs/extensions/mv3/options/index.md
@@ -79,6 +79,19 @@ document.getElementById('save').addEventListener('click',
     save_options);
 ```
 
+For this to work, you must add in the `manifest.json`:
+
+```json/3
+{
+  "name": "My extension",
+  ...
+  "permissions": [
+    "storage"
+  ]
+  ...
+}
+```
+
 ## Declare options page behavior {: #declare_options }
 
 There are two available types of extension options pages, [full page][2] and [embedded][3]. The type


### PR DESCRIPTION
Changes proposed in this pull request:

- Added storage permission for the Google Chrome extension options section.