### PR TITLE
Fix shorthand format for CSS nested layers

### DIFF
--- a/site/en/blog/cascade-layers/index.md
+++ b/site/en/blog/cascade-layers/index.md
@@ -187,7 +187,7 @@ Layers can also be nested within other layers. The following example comes from 
 In the above code snippet, you can access `framework.default`, using a `.` as a signifier of the `default` layer being nested within `framework`. You can also write this in a more shorthand format:
 
 ```css
-@layer.default {
+@layer framework.default {
   p { margin-block: 0.75em }
 }
 ```


### PR DESCRIPTION
Changes proposed in this pull request:

- Fix shorthand format of CSS nested layers on this page: https://developer.chrome.com/blog/cascade-layers/#nested-layers
- Based on https://developer.mozilla.org/en-US/docs/Web/CSS/@layer#nesting_layers