### PR TITLE
Enable workbox-webpack-plugin TSDoc generation

### DIFF
--- a/external/build/lib/dts-parse.js
+++ b/external/build/lib/dts-parse.js
@@ -807,6 +807,7 @@ module.exports = async function parse({silent, sources, mode}) {
   /** @type {typedoc.TypeScript.CompilerOptions} */
   const typescriptOptions = {
     declaration: true,
+    esModuleInterop: true,
   };
 
   /** @type {Partial<typedoc.TypeDocOptions>} */

--- a/external/build/workbox-types.js
+++ b/external/build/workbox-types.js
@@ -25,7 +25,7 @@ const workboxPackages = [
   'workbox-routing',
   'workbox-strategies',
   'workbox-streams',
-  // 'workbox-webpack-plugin',
+  'workbox-webpack-plugin',
   'workbox-window',
 ];
 
@@ -54,6 +54,12 @@ async function fetchAndPrepare(packages, targetDir) {
 async function run() {
   const t = tmp.dirSync();
   try {
+    // webpack is a peerDependency of workbox-webpack-plugin, and needs to be
+    // manually installed.
+    childProcess.execFileSync('npm', ['install', 'webpack'], {
+      cwd: t.name,
+      stdio: 'inherit',
+    });
     await fetchAndPrepare(workboxPackages, t.name);
 
     const sources = [];


### PR DESCRIPTION
Fixes #1936

Workbox v6.5.0 includes TypeScript definitions for `workbox-webpack-plugin`, so we can generate the TSDocs now.