### PR TITLE
Describe conventions used in CRX docs

### DIFF
--- a/site/_data/docs/handbook/toc.yml
+++ b/site/_data/docs/handbook/toc.yml
@@ -13,3 +13,4 @@
     - url: /docs/handbook/how-to/add-a-youtube-embed
     - url: /docs/handbook/how-to/display-a-banner
     - url: /docs/handbook/style-guide
+- url: /docs/handbook/extensions

--- a/site/en/docs/handbook/extensions/index.md
+++ b/site/en/docs/handbook/extensions/index.md
@@ -5,15 +5,21 @@ date: 2021-02-02
 updated: 2021-02-02
 ---
 
+## Metadata {: #metadata }
+
+Extensions documents should follow the conventions outlined in the [Add a Doc][add-a-doc] and [Add a
+Blog Post][add-a-blog] guides. One notable exception to that guidance is that we do not use the
+`tags` and `author` YAML Front Matter properties in extensions docs.
+
 ## Line wrapping {: #line-wrapping }
 
 Extensions docs are wrapped at 100 characters. New content and updates to existing content must
 follow this convention save for the following exceptions:
 
-* The existing page is already wrapped at another offset.
-    * You may continue wrapping the document at the current offset.
-* Rewrapping would introduce significant noise to a code review.
-    * Limiting line wrapping normalization to the text blocks your PR touches.
+- The existing page is already wrapped at another offset.
+    - You may continue wrapping the document at the current offset.
+- Rewrapping would introduce significant noise to a code review.
+    - Limiting line wrapping normalization to the text blocks your PR touches.
 
 ## Header IDs {: #header-ids }
 
@@ -169,3 +175,6 @@ git cl format --js <filename>
 [depot-tools]: https://commondatastorage.googleapis.com/chrome-infra-docs/flat/depot_tools/docs/html/depot_tools_tutorial.html
 [kebab-case]: https://en.wikipedia.org/wiki/Letter_case#Kebab_case
 [line-wrapping]: #line-wrapping
+
+[add-a-doc]: /docs/handbook/how-to/add-a-doc/
+[add-a-blog]: /docs/handbook/how-to/add-a-blog-post/

