### PR TITLE
#Force update numbering fix

### DIFF
--- a/site/en/docs/devtools/dom/index.md
+++ b/site/en/docs/devtools/dom/index.md
@@ -206,11 +206,11 @@ You can force nodes to remain in states like `:active`, `:hover`, `:focus`,
 
 1. Right-click **The Lord of the Flies** above and select **Inspect**.
 
-[more]: /web/tools/chrome-devtools/dom/imgs/more-actions.png
-
 1. Right-click `<li class="demo--hover">The Lord of the Flies</li>` and select **Force
    State** > **:hover**. See [Appendix: Missing options](#options) if you don't see this option.
    The background color remains orange even though you're not actually hovering over the node.
+
+[more]: /web/tools/chrome-devtools/dom/imgs/more-actions.png
 
 ### Hide a node {: #hide }
 


### PR DESCRIPTION
Excuse me if this was intentional, but under #Force State, the numbering appeared to be off and would reset the third step by to 1. I assume this is due to the more-actions.png link.

Changes proposed in this pull request:

- Move [more] link down a few lines in order to not interrupt numbering flow.