### PR TITLE
Changed wording and deleted extra word in index.md

### DIFF
--- a/site/en/docs/devtools/javascript/breakpoints/index.md
+++ b/site/en/docs/devtools/javascript/breakpoints/index.md
@@ -81,8 +81,8 @@ Use the **Breakpoints** pane to disable or remove line-of-code breakpoints from 
 - Right-click an entry to remove that breakpoint.
 - Right-click anywhere in the **Breakpoints** pane to deactivate all breakpoints, disable all
   breakpoints, or remove all breakpoints. Disabling all breakpoints is equivalent to unchecking each
-  one. Deactivating all breakpoints instructs DevTools to ignore all line-of-code breakpoints, but
-  to also maintain preserve their enabled state so that they are in the same state as before when
+  one. Deactivating all breakpoints instructs DevTools to ignore all line-of-code breakpoints as well as
+  preserve their enabled state so that they are in the same state as before when
   you reactivate them.
 
 {% Img src="image/admin/jR6uTu7EVph7vbfunUa3.png", alt="Deactivated breakpoints in the Breakpoints pane.", width="800", height="657" %}


### PR DESCRIPTION
No issue number associated with this pull request.

Changes proposed in this pull request:

- Deleted an extra, unnecessary word at line 85. Replaced 'maintain preserve' with 'preserve'.
- Changed overall section wording from "...but to also maintain preserve their enabled state..." to "...as well as preserve their enabled state..." to fit with the change and improve grammatical flow.