--- a/site/en/docs/handbook/extensions/index.md
+++ b/site/en/docs/handbook/extensions/index.md
@@ -1,0 +1,101 @@
+---
+title: Extensions docs
+layout: 'layouts/doc-post.njk'
+date: 2021-02-02
+updated: 2021-02-02
+---
+
+## Line wrapping {: #line-wrapping }
+
+Extensions docs are wrapped at 100 characters. New content and updates to existing content must
+follow this convention save for the following exceptions:
+
+* The existing page is already wrapped at another offset.
+    * Continue wrapping the document at the current offset.
+* Rewrapping would introduce significant noise to a code review.
+    * Try to limit line wrapping normalization to the text blocks your touch in a PR.
+
+## Header IDs {: #header-ids }
+
+Header IDs are automatically generated based on the content of the header. This means that renaming
+a header will also change the header's ID and break existing links to that header.
+
+In order to make our documentation more resilient to change, authors should manually headers IDs.
+
+```md
+// Do
+### Common use cases {: #use-cases }
+
+// Don't do
+### Common use cases
+```
+
+Header IDs should be short and meaningful. Try to use descriptive names that unambiguously identify
+the content of the section rather than a [kebab cased][kebab-case] version of the header's text
+value.
+
+## Link conventions {: #links }
+
+### Footer links
+
+By convention, extensions docs strongly prefer named footer links over inline links. Named links
+have a couple of advantages over inline links.
+
+- **Named links are typically shorter.** This makes it much easier to read and
+work with source Markdown file. 
+- **Named links are easier to maintain.** Authors can edit one link definition and update all uses
+of that link links across a given document. 
+
+```md
+// Do
+Lorem ipsum dolor [sit amet][mdn-global], consectetur adipiscing elit.
+Quisque aliquam rutrum pellentesque. Ut tincidunt purus ex, eget 
+congue lacus aliquet quis.
+
+[mdn-global]: https://developer.mozilla.org/en-US/docs/Glossary/Global_object
+
+// Don't do
+Lorem ipsum dolor [sit
+amet](https://developer.mozilla.org/en-US/docs/Glossary/Global_object),
+consectetur adipiscing elit. Quisque aliquam rutrum pellentesque. Ut
+tincidunt purus ex, eget congue lacus aliquet quis.
+```
+
+### Internal links {: #internal-links }
+
+When linking to other resources on `developer.chrome.com`, use the absolute path of the page rather
+than a relative path or full URL.
+
+```md
+// Do
+[doc-page]: /docs/extensions/page/
+
+// Don't do
+[doc-page]: https://develper.chrome.com/docs/extensions/page/
+[doc-page]: page/
+```
+
+Internal links should include a terminal slash. 
+
+```md
+// Do
+[doc-page]: /docs/extensions/dir/page/
+[doc-page]: /docs/extensions/sub/dir/page/#header
+
+// Don't do
+[doc-page]: /docs/extensions/dir/page
+[doc-page]: /docs/extensions/sub/dir/page#header
+```
+
+## Code formatting {: #code-formatting }
+
+Code samples in extensions documentation should be formatted using the Chromium project's `git cl
+format` command. See [Using clang-format][clang-format] for additional details.
+
+```bash
+# Use this command to format JS files and code samples
+git cl format --js <filename>
+```
+
+[clang-format]: https://chromium.googlesource.com/chromium/src/+/main/docs/clang_format.md
+[kebab-case]: https://en.wikipedia.org/wiki/Letter_case#Kebab_case

--- a/site/en/docs/handbook/extensions/index.md
+++ b/site/en/docs/handbook/extensions/index.md
@@ -9,7 +9,7 @@ updated: 2021-02-02
 
 Extensions documents should follow the conventions outlined in the [Add a Doc][add-a-doc] and [Add a
 Blog Post][add-a-blog] guides. One notable exception to that guidance is that we do not use the
-`tags` and `author` YAML Front Matter properties in extensions docs.
+`tags` and `author` YAML front matter properties in extensions docs.
 
 ## Line wrapping {: #line-wrapping }
 
@@ -26,7 +26,7 @@ follow this convention save for the following exceptions:
 Header IDs are automatically generated based on the content of the header. This means that renaming
 a header will also change the header's ID and break existing links to that header.
 
-To make your documentation more resilient to change, authors should manually declare headers IDs.
+To make your documentation more resilient to change, authors should manually declare header IDs.
 
 {% Compare 'better' %}
 

--- a/site/en/docs/handbook/extensions/index.md
+++ b/site/en/docs/handbook/extensions/index.md
@@ -11,16 +11,16 @@ Extensions docs are wrapped at 100 characters. New content and updates to existi
 follow this convention save for the following exceptions:
 
 * The existing page is already wrapped at another offset.
-    * Continue wrapping the document at the current offset.
+    * You may continue wrapping the document at the current offset.
 * Rewrapping would introduce significant noise to a code review.
-    * Try to limit line wrapping normalization to the text blocks your touch in a PR.
+    * Limiting line wrapping normalization to the text blocks your PR touches.
 
 ## Header IDs {: #header-ids }
 
 Header IDs are automatically generated based on the content of the header. This means that renaming
 a header will also change the header's ID and break existing links to that header.
 
-In order to make our documentation more resilient to change, authors should manually headers IDs.
+To make your documentation more resilient to change, authors should manually headers IDs.
 
 ```md
 // Do
@@ -30,7 +30,7 @@ In order to make our documentation more resilient to change, authors should manu
 ### Common use cases
 ```
 
-Header IDs should be short and meaningful. Try to use descriptive names that unambiguously identify
+Header IDs should be short and meaningful. Use descriptive names that unambiguously identify
 the content of the section rather than a [kebab cased][kebab-case] version of the header's text
 value.
 
@@ -42,7 +42,7 @@ By convention, extensions docs strongly prefer named footer links over inline li
 have a couple of advantages over inline links.
 
 - **Named links are typically shorter.** This makes it much easier to read and
-work with source Markdown file. 
+work with the source markdown file. 
 - **Named links are easier to maintain.** Authors can edit one link definition and update all uses
 of that link links across a given document. 
 
@@ -90,7 +90,7 @@ Internal links should include a terminal slash.
 ## Code formatting {: #code-formatting }
 
 Code samples in extensions documentation should be formatted using the Chromium project's `git cl
