### PR TITLE
Fix the layout in Web-accessible resources section

### DIFF
--- a/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
+++ b/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
@@ -201,7 +201,6 @@ This change limits access to extension resources to specific sites/extensions.
 Instead of providing a list of files, you now provide a list of objects, each
 of which can map to a set of resources to a set of URLs or extension IDs:
 
-{% Columns %}
 ```json
 // Manifest V2
 
@@ -234,8 +233,6 @@ Where the following placeholders are used:
   pattern][doc-match-pattern] that specifies which sites can access this set of resources.
 - <code><var>EXTENSION_IDS</var></code>: A list of strings, each containing the ID of a given
   extension.
-
-{% endColumns %}
 
 Previously, the list of web accessible resources applied to all websites and
 extensions, which created opportunities for fingerprinting or unintentional


### PR DESCRIPTION
Fixes #1978 

Changes proposed in this pull request:

- Remove the wrapping `{% Columns %}` and `{% endColumns %}`

|Before fix|After fix|
|---------|--------|
|<img width="847" alt="Screen Shot 2022-01-19 at 16 44 40" src="https://user-images.githubusercontent.com/25856620/150108791-5cb41ba9-2b97-4f1c-802b-80eebb2109f5.png">|<img width="758" alt="Screen Shot 2022-01-19 at 16 52 02" src="https://user-images.githubusercontent.com/25856620/150108818-a164d581-871c-48e9-8f43-7c90f0be7199.png">|

