### PR TITLE
Docs: Migrating to Service Workers - Typo

### DIFF
--- a/site/en/docs/extensions/mv3/migrating_to_service_workers/index.md
+++ b/site/en/docs/extensions/mv3/migrating_to_service_workers/index.md
@@ -115,7 +115,7 @@ The following Manifest V2 example recieves a name from a content script and pers
 // background.js
 
 // Don't do this! The service worker will be created and destroyed over the lifetime of your
-// exension, and this variable will be reset.
+// extension, and this variable will be reset.
 let savedName = undefined;
 
 chrome.runtime.onMessage.addListener(({ type, name }) => {


### PR DESCRIPTION
Description:

Missing `t` in the word `extension`.

Changes proposed in this pull request:

- Fix spelling of typo.