### PR TITLE
Updates a number of links to Workbox-related content on WebFundamentals.

### DIFF
--- a/site/en/docs/workbox/modules/workbox-background-sync/index.md
+++ b/site/en/docs/workbox/modules/workbox-background-sync/index.md
@@ -56,6 +56,7 @@ registerRoute(
 );
 ```
 
+[comment]: <> (TODO: update the using-plugins link when that doc is migrated)
 `BackgroundSyncPlugin` hooks into the
 [`fetchDidFail` plugin callback](https://developers.google.com/web/tools/workbox/guides/using-plugins), and
 `fetchDidFail` is only invoked if there's an exception thrown, most likely due

--- a/site/en/docs/workbox/modules/workbox-build/index.md
+++ b/site/en/docs/workbox/modules/workbox-build/index.md
@@ -65,7 +65,7 @@ This will generate a service worker with precaching setup for all of the files p
 
 ### Full `generateSW` Config
 
-A full set of configuration options can be found on [this reference page](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build#.generateSW).
+A full set of configuration options can be found on [this reference page](/docs/workbox/reference/workbox-build/#method-generateSW).
 
 ## `injectManifest` Mode
 
@@ -92,7 +92,7 @@ This will create a precache manifest based on the files picked up by your config
 
 ### Full `injectManifest` Config
 
-A full set of configuration options can be found on [this reference page](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build#.injectManifest).
+A full set of configuration options can be found on [this reference page](/docs/workbox/reference/workbox-build/#method-injectManifest).
 
 ## Additional modes
 
@@ -116,4 +116,4 @@ getManifest({
 ```
 
 A full set of configuration options can be found on
