### PR TITLE
Replace MVX with Manifest VX

### DIFF
--- a/site/_includes/partials/extensions/mv2page-in-mv3.md
+++ b/site/_includes/partials/extensions/mv2page-in-mv3.md
@@ -1,5 +1,5 @@
 {% Aside 'caution' %}
-This page was migrated directly from the MV2 documentation set. It has not yet
+This page was migrated directly from the Manifest V2 documentation set. It has not yet
 been validated for compliance with Manifest V3.
 {% endAside %}
 

--- a/site/en/blog/mv2-transition/index.md
+++ b/site/en/blog/mv2-transition/index.md
@@ -55,5 +55,5 @@ If you have feedback on Manifest V3 or are encountering unique challenges with t
 process, please post to the
 [chromium-extensions](https://groups.google.com/a/chromium.org/g/chromium-extensions) Google Group.
 The earlier issues are raised and the earlier feedback is given, the more options the team has to
-address them prior to MV2 phase-out.
+address them prior to Manifest V2 phase-out.
 

--- a/site/en/docs/extensions/mv3/content_scripts/index.md
+++ b/site/en/docs/extensions/mv3/content_scripts/index.md
@@ -667,7 +667,7 @@ separate website, such as making an [`XMLHttpRequest`][28], be careful to filter
 avoid ["man-in-the-middle"][30] attacks.
 
 Be sure to filter for malicious web pages. For example, the following patterns are dangerous, and
-disallowed in MV3:
+disallowed in Manifest V3:
 
 {% Compare 'worse' %}
 ```js

--- a/site/en/docs/extensions/mv3/devguide/index.md
+++ b/site/en/docs/extensions/mv3/devguide/index.md
@@ -7,7 +7,7 @@ description: An overview of Chrome Extension capabilities and components.
 ---
 
 After reading the [Getting Started][1] tutorial and [Overview][2], use this guide as an outline to
-extension components and abilities with MV3 availability. Developers are encouraged to explore and expand extension
+extension components and abilities with Manifest V3 availability. Developers are encouraged to explore and expand extension
 functionality.
 
 <table class="width-full">

--- a/site/en/docs/extensions/mv3/index.md
+++ b/site/en/docs/extensions/mv3/index.md
@@ -39,13 +39,13 @@ Beyond that, you might find useful entry points in these pages:
 
 {% Aside %}
 Now that Manifest V3 has launched, we've changed the default documentation to
-be for MV3. If you are maintaining a legacy Manifest V2 extension, see the [MV2
+be for Manifest V3. If you are maintaining a legacy Manifest V2 extension, see the [Manifest V2
 documentation](/docs/extensions/mv2).
 {% endAside %}
 
 {% Aside 'warning' %}
 As Manifest V3 approaches full feature parity with V2, we will be phasing out
-MV2. See [Manifest V2 support timeline](/docs/extensions/mv3/mv2-sunset) for details.
+Manifest V2. See [Manifest V2 support timeline](/docs/extensions/mv3/mv2-sunset) for details.
 {% endAside %}
 
 In addition to the documentation here, many developers find helpful community content at:

--- a/site/en/docs/extensions/mv3/intro/index.md
+++ b/site/en/docs/extensions/mv3/intro/index.md
@@ -24,27 +24,27 @@ date: 2020-11-09
 
 ---
 
-This site introduces Manifest V3 for Chrome Extensions (MV3). It presents the
-background and reasons for introducing MV3 and our vision for the platform's
-future, along with guidance on how to optimize your extensions to use MV3.
+This site introduces Manifest V3 for Chrome Extensions (Manifest V3). It presents the
+background and reasons for introducing Manifest V3 and our vision for the platform's
+future, along with guidance on how to optimize your extensions to use Manifest V3.
 
 Manifest V3 represents one of the biggest shifts in the extensions platform
-since it launched a decade ago. Extensions using MV3 will enjoy enhancements in
+since it launched a decade ago. Extensions using Manifest V3 will enjoy enhancements in
 security, privacy, and performance; they can also use more contemporary Open
-Web technologies adopted in MV3, such as service workers and promises.
-Developers can update their extensions today to take advantage of these MV3
-features; this will become mandatory as we phase out MV2 in the future.
+Web technologies adopted in Manifest V3, such as service workers and promises.
+Developers can update their extensions today to take advantage of these Manifest V3
+features; this will become mandatory as we phase out Manifest V2 in the future.
 
 Manifest V3 is part of a shift in the philosophy behind how we approach
 end-user security and privacy. The pages in this section provide an overview of
-MV3, the reasons behind it, and how to approach it:
+Manifest V3, the reasons behind it, and how to approach it:
 
 
-* [Platform vision](platform-vision) explains how the MV3 changes fit into the big picture of where the platform is going.
-* [Overview of Manifest V3](mv3-overview) summarizes the technical changes introduced with MV3.
-* [Migration guide](mv3-migration) tells you how to get started updating MV2 extensions so they work in MV3.
+* [Platform vision](platform-vision) explains how the Manifest V3 changes fit into the big picture of where the platform is going.
+* [Overview of Manifest V3](mv3-overview) summarizes the technical changes introduced with Manifest V3.
+* [Migration guide](mv3-migration) tells you how to get started updating Manifest V2 extensions so they work in Manifest V3.
 
-We're excited about the improvements that MV3 brings to the extensions
+We're excited about the improvements that Manifest V3 brings to the extensions
 platform. Look for further announcements on the [Chromium
 Blog](https://blog.chromium.org/) and the [Chromium Extensions
 forum](https://groups.google.com/a/chromium.org/g/chromium-extensions).

--- a/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
+++ b/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
@@ -2,16 +2,16 @@
 layout: 'layouts/doc-post.njk'
 title: Migrating to Manifest V3
 subhead: 'Getting you headed in the right direction.'
-description: 'A high-level guide to how you can migrate your MV2 extensions to MV3.'
+description: 'A high-level guide to how you can migrate your Manifest V2 extensions to Manifest V3.'
 date: 2020-11-09
 updated: 2021-08-13
 ---
 
 This guide provides developers with the information they need to begin
-migrating an extension from Manifest V2 to Manifest V3 (MV3). Some extensions
-will require very little change to make them MV3 compliant, while others will
-need to be redesigned to some degree. Developers experienced with MV2, and who
-are creating new MV3 extensions, may also find this helpful. For a quick
+migrating an extension from Manifest V2 to Manifest V3 (Manifest V3). Some extensions
+will require very little change to make them Manifest V3 compliant, while others will
+need to be redesigned to some degree. Developers experienced with Manifest V2, and who
+are creating new Manifest V3 extensions, may also find this helpful. For a quick
 reference guide see the [migration
 checklist](/docs/extensions/mv3/mv3-migration-checklist).
 
@@ -21,7 +21,7 @@ Manifest V3 offers a number of improvements reflecting the aims of our
 
 ## Feature summary  {: #feature-summary }
 
-There are a number of new features and functional changes for extensions using MV3:
+There are a number of new features and functional changes for extensions using Manifest V3:
 
 * [Service workers](/docs/extensions/mv3/intro/mv3-overview#service-workers)
   replace background pages.
@@ -37,15 +37,15 @@ There are a number of new features and functional changes for extensions using M
   methods.)
 * A number of other, relatively
   [minor feature changes](/docs/extensions/mv3/intro/mv3-overview#other-features)
-  are also introduced in MV3.
+  are also introduced in Manifest V3.
 
 For a fuller description of these changes, see the
-[MV3 Overview](/docs/extensions/mv3/intro/mv3-overview).
+[Manifest V3 Overview](/docs/extensions/mv3/intro/mv3-overview).
 
 
 ## Updating the manifest.json file  {: #updating-manifest-dot-json }
 
-To use the features of MV3, you need to first update your [manifest
+To use the features of Manifest V3, you need to first update your [manifest
 file](/docs/extensions/mv3/manifest). Naturally, you'll change the manifest
 version to "3", but there are a number of other things you need to change in
 the manifest file: host permissions, content security policy, action
@@ -55,7 +55,7 @@ declarations, and web-accessible resources.
 ### Manifest version  {: #manifest-version }
 
 Changing the value of the manifest_version element is the key to upgrading your
-extension. This determines whether you're using the MV2 or MV3 feature set:
+extension. This determines whether you're using the Manifest V2 or Manifest V3 feature set:
 
 {% Columns %}
 ```json
@@ -73,7 +73,7 @@ extension. This determines whether you're using the MV2 or MV3 feature set:
 
 ### Host permissions  {: #host-permissions }
 
-In MV3, you'll need to specify host permissions separately from other permissions:
+In Manifest V3, you'll need to specify host permissions separately from other permissions:
 
 {% Columns %}
 ```js
@@ -116,7 +116,7 @@ permissions requests by the Chrome Web Store review process.
 ### Content security policy  {: #content-security-policy }
 
 An extension's [content security policy](https://content-security-policy.com/)
-(CSP) was specified in MV2 as a string; in MV3 it is an object with members
+(CSP) was specified in Manifest V2 as a string; in Manifest V3 it is an object with members
 representing alternative CSP contexts:
 
 {% Columns %}
@@ -148,8 +148,8 @@ extension is `chrome-extension://EXTENSION_ID/foo.html`.
 **`sandbox`**: This policy covers any [sandboxed extension
 pages](/docs/extensions/mv3/manifest/sandbox) that your extension uses.
 
-In addition, MV3 disallows certain CSP modifications for `extension_pages` that
-were permitted in MV2. The `script-src,` `object-src`, and `worker-src`
+In addition, Manifest V3 disallows certain CSP modifications for `extension_pages` that
+were permitted in Manifest V2. The `script-src,` `object-src`, and `worker-src`
 directives may only have the following values:
 
 *   `self`
@@ -161,9 +161,9 @@ CSP modifications for `sandbox` have no such new restrictions.
 
 ### Action API unification  {: #action-api-unification }
 
-In MV2, there were two different APIs to implement actions: `browser_action`
+In Manifest V2, there were two different APIs to implement actions: `browser_action`
 and `page_action`. These APIs filled distinct roles when they were introduced,
-but over time they've become redundant so in MV3 we are unifying them into as
+but over time they've become redundant so in Manifest V3 we are unifying them into as
 single `action` API:
 
 {% Columns %}
@@ -243,20 +243,20 @@ documentation for usage information.
 
 ## Code execution  {: #code-execution }
 
-MV3 imposes new restrictions that limit an extension's ability to execute
+Manifest V3 imposes new restrictions that limit an extension's ability to execute
 unreviewed JavaScript through a combination of platform changes and policy
 limitations.
 
-Many extensions are unaffected by this change. However, if your MV2 extension
+Many extensions are unaffected by this change. However, if your Manifest V2 extension
 executes remotely hosted scripts, injects code strings into pages, or evals
 strings at runtime, you'll need to update your code execution strategies when
-migrating to MV3.
+migrating to Manifest V3.
 
 {% Aside %}
 With Manifest V3 the `executeScript()` method also moves to a different API.
 
-* **MV2:**&emsp;[chrome.tabs.executeScript()](/docs/extensions/reference/tabs/#method-executeScript)
-* **MV3:**&emsp;[chrome.scripting.executeScript()](/docs/extensions/reference/scripting/#method-executeScript).
+* **Manifest V2:**&emsp;[chrome.tabs.executeScript()](/docs/extensions/reference/tabs/#method-executeScript)
+* **Manifest V3:**&emsp;[chrome.scripting.executeScript()](/docs/extensions/reference/scripting/#method-executeScript).
 
 If you use executeScript() anywhere in your code, you'll need to update that call to use the new
 API. The `insertCSS()` and `removeCSS()` methods similarly move from chrome.tabs to
@@ -273,7 +273,7 @@ are considered remotely hosted code:
 *   JavaScript files pulled from a remote server
 *   a code string passed into eval at runtime
 
-In MV3, all of your extension's logic must be bundled with the extension. You
+In Manifest V3, all of your extension's logic must be bundled with the extension. You
 can no longer load and execute a remotely hosted file. A number of alternative
 approaches are available, depending on your use case and the reason for remote
 hosting. Two such approaches are:
@@ -376,7 +376,7 @@ implementation of `getCurrentTab`.
 
 ## Background service workers  {: #background-service-workers }
 
-Background pages in MV2 are replaced by service workers in MV3: this is a
+Background pages in Manifest V2 are replaced by service workers in Manifest V3: this is a
 foundational change that affects most extensions.
 
 [Service workers](https://developers.google.com/web/fundamentals/primers/service-workers)
@@ -387,7 +387,7 @@ Workers](/docs/extensions/mv3/migrating_to_service_workers) for additional
 details.
 
 {% Aside %}
-In order to aid with the migration process, MV2 extensions can use background
+In order to aid with the migration process, Manifest V2 extensions can use background
 service workers as of Chrome 87.
 {% endAside %}
 
@@ -403,7 +403,7 @@ network request modification, which provides an alternative for much of the
 ### When can you use blocking webRequest?  {: #when-use-blocking-webrequest }
 
 The blocking version of the [webRequest](/docs/extensions/reference/webRequest)
-API still exists in MV3 but its use is restricted to force-installed extensions
+API still exists in Manifest V3 but its use is restricted to force-installed extensions
 only. See Chrome Enterprise policies:
 [ExtensionSettings](https://cloud.google.com/docs/chrome-enterprise/policies/?policy=ExtensionSettings),
 [ExtensionInstallForcelist](https://cloud.google.com/docs/chrome-enterprise/policies/?policy=ExtensionInstallForcelist).
@@ -433,7 +433,7 @@ needing to read the actual requests.
 
 {% Aside %}
 In order to aid with the migration process, the declarativeNetRequest API is
-available for use in MV2 extensions as of Chrome 84.
+available for use in Manifest V2 extensions as of Chrome 84.
 {% endAside %}
 
 
@@ -484,4 +484,4 @@ As well as the undocumented:
 *   chrome.extension.onMessage
 
 If your extensions use any of these deprecated APIs, you'll need to make the
-appropriate changes when you migrate to MV3.
+appropriate changes when you migrate to Manifest V3.

--- a/site/en/docs/extensions/mv3/intro/mv3-overview/index.md
+++ b/site/en/docs/extensions/mv3/intro/mv3-overview/index.md
@@ -24,42 +24,42 @@ updated: 2021-10-03
 
 ---
 
-Manifest V3 (MV3) is a major step forward in steering towards our
+Manifest V3 (Manifest V3) is a major step forward in steering towards our
 [vision for the extensions platform](/docs/extensions/mv3/intro/platform-vision/).
-MV3 focuses on the three pillars of that vision: privacy, security, and
+Manifest V3 focuses on the three pillars of that vision: privacy, security, and
 performance, while preserving and improving our foundation of capability and
 webbiness.
 
-This article summarizes the features and major changes introduced by MV3. For
-help migrating Manifest V2 extensions to MV3, or to better understand the
-architectural impact of these changes, see also the [MV3 migration
+This article summarizes the features and major changes introduced by Manifest V3. For
+help migrating Manifest V2 extensions to Manifest V3, or to better understand the
+architectural impact of these changes, see also the [Manifest V3 migration
 guide](/docs/extensions/mv3/intro/mv3-migration/).
 
 Manifest V3 is available beginning with Chrome
 [88](https://chromiumdash.appspot.com/schedule), and the Chrome Web Store
-begins accepting MV3 extensions in January 2021.
+begins accepting Manifest V3 extensions in January 2021.
 
-New features and changes will continue to be added to MV3, just as they have
+New features and changes will continue to be added to Manifest V3, just as they have
 been in earlier manifest versions.
 
 
 ## Feature summary {: #feature-summary }
 
-There are a number of new features and functional changes for extensions using
-MV3:
+There are a number of new features and functional changes for extensions using Manifest V3:
 
 * [Service workers](#service-workers) replace background pages.
 * [Network request modification](#network-request-modification) is now handled with the new [declarativeNetRequest](/docs/extensions/reference/declarativeNetRequest) API.
 * [Remotely hosted code](#remotely-hosted-code) is no longer allowed; an extension can only execute JavaScript that is included within its package.
 * [Promise](#promises) support has been added to many methods, though callbacks are still supported as an alternative. (We will eventually support promises on all appropriate methods.)
-* A number of other, relatively [minor feature changes](#other-features) are also introduced in MV3.
+* A number of other, relatively [minor feature changes](#other-features) are also introduced in
+  Manifest V3.
 
 Each of these changes is summarized in the sections below.
 
 
 ## Major features {: #major-features }
 
-This section introduces the most important and impactful features of MV3.
+This section introduces the most important and impactful features of Manifest V3.
 
 
 ### Service workers {: #service-workers }
@@ -77,7 +77,7 @@ to relevant browser events exposed by Chrome's extensions APIs.
 
 ### Network request modification {: #network-request-modification }
 
-The way that extensions can modify network requests is changing in MV3. There's
+The way that extensions can modify network requests is changing in Manifest V3. There's
 a new [declarativeNetRequest](/docs/extensions/reference/declarativeNetRequest)
 API which lets extensions modify and block network requests in a
 privacy-preserving and performant way. The essence of this API is:
@@ -96,7 +96,7 @@ for further details.
 
 The blocking version of the
 [webRequest](/docs/extensions/reference/webRequest)
-API is restricted to force-installed extensions in MV3. This is because of
+API is restricted to force-installed extensions in Manifest V3. This is because of
 issues with the blocking webRequest approach:
 
 *   **Privacy**: This requires excessive access to user data, because extensions need to read each network request made for the user.
@@ -109,7 +109,7 @@ blocking functionality, without requiring any host permissions.
 
 ### Remotely hosted code {: #remotely-hosted-code }
 
-A key security improvement in MV3 is that extensions can't load remote code
+A key security improvement in Manifest V3 is that extensions can't load remote code
 like JavaScript or Wasm files. This lets us more reliably and efficiently
 review the safe behavior of extensions when they're submitted to the Chrome Web
 Store. Specifically, all logic must be included in the extension's package.
@@ -121,7 +121,7 @@ for more about how to work with this change.
 
 ### Promises {: #promises }
 
-MV3 provides first-class support for promises: many popular APIs support
+Manifest V3 provides first-class support for promises: many popular APIs support
 promises now, and we will eventually support promises on all appropriate
 methods.
 
@@ -135,7 +135,7 @@ Some scenarios, such as event listeners, will still require callbacks.
 
 ## Other features {: #other-features }
 
-There are a number of other changes introduced in MV3:
+There are a number of other changes introduced in Manifest V3:
 
 * [Action API consolidation](/docs/extensions/mv3/intro/mv3-migration#action-api-unification):
   The Browser Action and Page Action APIs are unified into a single Action API.
@@ -143,12 +143,12 @@ There are a number of other changes introduced in MV3:
 * [Content security policy (CSP)](/docs/extensions/mv3/intro/mv3-migration#content-security-policy): You now specify separate CSP for different execution contexts in a single object, and certain policies are disallowed.
 * [executeScript() changes](/docs/extensions/mv3/intro/mv3-migration#executing-arbitrary-strings): Extensions can no longer execute arbitrary strings, only script files and functions. This method is also migrating from the Tabs API to the new Scripting API.
 
-The following features will be added to MV3 soon:
+The following features will be added to Manifest V3 soon:
 
 * **Dynamic content scripts:** the new [Scripting API][1] lets extensions register and unregister content scripts at runtime.
 * **New favicon API:** this new JavaScript API replaces "chrome://favicons" and gives  developers a way to retrieve websites' favicons.
 * **In-memory storage:** a new StorageArea on the Storage API that can be used to store values in memory across service worker restarts.
 
-Look for announcements of these and other MV3 features as they become available.
+Look for announcements of these and other Manifest V3 features as they become available.
 
 [1]: /docs/extensions/reference/scripting/

--- a/site/en/docs/extensions/mv3/intro/platform-vision/index.md
+++ b/site/en/docs/extensions/mv3/intro/platform-vision/index.md
@@ -179,13 +179,13 @@ V3](/docs/extensions/mv3/intro/mv3-overview).
 
 ### Manifest V3 related changes
 
-There are a number of features that aren't actually part of MV3, but are
-scheduled for release in the same time frame. These features are related to MV3
-in that they impose new requirements that MV3 is designed to address.
+There are a number of features that aren't actually part of Manifest V3, but are
+scheduled for release in the same time frame. These features are related to Manifest V3
+in that they impose new requirements that Manifest V3 is designed to address.
 
 The key feature launching in this category is the changing way that host
-permissions are granted. Again, this isn't an MV3 feature, but it does motivate
-MV3 changes. Expect these changes in early 2021.
+permissions are granted. Again, this isn't an Manifest V3 feature, but it does motivate
+Manifest V3 changes. Expect these changes in early 2021.
 
 The initial steps in this area have already launched:
 

--- a/site/en/docs/extensions/mv3/manifest/web_accessible_resources/index.md
+++ b/site/en/docs/extensions/mv3/manifest/web_accessible_resources/index.md
@@ -19,7 +19,7 @@ Prior to Manifest V2 all resources within an extension could be accessed from an
 web. This allowed a malicious website to [fingerprint][6] the extensions that a user has installed
 or exploit vulnerabilities (for example [XSS bugs][7]) within installed extensions. 
 
-Beginning with Manifest V2, access to those resources was limited to protect the privacy of users. MV2
+Beginning with Manifest V2, access to those resources was limited to protect the privacy of users. Manifest V2
 extensions exposed only those resources explicitly designated as web accessible.
 
 Manifest V3 provides finer-grained control, letting you expose individual resources to specified

--- a/site/en/docs/extensions/mv3/migrating_to_service_workers/index.md
+++ b/site/en/docs/extensions/mv3/migrating_to_service_workers/index.md
@@ -71,7 +71,7 @@ chrome.storage.local.get(["badgeText"], ({ badgeText }) => {
   chrome.action.setBadgeText({ text: badgeText });
 
   // Listener is registered asynchronously
-  // This is NOT guaranteed to work in MV3/service workers! Don't do this!
+  // This is NOT guaranteed to work in Manifest V3/service workers! Don't do this!
   chrome.action.onClicked.addListener(handleActionClick);
 });
 ```
@@ -129,7 +129,7 @@ chrome.browserAction.onClicked.addListener((tab) => {
 });
 ```
 
-If we port this code directly to MV3, requiring service workers, it's possible that the code will be
+If we port this code directly to Manifest V3, requiring service workers, it's possible that the code will be
 terminated between when the name is set and the user clicks the browser action. If this happens, the
 set name will have been lost&mdash;and `savedName` will again be `undefined`.
 
@@ -159,7 +159,7 @@ cancel the timers when the service worker is terminated.
 ```js
 // background.js
 
-// This worked in MV2.
+// This worked in Manifest V2.
 const TIMEOUT = 3 * 60 * 1000; // 3 minutes in milliseconds
 setTimeout(() => {
   chrome.action.setIcon({
@@ -228,7 +228,7 @@ create and cache assets. While service workers don't have access to DOM and ther
 
 ```js
 // background.js
-// for MV2 background pages
+// for Manifest V2 background pages
 function buildCanvas(width, height) {
   const canvas = document.createElement("canvas");
   canvas.width = width;
@@ -242,7 +242,7 @@ In the above block we're constructing a canvas element. To migrate to offscreen 
 
 ```js
 // background.js
-// for MV3 service workers
+// for Manifest V3 service workers
 function buildCanvas(width, height) {
   const canvas = new OffscreenCanvas(width, height);
   return canvas;

--- a/site/en/docs/extensions/mv3/mv2-sunset/index.md
+++ b/site/en/docs/extensions/mv3/mv2-sunset/index.md
@@ -11,11 +11,11 @@ date: 2021-09-23
 
 ---
 
-As MV3 approaches full feature parity with MV2, we'll be progressively phasing out MV2. This page
+As Manifest V3 approaches full feature parity with Manifest V2, we'll be progressively phasing out Manifest V2. This page
 specifies the timetable for this deprecation and describes the meaning of each milestone.
 
-{% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/zXdU3hdkj1K0Ks6tAfB4.png", alt="Diagram of MV2
-support timeline", width="800", height="270" %}
+{% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/zXdU3hdkj1K0Ks6tAfB4.png",
+  alt="Diagram of Manifest V2 support timeline", width="800", height="270" %}
 
 {% Aside %}
 Check this page for any updates and for more specific dates as these milestones get closer.

--- a/site/en/docs/extensions/mv3/mv3-migration-checklist/index.md
+++ b/site/en/docs/extensions/mv3/mv3-migration-checklist/index.md
@@ -8,8 +8,8 @@ description: A quick reference on migrating your Chrome Extensions from Manifest
 ---
 
 This page provides a quick reference to help you identify any changes you might need to
-make to an Manifest V2 extension so that it works under Manifest V3 (MV3). For more
-description of the nature of these changes see the [MV3 migration guide](/docs/extensions/mv3/intro/mv3-migration).
+make to an Manifest V2 extension so that it works under Manifest V3. For more
+description of the nature of these changes see the [Manifest V3 migration guide](/docs/extensions/mv3/intro/mv3-migration).
 
 
 ## API checklist {: #api_checklist }
@@ -18,13 +18,13 @@ There are some changes you may need to make based on changes to the API surface.
 
 **Do you have host permissions in your manifest?**
 <br/>
-*Host permissions in MV3 [are a separate element](/docs/extensions/mv3/intro/mv3-migration#host-permissions); you don't specify them in `permissions` or `optional_permissions`.*
+*Host permissions in Manifest V3 [are a separate element](/docs/extensions/mv3/intro/mv3-migration#host-permissions); you don't specify them in `permissions` or `optional_permissions`.*
 
 - Move host permissions into the `host_permissions` field in manifest.json.
 
 **Are you using background pages?**
 <br/>
-*Background pages are [replaced by service workers](/docs/extensions/mv3/intro/mv3-migration#background-service-workers) in MV3.*
+*Background pages are [replaced by service workers](/docs/extensions/mv3/intro/mv3-migration#background-service-workers) in Manifest V3.*
 
 - Replace `background.page` or `background.scripts` with `background.service_worker` in
   manifest.json. Note that the `service_worker` field takes a string, not an array of strings.
@@ -37,22 +37,21 @@ Service workers must be registered at root level: they cannot be in a nested dir
 
 **Are you using the `browser_action` or `page_action` property in manifest.json?**
 <br/>
-*These properties are [unified into a single property](/docs/extensions/mv3/intro/mv3-migration#action-api-unification) in MV3.*
+*These properties are [unified into a single property](/docs/extensions/mv3/intro/mv3-migration#action-api-unification) in Manifest V3.*
 
 - Replace these properties with `action`.
 
 **Are you using the `chrome.browserAction` or `chrome.pageAction` JavaScript API?**
 <br/>
-*These two equivalent APIs are [unified into a single API](/docs/extensions/mv3/intro/mv3-migration#action-api-unification) in MV3.*
+*These two equivalent APIs are [unified into a single API](/docs/extensions/mv3/intro/mv3-migration#action-api-unification) in Manifest V3.*
 - Migrate to the `chrome.action` API.
 
 **Are you currently using the blocking version of `chrome.webRequest`?**
 <br/>
-*This API is [replaced by `declarativeNetRequest`](/docs/extensions/mv3/intro/mv3-migration#modifying-network-requests) in MV3.*
+*This API is [replaced by `declarativeNetRequest`](/docs/extensions/mv3/intro/mv3-migration#modifying-network-requests) in Manifest V3.*
 
 {% Aside %}
-This only applies to user-installed extensions; force installed extensions (extensions
-distributed using
+This only applies to user-installed extensions; force installed extensions (extensions distributed using
 [ExtensionInstallForcelist](https://www.chromium.org/administrators/policy-list-3#ExtensionInstallForcelist)).
 These extensions &mdash; typically used in an enterprise setting &mdash; can
 still use the blocking version of `chrome.webRequest`. 
@@ -68,7 +67,7 @@ still use the blocking version of `chrome.webRequest`.
 <br/>
 *In Manifest V3, several methods move from `chrome.tabs` to the `chrome.scripting` API.*
 
-- Change any of the following MV2 calls to use the correct MV3 API:
+- Change any of the following Manifest V2 calls to use the correct Manifest V3 API:
 
 <table class="with-heading-tint">
   <thead>
@@ -100,10 +99,9 @@ logic](/docs/extensions/mv3/intro/mv3-migration#remotely-hosted-code) using `chr
 - Update script and style references to load resources from the extension bundle.
 - Use `chrome.runtime.getURL()` to build resource URLs at runtime.
 
-**Are you executing functions that expect an MV2 background context?**
+**Are you executing functions that expect an Manifest V2 background context?**
 <br/>
-*The [adoption of service workers](/docs/extensions/mv3/intro/mv3-migration#background-service-workers) in MV3 isn't compatible with 
-methods like `chrome.runtime.getBackgroundPage()`,
+*The [adoption of service workers](/docs/extensions/mv3/intro/mv3-migration#background-service-workers) in Manifest V3 isn't compatible with methods like `chrome.runtime.getBackgroundPage()`,
 `chrome.extension.getBackgroundPage()`, `chrome.extension.getExtensionTabs()`,
 and `chrome.extension.getViews()`.*
 
@@ -111,7 +109,8 @@ and `chrome.extension.getViews()`.*
 
 ## Security Checklist {: #security_checklist }
 
-There are some changes you may need to make based on changes in security policy. This section lists these changes.
+There are some changes you may need to make based on changes in security policy. This section lists
+these changes.
 
 **Are you making CORS requests in content scripts?**
 - Move these requests to the background service worker.

--- a/site/en/docs/extensions/mv3/user_interface/index.md
+++ b/site/en/docs/extensions/mv3/user_interface/index.md
@@ -6,7 +6,7 @@ updated: 2021-08-18
 description: UI and design guidelines for Chrome Extensions.
 ---
 
-<!-- Note to editors: this is largely identical to the MV2 version, but removes 
+<!-- Note to editors: this is largely identical to the Manifest V2 version, but removes
     browser_action and page_action in favor of action -->
 
 The extension user interface should be purposeful and minimal. Just like extensions themselves, the

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -248,5 +248,5 @@ GitHub](https://github.com/GoogleChromeLabs/extension-manifest-converter).
 Manifest V3 is a major update to the extensions platform; see [Overview of Manifest
 V3](/docs/extensions/mv3/intro/mv3-overview/) for a summary of new and changed features. Extensions
 may continue to use Manifest V2 for now, but this will be phased out in the near future. We strongly
-recommend that you use MV3 for any new extensions, and begin to migrate existing extensions to MV3
+recommend that you use Manifest V3 for any new extensions, and begin to migrate existing extensions to Manifest V3
 as soon as possible.

--- a/site/en/docs/webstore/cws-dashboard-privacy/index.md
+++ b/site/en/docs/webstore/cws-dashboard-privacy/index.md
@@ -49,7 +49,7 @@ code and do not declare and justify it using the field shown above will be rejec
 
 {% Aside 'warning' %}
 
-In **MV3** you can no longer load and execute a [remotely hosted file][remote-code].
+In **Manifest V3** you can no longer load and execute a [remotely hosted file][remote-code].
 
 {% endAside %}
 


### PR DESCRIPTION
A while back Devlin and I settled on eschewing the use of "MV3" and "MV2" in our documentation. Similarly, we do not use CWS when discussing the Chrome Web Store. While new documentation was authored with this guidance in mind, existing uses of these abbreviations were not changed. 

This PR addresses that inconsistency by replacing MV2 and MV3 with their longer form counterparts. In order to make review easier, this PR also avoids rewrapping lines or making whitespace changes on unrelated lines. 