### PR TITLE
Add UA deprecation trial post

### DIFF
--- a/site/_data/authorsData.json
+++ b/site/_data/authorsData.json
@@ -392,5 +392,11 @@
     "github": "heyawhite",
     "twitter": "heyawhite",
     "image": "image/VbsHyyQopiec0718rMq2kTE1hke2/tKKMrgVB852NNd1UMRzN.png"
+  },
+  "victortan": {
+    "country": "US",
+    "github": "victortan",
+    "twitter": "victortan",
+    "image": "image/vgdbNJBYHma2o62ZqYmcnkq3j0o1/j7BoDYMJWpcjTNyhbnYu.jpeg"
   }
 }

--- a/site/_data/i18n/authors.yaml
+++ b/site/_data/i18n/authors.yaml
@@ -354,3 +354,9 @@ rsheeter:
     en: 'Rod Sheeter'
   description:
     en: 'Tech Lead, Google Fonts'
+victortan:
+  title:
+    en: 'Victor Tan'
+  description:
+    en: 'Software Engineer, Google Chrome'
+    

--- a/site/en/blog/user-agent-reduction-deprecation-trial/index.md
+++ b/site/en/blog/user-agent-reduction-deprecation-trial/index.md
@@ -50,7 +50,7 @@ Once you've registerd for the trial, update your HTTP response headers with the 
 1. To resend the first navigation request with the full User-Agent string, add `Critical-CH: Sec-CH-UA-Full` to your HTTP response header, in addition to the `Accept-CH` and `Origin-Trial` headers.
 1.  If you want third-party subresource requests to also receive the full UA string, you have two options:
     - Add a `Permissions-Policy` header with the third-party domains that should receive the full UA.
-        -  To allow a named list of third-party domains, add `Permissions-Policy: ch-ua-full=(self "[https://google.com](https://google.com)")`.
+        -  To allow a named list of third-party domains, add `Permissions-Policy: ch-ua-full=(self "https://google.com")`.
         -  To allow all third-party domains, add `Permissions-Policy: ch-ua-full=*`.
     - Add an `Accept-CH` meta tag with the third-party domains that should receive the full UA (only in Chrome 100 and above).
         -  To allow a named list of third-party domains, add `<meta name="accept-ch" content="ch-ua-full=( https://google.com )">`.

--- a/site/en/blog/user-agent-reduction-deprecation-trial/index.md
+++ b/site/en/blog/user-agent-reduction-deprecation-trial/index.md
@@ -18,9 +18,9 @@ tags:
 ---
 
 
