### PR TITLE
Adds a link proposed in GoogleChrome/web.dev#7211 to an audit doc.

### DIFF
--- a/site/en/docs/lighthouse/performance/uses-responsive-images/index.md
+++ b/site/en/docs/lighthouse/performance/uses-responsive-images/index.md
@@ -30,10 +30,8 @@ Ideally, your page should never serve images that are larger than the version
 that's rendered on the user's screen.
 Anything larger than that just results in wasted bytes and slows down page load time.
 
-The main strategy for serving appropriately sized images is called "responsive images".
-With responsive images, you generate multiple versions of each image,
-and then specify which version to use in your HTML or CSS using media queries, viewport dimensions, and so on.
-See [Serve responsive images](https://web.dev/serve-responsive-images/) to learn more.
+The main strategy for serving appropriately sized images is called "responsive images". With responsive images, you generate multiple versions of each image,
+and then specify which version to use in your HTML or CSS using media queries, viewport dimensions, and so on. Additionally, [RespImageLint](https://ausi.github.io/respimagelint/) is a helpful bookmarklet for identifying the optimal `srcset` and `sizes` values for your images. See [Serve responsive images](/serve-responsive-images) to learn more about these attributes.
 
 [Image CDNs](https://web.dev/image-cdns/) are another main strategy for serving appropriately sized images.
 You can think of image CDNs like web service APIs for transforming images.


### PR DESCRIPTION
Fixes GoogleChrome/web.dev#7211

Changes proposed in this pull request:

- @danielbachhuber proposed a change in the Lighthouse responsive images audit doc in the web.dev repo, but since we are moving those docs to d.c.c, this adds his suggestion to that version of the doc on d.c.c. (but only in English).