### PR TITLE
Add Manifest V2 support timeline link to manifest_version

### DIFF
--- a/site/en/docs/extensions/mv3/manifest/manifest_version/index.md
+++ b/site/en/docs/extensions/mv3/manifest/manifest_version/index.md
@@ -18,8 +18,9 @@ Supported values for this key are:
 * `2`: Use the [Manifest V2][mv2] format and associated feature set.
 
 The current version is Manifest V3. Manifest V2 is also currently permitted, but will be phased out
-in the future. There will be other manifest versions in the future (V4 and beyond) but these aren't
+in the future (see [Manifest V2 support timeline][mv2-timeline] for more details). There will be other manifest versions in the future (V4 and beyond) but these aren't
 scheduled yet.
 
 [mv3]: /docs/extensions/mv3/intro/mv3-overview/
 [mv2]: /docs/extensions/mv2/manifest/
+[mv2-timeline]: /docs/extensions/mv3/mv2-sunset/

--- a/site/en/docs/extensions/mv3/manifest/manifest_version/index.md
+++ b/site/en/docs/extensions/mv3/manifest/manifest_version/index.md
@@ -18,8 +18,8 @@ Supported values for this key are:
 * `2`: Use the [Manifest V2][mv2] format and associated feature set.
 
 The current version is Manifest V3. Manifest V2 is also currently permitted, but will be phased out
-in the future (see [Manifest V2 support timeline][mv2-timeline] for more details). There will be other manifest versions in the future (V4 and beyond) but these aren't
-scheduled yet.
+in the future (see [Manifest V2 support timeline][mv2-timeline] for more details). There will be
+other manifest versions in the future (V4 and beyond) but these aren't scheduled yet.
 
 [mv3]: /docs/extensions/mv3/intro/mv3-overview/
 [mv2]: /docs/extensions/mv2/manifest/


### PR DESCRIPTION
Adds Manifest V2 support timeline link to [Manifest version](https://developer.chrome.com/docs/extensions/mv3/manifest/manifest_version/)