-format` command. To use this command, you must have [depot_tools][depot-tools] installed. See [Using clang-format][clang-format] for additional details.
+format` command. To use this command, you must first install [depot_tools][depot-tools]. See [Using clang-format][clang-format] for additional details.
 
 ```bash
 # Use this command to format JS files and code samples

--- a/site/en/docs/handbook/extensions/index.md
+++ b/site/en/docs/handbook/extensions/index.md
@@ -20,23 +20,32 @@ follow this convention save for the following exceptions:
 Header IDs are automatically generated based on the content of the header. This means that renaming
 a header will also change the header's ID and break existing links to that header.
 
-To make your documentation more resilient to change, authors should manually headers IDs.
+To make your documentation more resilient to change, authors should manually declare headers IDs.
 
 {% Compare 'better' %}
+
 ```md
 ### Common use cases {: #use-cases }
 ```
+
 {% endCompare %}
 
 {% Compare 'worse' %}
+
 ```md
 ### Common use cases
 ```
+
+{% CompareCaption %}
+
+Automatically generated IDs are brittle. If this header were renamed in a future revision, it would
+be given a new ID and all existing links to this section would break. 
+
+{% endCompareCaption %}
 {% endCompare %}
 
-Header IDs should be short and meaningful. Use descriptive names that unambiguously identify
-the content of the section rather than a [kebab cased][kebab-case] version of the header's text
-value.
+Header IDs should be short and meaningful. Use descriptive names that unambiguously identify the
+content of the section rather than a [kebab cased][kebab-case] version of the header's text value.
 
 ## Link conventions {: #links }
 
@@ -45,12 +54,13 @@ value.
 By convention, extensions docs strongly prefer named footer links over inline links. Named links
 have a couple of advantages over inline links.
 
-- **Named links are typically shorter.** This makes it much easier to read and
-work with the source markdown file. 
+- **Named links are typically shorter.** This makes it much easier to read and work with the source
+  markdown file. 
 - **Named links are easier to maintain.** Authors can edit one link definition and update all uses
-of that link links across a given document. 
+  of that link links across a given document. 
 
 {% Compare 'better' %}
+
 ```md
 Lorem ipsum dolor [sit amet][mdn-global], consectetur adipiscing elit.
 Quisque aliquam rutrum pellentesque. Ut tincidunt purus ex, eget 
