### PR TITLE
Extensions docs: cookies: fix `host_permissions` typo

### DIFF
--- a/site/en/docs/extensions/reference/cookies/index.md
+++ b/site/en/docs/extensions/reference/cookies/index.md
@@ -13,7 +13,7 @@ to access. For example:
   "name": "My extension",
   ...
   "host_permissions": [
-    "*://*.google.com"
+    "*://*.google.com/"
   ],
   "permissions": [
     "cookies"


### PR DESCRIPTION
The permission syntax requires a trailing /.  Without one, this example
makes Chrome throws errors when loading the manifest.