### PR TITLE
Clarify wording for "3rd party matching" use case

### DIFF
--- a/site/en/docs/privacy-sandbox/user-agent/index.md
+++ b/site/en/docs/privacy-sandbox/user-agent/index.md
@@ -169,7 +169,7 @@ expressions.
 [Register for the Chrome origin trial](/origintrials/#/view_trial/-7123568710593282047)
 to test the reduced User-Agent with your platform on real user traffic.
 
-If you provide content (like e.g. scripts) that is used by other websites in 
+If you provide content that is used by other websites in 
 a 3rd party context, then you can participate in a [third-party origin
 trial](/blog/third-party-origin-trials/) and test this change across multiple
 sites. When you register for the Chrome origin trial, select the "third-party

--- a/site/en/docs/privacy-sandbox/user-agent/index.md
+++ b/site/en/docs/privacy-sandbox/user-agent/index.md
@@ -170,7 +170,7 @@ expressions.
 to test the reduced User-Agent with your platform on real user traffic.
 
 If you create content that is embedded onto other websites (in other words,
-a 3rd party context, then you can participate in a [third-party origin
+3rd-party content), then you can participate in a [third-party origin
 trial](/blog/third-party-origin-trials/) and test this change across multiple
 sites. When you register for the Chrome origin trial, select the "third-party
 matching" option to allow the script to be injected when your site is embedded

--- a/site/en/docs/privacy-sandbox/user-agent/index.md
+++ b/site/en/docs/privacy-sandbox/user-agent/index.md
@@ -169,7 +169,7 @@ expressions.
 [Register for the Chrome origin trial](/origintrials/#/view_trial/-7123568710593282047)
 to test the reduced User-Agent with your platform on real user traffic.
 
-If you provide content that is used by other websites in 
+If you create content that is embedded onto other websites (in other words,
 a 3rd party context, then you can participate in a [third-party origin
 trial](/blog/third-party-origin-trials/) and test this change across multiple
 sites. When you register for the Chrome origin trial, select the "third-party

--- a/site/en/docs/privacy-sandbox/user-agent/index.md
+++ b/site/en/docs/privacy-sandbox/user-agent/index.md
@@ -169,7 +169,8 @@ expressions.
 [Register for the Chrome origin trial](/origintrials/#/view_trial/-7123568710593282047)
 to test the reduced User-Agent with your platform on real user traffic.
 
-If you work with embedded content, you can participate in a [third-party origin
+If you provide content (like e.g. scripts) that is used by other websites in 
+a 3rd party context, then you can participate in a [third-party origin
 trial](/blog/third-party-origin-trials/) and test this change across multiple
 sites. When you register for the Chrome origin trial, select the "third-party
 matching" option to allow the script to be injected when your site is embedded


### PR DESCRIPTION
The original wording "If you work with embedded content..." might be misleading, as almost every website is "working with embedded content", like e.g. "analytics scripts", "payment scripts", "widgets", etc. Developers might think that they need to follow these steps if they want to test this "embedded content" on their website, which is not the intended use case.

The new wording should clarify that this section is meant for "providers of embedded content".