@@ -58,15 +68,25 @@ congue lacus aliquet quis.
 
 [mdn-global]: https://developer.mozilla.org/en-US/docs/Glossary/Global_object
 ```
+
 {% endCompare %}
 
 {% Compare 'worse' %}
+
 ```md
 Lorem ipsum dolor [sit
 amet](https://developer.mozilla.org/en-US/docs/Glossary/Global_object),
 consectetur adipiscing elit. Quisque aliquam rutrum pellentesque. Ut
 tincidunt purus ex, eget congue lacus aliquet quis.
 ```
+
+{% CompareCaption %}
+
+Inline links make the source markdown appear longer than the rendered output, increases the
+likelihood that a link will wrap across lines, and may make a single line extend past the [wrap
+column][line-wrapping].
+
+{% endCompareCaption %}
 {% endCompare %}
 
 ### Internal links {: #internal-links }
@@ -75,16 +95,39 @@ When linking to other resources on `developer.chrome.com`, use the relative path
 root rather than a relative path from the page or a full URL.
 
 {% Compare 'better' %}
+
 ```md
 [doc-page]: /docs/extensions/page/
 ```
+
 {% endCompare %}
 
 {% Compare 'worse' %}
+
 ```md
 [doc-page]: https://develper.chrome.com/docs/extensions/page/
+```
+
+{% CompareCaption %}
+
+Absolute URLs force links to reference the live site rather than the development or preview servers
+we test against when authoring or reviewing changes.
+
+{% endCompareCaption %}
+{% endCompare %}
+
+{% Compare 'worse' %}
+
+```md
 [doc-page]: page/
 ```
+
+{% CompareCaption %}
+
+Page-relative paths are harder to find and update than their root-relative counterparts. This makes
+them making them more likely to break when reorganizing site content.
+
+{% endCompareCaption %}
 {% endCompare %}
 
 Internal links should include a terminal slash. 
@@ -101,12 +144,21 @@ Internal links should include a terminal slash.
 [doc-page]: /docs/extensions/dir/page
 [doc-page]: /docs/extensions/sub/dir/page#header
 ```
+
+{% CompareCaption %}
+
+These links only work as expected if the Node.js redirect server is running, which may not be true
+in all cases. Including the terminal slash makes links more robust.
+
+{% endCompareCaption %}
 {% endCompare %}
+
 
 ## Code formatting {: #code-formatting }
 
 Code samples in extensions documentation should be formatted using the Chromium project's `git cl
-format` command. To use this command, you must first install [depot_tools][depot-tools]. See [Using clang-format][clang-format] for additional details.
+format` command. To use this command, you must first install [depot_tools][depot-tools]. See [Using
+clang-format][clang-format] for additional details.
 
 ```bash
 # Use this command to format JS files and code samples
@@ -116,3 +168,4 @@ git cl format --js <filename>
 [clang-format]: https://chromium.googlesource.com/chromium/src/+/main/docs/clang_format.md
 [depot-tools]: https://commondatastorage.googleapis.com/chrome-infra-docs/flat/depot_tools/docs/html/depot_tools_tutorial.html
 [kebab-case]: https://en.wikipedia.org/wiki/Letter_case#Kebab_case
+[line-wrapping]: #line-wrapping

--- a/site/en/docs/handbook/extensions/index.md
+++ b/site/en/docs/handbook/extensions/index.md
@@ -71,8 +71,8 @@ tincidunt purus ex, eget congue lacus aliquet quis.
 
 ### Internal links {: #internal-links }
 
-When linking to other resources on `developer.chrome.com`, use the absolute path of the page rather
-than a relative path or full URL.
+When linking to other resources on `developer.chrome.com`, use the relative path from the site's
+root rather than a relative path from the page or a full URL.
 
 {% Compare 'better' %}
 ```md

--- a/site/en/docs/handbook/extensions/index.md
+++ b/site/en/docs/handbook/extensions/index.md
@@ -22,13 +22,17 @@ a header will also change the header's ID and break existing links to that heade
 
 To make your documentation more resilient to change, authors should manually headers IDs.
 
+{% Compare 'better' %}
 ```md
-// Do
 ### Common use cases {: #use-cases }
+```
+{% endCompare %}
 
-// Don't do
+{% Compare 'worse' %}
+```md
 ### Common use cases
 ```
+{% endCompare %}
 
 Header IDs should be short and meaningful. Use descriptive names that unambiguously identify
 the content of the section rather than a [kebab cased][kebab-case] version of the header's text
@@ -46,46 +50,58 @@ work with the source markdown file.
 - **Named links are easier to maintain.** Authors can edit one link definition and update all uses
 of that link links across a given document. 
 
+{% Compare 'better' %}
 ```md
-// Do
 Lorem ipsum dolor [sit amet][mdn-global], consectetur adipiscing elit.
 Quisque aliquam rutrum pellentesque. Ut tincidunt purus ex, eget 
 congue lacus aliquet quis.
 
 [mdn-global]: https://developer.mozilla.org/en-US/docs/Glossary/Global_object
+```
+{% endCompare %}
 
-// Don't do
+{% Compare 'worse' %}
+```md
 Lorem ipsum dolor [sit
 amet](https://developer.mozilla.org/en-US/docs/Glossary/Global_object),
 consectetur adipiscing elit. Quisque aliquam rutrum pellentesque. Ut
 tincidunt purus ex, eget congue lacus aliquet quis.
 ```
+{% endCompare %}
 
 ### Internal links {: #internal-links }
 
 When linking to other resources on `developer.chrome.com`, use the absolute path of the page rather
 than a relative path or full URL.
 
+{% Compare 'better' %}
 ```md
-// Do
 [doc-page]: /docs/extensions/page/
+```
+{% endCompare %}
 
-// Don't do
+{% Compare 'worse' %}
+```md
 [doc-page]: https://develper.chrome.com/docs/extensions/page/
 [doc-page]: page/
 ```
+{% endCompare %}
 
 Internal links should include a terminal slash. 
 
+{% Compare 'better' %}
 ```md
-// Do
 [doc-page]: /docs/extensions/dir/page/
 [doc-page]: /docs/extensions/sub/dir/page/#header
+```
+{% endCompare %}
 
-// Don't do
+{% Compare 'worse' %}
+```md
 [doc-page]: /docs/extensions/dir/page
 [doc-page]: /docs/extensions/sub/dir/page#header
 ```
+{% endCompare %}
 
 ## Code formatting {: #code-formatting }
 

--- a/site/en/docs/handbook/extensions/index.md
+++ b/site/en/docs/handbook/extensions/index.md
@@ -90,7 +90,7 @@ Internal links should include a terminal slash.
 ## Code formatting {: #code-formatting }
 
 Code samples in extensions documentation should be formatted using the Chromium project's `git cl
-format` command. See [Using clang-format][clang-format] for additional details.
+format` command. To use this command, you must have [depot_tools][depot-tools] installed. See [Using clang-format][clang-format] for additional details.
 
 ```bash
 # Use this command to format JS files and code samples
@@ -98,4 +98,5 @@ git cl format --js <filename>
 ```
 
 [clang-format]: https://chromium.googlesource.com/chromium/src/+/main/docs/clang_format.md
+[depot-tools]: https://commondatastorage.googleapis.com/chrome-infra-docs/flat/depot_tools/docs/html/depot_tools_tutorial.html
 [kebab-case]: https://en.wikipedia.org/wiki/Letter_case#Kebab_case


### PR DESCRIPTION
Adds a new page to the Handbook that describes the conventions used in the Chrome Extensions and Chrome Web Store documentation sets.

[Preview page](https://deploy-preview-2071--developer-chrome-com.netlify.app/docs/handbook/extensions/)