-Starting from Chrome 101, the information available in the User-Agent string will be reduced [using a phased approach](https://blog.chromium.org/2021/09/user-agent-reduction-origin-trial-and-dates.html). Sites that haven't had time to migrate away from using the reduced User-Agent string and [move toward User-Agent Client Hints](https://web.dev/migrate-to-ua-ch/) can take part in a deprecation trial to continue receiving the full User-Agent string.
+Starting from Chrome 101, the information available in the User-Agent (UA) string will be reduced [using a phased approach](https://blog.chromium.org/2021/09/user-agent-reduction-origin-trial-and-dates.html). Sites that haven't had time to migrate away from using the reduced User-Agent string and [move toward User-Agent Client Hints](https://web.dev/migrate-to-ua-ch/) can take part in a deprecation trial to continue receiving the full User-Agent string.
 
-The registration for the deprecation trial will begin with the [Chrome 100](https://chromiumdash.appspot.com/schedule) Beta. It will allow sites to receive the full User-Agent string ahead of the Chrome 101 release, where the minor version string will be reduced. If you would like to test the origin trial on Chrome 100 Beta before it launches to the stable channel, be sure to register and test before the release date for Chrome 100 currently ([scheduled for March 31st, 2022](https://chromiumdash.appspot.com/schedule)).
+The registration for the deprecation trial will begin with the [Chrome 100](https://chromiumdash.appspot.com/schedule) Beta. It will allow sites to receive the full User-Agent string ahead of the Chrome 101 release, where the minor version string will be reduced. If you would like to test the origin trial on Chrome 100 Beta before it launches to the stable channel, be sure to register and test before the release date for Chrome 100 ([currently scheduled for March 31st, 2022](https://chromiumdash.appspot.com/schedule)).
 
 Below is an overview of the deprecation trial and what to expect. If you have feedback to share or you encounter any issues throughout this trial let us know in the [UA Reduction Github repository](https://github.com/abeyad/user-agent-reduction/issues).
 
@@ -33,13 +33,13 @@ By enrolling in the deprecation trial, sites will continue to receive the full U
 -   The `navigator.platform` Javascript getter
 -   The `navigator.appVersion` Javascript getter
 
-Sites should still audit their usage of the User-Agent header and related APIs, and if needed prepare to [migrate to User-Agent Client Hints](https://web.dev/migrate-to-ua-ch/) before the deprecation trial expires. The intent is to expire this Deprecation Trial once the [User-Agent Reduction rollout](https://blog.chromium.org/2021/09/user-agent-reduction-origin-trial-and-dates.html) is complete.
+Sites should still audit their usage of the User-Agent header and related APIs, and if needed prepare to [migrate to User-Agent Client Hints](https://web.dev/migrate-to-ua-ch/) before the deprecation trial expires. The intent is to expire this deprecation trial once the [User-Agent Reduction rollout](https://blog.chromium.org/2021/09/user-agent-reduction-origin-trial-and-dates.html) is complete.
 
 ## How do I participate in the User-Agent Reduction deprecation  trial?
 
 ### Register for the trial
 
-To register for the origin trial and get a token for your domains, visit the Trial for [User Agent Reduction Deprecation page](/origintrials/#/view_trial/2608710084154359809).
+To register for the origin trial and get a token for your domains, visit the [User Agent Reduction deprecation trial page](/origintrials/#/view_trial/2608710084154359809).
 
 ### Setup
 

--- a/site/en/blog/user-agent-reduction-deprecation-trial/index.md
+++ b/site/en/blog/user-agent-reduction-deprecation-trial/index.md
@@ -46,13 +46,13 @@ To register for the origin trial and get a token for your domains, visit the [Us
 Once you've registerd for the trial, update your HTTP response headers with the following:
 
 1.  Add `Origin-Trial: <ORIGIN TRIAL TOKEN>` to your HTTP response header. <`ORIGIN TRIAL TOKEN`> contains the token you got when registering for the origin trial.
-1.  Add `Accept-CH: Sec-CH-UA-Full` to your HTTP response header. Setting `Accept-CH` will only cause the reduced User-Agent string to be sent on subsequent requests to the origin. 
-1. To resend the first navigation request with the reduced User-Agent string, add `Critical-CH: Sec-CH-UA-Full` to your HTTP response header, in addition to the `Accept-CH` and `Origin-Trial` headers.
-1.  If you want third-party subresource requests to also receive the reduced UA string, you have two options:
-    - Add a `Permissions-Policy` header with the third-party domains that should receive the reduced UA.
+1.  Add `Accept-CH: Sec-CH-UA-Full` to your HTTP response header. Setting `Accept-CH` will only cause the full User-Agent string to be sent on subsequent requests to the origin. 
+1. To resend the first navigation request with the full User-Agent string, add `Critical-CH: Sec-CH-UA-Full` to your HTTP response header, in addition to the `Accept-CH` and `Origin-Trial` headers.
+1.  If you want third-party subresource requests to also receive the full UA string, you have two options:
+    - Add a `Permissions-Policy` header with the third-party domains that should receive the full UA.
         -  To allow a named list of third-party domains, add `Permissions-Policy: ch-ua-full=(self "[https://google.com](https://google.com)")`.
         -  To allow all third-party domains, add `Permissions-Policy: ch-ua-full=*`.
-    - Add an `Accept-CH` meta tag with the third-party domains that should receive the reduced UA (only in Chrome 100 and above).
+    - Add an `Accept-CH` meta tag with the third-party domains that should receive the full UA (only in Chrome 100 and above).
         -  To allow a named list of third-party domains, add `<meta name="accept-ch" content="ch-ua-full=( https://google.com )">`.
         -  It's not possible to delegate to all third-party domains via `*` in the meta tag.
 1. Load your website in Chrome 100 (or later) and continue receiving the full User-Agent string.

--- a/site/en/blog/user-agent-reduction-deprecation-trial/index.md
+++ b/site/en/blog/user-agent-reduction-deprecation-trial/index.md
@@ -1,0 +1,98 @@
+---
+layout: "layouts/blog-post.njk"
+title: "User-Agent Reduction deprecation trial"
+subhead: > 
+  Register to continue receiving the full User-Agent string.
+description: >
+  Starting from Chrome 101, the information available in the User-Agent string will be reduced.
+  Sites that haven’t had time to migrate away from using the reduced User-Agent string can take
+  part in a deprecation trial to continue receiving the full User-Agent string.
+authors:
+  - abeyad
+date: 2022-02-24
+tags:
+  - privacy
+  - origin-trials
+  - chrome-101
+---
+
+
+Starting from Chrome 101, the information available in the User-Agent string will be reduced [using a phased approach](https://blog.chromium.org/2021/09/user-agent-reduction-origin-trial-and-dates.html). Sites that haven't had time to migrate away from using the reduced User-Agent string and [move toward User-Agent Client Hints](https://web.dev/migrate-to-ua-ch/) can take part in a deprecation trial to continue receiving the full User-Agent string.
+
+The registration for the deprecation trial will begin with the [Chrome 100 ](https://chromiumdash.appspot.com/schedule)Beta. It will allow sites to receive the full User-Agent string ahead of the Chrome 101 release, where the minor version string will be reduced. If you would like to test the origin trial on Chrome 100 Beta before it launches to the stable channel, be sure to register and test before the release date for Chrome 100 currently ([scheduled for March 31st, 2022](https://chromiumdash.appspot.com/schedule)).
+
+Below is an overview of the deprecation trial and what to expect. If you have feedback to share or you encounter any issues throughout this trial let us know in the [UA Reduction Github repository](https://github.com/abeyad/user-agent-reduction/issues).
+
+## What does this mean for web developers?
+
+By enrolling in the deprecation trial, sites will continue to receive the full UA string in `navigator.userAgent` and non-reduced values in the related `navigator.platform` and `navigator.appVersion` JavaScript getters:
+
+-   The `User-Agent` HTTP request header
+-   The `navigator.userAgent` Javascript getter
+-   The `navigator.platform` Javascript getter
+-   The `navigator.appVersion` Javascript getter
+
+Sites should still audit their usage of the User-Agent header and related APIs, and if needed prepare to [migrate to User-Agent Client Hints](https://web.dev/migrate-to-ua-ch/) before the deprecation trial expires. The intent is to expire this Deprecation Trial once the [User-Agent Reduction rollout](https://blog.chromium.org/2021/09/user-agent-reduction-origin-trial-and-dates.html) is complete.
+
+## How do I participate in the User-Agent Reduction deprecation  trial?
+
+### Register for the trial
+
+To register for the origin trial and get a token for your domains, visit the Trial for [User Agent Reduction Deprecation page](https://developer.chrome.com/origintrials/#/view_trial/2608710084154359809).
+
+### Setup
+
+Once you've registerd for the trial, update your HTTP response headers with the following:
+
+1.  Add `Origin-Trial: <ORIGIN TRIAL TOKEN>` to your HTTP response header. <`ORIGIN TRIAL TOKEN`> contains the token you got when registering for the origin trial.
+1.  Add `Accept-CH: Sec-CH-UA-Full` to your HTTP response header. Setting `Accept-CH` will only cause the reduced User-Agent string to be sent on subsequent requests to the origin. 
+1. To resend the first navigation request with the reduced User-Agent string, add `Critical-CH: Sec-CH-UA-Full` to your HTTP response header, in addition to the `Accept-CH` and `Origin-Trial` headers.
+1.  If you want third-party subresource requests to also receive the reduced UA string, you have two options:
+    - Add a `Permissions-Policy` header with the third-party domains that should receive the reduced UA.
+        -  To allow a named list of third-party domains, add `Permissions-Policy: ch-ua-full=(self "[https://google.com](https://google.com)")`.
+        -  To allow all third-party domains, add `Permissions-Policy: ch-ua-full=*`.
+    - Add an `Accept-CH` meta tag with the third-party domains that should receive the reduced UA (only in Chrome 100 and above).
+        -  To allow a named list of third-party domains, add <meta name="accept-ch" content="ch-ua-full=( https://google.com )">
+        -  It's not possible to delegate to all third-party domains via `*` in the meta tag.
+1. Load your website in Chrome M100 (or later) and continue receiving the full User-Agent string.
+
+### Demo
+
+See [https://uard-ot-demo.glitch.me](https://uard-ot-demo.glitch.me) for a demonstration of the trial (along with the source code).
+
+## How do I validate that the trial is working?
+
+To validate that the origin trial is working, examine the request headers and ensure the following:
+
+1.  The User-Agent header contains the full version. It shouldn't contain any of the reduced values (found in the [list of samples of reduced User-Agent strings](https://www.chromium.org/updates/ua-reduction#TOC-Sample-UA-Strings:-Phase-4)). An easy way to tell is that the Chrome minor version string should **not** be `0.0.0`.
+1.  The `Sec-CH-UA-Full` header is set to `?1`.
+
+The initial response's headers containing the origin-trial token should look like:
+
+{% Img src="image/vgdbNJBYHma2o62ZqYmcnkq3j0o1/AIlPxFBDvO7jQrXuKfWU.png", alt="", width="800", height="175" %}
+
+Subsequent request headers containing the full User-Agent string should look like:
+
+{% Img src="image/vgdbNJBYHma2o62ZqYmcnkq3j0o1/Hzi5O1mZQyZEKeokCQSe.png", alt="", width="800", height="191" %}
+
+## How do I stop participating in the User-Agent Reduction deprecation trial?
+
+At any given point in time during the trial, you can stop participating and receive the reduced User-Agent string. To stop participating:
+
+1.  Send an `Accept-CH` header in your HTTP response that does **not** include `Sec-CH-UA-Full`. Note that `Accept-CH` with an empty value is a valid way to accomplish this if your site does not request any other Client Hints.
+1.  Remove the `Origin-Trial` header for the User-Agent Reduction deprecation trial from your HTTP response.
+1.  If set, remove `Sec-CH-UA-Full` from the `Critical-CH` header in your HTTP response.
+
+## How is this trial different from other User-Agent origin trials?
+
+Chrome is running two origin trials related to User Agent reduction. The first was [User Agent Reduction origin trial](https://developer.chrome.com/origintrials/#/view_trial/-7123568710593282047), which allowed sites to receive the reduced user agent string to test their use cases and provide feedback before it becomes the default behavior in Chrome.
+
+The second, referenced here, is a deprecation trial intended for sites that need a little more time to migrate to the [User-Agent Client Hints API](https://developer.mozilla.org/en-US/docs/Web/API/User-Agent_Client_Hints_API). It enables sites to continue receiving the full User-Agent string.
+
+## How long will the deprecation trial last?
+
+The UA Reduction deprecation trial will run from Chrome 100 to Chrome 112. Chrome 113 will be the first release where only the completely reduced User-Agent string is sent.
+
+## How do I share feedback for the User-Agent Reduction depreciation trial?
+
+Submit any issues or feedback to the [User-Agent Reduction Github repository](https://github.com/abeyad/user-agent-reduction/issues).

--- a/site/en/blog/user-agent-reduction-deprecation-trial/index.md
+++ b/site/en/blog/user-agent-reduction-deprecation-trial/index.md
@@ -9,6 +9,7 @@ description: >
   part in a deprecation trial to continue receiving the full User-Agent string.
 authors:
   - abeyad
+  - victortan
 date: 2022-02-24
 tags:
   - privacy
@@ -54,7 +55,7 @@ Once you've registerd for the trial, update your HTTP response headers with the 
     - Add an `Accept-CH` meta tag with the third-party domains that should receive the reduced UA (only in Chrome 100 and above).
         -  To allow a named list of third-party domains, add <meta name="accept-ch" content="ch-ua-full=( https://google.com )">
         -  It's not possible to delegate to all third-party domains via `*` in the meta tag.
-1. Load your website in Chrome M100 (or later) and continue receiving the full User-Agent string.
+1. Load your website in Chrome 100 (or later) and continue receiving the full User-Agent string.
 
 ### Demo
 

--- a/site/en/blog/user-agent-reduction-deprecation-trial/index.md
+++ b/site/en/blog/user-agent-reduction-deprecation-trial/index.md
@@ -19,7 +19,7 @@ tags:
 
 Starting from Chrome 101, the information available in the User-Agent string will be reduced [using a phased approach](https://blog.chromium.org/2021/09/user-agent-reduction-origin-trial-and-dates.html). Sites that haven't had time to migrate away from using the reduced User-Agent string and [move toward User-Agent Client Hints](https://web.dev/migrate-to-ua-ch/) can take part in a deprecation trial to continue receiving the full User-Agent string.
 
-The registration for the deprecation trial will begin with the [Chrome 100 ](https://chromiumdash.appspot.com/schedule) Beta. It will allow sites to receive the full User-Agent string ahead of the Chrome 101 release, where the minor version string will be reduced. If you would like to test the origin trial on Chrome 100 Beta before it launches to the stable channel, be sure to register and test before the release date for Chrome 100 currently ([scheduled for March 31st, 2022](https://chromiumdash.appspot.com/schedule)).
+The registration for the deprecation trial will begin with the [Chrome 100](https://chromiumdash.appspot.com/schedule) Beta. It will allow sites to receive the full User-Agent string ahead of the Chrome 101 release, where the minor version string will be reduced. If you would like to test the origin trial on Chrome 100 Beta before it launches to the stable channel, be sure to register and test before the release date for Chrome 100 currently ([scheduled for March 31st, 2022](https://chromiumdash.appspot.com/schedule)).
 
 Below is an overview of the deprecation trial and what to expect. If you have feedback to share or you encounter any issues throughout this trial let us know in the [UA Reduction Github repository](https://github.com/abeyad/user-agent-reduction/issues).
 

--- a/site/en/blog/user-agent-reduction-deprecation-trial/index.md
+++ b/site/en/blog/user-agent-reduction-deprecation-trial/index.md
@@ -19,7 +19,7 @@ tags:
 
 Starting from Chrome 101, the information available in the User-Agent string will be reduced [using a phased approach](https://blog.chromium.org/2021/09/user-agent-reduction-origin-trial-and-dates.html). Sites that haven't had time to migrate away from using the reduced User-Agent string and [move toward User-Agent Client Hints](https://web.dev/migrate-to-ua-ch/) can take part in a deprecation trial to continue receiving the full User-Agent string.
 
-The registration for the deprecation trial will begin with the [Chrome 100 ](https://chromiumdash.appspot.com/schedule)Beta. It will allow sites to receive the full User-Agent string ahead of the Chrome 101 release, where the minor version string will be reduced. If you would like to test the origin trial on Chrome 100 Beta before it launches to the stable channel, be sure to register and test before the release date for Chrome 100 currently ([scheduled for March 31st, 2022](https://chromiumdash.appspot.com/schedule)).
+The registration for the deprecation trial will begin with the [Chrome 100 ](https://chromiumdash.appspot.com/schedule) Beta. It will allow sites to receive the full User-Agent string ahead of the Chrome 101 release, where the minor version string will be reduced. If you would like to test the origin trial on Chrome 100 Beta before it launches to the stable channel, be sure to register and test before the release date for Chrome 100 currently ([scheduled for March 31st, 2022](https://chromiumdash.appspot.com/schedule)).
 
 Below is an overview of the deprecation trial and what to expect. If you have feedback to share or you encounter any issues throughout this trial let us know in the [UA Reduction Github repository](https://github.com/abeyad/user-agent-reduction/issues).
 
@@ -38,7 +38,7 @@ Sites should still audit their usage of the User-Agent header and related APIs, 
 
 ### Register for the trial
 
-To register for the origin trial and get a token for your domains, visit the Trial for [User Agent Reduction Deprecation page](https://developer.chrome.com/origintrials/#/view_trial/2608710084154359809).
+To register for the origin trial and get a token for your domains, visit the Trial for [User Agent Reduction Deprecation page](/origintrials/#/view_trial/2608710084154359809).
 
 ### Setup
 
@@ -85,9 +85,9 @@ At any given point in time during the trial, you can stop participating and rece
 
 ## How is this trial different from other User-Agent origin trials?
 
-Chrome is running two origin trials related to User Agent reduction. The first was [User Agent Reduction origin trial](https://developer.chrome.com/origintrials/#/view_trial/-7123568710593282047), which allowed sites to receive the reduced user agent string to test their use cases and provide feedback before it becomes the default behavior in Chrome.
+Chrome is running two origin trials related to User Agent reduction. The first was [User Agent Reduction origin trial](/origintrials/#/view_trial/-7123568710593282047), which allowed sites to receive the reduced user agent string to test their use cases and provide feedback before it becomes the default behavior in Chrome.
 
-The second, referenced here, is a deprecation trial intended for sites that need a little more time to migrate to the [User-Agent Client Hints API](https://developer.mozilla.org/en-US/docs/Web/API/User-Agent_Client_Hints_API). It enables sites to continue receiving the full User-Agent string.
+The second, referenced here, is a deprecation trial intended for sites that need a little more time to migrate to the [User-Agent Client Hints API](https://developer.mozilla.org/docs/Web/API/User-Agent_Client_Hints_API). It enables sites to continue receiving the full User-Agent string.
 
 ## How long will the deprecation trial last?
 

--- a/site/en/blog/user-agent-reduction-deprecation-trial/index.md
+++ b/site/en/blog/user-agent-reduction-deprecation-trial/index.md
@@ -53,7 +53,7 @@ Once you've registerd for the trial, update your HTTP response headers with the 
         -  To allow a named list of third-party domains, add `Permissions-Policy: ch-ua-full=(self "[https://google.com](https://google.com)")`.
         -  To allow all third-party domains, add `Permissions-Policy: ch-ua-full=*`.
     - Add an `Accept-CH` meta tag with the third-party domains that should receive the reduced UA (only in Chrome 100 and above).
-        -  To allow a named list of third-party domains, add <meta name="accept-ch" content="ch-ua-full=( https://google.com )">
+        -  To allow a named list of third-party domains, add `<meta name="accept-ch" content="ch-ua-full=( https://google.com )">`.
         -  It's not possible to delegate to all third-party domains via `*` in the meta tag.
 1. Load your website in Chrome 100 (or later) and continue receiving the full User-Agent string.
 

--- a/site/en/docs/privacy-sandbox/user-agent/index.md
+++ b/site/en/docs/privacy-sandbox/user-agent/index.md
@@ -14,6 +14,7 @@ authors:
 ## Implementation status
 
 *  [In origin trial](/blog/user-agent-reduction-origin-trial/) Chrome 95 to 100
+*  [In deprecation trial](/blog/user-agent-deprecation-origin-trial/) Chrome 100 to Chrome 112
 *  [Register for the trial](/origintrials/#/view_trial/-7123568710593282047)
 *  [Chrome DevTools integration](/blog/new-in-devtools-89/#ua-ch)
 *  [UA-CH Chrome platform status](https://chromestatus.com/feature/5995832180473856)


### PR DESCRIPTION
Fixes #2140

Changes proposed in this pull request:

- Add deprecation trial post
- Add Victor Tan to dcc authors

To do:

- [x]  See if we should link to this post from the UA landing page
- [ ]  Fix origin trial links on lines 42 and 89.
    - Should be [1](https://developer.chrome.com/origintrials/#/view_trial/2608710084154359809) and [2](https://developer.chrome.com/origintrials/#/view_trial/-7123568710593282047). The linter forces relative links but they don't work.
  

cc @abeyad 