### PR TITLE
Update site affiliation post

### DIFF
--- a/site/_includes/partials/footer.njk
+++ b/site/_includes/partials/footer.njk
@@ -43,7 +43,7 @@
             </a>
           </li>
           <li>
-            <a class="footer__link" href="https://developers.google.com/web/">
+            <a class="footer__link" href="https://developers.google.com/web/fundamentals">
               {{ 'i18n.footer.web_fundamentals' | i18n(locale) }}
             </a>
           </li>

--- a/site/en/blog/site-affiliation/index.md
+++ b/site/en/blog/site-affiliation/index.md
@@ -46,7 +46,7 @@ associated with Digital Asset Links.
 
 {% Aside %}
 There's a similar potential web platform feature called [First-Party
-Sets](https://github.com/privacycg/first-party-sets). However, while it allows
+Sets](/blog/first-party-sets-sameparty). However, while it allows
 for  embeds from cross-site to be treated as the same party when the top-level
 domain is owned by the same organization, there's no plan to have any effect on
 handling passwords. The Digital Asset Links is Google's technology that can be
@@ -178,12 +178,8 @@ at `/.well-known/assetlinks.json` on the respective domains.
     Allow: /.well-known/
     ```
 
-1.  Submit [a
-    form](https://docs.google.com/forms/d/1e4vVbcI7rqQls5HQ4F4bH_4bHcqfC8r0oEY5CxjSrag/viewform)
-    to request starting crawling `assetlinks.json` files on your affiliations.
-
 {% Aside %}
-It may take a while for Googlebot to fetch the resource and recognize the
+It may take a while for [Googlebot](https://developers.google.com/search/docs/advanced/crawling/googlebot) to fetch the resource and recognize the
 association.
 {% endAside %}
 

--- a/site/en/blog/site-affiliation/index.md
+++ b/site/en/blog/site-affiliation/index.md
@@ -21,6 +21,12 @@ tags:
   - security
 ---
 
+{% Aside %}
+Starting in Chrome 97, you no longer need to submit a request
+through a form for Googlebot to starting crawling `assetlinks.json`
+files on your affiliations.
+{% endAside %}
+
 Chrome's password manager already autofills credentials for sites with saved
 credentials, as well as in the following two cases:
 
@@ -60,7 +66,7 @@ at `/.well-known/assetlinks.json` on the respective domains.
 
 ## Prerequisites
 
-1.  Use Chrome 91 or later.
+1.  Use Chrome 97 or later.
 1.  Enable the flag at `chrome://flags#filling-across-affiliated-websites`.
 1.  Make sure "Offer to save passwords" is turned on in
     `chrome://settings/passwords`.


### PR DESCRIPTION
The full feature without the workaround is currently available only in 1% of stable, PR on hold until we hit Chrome 100.

Changes proposed in this pull request:

- Remove the workaround
- Add a link to the First Party Sets explainer
- Add link to Googlebot explainer