### PR TITLE
Add a caveat about using BroadcastUpdatePlugin with workbox-precaching

### DIFF
--- a/site/en/docs/workbox/modules/workbox-broadcast-update/index.md
+++ b/site/en/docs/workbox/modules/workbox-broadcast-update/index.md
@@ -52,6 +52,10 @@ caching strategy, since that strategy involves returning a cached
 response immediately, but also provides a mechanism for updating the
 cache asynchronously.
 
+{% Aside %}
+The `BroadcastUpdatePlugin` can't be used to broadcast information about `workbox-precaching`'s updates. `BroadcastUpdatePlugin` detects when a previously cached URL has been overwritten with new contents. `workbox-precaching` creates cache entries with URLs that uniquely correspond to the contents, so it will never overwrite existing cache entries.
+{% endAside %}
+
 To broadcast updates, you just need to add a `broadcastUpdate.BroadcastUpdatePlugin` to your
 strategy options.
 


### PR DESCRIPTION
This addresses some developer confusion about using BroadcastUpdatePlugin with `workbox-precaching`.

C.f. https://github.com/GoogleChrome/workbox/issues/2931#issuecomment-1020481215