### PR TITLE
Restore side by side code sample in MV3 migration guide

### DIFF
--- a/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
+++ b/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
@@ -201,6 +201,8 @@ This change limits access to extension resources to specific sites/extensions.
 Instead of providing a list of files, you now provide a list of objects, each
 of which can map to a set of resources to a set of URLs or extension IDs:
 
+{% Columns %}
+
 ```json
 // Manifest V2
 
@@ -208,11 +210,6 @@ of which can map to a set of resources to a set of URLs or extension IDs:
   RESOURCE_PATHS
 ]
 ```
-
-Where the following placeholders are used:
-
-- <code><var>RESOURCE_PATHS</var></code>: A list of strings, each containing a relative path to a
-  given resource from the extension's root directory.
 
 ```json
 // Manifest V3
@@ -225,7 +222,9 @@ Where the following placeholders are used:
 }]
 ```
 
-Where the following placeholders are used:
+{% endColumns %}
+
+Replace the following:
 
 - <code><var>RESOURCE_PATHS</var></code>: A list of strings, each containing a relative path to a
   given resource from the extension's root directory.


### PR DESCRIPTION
PR #1953 introduced a bug that caused the web accessible resources code samples to render as long, thin columns (#1978). #1953 provided a stopgap solution to this rendering issue, but did so by dropping the columnar code samples. 

This PR re-introduces the side-by-side code samples and moves placeholder descriptions out of `{% Columns % }` container.