### PR TITLE
Remove inaccurate line regarding extension SW lifetimes

### DIFF
--- a/site/en/docs/extensions/mv3/service_workers/index.md
+++ b/site/en/docs/extensions/mv3/service_workers/index.md
@@ -192,7 +192,8 @@ chrome.runtime.onMessage.addListener((message, callback) => {
 The lifetime of a background service worker is observable by monitoring when an entry for the
 extension appears and disappears from Chrome's task manager.
 
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/occ8HD81vNq2zboXIbiu.png", alt="Chrome with an extension's popup open.", height="623", width="730" %}
+{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/occ8HD81vNq2zboXIbiu.png",
+       alt="Chrome with an extension's popup open.", height="623", width="730" %}
 
 Open the task manager by clicking the Chrome menu, hovering over more tools and selecting "Task
 Manager".

--- a/site/en/docs/extensions/mv3/service_workers/index.md
+++ b/site/en/docs/extensions/mv3/service_workers/index.md
@@ -20,9 +20,8 @@ examples of events include:
 - A content script or other extension [sends a message.][1]
 - Another view in the extension, such as a popup, calls [`runtime.getBackgroundPage`][2].
 
-Once it has been loaded, a service worker keeps running as long as it is performing an action, such
-as calling a Chrome API or issuing a network request. Additionally, the service worker won't unload
-until all visible views and all message ports are closed.
+Once it has been loaded, an extension's service worker generally keeps running as long as it is
+performing an action, such as calling a Chrome API or issuing a network request. 
 
 {% Aside %}
 
@@ -231,3 +230,5 @@ in case of a crash.
 [15]: /docs/extensions/reference/runtime#event-onSuspend
 [16]: /docs/extensions/reference/runtime#event-onSuspend
 [sw-module]: https://web.dev/es-modules-in-sw/
+
+[doc-sw-migration]: /docs/extensions/mv3/migrating_to_service_workers

--- a/site/en/docs/extensions/mv3/service_workers/index.md
+++ b/site/en/docs/extensions/mv3/service_workers/index.md
@@ -192,8 +192,7 @@ chrome.runtime.onMessage.addListener((message, callback) => {
 The lifetime of a background service worker is observable by monitoring when an entry for the
 extension appears and disappears from Chrome's task manager.
 
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/occ8HD81vNq2zboXIbiu.png",
-       alt="Chrome with an extension's popup open.", height="623", width="730" %}
+{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/occ8HD81vNq2zboXIbiu.png", alt="Chrome with an extension's popup open.", height="623", width="730" %}
 
 Open the task manager by clicking the Chrome menu, hovering over more tools and selecting "Task
 Manager".

--- a/site/en/docs/extensions/mv3/service_workers/index.md
+++ b/site/en/docs/extensions/mv3/service_workers/index.md
@@ -228,6 +228,6 @@ in case of a crash.
 [14]: /docs/extensions/reference/runtime#property-Port-disconnect
 [15]: /docs/extensions/reference/runtime#event-onSuspend
 [16]: /docs/extensions/reference/runtime#event-onSuspend
-[sw-module]: https://web.dev/es-modules-in-sw/
 
 [doc-sw-migration]: /docs/extensions/mv3/migrating_to_service_workers
+[sw-module]: https://web.dev/es-modules-in-sw/

--- a/site/en/docs/extensions/mv3/service_workers/index.md
+++ b/site/en/docs/extensions/mv3/service_workers/index.md
@@ -12,7 +12,7 @@ Extensions monitor these events using scripts in their background [service
 worker][doc-sw-migration], which then react with specified instructions.
 
 A background service worker is loaded when it is needed, and unloaded when it goes idle. Some
-examples of events include:
+examples include:
 
 - The extension is first installed or updated to a new version.
 - The background page was listening for an event, and the event is dispatched.
@@ -195,7 +195,7 @@ extension appears and disappears from Chrome's task manager.
 {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/occ8HD81vNq2zboXIbiu.png",
        alt="Chrome with an extension's popup open.", height="623", width="730" %}
 
-Open the task manager by clicking the Chrome Menu, hovering over more tools and selecting "Task
+Open the task manager by clicking the Chrome menu, hovering over more tools and selecting "Task
 Manager".
 
 Service workers unload on their own after a few seconds of inactivity. If any last minute cleanup is

--- a/site/en/docs/extensions/mv3/service_workers/index.md
+++ b/site/en/docs/extensions/mv3/service_workers/index.md
@@ -9,8 +9,7 @@ description: How to respond to browser triggers (events) from a Chrome Extension
 Extensions are event-based programs used to modify or enhance the Chrome browsing experience. Events
 are browser triggers, such as navigating to a new page, removing a bookmark, or closing a tab.
 Extensions monitor these events using scripts in their background [service
-worker](/docs/extensions/mv3/migrating_to_service_workers), which then react with specified
-instructions.
+worker][doc-sw-migration], which then react with specified instructions.
 
 A background service worker is loaded when it is needed, and unloaded when it goes idle. Some
 examples of events include:

--- a/site/en/docs/extensions/mv3/service_workers/index.md
+++ b/site/en/docs/extensions/mv3/service_workers/index.md
@@ -8,24 +8,27 @@ description: How to respond to browser triggers (events) from a Chrome Extension
 
 Extensions are event-based programs used to modify or enhance the Chrome browsing experience. Events
 are browser triggers, such as navigating to a new page, removing a bookmark, or closing a tab.
-Extensions monitor these events using scripts in their background
-[service worker](/docs/extensions/mv3/migrating_to_service_workers), which then react
-with specified instructions.
+Extensions monitor these events using scripts in their background [service
+worker](/docs/extensions/mv3/migrating_to_service_workers), which then react with specified
+instructions.
 
-A background service worker is loaded when it is needed, and unloaded when it goes idle. Some examples of
-events include:
+A background service worker is loaded when it is needed, and unloaded when it goes idle. Some
+examples of events include:
 
 - The extension is first installed or updated to a new version.
 - The background page was listening for an event, and the event is dispatched.
 - A content script or other extension [sends a message.][1]
 - Another view in the extension, such as a popup, calls [`runtime.getBackgroundPage`][2].
 
-Once it has been loaded, a service worker keeps running as long as it is performing an action,
-such as calling a Chrome API or issuing a network request. Additionally, the service worker won't
-unload until all visible views and all message ports are closed.
+Once it has been loaded, a service worker keeps running as long as it is performing an action, such
+as calling a Chrome API or issuing a network request. Additionally, the service worker won't unload
+until all visible views and all message ports are closed.
 
 {% Aside %}
-Opening a view doesn't cause the service worker to load, but only prevents it from closing once loaded.
+
+Opening a view doesn't cause the service worker to load, but only prevents it from closing once
+loaded.
+
 {% endAside %}
 
 Effective background scripts stay dormant until an event they are listening for fires, react with
@@ -48,7 +51,9 @@ field. This field uses the `"service_worker"` key, which specifies a single Java
 ```
 
 {% Aside %}
+
 The script used for `"service_worker"` must be located in your extension's root directory.
+
 {% endAside %}
 
 You can optionally specify an extra field of `"type": "module"` to include the service worker as an
@@ -118,7 +123,7 @@ that event.
 
 ```js
 chrome.runtime.onMessage.addListener((message, sender, reply) => {
- chrome.runtime.onMessage.removeListener(event);
+  chrome.runtime.onMessage.removeListener(event);
 });
 ```
 
@@ -137,6 +142,7 @@ const filter = {
     },
   ],
 };
+
 chrome.webNavigation.onCompleted.addListener(() => {
   console.info("The user has loaded my favorite website!");
 }, filter);
@@ -194,8 +200,8 @@ extension appears and disappears from Chrome's task manager.
 Open the task manager by clicking the Chrome Menu, hovering over more tools and selecting "Task
 Manager".
 
-Service workers unload on their own after a few seconds of inactivity. If any last minute cleanup
-is required, listen to the [`runtime.onSuspend`][15] event.
+Service workers unload on their own after a few seconds of inactivity. If any last minute cleanup is
+required, listen to the [`runtime.onSuspend`][15] event.
 
 ```js
 chrome.runtime.onSuspend.addListener(() => {


### PR DESCRIPTION
The docs currently state that "the service worker won't unload until all visible views and all message ports are closed." This statement is not accurate. It appears to be a carry over from the MV2 [Manage events with background scripts](https://developer.chrome.com/docs/extensions/mv2/background_pages/) article.

This is a small change before I begin working on a larger revision of the extension service worker documentation.