-[this reference page](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build#.getManifest).
+[this reference page](/docs/workbox/reference/workbox-build/#method-getManifest).

--- a/site/en/docs/workbox/modules/workbox-cli/index.md
+++ b/site/en/docs/workbox/modules/workbox-cli/index.md
@@ -175,9 +175,9 @@ automatically by `workbox wizard` or tweaked manually.
 ### Options used by `generateSW`
 
 A full set of configuration options can be found on
-[this reference page](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build#.generateSW).
+[this reference page](/docs/workbox/reference/workbox-build/#method-generateSW).
 
 ### Options used by `injectManifest`
 
 A full set of configuration options can be found on
-[this reference page](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build#.injectManifest).
+[this reference page](/docs/workbox/reference/workbox-build/#method-injectManifest).

--- a/site/en/docs/workbox/modules/workbox-recipes/index.md
+++ b/site/en/docs/workbox/modules/workbox-recipes/index.md
@@ -11,7 +11,7 @@ A number of common patters, especially around [routing](/docs/workbox/modules/wo
 
 ## Recipes
 
-Each recipe combines a number of [Workbox modules](https://developers.google.com/web/tools/workbox/modules) together, bundling them into commonly used patterns. The recipes below will show the **recipe** you use when using this module, and the equivalent **pattern** it's using under the hood, should you want to write it yourself.
+Each recipe combines a number of [Workbox modules](/docs/workbox/modules/) together, bundling them into commonly used patterns. The recipes below will show the **recipe** you use when using this module, and the equivalent **pattern** it's using under the hood, should you want to write it yourself.
 
 ### Offline fallback
 

--- a/site/en/docs/workbox/modules/workbox-routing/index.md
+++ b/site/en/docs/workbox/modules/workbox-routing/index.md
@@ -245,7 +245,7 @@ through Workbox.
 
 If you need more verbose information, you can set the log level to `debug` to
 view logs on requests not handled by the Router. See our
-[debugging guide](https://developers.google.com/web/tools/workbox/guides/troubleshoot-and-debug) for more info on
+[debugging guide](/docs/workbox/troubleshooting-and-logging/) for more info on
 setting the log level.
 
 {% Img src="image/jL3OLOhcWUQDnR4XjewLBx4e3PC3/lAJuL5UQuLYiTWTp5qH4.png", alt="Debug and Log Routing Messages", width="800", height="223" %}
@@ -255,7 +255,7 @@ setting the log level.
 If you want to have more control over when the Workbox Router is given
 requests, you can create your own
 [`Router`](/docs/workbox/reference/workbox-routing/#type-Router) instance and call
-it's [`handleRequest()`](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-routing.Router#handleRequest)
+it's [`handleRequest()`](/docs/workbox/reference/workbox-routing/#method-Router-handleRequest)
 method whenever you want to use the router to respond to a request.
 
 ```js

--- a/site/en/docs/workbox/modules/workbox-strategies/index.md
+++ b/site/en/docs/workbox/modules/workbox-strategies/index.md
@@ -202,6 +202,7 @@ class NewStrategy extends Strategy {
 In this example, `handle()` is used as a request strategy to define specific handling logic. There
 are two request strategies that can be used:
 
+[comment]: <> (TODO: update the using-plugins link when that doc is migrated)
 - `handle()`: Perform a request strategy and return a `Promise` that will resolve with a `Response`,
   invoking all [relevant plugin
   callbacks](https://developers.google.com/web/tools/workbox/guides/using-plugins#lifecycle_callbacks).
@@ -314,4 +315,4 @@ self.addEventListener('fetch', event => {
 ```
 
 You can find the list of available classes in the
-[workbox-strategies reference docs](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-strategies).
+[workbox-strategies reference docs](/docs/workbox/reference/workbox-strategies/).

--- a/site/en/docs/workbox/modules/workbox-window/index.md
+++ b/site/en/docs/workbox/modules/workbox-window/index.md
@@ -689,5 +689,7 @@ Starting with Workbox v6, the `messageSkipWaiting()` method can be used to send 
 current service worker registration. It will silently do nothing if there isn't a
 waiting service worker.
 
-For guidance on using `messageSkipWaiting()`, see the
-"[Offer a page reload for users](https://developers.google.com/web/tools/workbox/guides/advanced-recipes#offer_a_page_reload_for_users)" recipe.
+{% Aside %}
+For further guidance on using `messageSkipWaiting()`, see the
+"[Handling service worker updates with immediacy](/docs/workbox/handling-service-worker-updates/)" recipe.
+{% endAside %}

--- a/site/en/docs/workbox/navigation-preload/index.md
+++ b/site/en/docs/workbox/navigation-preload/index.md
@@ -28,7 +28,6 @@ The best time to use navigation preload is when a website can't precache HTML. T
 
 Using navigation preload directly in a service worker not powered by Workbox is tricky. First, [it's not supported in all browsers](https://caniuse.com/mdn-api_navigationpreloadmanager). Secondly, it can be difficult to get right. You can learn how to use it directly in [this great explainer by Jake Archibald](https://developers.google.com/web/updates/2017/02/navigation-preload).
 
-[comment]: <> (TODO: POINT REFERENCE LINK TO NEW REFERENCE DOCS)
 Workbox simplifies using navigation preload, because the `workbox-navigation-preload` module's [`enable` method](/docs/workbox/reference/workbox-navigation-preload/#method-enable) does the necessary feature support checks, as well as creating the `activate` event listener to enable it for you.
 
 From here, the benefits of navigation preload are realized in supporting browsers by using Workbox to handle navigation requests using a network-first strategy handler:
@@ -76,8 +75,7 @@ If you don't register a route to handle the preloaded response using a network-f
 
 ## How can I tell if navigation preload is working?
 
-[comment]: <> (TODO: WIRE UP LINK)
-In [development builds](LINK IT UP!), Workbox logs a _lot_ about what it does. If you want to check if navigation preload is working in Workbox, open the console in a supporting browser during a navigation request and you'll see a log message saying as much:
+In [development builds](/docs/workbox/troubleshooting-and-logging/), Workbox logs a _lot_ about what it does. If you want to check if navigation preload is working in Workbox, open the console in a supporting browser during a navigation request and you'll see a log message saying as much:
 
 {% Img src="image/jL3OLOhcWUQDnR4XjewLBx4e3PC3/1TbMFuUG7c1OZp4zAOJH.png", alt="A screenshot of Workbox logs in the console of Chrome's DevTools. The messages read, from top to bottom: 'Router is responding to /', 'Using a preloaded navigation request for /', and 'Using NetworkFirst to respond to /'", width="800", height="89" %}
 
@@ -97,5 +95,4 @@ Then, in your application backend of choice, you can check for this header and m
 
 ## Conclusion
 
-[comment]: <> (TODO: POINT REFERENCE LINK TO NEW REFERENCE DOCS)
 Navigation preload is hard to get right when used directly, but that hard work is worth it to ensure that a service worker doesn't hold the browser up from making navigation requests. Thanks to Workbox, you can benefit from navigation preload with a lot less work. To get more details on the `workbox-navigation-preload` module, [check out its reference documentation](/docs/workbox/reference/workbox-navigation-preload/).

--- a/site/en/docs/workbox/precaching-with-workbox/index.md
+++ b/site/en/docs/workbox/precaching-with-workbox/index.md
@@ -14,7 +14,7 @@ Precaching is one of the most common things you'll do in a service worker, and W
 
 `generateSW` does different things by default depending on which build tool you use. When using `workbox-webpack-plugin`, you don't have to specify any configuration options. By default, the plugin will precache everything webpack includes in its [dependency graph](https://webpack.js.org/concepts/dependency-graph/) and write a service worker named `service-worker.js` to the directory specified by [`output.path`](https://webpack.js.org/configuration/output/#outputpath)
 
-On the other hand, if you use `workbox-build` or `workbox-cli`, only HTML, CSS and JavaScript assets read from the local filesystem will be precached by default. Configuration-wise, you have to specify `swDest` and [the globDirectoryoption in the [`generateSW` config](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build#.generateSW) for precaching to work. Chances are, you'll want to configure additional options affecting your service worker behavior as well, so take a look through the documentation.
+On the other hand, if you use `workbox-build` or `workbox-cli`, only HTML, CSS and JavaScript assets read from the local filesystem will be precached by default. Configuration-wise, you have to specify `swDest` and [the globDirectoryoption in the [`generateSW` config](/docs/workbox/reference/workbox-build/#method-generateSW) for precaching to work. Chances are, you'll want to configure additional options affecting your service worker behavior as well, so take a look through the documentation.
 
 {% Aside 'warning' %}
 If too many assets in your project are precached with the default settings, use one of the glob options to exclude resources in the `generateSW` configuration. When using `workbox-webpack-plugin`, consult the plugin's [`GenerateSW` documentation](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-webpack-plugin.GenerateSW) to find out how to prevent unwanted assets from being precached, as its configuration differs from `generateSW`.
@@ -30,7 +30,7 @@ When you use `injectManifest`, you're responsible for wiring up precaching logic
 If you need to change the string `injectManifest` looks for to something different than `self.__WB_MANIFEST`, you can do so by specifying the `injectionPoint` option in its configuration.
 {% endAside %}
 
-The list of entries in the precache manifest can be tweaked with additional [configuration options](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build#.injectManifest).
+The list of entries in the precache manifest can be tweaked with additional [configuration options](/docs/workbox/reference/workbox-build/#method-injectManifest).
 
 {% Aside 'caution' %}
 Unlike `generateSW`, `injectManifest` won't automatically bundle the Workbox runtime for you! To see how to manage this in use cases that rely on `injectManifest`, check out the side-by-side comparison below.

--- a/site/en/docs/workbox/retrying-requests-when-back-online/index.md
+++ b/site/en/docs/workbox/retrying-requests-when-back-online/index.md
@@ -39,6 +39,7 @@ registerRoute(
 
 Here, `BackgroundSyncPlugin` is applied to a route matching POST requests to an API route that retrieves JSON data. If the user is offline, `BackgroundSyncPlugin` will retry the request when the user is back online, but only for up to a day.
 
+[comment]: <> (TODO: update the using-plugins link when that doc is migrated)
 {% Aside 'warning' %}
 Because `BackgroundSyncPlugin` hooks into the [`FetchDidFail` plugin's callback](https://developers.google.com/web/tools/workbox/guides/using-plugins), failed requests must be the result of a network failure. Requests that result in a [400](https://developer.mozilla.org/docs/Web/HTTP/Status#client_error_responses) or [500-level error status](https://developer.mozilla.org/docs/Web/HTTP/Status#server_error_responses) will not be retried. To retry requests resulting in these types of failures, try [adding a `FetchDidSucceed` plugin to your strategy](https://github.com/GoogleChrome/workbox/issues/2599#issuecomment-900304969).
 {% endAside %}

--- a/site/en/docs/workbox/the-ways-of-workbox/index.md
+++ b/site/en/docs/workbox/the-ways-of-workbox/index.md
@@ -18,9 +18,8 @@ You'll rely on one of two core methods of Workbox's build tools: `generateSW` or
 
 You should use `generateSW` if:
 
-[comment]: <> (TODO: UPDATE REFERENCE DOC LINK)
 - You want to precache files associated with your build process, including files whose URLs contain hashes that you might not know ahead of time.
-- You have simple runtime caching needs that can be configured via [`generateSW`'s options](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build#.generateSW).
+- You have simple runtime caching needs that can be configured via [`generateSW`'s options](/docs/workbox/reference/workbox-build/#method-generateSW).
 
 ### When _not_ to use `generateSW`
 

--- a/site/en/docs/workbox/using-workbox-window/index.md
+++ b/site/en/docs/workbox/using-workbox-window/index.md
@@ -6,7 +6,7 @@ description: >
   Sometimes users go offline. Learn how to adapt, and help them resume requests when they eventually go back online.
 ---
 
-One Workbox module that hasn't gotten much coverage yet in this documentation is [`workbox-window`](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-window.Workbox), which is a set of modules intended to run in the [`window`](https://developer.mozilla.org/docs/Web/API/Window). The goals of this module are:
+One Workbox module that hasn't gotten much coverage yet in this documentation is [`workbox-window`](/docs/workbox/reference/workbox-window/), which is a set of modules intended to run in the [`window`](https://developer.mozilla.org/docs/Web/API/Window). The goals of this module are:
 
 - To simplify service worker registration and updates by helping developers identify critical moments of the [service worker lifecycle](/docs/workbox/service-worker-lifecycle/), making it easier to respond in those moments.
 - To prevent developers from making common mistakes, such as registering a service worker in the wrong scope.
@@ -81,7 +81,7 @@ wb.register();
 It may seem that this is the same as registering a service worker yourself using [`navigator.serviceWorker.register`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer/register). However,  `Workbox.register` takes care of waiting until the [`window` `load`](https://developer.mozilla.org/docs/Web/API/Window/load_event) event before registering the service worker. This is desirable in situations where precaching is involved so bandwidth contention that may delay page startup can be avoided.
 
 {% Aside %}
-The `Workbox` class offers numerous other convenience methods that make working with the service worker API easier. For more information, check out [the reference documentation](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-window.Workbox).
+The `Workbox` class offers numerous other convenience methods that make working with the service worker API easier. For more information, check out [the reference documentation](/docs/workbox/reference/workbox-window/).
 {% endAside %}
 
 ## Communicating between the `window` and the service worker scope

--- a/site/en/docs/workbox/what-is-workbox/index.md
+++ b/site/en/docs/workbox/what-is-workbox/index.md
@@ -21,11 +21,11 @@ Workbox aims to make using service workers as easy as possible,
 while allowing the flexibility to accommodate complex application requirements where needed.
 
 In the simplest cases,
-[`workbox-build`](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build)
+[`workbox-build`](/docs/workbox/reference/workbox-build/)
 offers a couple of methods that can generate a service worker that precaches specified assets.
-The [`generateSW`](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build#.generateSW)
+The [`generateSW`](/docs/workbox/reference/workbox-build/#method-generateSW)
 method does most of the work out of the box,
-while the [`injectManifest`](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build#.injectManifest)
+while the [`injectManifest`](/docs/workbox/reference/workbox-build/#method-injectManifest)
 method offers more control when necessary.
 
 For more advanced use cases, other modules can help. A few such modules are:
@@ -36,6 +36,6 @@ For more advanced use cases, other modules can help. A few such modules are:
 - [`workbox-expiration`](/docs/workbox/modules/workbox-expiration) for managing caches.
 - [`workbox-window`](/docs/workbox/modules/workbox-window) for registering a service worker and handling updates in the [`window context`](https://developer.mozilla.org/docs/Web/API/Window).
 
-These and [other modules](https://developers.google.com/web/tools/workbox/modules)
+These and [other modules](/docs/workbox/modules/)
 help compose service worker code in a declarative fashion that's easier to read and maintain than using service worker APIs directly.
 This documentation will explain how to use them in an applied fashion.


### PR DESCRIPTION
Some links in the new Workbox documentation still points to Workbox-related stuff on developers.google.com. This PR updates as many of those links where possible (although some exist, such as reference docs for `workbox-webpack-plugin` and etc).