### PR TITLE
Normalize format of titles and dates in extensions What's New page

### DIFF
--- a/site/en/blog/extension-manifest-converter/index.md
+++ b/site/en/blog/extension-manifest-converter/index.md
@@ -1,6 +1,6 @@
 ---
 layout: 'layouts/blog-post.njk'
-title: Extension manifest converter
+title: Extension Manifest Converter
 description: >
   Open source tool to convert extensions to Manifest V3. You'll still need to manually update any
   code with non-mechanical changes, such as adapting to use service workers or some script
@@ -8,7 +8,7 @@ description: >
 subhead: >
   Easily convert an entire directory, extension zip file, or manifest.json file.
 date: 2021-04-28
-updated: 2021-04-28
+updated: 2022-02-16
 authors:
   - solomonkinard
   - dotproto

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -39,7 +39,7 @@ January 27, 2022
 The [`chrome.i18n.getMessage()`](/docs/extensions/reference/i18n/#method-getMessage) API is now
 supported in extension service worker contexts.
 
-### Chrome 99: `match_origin_as_fallback` in Canary {: #canary-match-origin-as-fallback }
+### Chrome 99: match_origin_as_fallback in Canary {: #canary-match-origin-as-fallback }
 
 January 5, 2022
 
@@ -56,7 +56,7 @@ Service worker-based Manifest V2 and Manifest V3 extensions can now use the Fetc
 `file:`-scheme URLs. Access to `file:`-scheme URLs still requires that the user enable 'Allow access
 to File URLs' for the extension in the `chrome://extensions` page.
 
-### Chrome 99: Promise support for messaging APIs in Canary {: #canary-message-promise-support }
+### Chrome 99: promise support for messaging APIs in Canary {: #canary-message-promise-support }
 
 December 28, 2021
 
@@ -74,7 +74,7 @@ Added [a new reference page](/docs/webstore/review-process) that provides an ove
 Web Store review process and explains how [developer program
 policy](/docs/webstore/program_policies/) enforcement is handled.
 
-### Docs update: Review violation troubleshooting updates {: #2021-10-27-reivew-troubleshooting }
+### Docs update: review violation troubleshooting updates {: #2021-10-27-reivew-troubleshooting }
 
 October 27, 2021
 
@@ -154,7 +154,7 @@ manifest.json or programmatically injected at runtime with
 
 September 23, 2021
 
-The Manifest V2->V3 transition timeline was [announced in this blog post](/blog/mv2-transition/) and
+The Manifest V2 to V3 transition timeline was [announced in this blog post](/blog/mv2-transition/) and
 a more detailed [timeline page](/docs/extensions/mv3/mv2-sunset) was published.
 
 ### Chrome 96: `declarativeNetRequestWithHostAccess` permission
@@ -185,7 +185,7 @@ August 30, 2021
 Methods on the Manifest V3 version of the [`chrome.storage`](/docs/extensions/reference/storage/)
 API now return promises.
 
-### Policy update: Two step verification enforcement {: #two-step-verification-enforcement }
+### Policy update: two step verification enforcement {: #two-step-verification-enforcement }
 
 August 4, 2021
 
@@ -213,7 +213,7 @@ isolation](https://web.dev/cross-origin-isolation-guide/). This feature limits w
 resources can load an extension's pages and enables the use of low level web platform features like
 [`SharedArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer). Opt in will be required starting in Chrome 95.
 
-### Policy update: Developer program policies updated {: #developer-program-policies-updated }
+### Policy update: developer program policies updated {: #developer-program-policies-updated }
 
 June 29, 2021
 
@@ -222,7 +222,7 @@ with clarifications to the deceptive installation tactics, spam, and repetitive 
 This update also includes a new two step verification requirement to publish on the Chrome Web
 Store. [Read the blog post](/blog/policy-update-2sv/) for more information.
 
-### Blog post: Extension actions in Manifest V3 {: #new-blog-post-extension-actions-in-manifest-v3 }
+### Blog post: extension actions in Manifest V3 {: #new-blog-post-extension-actions-in-manifest-v3 }
 
 June 23, 2021
 
@@ -231,7 +231,7 @@ V3 replaced both with a generic [`chrome.actions`](/docs/extensions/reference/ac
 post explores the history of these APIs and what has changed in Manifest V3. [Read the
 post](/blog/mv3-actions).
 
-### Blog post: Introducing chrome.scripting {: #new-blog-post-introducing-chromescripting }
+### Blog post: introducing chrome.scripting {: #new-blog-post-introducing-chromescripting }
 
 June 8, 2021
 
@@ -239,7 +239,7 @@ The [`chrome.scripting`](/docs/extensions/reference/scripting/) API is a new Man
 on, well, scripting. In this post we dig into the motivations for this change and take a closer look
 at it's new capabilities. [Read the post](/blog/crx-scripting-api).
 
-### Chrome 92: Module service worker support {: #es-modules-for-service-workers }
+### Chrome 92: module service worker support {: #es-modules-for-service-workers }
 
 April 13, 2021
 
@@ -273,7 +273,7 @@ method allows extensions to remove CSS that was previously inserted via
 [`chrome.scripting.insertCSS()`](/docs/extensions/reference/scripting/#method-insertCSS). It
 replaces [`chrome.tabs.removeCSS()`](/docs/extensions/reference/tabs/#method-removeCSS).
 
-### Chrome 90: Returning promises from `scripting.executeScript()` {: #m96-execute-script }
+### Chrome 90: returning promises from scripting.executeScript() {: #m96-execute-script }
 
 February 24, 2021
 
@@ -307,7 +307,7 @@ December 23, 2020
 Manifest V3 have changed to let extensions restrict resource access based on the requester's origin
 or extension ID.
 
-### Blog post: Extension Manifest Converter {: #extension-manifest-converter}
+### Blog post: extension Manifest Converter {: #extension-manifest-converter}
 
 April 28, 2021
 
@@ -323,5 +323,5 @@ January 19, 2021
 Manifest V3 is a major update to the extensions platform; see [Overview of Manifest
 V3](/docs/extensions/mv3/intro/mv3-overview/) for a summary of new and changed features. Extensions
 may continue to use Manifest V2 for now, but this will be phased out in the near future. We strongly
-recommend that you use Manifest V3 for any new extensions, and begin to migrate existing extensions
+recommend that you use Manifest V3 for any new extensions, and begin migrating existing extensions
 to Manifest V3 as soon as possible.

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -48,7 +48,7 @@ related to a matching frame, including frames with `about:`, `data:`, `blob:`, a
 URLs.  See the [content scripts](/docs/extensions/mv3/content_scripts/#injecting-in-related-frames)
 documentation for details.
 
-### Chrome 99: Extension service worker support for file: schemes in Canary {: #canary-file-access }
+### Chrome 99: extension service worker support for file: schemes in Canary {: #canary-file-access }
 
 December 30, 2021
 
@@ -81,7 +81,7 @@ October 27, 2021
 The [Troubleshooting Chrome Web Store violations](/docs/webstore/troubleshooting/) page has been
 updated to provide developers with more detailed guidance for common reasons for rejection.
 
-### Chrome 96: Expanded promise support to 27 more APIs {: #m96-promise-support }
+### Chrome 96: expanded promise support to 27 more APIs {: #m96-promise-support }
 
 October 1, 2021
 
@@ -137,7 +137,7 @@ Chrome OS APIs
 
 {% endDetails %}
 
-### Chrome 96: Dynamic content scripts {: #m96-dynamic-content-scripts }
+### Chrome 96: dynamic content scripts {: #m96-dynamic-content-scripts }
 
 September 24, 2021
 
@@ -168,7 +168,7 @@ extension has host permissions for. This also enables existing Manifest V2 exten
 [`chrome.declarativeNetRequest`](/docs/extensions/reference/declarativeNetRequest/) API without
 requiring the user to approve new permissions.
 
-### Chrome 95: Inject scripts directly into pages {: #m95-page-script-injection }
+### Chrome 95: inject scripts directly into pages {: #m95-page-script-injection }
 
 September 2, 2021
 
@@ -178,7 +178,7 @@ inject scripts directly into a page's main world. Previously, extensions could o
 into the extension's isolated world. For more information on isolated worlds, see the documentation
 on [content scripts](/docs/extensions/mv3/content_scripts/#isolated_world).
 
-### Chrome 95: Promise support for Storage API {: #m95-storage-promise-support }
+### Chrome 95: promise support for Storage API {: #m95-storage-promise-support }
 
 August 30, 2021
 
@@ -192,7 +192,7 @@ August 4, 2021
 The [policy update blog post](/blog/policy-update-2sv/) published on June 29, 2021 has been updated
 to correct the two step verification deployment timeline.
 
-### Chrome 94: Declarative net request static ruleset changes
+### Chrome 94: declarative net request static ruleset changes
 
 July 28, 2021
 
@@ -203,7 +203,7 @@ and enabling up to 10 rulesets
 ([MAX_NUMBER_OF_ENABLED_STATIC_RULESETS](/docs/extensions/reference/declarativeNetRequest/#property-MAX_NUMBER_OF_ENABLED_STATIC_RULESETS))
 at a time.
 
-### Chrome 93: Cross origin isolation support
+### Chrome 93: cross origin isolation support
 
 July 12, 2021
 
@@ -291,7 +291,7 @@ now include the [frameId](/docs/extensions/reference/webNavigation/#a-note-about
 The `frameId` property indicates the frame that the result is from, letting extensions easily
 associate results with the individual frames when injecting in multiple frames.
 
-### Chrome 89: New API for managing tab groups {: #new-api-for-tab-groups-mv3-only }
+### Chrome 89: new API for managing tab groups {: #new-api-for-tab-groups-mv3-only }
 
 January 14, 2021
 
@@ -299,7 +299,7 @@ The new [`chrome.tabGroups`](/docs/extensions/reference/tabGroups/) API and new 
 [`chrome.tabs`](/docs/extensions/reference/tabs/) let extensions read and manipulate tab groups.
 Requires Manifest V3.
 
-### Chrome 89: Customizable permissions for web accessible resources {: #customizable-permissions-for-mv3-web-accessible-resources }
+### Chrome 89: customizable permissions for web accessible resources {: #customizable-permissions-for-mv3-web-accessible-resources }
 
 December 23, 2020
 
@@ -307,7 +307,7 @@ December 23, 2020
 Manifest V3 have changed to let extensions restrict resource access based on the requester's origin
 or extension ID.
 
-### Blog post: extension Manifest Converter {: #extension-manifest-converter}
+### Blog post: Extension Manifest Converter {: #extension-manifest-converter}
 
 April 28, 2021
 

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -4,7 +4,7 @@ layout: 'layouts/doc-post.njk'
 title: What's new in Chrome extensions
 description: 'Recent changes to the Chrome extensions platform, documentation, and policy'
 date: 2021-02-25
-updated: 2022-01-20
+updated: 2022-02-14
 
 # Note: disabling the linter for duplicate headings because this isn't hierarchical and it needs
 # smaller font headings.
@@ -34,24 +34,31 @@ suggestion has been properly set.
 
 ### Chrome 100: i18n.getMessage() support in extension service workers {: #m100-i18n-getmessage }
 
-The [`chrome.i18n.getMessage()`](/docs/extensions/reference/i18n/#method-getMessage) API is now
-supported in extension service worker contexts. This change landed in Canary on January 27, 2022
-and is expected to reach Stable in Chrome 100.
+January 27, 2022
 
-### 2022.01.05: `match_origin_as_fallback` in Canary {: #canary-match-origin-as-fallback }
+The [`chrome.i18n.getMessage()`](/docs/extensions/reference/i18n/#method-getMessage) API is now
+supported in extension service worker contexts.
+
+### Chrome 99: `match_origin_as_fallback` in Canary {: #canary-match-origin-as-fallback }
+
+January 5, 2022
 
 Content scripts can now specify the `match_origin_as_fallback` key to inject into frames that are
 related to a matching frame, including frames with `about:`, `data:`, `blob:`, and `filesystem:`
 URLs.  See the [content scripts](/docs/extensions/mv3/content_scripts/#injecting-in-related-frames)
 documentation for details.
 
-### 2021.12.30: Extension service worker support for `file:` schemes in Canary {: #canary-file-access }
+### Chrome 99: Extension service worker support for `file:` schemes in Canary {: #canary-file-access }
+
+December 30, 2021
 
 Service worker-based Manifest V2 and Manifest V3 extensions can now use the Fetch API to request
-`file:`-scheme URLs. Access to `file:`-scheme URLs still requires that the user enable 'Allow access to File
-URLs' for the extension in the `chrome://extensions` page.
+`file:`-scheme URLs. Access to `file:`-scheme URLs still requires that the user enable 'Allow access
+to File URLs' for the extension in the `chrome://extensions` page.
 
-### 2021.12.28: Promise support for messaging APIs in Canary {: #canary-message-promise-support }
+### Chrome 99: Promise support for messaging APIs in Canary {: #canary-message-promise-support }
+
+December 28, 2021
 
 Promise support has been added to
 [`tabs.sendMessage`](/docs/extensions/reference/tabs/#method-sendMessage),
@@ -59,30 +66,24 @@ Promise support has been added to
 [`runtime.sendNativeMessage`](/docs/extensions/reference/runtime/#method-sendNativeMessage) for
 extensions built for Manifest V3.
 
-### Chrome 98: Returning promises from `scripting.executeScript()` {: #m96-execute-script }
+### Docs update: Chrome Web Store review documentation {: #cws-review-doc }
 
-[`chrome.scripting.executeScript()`](/docs/extensions/reference/scripting/#method-executeScript)
-now supports returning promises. When a script evaluates to a promise, Chrome will wait for the
-promise to settle and return its resulting value.
-
-### 2021.12.10: Chrome Web Store review documentation {: #cws-review-doc }
+December 10, 2021
 
 Added [a new reference page](/docs/webstore/review-process) that provides an overview of the Chrome
 Web Store review process and explains how [developer program
 policy](/docs/webstore/program_policies/) enforcement is handled.
 
-### Chrome 96: Dynamic content scripts {: #m96-dynamic-content-scripts }
+### Docs update: Review violation troubleshooting updates {: #2021-10-27-reivew-troubleshooting }
 
-The [`chrome.scripting`](/docs/extensions/reference/scripting/) API now supports
-[registering](/docs/extensions/reference/scripting/#method-registerContentScripts),
-[updating](/docs/extensions/reference/scripting/#method-updateContentScripts),
-[unregistering](/docs/extensions/reference/scripting/#method-unregisterContentScripts), and [getting
-a list](/docs/extensions/reference/scripting/#method-getRegisteredContentScripts) of content scripts
-at runtime. Previously, content scripts could only be statically declared in an extension's
-manifest.json or programmatically injected at runtime with
-[`chrome.scripting.executeScript()`](/docs/extensions/reference/scripting/#method-executeScript).
+October 27, 2021
+
+The [Troubleshooting Chrome Web Store violations](/docs/webstore/troubleshooting/) page has been
+updated to provide developers with more detailed guidance for common reasons for rejection.
 
 ### Chrome 96: Expanded promise support to 27 more APIs {: #m96-promise-support }
+
+October 1, 2021
 
 This release contains significantly more promise updates than any previous release. Updates include
 both general and Chrome OS-specific extensions APIs. Expand the following sections for details.
@@ -136,7 +137,29 @@ Chrome OS APIs
 
 {% endDetails %}
 
+### Chrome 96: Dynamic content scripts {: #m96-dynamic-content-scripts }
+
+September 24, 2021
+
+The [`chrome.scripting`](/docs/extensions/reference/scripting/) API now supports
+[registering](/docs/extensions/reference/scripting/#method-registerContentScripts),
+[updating](/docs/extensions/reference/scripting/#method-updateContentScripts),
+[unregistering](/docs/extensions/reference/scripting/#method-unregisterContentScripts), and [getting
+a list](/docs/extensions/reference/scripting/#method-getRegisteredContentScripts) of content scripts
+at runtime. Previously, content scripts could only be statically declared in an extension's
+manifest.json or programmatically injected at runtime with
+[`chrome.scripting.executeScript()`](/docs/extensions/reference/scripting/#method-executeScript).
+
+### Docs update: Manifest V2 support timeline {: #manifest-v2-support-timeline }
+
+September 23, 2021
+
+The Manifest V2->V3 transition timeline was [announced in this blog post](/blog/mv2-transition/) and
+a more detailed [timeline page](/docs/extensions/mv3/mv2-sunset) was published.
+
 ### Chrome 96: `declarativeNetRequestWithHostAccess` permission
+
+September 20, 2021
 
 The new `declarativeNetRequestWithHostAccess` permission allows extensions to use the
 [`chrome.declarativeNetRequest`](/docs/extensions/reference/declarativeNetRequest/) API on sites the
@@ -145,12 +168,9 @@ extension has host permissions for. This also enables existing Manifest V2 exten
 [`chrome.declarativeNetRequest`](/docs/extensions/reference/declarativeNetRequest/) API without
 requiring the user to approve new permissions.
 
-### 2021.10.27: Review violation troubleshooting updates {: #2021-10-27-reivew-troubleshooting }
-
-The [Troubleshooting Chrome Web Store violations](/docs/webstore/troubleshooting/) page has been
-updated to provide developers with more detailed guidance for common reasons for rejection.
-
 ### Chrome 95: Inject scripts directly into pages {: #m95-page-script-injection }
+
+September 2, 2021
 
 The [`chrome.scripting`](/docs/extensions/reference/scripting) API's
 [`executeScript()`](/docs/extensions/reference/scripting/#method-executeScript) method can now
@@ -160,15 +180,21 @@ on [content scripts](/docs/extensions/mv3/content_scripts/#isolated_world).
 
 ### Chrome 95: Promise support for Storage API {: #m95-storage-promise-support }
 
+August 30, 2021
+
 Methods on the Manifest V3 version of the [`chrome.storage`](/docs/extensions/reference/storage/)
 API now return promises.
 
-### 2021.09.23: Manifest V2 support timeline {: #manifest-v2-support-timeline }
+### Policy update: Two step verification enforcement {: #two-step-verification-enforcement }
 
-The Manifest V2->V3 transition timeline was [announced in this blog post](/blog/mv2-transition/) and
-a more detailed [timeline page](/docs/extensions/mv3/mv2-sunset) was published.
+August 4, 2021
+
+The [policy update blog post](/blog/policy-update-2sv/) published on June 29, 2021 has been updated
+to correct the two step verification deployment timeline.
 
 ### Chrome 94: Declarative net request static ruleset changes
+
+July 28, 2021
 
 The [`chrome.declarativeNetRequest`](/docs/extensions/reference/declarativeNetRequest/) now supports
 specifying up to 50 static rulesets
@@ -179,38 +205,43 @@ at a time.
 
 ### Chrome 93: Cross origin isolation support
 
+July 12, 2021
+
 Both [Manifest V2](/docs/extensions/mv2/cross-origin-isolation/) and [Manifest
 V3](/docs/extensions/mv3/cross-origin-isolation/) extensions can now opt into [cross origin
 isolation](https://web.dev/cross-origin-isolation-guide/). This feature limits which cross-origin
 resources can load an extension's pages and enables the use of low level web platform features like
 [`SharedArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer). Opt in will be required starting in Chrome 95.
 
-### 2021.08.04: Two step verification enforcement {: #two-step-verification-enforcement }
+### Policy update: Developer program policies updated {: #developer-program-policies-updated }
 
-The [policy update blog post](/blog/policy-update-2sv/) published on 2021.06.29 has been updated to
-correct the two step verification deployment timeline.
-
-### 2021.06.29: Developer program policies updated {: #developer-program-policies-updated }
+June 29, 2021
 
 The Chrome Web Store [Developer Program Policies](/docs/webstore/program_policies) have been updated
 with clarifications to the deceptive installation tactics, spam, and repetitive content policies.
 This update also includes a new two step verification requirement to publish on the Chrome Web
 Store. [Read the blog post](/blog/policy-update-2sv/) for more information.
 
-### 2021.06.23: "Extension actions in Manifest V3" blog post {: #new-blog-post-extension-actions-in-manifest-v3 }
+### Blog post: Extension actions in Manifest V3 {: #new-blog-post-extension-actions-in-manifest-v3 }
+
+June 23, 2021
 
 Chrome extensions had `chrome.browserAction` and `chrome.pageActions` APIs for years, but Manifest
 V3 replaced both with a generic [`chrome.actions`](/docs/extensions/reference/action/) API. This
 post explores the history of these APIs and what has changed in Manifest V3. [Read the
 post](/blog/mv3-actions).
 
-### 2021.06.08: "Introducing chrome.scripting" blog post {: #new-blog-post-introducing-chromescripting }
+### Blog post: Introducing chrome.scripting {: #new-blog-post-introducing-chromescripting }
+
+June 8, 2021
 
 The [`chrome.scripting`](/docs/extensions/reference/scripting/) API is a new Manifest V3 API focused
 on, well, scripting. In this post we dig into the motivations for this change and take a closer look
 at it's new capabilities. [Read the post](/blog/crx-scripting-api).
 
-### Chrome 91: Module service worker support {: #es-modules-for-service-workers }
+### Chrome 92: Module service worker support {: #es-modules-for-service-workers }
+
+April 13, 2021
 
 Chrome now supports JavaScript modules in service workers. To specify a module a module in your
 manifest:
@@ -227,18 +258,32 @@ worker's script to import other modules.
 
 ### Chrome 91: `chrome.action.getUserSettings()` {: #chromeactiongetusersettings-available }
 
+April 2, 2021
+
 The new
 [`chrome.action.getUserSettings()`](/docs/extensions/reference/action/#method-getUserSettings)
 method allows extensions to determine if the user has pinned the extension to the main toolbar.
 
 ### Chrome 90: `chrome.scripting.removeCSS()` {: #chromescriptingremovecss-available }
 
+February 10, 2021
+
 The new [`chrome.scripting.removeCSS()`](/docs/extensions/reference/scripting/#method-removeCSS)
 method allows extensions to remove CSS that was previously inserted via
 [`chrome.scripting.insertCSS()`](/docs/extensions/reference/scripting/#method-insertCSS). It
 replaces [`chrome.tabs.removeCSS()`](/docs/extensions/reference/tabs/#method-removeCSS).
 
+### Chrome 90: Returning promises from `scripting.executeScript()` {: #m96-execute-script }
+
+February 24, 2021
+
+[`chrome.scripting.executeScript()`](/docs/extensions/reference/scripting/#method-executeScript)
+now supports returning promises. When a script evaluates to a promise, Chrome will wait for the
+promise to settle and return its resulting value.
+
 ### Chrome 90: `chrome.scripting.executeScript()` results include frameId {: # chromescriptingexecutescript-results-include-frameid }
+
+January 27, 2021
 
 Results returned from
 [`chrome.scripting.executeScript()`](/docs/extensions/reference/scripting/#method-executeScript)
@@ -248,17 +293,23 @@ associate results with the individual frames when injecting in multiple frames.
 
 ### Chrome 89: New API for managing tab groups {: #new-api-for-tab-groups-mv3-only }
 
+January 14, 2021
+
 The new [`chrome.tabGroups`](/docs/extensions/reference/tabGroups/) API and new capabilities in
 [`chrome.tabs`](/docs/extensions/reference/tabs/) let extensions read and manipulate tab groups.
 Requires Manifest V3.
 
 ### Chrome 89: Customizable permissions for web accessible resources {: #customizable-permissions-for-mv3-web-accessible-resources }
 
+December 23, 2020
+
 [Web accessible resources](/docs/extensions/mv3/manifest/web_accessible_resources/) definitions in
 Manifest V3 have changed to let extensions restrict resource access based on the requester's origin
 or extension ID.
 
-### 2021.04.08: Extension Manifest Converter {: #extension-manifest-converter}
+### Blog post: Extension Manifest Converter {: #extension-manifest-converter}
+
+April 28, 2021
 
 The Chrome Extensions team has open sourced "Extension Manifest Converter", a Python tool that
 automates some of the mechanical aspects of converting extensions to Manifest V3. See the
@@ -267,8 +318,10 @@ GitHub](https://github.com/GoogleChromeLabs/extension-manifest-converter).
 
 ### Chrome 88: Manifest V3 general availability {: #manifest-v3-general-availability }
 
+January 19, 2021
+
 Manifest V3 is a major update to the extensions platform; see [Overview of Manifest
 V3](/docs/extensions/mv3/intro/mv3-overview/) for a summary of new and changed features. Extensions
 may continue to use Manifest V2 for now, but this will be phased out in the near future. We strongly
-recommend that you use Manifest V3 for any new extensions, and begin to migrate existing extensions to Manifest V3
-as soon as possible.
+recommend that you use Manifest V3 for any new extensions, and begin to migrate existing extensions
+to Manifest V3 as soon as possible.

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -277,9 +277,9 @@ replaces [`chrome.tabs.removeCSS()`](/docs/extensions/reference/tabs/#method-rem
 
 February 24, 2021
 
-[`chrome.scripting.executeScript()`](/docs/extensions/reference/scripting/#method-executeScript)
-now supports returning promises. When a script evaluates to a promise, Chrome will wait for the
-promise to settle and return its resulting value.
+[`chrome.scripting.executeScript()`](/docs/extensions/reference/scripting/#method-executeScript) now
+supports returning promises. If the resulting value of the script execution is a promise, Chrome
+will wait for the promise to settle and return its resulting value.
 
 ### Chrome 90: chrome.scripting.executeScript() results include frameId {: # chromescriptingexecutescript-results-include-frameid }
 

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -4,7 +4,7 @@ layout: 'layouts/doc-post.njk'
 title: What's new in Chrome extensions
 description: 'Recent changes to the Chrome extensions platform, documentation, and policy'
 date: 2021-02-25
-updated: 2022-02-14
+updated: 2022-02-17
 
 # Note: disabling the linter for duplicate headings because this isn't hierarchical and it needs
 # smaller font headings.
@@ -20,8 +20,8 @@ and related policy or other changes.
 
 February 9, 2022
 
-Connecting to a native messaging host using `chrome.runtime.connectNative()` in an extension's service
-worker will keep the service worker alive as long as the port is open. 
+Connecting to a native messaging host using `chrome.runtime.connectNative()` in an extension's
+service worker will keep the service worker alive as long as the port is open. 
 
 ### Chrome 100: omnibox.setDefaultSuggestion() supports promises and callbacks {: #m100-omnibox-setdefault }
 
@@ -48,7 +48,7 @@ related to a matching frame, including frames with `about:`, `data:`, `blob:`, a
 URLs.  See the [content scripts](/docs/extensions/mv3/content_scripts/#injecting-in-related-frames)
 documentation for details.
 
-### Chrome 99: Extension service worker support for `file:` schemes in Canary {: #canary-file-access }
+### Chrome 99: Extension service worker support for file: schemes in Canary {: #canary-file-access }
 
 December 30, 2021
 
@@ -157,7 +157,7 @@ September 23, 2021
 The Manifest V2 to V3 transition timeline was [announced in this blog post](/blog/mv2-transition/) and
 a more detailed [timeline page](/docs/extensions/mv3/mv2-sunset) was published.
 
-### Chrome 96: `declarativeNetRequestWithHostAccess` permission
+### Chrome 96: declarativeNetRequestWithHostAccess permission
 
 September 20, 2021
 
@@ -256,7 +256,7 @@ manifest:
 This loads the worker script as an ES module, which lets you use the `import` keyword in the
 worker's script to import other modules.
 
-### Chrome 91: `chrome.action.getUserSettings()` {: #chromeactiongetusersettings-available }
+### Chrome 91: chrome.action.getUserSettings() {: #chromeactiongetusersettings-available }
 
 April 2, 2021
 
@@ -264,7 +264,7 @@ The new
 [`chrome.action.getUserSettings()`](/docs/extensions/reference/action/#method-getUserSettings)
 method allows extensions to determine if the user has pinned the extension to the main toolbar.
 
-### Chrome 90: `chrome.scripting.removeCSS()` {: #chromescriptingremovecss-available }
+### Chrome 90: chrome.scripting.removeCSS() {: #chromescriptingremovecss-available }
 
 February 10, 2021
 
@@ -281,7 +281,7 @@ February 24, 2021
 now supports returning promises. When a script evaluates to a promise, Chrome will wait for the
 promise to settle and return its resulting value.
 
-### Chrome 90: `chrome.scripting.executeScript()` results include frameId {: # chromescriptingexecutescript-results-include-frameid }
+### Chrome 90: chrome.scripting.executeScript() results include frameId {: # chromescriptingexecutescript-results-include-frameid }
 
 January 27, 2021
 


### PR DESCRIPTION
The live version of the extensions What's New page uses a couple different header and date formats. This PR addresses those inconsistencies by applying a common date formatting scheme.

All updates now contain a date as their first paragraph. For platform updates, this refers to the date on which the change was merged into Chromium's `main` branch. For all other updates, this refers to the date on which the update was published. 

Additionally, titles are now formatted to indicate `<type of change>: <shot description>`. For platform updates, the <type of change> value indicates the expected revision where the feature will land stable. For all others, <type of change> is "Docs update", "Policy update", "Blog post", etc.

[Live server](https://developer.chrome.com/docs/extensions/whatsnew)
[Preview server](https://deploy-preview-2119--developer-chrome-com.netlify.app/docs/extensions/whatsnew)