### PR TITLE
Adds video embeds to Workbox docs, updates links to the "Using Plugins" guide.

### DIFF
--- a/site/en/docs/workbox/caching-resources-during-runtime/index.md
+++ b/site/en/docs/workbox/caching-resources-during-runtime/index.md
@@ -6,6 +6,8 @@ description: >
   Learn how to handle caching resources during runtime, including cross-origin resources.
 ---
 
+{% YouTube id='BO9fplbCTuQ' %}
+
 Some assets in your web application may be infrequently used, very large, or vary based on the user's device (such as responsive images) or language. These are instances where [precaching may be an anti-pattern](/docs/workbox/precaching-dos-and-donts/), and you should rely on runtime caching instead.
 
 In Workbox, you can handle runtime caching for assets using the [`workbox-routing` module](/docs/workbox/modules/workbox-routing/) to match routes, and handle caching strategies for them with the [`workbox-strategies` module](/docs/workbox/modules/workbox-strategies/).

--- a/site/en/docs/workbox/caching-strategies-overview/index.md
+++ b/site/en/docs/workbox/caching-strategies-overview/index.md
@@ -6,6 +6,8 @@ description: >
   An overview of caching in service workers.
 ---
 
+{% YouTube id='ZCVgDKjtgl0' %}
+
 Until now, there have only been mentions and tiny code snippets of the
 [`Cache` interface](https://developer.mozilla.org/docs/Web/API/Cache).
 To use service workers effectively, it's necessary to adopt one or more caching strategies,

--- a/site/en/docs/workbox/managing-fallback-responses/index.md
+++ b/site/en/docs/workbox/managing-fallback-responses/index.md
@@ -6,6 +6,8 @@ description: >
   Sometimes users encounter network failures or go offline. Learn how to adapt to those situations and provide a fallback response.
 ---
 
+{% YouTube id='M7gQg9JojGE' %}
+
 In certain situations, you may want a fallback response cached in case the user is offline. Implementing a fallback is an alternative to caching behaviors that strategies like network-first or stale-while-revalidate provide.
 
 A fallback is a generic, one-size-fits-all response that's a better placeholder than what the browser would provide by default when a request fails. Some examples are:

--- a/site/en/docs/workbox/modules/workbox-background-sync/index.md
+++ b/site/en/docs/workbox/modules/workbox-background-sync/index.md
@@ -58,7 +58,7 @@ registerRoute(
 
 [comment]: <> (TODO: update the using-plugins link when that doc is migrated)
 `BackgroundSyncPlugin` hooks into the
-[`fetchDidFail` plugin callback](https://developers.google.com/web/tools/workbox/guides/using-plugins), and
+[`fetchDidFail` plugin callback](/docs/workbox/using-plugins/), and
 `fetchDidFail` is only invoked if there's an exception thrown, most likely due
 to a network failure. This means that requests won't be retried if there's a
 response received with a

--- a/site/en/docs/workbox/modules/workbox-strategies/index.md
+++ b/site/en/docs/workbox/modules/workbox-strategies/index.md
@@ -205,7 +205,7 @@ are two request strategies that can be used:
 [comment]: <> (TODO: update the using-plugins link when that doc is migrated)
 - `handle()`: Perform a request strategy and return a `Promise` that will resolve with a `Response`,
   invoking all [relevant plugin
-  callbacks](https://developers.google.com/web/tools/workbox/guides/using-plugins#lifecycle_callbacks).
+  callbacks](/docs/workbox/using-plugins/#methods-for-custom-plugins).
 - `handleAll()`: Similar to `handle()`, but returns two `Promise` objects. The first is
   equivalent to what `handle()` returns and the second will resolve when promises that were
   added to `event.waitUntil()` within the strategy have completed.

--- a/site/en/docs/workbox/navigation-preload/index.md
+++ b/site/en/docs/workbox/navigation-preload/index.md
@@ -6,6 +6,8 @@ description: >
   What Navigation Preload is, how it can make navigations faster, and how to use it in Workbox.
 ---
 
+{% YouTube id='25aCD5XL1Jk' %}
+
 When a service worker handles `fetch` events, the browser waits for the service worker to provide a response. While the latency of the network request is a big part of the wait, the browser may also have to wait for the service worker to boot up and fire `fetch` event callbacks.
 
 Bootup time varies based on the device and its capabilities, but the time involved can be substantial, sometimes up to a half a second when a CPU is slow, or is working in a throttled state due to ambient conditions. The performance gain of avoiding the network is likely to outweigh this startup time when your navigation responses are served from a `Cache` instance. For navigation requests that go to the network, introducing a service worker can create a perceptible delay.

--- a/site/en/docs/workbox/precaching-with-workbox/index.md
+++ b/site/en/docs/workbox/precaching-with-workbox/index.md
@@ -6,6 +6,8 @@ description: >
   Learn how to precache assets in a service worker with Workbox.
 ---
 
+{% YouTube id='sOq92prx00w' %}
+
 Precaching is one of the most common things you'll do in a service worker, and Workbox offers lots of flexibility in how you can accomplish this important task, regardless of which one of [Workbox's build tools](/docs/workbox/the-ways-of-workbox/) you choose. In this guide, you'll learn how to precache assets using both `generateSW` and `injectManifest`, as well as which of these methods might be the best fit for your project.
 
 ## Precaching with `generateSW`

--- a/site/en/docs/workbox/retrying-requests-when-back-online/index.md
+++ b/site/en/docs/workbox/retrying-requests-when-back-online/index.md
@@ -41,7 +41,7 @@ Here, `BackgroundSyncPlugin` is applied to a route matching POST requests to an 
 
 [comment]: <> (TODO: update the using-plugins link when that doc is migrated)
 {% Aside 'warning' %}
-Because `BackgroundSyncPlugin` hooks into the [`FetchDidFail` plugin's callback](https://developers.google.com/web/tools/workbox/guides/using-plugins), failed requests must be the result of a network failure. Requests that result in a [400](https://developer.mozilla.org/docs/Web/HTTP/Status#client_error_responses) or [500-level error status](https://developer.mozilla.org/docs/Web/HTTP/Status#server_error_responses) will not be retried. To retry requests resulting in these types of failures, try [adding a `FetchDidSucceed` plugin to your strategy](https://github.com/GoogleChrome/workbox/issues/2599#issuecomment-900304969).
+Because `BackgroundSyncPlugin` hooks into the [`FetchDidFail` plugin's callback](/docs/workbox/using-plugins/), failed requests must be the result of a network failure. Requests that result in a [400](https://developer.mozilla.org/docs/Web/HTTP/Status#client_error_responses) or [500-level error status](https://developer.mozilla.org/docs/Web/HTTP/Status#server_error_responses) will not be retried. To retry requests resulting in these types of failures, try [adding a `FetchDidSucceed` plugin to your strategy](https://github.com/GoogleChrome/workbox/issues/2599#issuecomment-900304969).
 {% endAside %}
 
 ## Advanced usage

--- a/site/en/docs/workbox/using-plugins/index.md
+++ b/site/en/docs/workbox/using-plugins/index.md
@@ -6,6 +6,8 @@ description: >
   While Workbox offers a lot of off-the-shelf utility, there may be times when you need to extend it to satisfy your application requirements. That's where Workbox's plugin architecture can come in handy.
 ---
 
+{% YouTube id='jR9-aDWZeSE' %}
+
 When using Workbox, you might want to manipulate a request and a response as it's being fetched or cached. Workbox plugins allow you to add additional behaviors to your service worker with minimal extra boilerplate. They can be packaged up and reused in your own projects, or released publicly for others to use as well.
 
 Workbox provides a number of plugins out of the box available for us, and&mdash;if you're the crafty sort&mdash;you can write custom plugins tailored to your application's requirements.


### PR DESCRIPTION
Changes proposed in this pull request:

- Adds YouTube video embeds to various Workbox docs.
- Updates internal links to the old "Using Plugins" Workbox doc on developers.google.com to the new guide on d.c.c.