### PR TITLE
Fix typo 'default_icons' -> 'default_icon'

### DIFF
--- a/site/en/docs/extensions/mv3/getstarted/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/index.md
@@ -184,7 +184,7 @@ button.current {
 }
 ```
 
-Designation for toolbar icons is also included under `action` in the `default_icons` field.
+Designation for toolbar icons is also included under `action` in the `default_icon` field.
 Download the images folder [here][18], unzip it, and place it in the extension's directory. Update
 the manifest so the extension knows how to use the images.
 


### PR DESCRIPTION
Fix typo: `default_icons` should be `default_icon`
![Screen Shot 2022-02-22 at 9 48 32 PM](https://user-images.githubusercontent.com/63318084/155253876-adfdb381-ae72-44ca-b9d4-82aec2690c1b.png)
