### PR TITLE
Update partial to highlight CWS changes

### DIFF
--- a/site/_includes/partials/extensions/mv2-legacy-page.md
+++ b/site/_includes/partials/extensions/mv2-legacy-page.md
@@ -1,5 +1,9 @@
 {% Aside 'warning' %}
-The page you're viewing describes extensions using Manifest V2. Now that
-[Manifest V3 has launched](/docs/extensions/mv3/intro), we strongly recommend
-that you use it for any new extensions that you create.
+
+The page you're viewing describes the Manifest V2 extension platform.
+
+As of [January 17, 2022](/docs/extensions/mv3/mv2-sunset/) Chrome Web Store has stopped accepting
+new Manifest V2 extensions. We strongly recommend new extensions target [Manifest
+V3](/docs/extensions/mv3/intro).
+
 {% endAside %}

--- a/site/_includes/partials/extensions/mv2-legacy-page.md
+++ b/site/_includes/partials/extensions/mv2-legacy-page.md
@@ -3,7 +3,7 @@
 The page you're viewing describes the Manifest V2 extension platform.
 
 As of [January 17, 2022](/docs/extensions/mv3/mv2-sunset/) Chrome Web Store has stopped accepting
-new Manifest V2 extensions. We strongly recommend new extensions target [Manifest
+new Manifest V2 extensions. We strongly recommend that new extensions target [Manifest
 V3](/docs/extensions/mv3/intro).
 
 {% endAside %}


### PR DESCRIPTION
Revise the MV2 deprecation header to highlight that Chrome Web Store is not accepting new Manifest V2 extensions. In addition to setting this context, I also wanted to to update this header to include a link to the [mv2-sunset](https://developer.chrome.com/docs/extensions/mv3/mv2-sunset/) page. 