### PR TITLE
Reflect feedback on document.domain article

### DIFF
--- a/site/en/blog/immutable-document-domain/index.md
+++ b/site/en/blog/immutable-document-domain/index.md
@@ -116,15 +116,16 @@ Chrome plans to make `document.domain` immutable in the future.
 
 ### How do I know my site is affected?
 
-If your website is affected by this change, Chrome will complain that `Setting
+If your website is affected by this change, Chrome will warn that `Setting
 document.domain will be deprecated.` in the DevTools console.
 
-It will also send a deprecation report. You can receive it if you have a server
-side set up. Learn more about [the Reporting
-API](https://web.dev/reporting-api/).
+Affected websites will also get sent with deprecation reports, if they have a
+reporting endpoint set up. Learn more about [using the Reporting
+API](https://web.dev/reporting-api/) with either existing report collection
+services or by building your own in-house solution.
 
-Also, you can run by [the Lighthouse to see if your website is using a
-deprecated API](https://web.dev/deprecations/). 
+Also, you can run your site through [LightHouse's deprecated API
+audit](https://web.dev/deprecations/). 
 
 ## Alternative cross-origin communication
 
@@ -206,7 +207,7 @@ even after it becomes immutable by default.
 * [The Origin
   specification](https://html.spec.whatwg.org/multipage/origin.html#:~:text=Because%20of%20these%20security%20pitfalls%2C%20this%20feature%20is%20in%20the%20process%20of%20being%20removed%20from%20the%20web%20platform),
   states that the feature should be removed.
-* [Mozilla considers it's worth
+* [Mozilla considers disabling `document.domain` by default worth
   prototyping.](https://github.com/mozilla/standards-positions/issues/601)
 * [WebKit indicated that they are moderately positive about deprecating
   `document.domain`

--- a/site/en/blog/immutable-document-domain/index.md
+++ b/site/en/blog/immutable-document-domain/index.md
@@ -5,7 +5,7 @@ description: >
   If your website relies on setting `document.domain`, your action is required.
 subhead: >
   If your website relies on setting `document.domain`, your action is required.
-date: 2022-01-11
+date: 2022-02-07
 authors:
   - agektmr
 tags:
@@ -112,7 +112,19 @@ To learn more about the security implications of setting `document.domain`, read
 ["Document.domain" page on
 MDN](https://developer.mozilla.org/docs/Web/API/Document/domain#setter).
 
-Chrome plans to make `document.domain` immutable from Chrome 101.
+Chrome plans to make `document.domain` immutable in the future.
+
+### How do I know my site is affected?
+
+If your website is affected by this change, Chrome will complain that `Setting
+document.domain will be deprecated.` in the DevTools console.
+
+It will also send a deprecation report. You can receive it if you have a server
+side set up. Learn more about [the Reporting
+API](https://web.dev/reporting-api/).
+
+Also, you can run by [the Lighthouse to see if your website is using a
+deprecated API](https://web.dev/deprecations/). 
 
 ## Alternative cross-origin communication
 
@@ -172,7 +184,7 @@ with `postMessage()` or Channel Messaging API, let us know on [Twitter via
 `document.domain`
 tag](https://stackoverflow.com/questions/tagged/document.domain).
 
-### Send `Origin-Agent-Cluster: ?0` header to continue using `document.domain`
+### In the last resort, send the `Origin-Agent-Cluster: ?0` header
 
 If you have strong reasons to continue setting `document.domain`, you can send
 `Origin-Agent-Cluster: ?0` response header along with the target document.
@@ -194,6 +206,8 @@ even after it becomes immutable by default.
 * [The Origin
   specification](https://html.spec.whatwg.org/multipage/origin.html#:~:text=Because%20of%20these%20security%20pitfalls%2C%20this%20feature%20is%20in%20the%20process%20of%20being%20removed%20from%20the%20web%20platform),
   states that the feature should be removed.
+* [Mozilla considers it's worth
+  prototyping.](https://github.com/mozilla/standards-positions/issues/601)
 * [WebKit indicated that they are moderately positive about deprecating
   `document.domain`
   setter](https://github.com/w3ctag/design-reviews/issues/564#issuecomment-768450217).

--- a/site/en/blog/immutable-document-domain/index.md
+++ b/site/en/blog/immutable-document-domain/index.md
@@ -28,9 +28,9 @@ communication](#alternative-cross-origin-communication)
 [`document.domain`](https://developer.mozilla.org/docs/Web/API/Document/domain)
 was designed to get or set the origin's hostname.
 
-On Chrome, websites will be unable to set `document.domain`. They will need to
-use alternative approaches such as `postMessage()` or Channel Messaging API to
-communicate cross-origin. We're targeting Chrome 101 to ship this change at the
+On Chrome, websites will be unable to set `document.domain`. You will need to
+use alternative approaches, such as `postMessage()` or the Channel Messaging API,
+to communicate cross-origin. We're targeting Chrome 101 to ship this change at the
 earliest, but this is dependent on the response to the [Intent to
 Ship](https://groups.google.com/a/chromium.org/g/blink-dev/c/_oRc19PjpFo/).
 
@@ -115,18 +115,19 @@ MDN](https://developer.mozilla.org/docs/Web/API/Document/domain#setter).
 
 Chrome plans to make `document.domain` immutable in the future.
 
-### How do I know my site is affected?
+### How do I know if my site is affected?
 
-If your website is affected by this change, Chrome will warn that `Setting
-document.domain will be deprecated.` in the DevTools console.
+If your website is affected by this change, Chrome will display a warning in
+the DevTools console: `Setting document.domain will be deprecated`.
 
-Affected websites will also get sent with deprecation reports, if they have a
-reporting endpoint set up. Learn more about [using the Reporting
+If you have a reporting endpoint set up, you will also be sent deprecation
+reports. Learn more about [how to use the Reporting
 API](https://web.dev/reporting-api/) with either existing report collection
 services or by building your own in-house solution.
 
-Also, you can run your site through [LightHouse's deprecated API
-audit](https://web.dev/deprecations/). 
+You can run your site through the [LightHouse deprecated API
+audit](https://web.dev/deprecations/) to find all APIs that are scheduled to
+be removed from Chrome.
 
 ## Alternative cross-origin communication
 
@@ -186,7 +187,7 @@ with `postMessage()` or Channel Messaging API, let us know on [Twitter via
 `document.domain`
 tag](https://stackoverflow.com/questions/tagged/document.domain).
 
-### In the last resort, send the `Origin-Agent-Cluster: ?0` header
+### As a last resort, send the `Origin-Agent-Cluster: ?0` header
 
 If you have strong reasons to continue setting `document.domain`, you can send
 `Origin-Agent-Cluster: ?0` response header along with the target document.
@@ -209,7 +210,7 @@ even after it becomes immutable by default.
   specification](https://html.spec.whatwg.org/multipage/origin.html#:~:text=Because%20of%20these%20security%20pitfalls%2C%20this%20feature%20is%20in%20the%20process%20of%20being%20removed%20from%20the%20web%20platform),
   states that the feature should be removed.
 * [Mozilla considers disabling `document.domain` by default worth
-  prototyping.](https://github.com/mozilla/standards-positions/issues/601)
+  prototyping](https://github.com/mozilla/standards-positions/issues/601).
 * [WebKit indicated that they are moderately positive about deprecating
   `document.domain`
   setter](https://github.com/w3ctag/design-reviews/issues/564#issuecomment-768450217).

--- a/site/en/blog/immutable-document-domain/index.md
+++ b/site/en/blog/immutable-document-domain/index.md
@@ -5,7 +5,8 @@ description: >
   If your website relies on setting `document.domain`, your action is required.
 subhead: >
   If your website relies on setting `document.domain`, your action is required.
-date: 2022-02-07
+date: 2022-01-11
+updated: 2022-02-04
 authors:
   - agektmr
 tags:

--- a/site/en/blog/immutable-document-domain/index.md
+++ b/site/en/blog/immutable-document-domain/index.md
@@ -16,6 +16,12 @@ alt: >
   A dog in disguise.
 ---
 
+**Updates**
+
+- **February 4, 2022**: Updated with the new timeline - we'll show a warning in
+  the Issues panel starting from Chrome 100, removing `document.domain` setter
+  by default starting from Chrome 106.
+
 {% Aside 'warning' %}
 
 If your website relies on relaxing the same-origin policy via `document.domain`,
@@ -29,9 +35,9 @@ communication](#alternative-cross-origin-communication)
 was designed to get or set the origin's hostname.
 
 On Chrome, websites will be unable to set `document.domain`. You will need to
-use alternative approaches, such as `postMessage()` or the Channel Messaging API,
-to communicate cross-origin. We're targeting Chrome 101 to ship this change at the
-earliest, but this is dependent on the response to the [Intent to
+use alternative approaches, such as `postMessage()` or the Channel Messaging
+API, to communicate cross-origin. We're targeting Chrome 106 to ship this change
+at the earliest, but this is dependent on the response to the [Intent to
 Ship](https://groups.google.com/a/chromium.org/g/blink-dev/c/_oRc19PjpFo/).
 
 If your website relies on same-origin policy relaxation via `document.domain`
@@ -113,12 +119,19 @@ To learn more about the security implications of setting `document.domain`, read
 ["Document.domain" page on
 MDN](https://developer.mozilla.org/docs/Web/API/Document/domain#setter).
 
-Chrome plans to make `document.domain` immutable in the future.
+Chrome plans to make `document.domain` immutable in Chrome 106.
 
 ### How do I know if my site is affected?
 
-If your website is affected by this change, Chrome will display a warning in
-the DevTools console: `Setting document.domain will be deprecated`.
+If your website is affected by this change, Chrome will warn in the DevTools
+Issues panel. Notice the yellow flag at the top right corner.
+
+<figure class="w-figcaption">
+{% Img src="image/YLflGBAPWecgtKJLqCJHSzHqe2J2/emNay9XjqqyNy3wEi0Aa.png",
+alt="When document.domain is modified, a warning is displayed in the Issues
+panel.", width="800", height="501" %}
+<figcaption>When document.domain is modified, a warning is displayed in the Issues panel.</figcaption>
+<figure>
 
 If you have a reporting endpoint set up, you will also be sent deprecation
 reports. Learn more about [how to use the Reporting


### PR DESCRIPTION
Reflected feedback from @yoavweiss :

* I don't see a clear "how do I know my site is affected?" section. It seems worthwhile to add one about related console warnings, deprecation reports and [LightHouse deprecation audits](https://web.dev/deprecations/).
* Right now the article says that "Chrome plans to make document.domain immutable from Chrome 101". Would be good to soften this.
* Mozilla's position landed on "worth prototyping". It seems worthwhile to note we have their backing.
* I'd rephrase ["send ... header to continue.."](https://developer.chrome.com/blog/immutable-document-domain/#send-origin-agent-cluster-0-header-to-continue-using-documentdomain) as a last resort mechanism (so a "I can't make the proper change on time" solution, rather than a legitimate alternative).