### PR TITLE
Cleanup of Workbox build examples

### DIFF
--- a/site/en/docs/workbox/modules/workbox-build/index.md
+++ b/site/en/docs/workbox/modules/workbox-build/index.md
@@ -126,7 +126,7 @@ injectManifest({
 
 This will create a precache manifest based on the files picked up by your configuration and inject it into your existing service worker file.
 
-A full set of configuration options can be found on [in the reference documentation](/docs/workbox/reference/workbox-build/#type-InjectManifestOptions).
+A full set of configuration options can be found [in the reference documentation](/docs/workbox/reference/workbox-build/#type-InjectManifestOptions).
 
 ## Additional modes
 

--- a/site/en/docs/workbox/modules/workbox-build/index.md
+++ b/site/en/docs/workbox/modules/workbox-build/index.md
@@ -93,7 +93,7 @@ generateSW({
 
 This will generate a service worker with precaching setup for all of the files picked up by your configuration, and the runtime caching rules provided.
 
-A full set of configuration options can be found on [in the reference documentation](/docs/workbox/reference/workbox-build/#type-GenerateSWOptions).
+A full set of configuration options can be found [in the reference documentation](/docs/workbox/reference/workbox-build/#type-GenerateSWOptions).
 
 ## `injectManifest` Mode
 

--- a/site/en/docs/workbox/modules/workbox-build/index.md
+++ b/site/en/docs/workbox/modules/workbox-build/index.md
@@ -2,9 +2,9 @@
 layout: 'layouts/doc-post.njk'
 title: workbox-build
 date: 2018-01-31
-updated: 2020-01-17
+updated: 2022-03-13
 description: >
-  A module that can generate a service worker, inject a precache manifest, or create a local copy the Workbox libraries.
+  A module that can generate a service worker, inject a precache manifest into existing code, or create a precache manifest.
 ---
 
 The `workbox-build` module integrates into a node-based build process and can generate an entire service worker, or just generate a list of assets to precache that could be used within an existing service worker.
@@ -15,17 +15,17 @@ The two modes that most developers will use are `generateSW` and `injectManifest
 
 ### `generateSW`
 
-The `generateSW` mode creates a service worker file for you, and writes it out to disk.
+The `generateSW` mode creates a service worker file for you, customized via configuration options, and writes it out to disk.
 
 #### When to use `generateSW`
 
 - You want to precache files.
-- You have simple runtime configuration needs (e.g. the configuration allows you to define routes and strategies).
+- You have simple runtime caching needs.
 
 #### When NOT to use `generateSW`
 
-- You want to use other Service Worker features (i.e. Web Push).
-- You want to import additional scripts or add additional logic.
+- You want to use other Service Worker features (i.e. [Web Push](https://developer.mozilla.org/docs/Web/API/Push_API)).
+- You want to import additional scripts, or add additional logic for custom caching strategies.
 
 ### `injectManifest`
 
@@ -35,8 +35,8 @@ The `injectManifest` mode will generate a list of URLs to precache, and add that
 
 - You want more control over your service worker.
 - You want to precache files.
-- You have more complex needs in terms of routing.
-- You would like to use your service worker with other API's (e.g. Web Push).
+- You need to customize routing and strategies.
+- You would like to use your service worker with other platform features (e.g. [Web Push](https://developer.mozilla.org/docs/Web/API/Push_API)).
 
 #### When NOT to use `injectManifest`
 
@@ -44,55 +44,89 @@ The `injectManifest` mode will generate a list of URLs to precache, and add that
 
 ## `generateSW` Mode
 
-You can use the `generateSW` mode within a node-based build script like so:
+You can use the `generateSW` mode within a node-based build script, using the most common [configuration options](/docs/workbox/reference/workbox-build/#type-GenerateSWOptions), like so:
 
 ```js
 // Inside of build.js:
 const {generateSW} = require('workbox-build');
 
-const swDest = 'build/sw.js';
+// These are some common options, and not all are required.
+// Consult the docs for more info.
 generateSW({
-  swDest,
-  // Other configuration options...
-}).then(({count, size}) => {
-  console.log(
-    `Generated ${swDest}, which will precache ${count} files, totaling ${size} bytes.`
-  );
+  dontCacheBustURLsMatching: [new RegExp('...')],
+  globDirectory: '...',
+  globPatterns: ['...', '...'],
+  maximumFileSizeToCacheInBytes: ...,
+  navigateFallback: '...',
+  runtimeCaching: [{
+    // Routing via a matchCallback function:
+    urlPattern: ({request, url}) => ...,
+    handler: '...',
+    options: {
+      cacheName: '...',
+      expiration: {
+        maxEntries: ...,
+      },
+    },
+  }, {
+    // Routing via a RegExp:
+    urlPattern: new RegExp('...'),
+    handler: '...',
+    options: {
+      cacheName: '...',
+      plugins: [..., ...],
+    },
+  }],
+  skipWaiting: ...,
+  swDest: '...',
+}).then(({count, size, warnings}) => {
+  if (warnings.length > 0) {
+    console.warn(
+      'Warnings encountered while generating a service worker:'
+      warnings.join('\n')
+    );
+  }
+
+  console.log(`Generated a service worker, which will precache ${count} files, totaling ${size} bytes.`);
 });
 ```
 
-This will generate a service worker with precaching setup for all of the files picked up by your configuration.
+This will generate a service worker with precaching setup for all of the files picked up by your configuration, and the runtime caching rules provided.
 
-### Full `generateSW` Config
-
-A full set of configuration options can be found on [this reference page](/docs/workbox/reference/workbox-build/#method-generateSW).
+A full set of configuration options can be found on [in the reference documentation](/docs/workbox/reference/workbox-build/#type-GenerateSWOptions).
 
 ## `injectManifest` Mode
 
-You can use the `injectManifest` mode within a node-based build script like so:
+You can use the `injectManifest` mode within a node-based build script, using the most common [configuration options](/docs/workbox/reference/workbox-build/#type-InjectManifestOptions), like so:
 
 ```js
 // Inside of build.js:
 const {injectManifest} = require('workbox-build');
 
-const swSrc = 'src/sw.js';
-const swDest = 'build/sw.js';
+// These are some common options, and not all are required.
+// Consult the docs for more info.
 injectManifest({
-  swSrc,
-  swDest,
-  // Other configuration options...
-}).then(({count, size}) => {
-  console.log(
-    `Generated ${swDest}, which will precache ${count} files, totaling ${size} bytes.`
-  );
+  dontCacheBustURLsMatching: [new RegExp('...')],
+  globDirectory: '...',
+  globPatterns: ['...', '...'],
+  maximumFileSizeToCacheInBytes: ...,
+  swDest: '...',
+  swSrc: '...',
+}).then(({count, size, warnings}) => {
+  if (warnings.length > 0) {
+    console.warn(
+      'Warnings encountered while injecting the manifest:'
+      warnings.join('\n')
+    );
+  }
+
+  console.log(`Injected a manifest which will precache ${count} files, totaling ${size} bytes.`);
 });
 ```
 
 This will create a precache manifest based on the files picked up by your configuration and inject it into your existing service worker file.
 
-### Full `injectManifest` Config
-
-A full set of configuration options can be found on [this reference page](/docs/workbox/reference/workbox-build/#method-injectManifest).
+A full set of configuration options can be found on [in the reference documentation](/docs/workbox/reference/workbox-build/#type-InjectManifestOptions).
 
 ## Additional modes
 
@@ -102,18 +136,29 @@ We expect that `generateSW` or `injectManifest` will suit most developers' needs
 
 This is conceptually similar to the `injectManifest` mode, but instead of adding the manifest into the source service worker file, it returns the array of manifest entries, along with information about the number of entries and total size.
 
-You can use the `getManifest` mode within a node-based build script like so:
+You can use the `injectManifest` mode within a node-based build script, using the most common [configuration options](/docs/workbox/reference/workbox-build/#type-GetManifestOptions), like so:
 
 ```js
 // Inside of build.js:
 const {getManifest} = require('workbox-build');
 
+// These are some common options, and not all are required.
+// Consult the docs for more info.
 getManifest({
-  // Configuration options...
-}).then(({manifestEntries, count, size}) => {
+  dontCacheBustURLsMatching: [new RegExp('...')],
+  globDirectory: '...',
+  globPatterns: ['...', '...'],
+  maximumFileSizeToCacheInBytes: ...,
+}).then(({manifestEntries, count, size, warnings}) => {
+  if (warnings.length > 0) {
+    console.warn(
+      'Warnings encountered while getting the manifest:'
+      warnings.join('\n')
+    );
+  }
+
   // Do something with the manifestEntries, and potentially log count and size.
 });
 ```
 
-A full set of configuration options can be found on
-[this reference page](/docs/workbox/reference/workbox-build/#method-getManifest).
+A full set of configuration options can be found on [in the reference documentation](/docs/workbox/reference/workbox-build/#type-GetManifestOptions).

--- a/site/en/docs/workbox/modules/workbox-build/index.md
+++ b/site/en/docs/workbox/modules/workbox-build/index.md
@@ -161,4 +161,4 @@ getManifest({
 });
 ```
 
-A full set of configuration options can be found on [in the reference documentation](/docs/workbox/reference/workbox-build/#type-GetManifestOptions).
+A full set of configuration options can be found [in the reference documentation](/docs/workbox/reference/workbox-build/#type-GetManifestOptions).

--- a/site/en/docs/workbox/modules/workbox-cli/index.md
+++ b/site/en/docs/workbox/modules/workbox-cli/index.md
@@ -178,4 +178,4 @@ A full set of configuration options can be found on [in the reference documentat
 
 ### Options used by `injectManifest`
 
-A full set of configuration options can be found on [in the reference documentation](/docs/workbox/reference/workbox-build/#type-InjectManifestOptions).
+A full set of configuration options can be found [in the reference documentation](/docs/workbox/reference/workbox-build/#type-InjectManifestOptions).

--- a/site/en/docs/workbox/modules/workbox-cli/index.md
+++ b/site/en/docs/workbox/modules/workbox-cli/index.md
@@ -2,7 +2,7 @@
 layout: 'layouts/doc-post.njk'
 title: workbox-cli
 date: 2017-11-27
-updated: 2020-01-17
+updated: 2022-03-03
 description: >
   Generate a service worker, inject a precache manifest, or create a local copy the Workbox libraries from the command line.
 ---
@@ -68,12 +68,12 @@ are recommended to use `generateSW` mode.
 #### When to use `generateSW`
 
 - You want to precache files.
-- You have simple runtime configuration needs (e.g. the configuration allows you to define routes and strategies).
+- You have simple runtime caching needs.
 
 #### When NOT to use `generateSW`
 
-- You want to use other Service Worker features (i.e. Web Push).
-- You want to import additional scripts or add additional logic.
+- You want to use other Service Worker features (i.e. [Web Push](https://developer.mozilla.org/docs/Web/API/Push_API)).
+- You want to import additional scripts, or add additional logic for custom caching strategies.
 
 ### `injectManifest`
 
@@ -96,14 +96,14 @@ npx workbox injectManifest path/to/config.js
 
 #### When to use `injectManifest`
 
-You want more control over your service worker.
-You want to precache files.
-You have more complex needs in terms of routing.
-You would like to use your service worker with other API's (e.g. Web Push).
+- You want more control over your service worker.
+- You want to precache files.
+- You need to customize routing and strategies.
+- You would like to use your service worker with other platform features (e.g. [Web Push](https://developer.mozilla.org/docs/Web/API/Push_API)).
 
 #### When NOT to use `injectManifest`
 
-You want the easiest path to adding a service worker to your site.
+- You want the easiest path to adding a service worker to your site.
 
 ### `copyLibraries`
 
@@ -174,10 +174,8 @@ automatically by `workbox wizard` or tweaked manually.
 
 ### Options used by `generateSW`
 
-A full set of configuration options can be found on
-[this reference page](/docs/workbox/reference/workbox-build/#method-generateSW).
+A full set of configuration options can be found on [in the reference documentation](/docs/workbox/reference/workbox-build/#type-GenerateSWOptions).
 
 ### Options used by `injectManifest`
 
-A full set of configuration options can be found on
-[this reference page](/docs/workbox/reference/workbox-build/#method-injectManifest).
+A full set of configuration options can be found on [in the reference documentation](/docs/workbox/reference/workbox-build/#type-InjectManifestOptions).

--- a/site/en/docs/workbox/modules/workbox-cli/index.md
+++ b/site/en/docs/workbox/modules/workbox-cli/index.md
@@ -174,7 +174,7 @@ automatically by `workbox wizard` or tweaked manually.
 
 ### Options used by `generateSW`
 
-A full set of configuration options can be found on [in the reference documentation](/docs/workbox/reference/workbox-build/#type-GenerateSWOptions).
+A full set of configuration options can be found [in the reference documentation](/docs/workbox/reference/workbox-build/#type-GenerateSWOptions).
 
 ### Options used by `injectManifest`
 

--- a/site/en/docs/workbox/modules/workbox-webpack-plugin/index.md
+++ b/site/en/docs/workbox/modules/workbox-webpack-plugin/index.md
@@ -121,7 +121,7 @@ module.exports = {
 
 This will create a precache manifest based on the webpack assets picked up by your configuration and inject it into your bundled and compiled service worker file.
 
-A full set of configuration options can be found on [in the reference documentation](/docs/workbox/reference/workbox-build/#type-WebpackInjectManifestOptions).
+A full set of configuration options can be found [in the reference documentation](/docs/workbox/reference/workbox-build/#type-WebpackInjectManifestOptions).
 
 ## Extra Info
 

--- a/site/en/docs/workbox/modules/workbox-webpack-plugin/index.md
+++ b/site/en/docs/workbox/modules/workbox-webpack-plugin/index.md
@@ -94,7 +94,7 @@ module.exports = {
 
 This will generate a service worker with precaching setup for all of the webpack assets picked up by your configuration, and the runtime caching rules provided.
 
-A full set of configuration options can be found on [in the reference documentation](/docs/workbox/reference/workbox-build/#type-WebpackGenerateSWOptions).
+A full set of configuration options can be found [in the reference documentation](/docs/workbox/reference/workbox-build/#type-WebpackGenerateSWOptions).
 
 ## `InjectManifest` Plugin
 

--- a/site/en/docs/workbox/modules/workbox-webpack-plugin/index.md
+++ b/site/en/docs/workbox/modules/workbox-webpack-plugin/index.md
@@ -2,7 +2,7 @@
 layout: 'layouts/doc-post.njk'
 title: workbox-webpack-plugin
 date: 2017-12-15
-updated: 2020-02-03
+updated: 2022-03-03
 description: >
   Generate a service worker or inject a precache manifest, using the webpack build tool.
 ---
@@ -25,12 +25,12 @@ add it to the webpack asset pipeline.
 #### When to use `GenerateSW`
 
 - You want to precache files.
-- You have simple runtime configuration needs (e.g. the configuration allows you to define routes and strategies).
+- You have simple runtime caching needs.
 
 #### When NOT to use `GenerateSW`
 
-- You want to use other Service Worker features (i.e. Web Push).
-- You want to import additional scripts or add additional logic.
+- You want to use other Service Worker features (i.e. [Web Push](https://developer.mozilla.org/docs/Web/API/Push_API)).
+- You want to import additional scripts, or add additional logic for custom caching strategies.
 
 ### `InjectManifest`
 
@@ -42,8 +42,8 @@ file. It will otherwise leave the file as-is.
 
 - You want more control over your service worker.
 - You want to precache files.
-- You have more complex needs in terms of routing.
-- You would like to use your service worker with other API's (e.g. Web Push).
+- You need to customize routing and strategies.
+- You would like to use your service worker with other platform features (e.g. [Web Push](https://developer.mozilla.org/docs/Web/API/Push_API)).
 
 #### When NOT to use `InjectManifest`
 
@@ -61,38 +61,40 @@ module.exports = {
   // Other webpack config...
   plugins: [
     // Other plugins...
-    new GenerateSW(),
-  ],
-};
-```
-
-This will generate a service worker with precaching setup for all of your
-webpack assets.
-
-### Full `GenerateSW` Config
-
-If you want to use any of the configuration options for the `GenerateSW` plugin,
-you'd just need to add an `Object` to the plugin's constructor.
-
-For example:
-
-```js
-// Inside of webpack.config.js:
-const {GenerateSW} = require('workbox-webpack-plugin');
-
-module.exports = {
-  // Other webpack config...
-  plugins: [
-    // Other plugins...
     new GenerateSW({
-      option: 'value',
+      // These are some common options, and not all are required.
+      // Consult the docs for more info.
+      exclude: [/.../, '...'],
+      maximumFileSizeToCacheInBytes: ...,
+      navigateFallback: '...',
+      runtimeCaching: [{
+        // Routing via a matchCallback function:
+        urlPattern: ({request, url}) => ...,
+        handler: '...',
+        options: {
+          cacheName: '...',
+          expiration: {
+            maxEntries: ...,
+          },
+        },
+      }, {
+        // Routing via a RegExp:
+        urlPattern: new RegExp('...'),
+        handler: '...',
+        options: {
+          cacheName: '...',
+          plugins: [..., ...],
+        },
+      }],
+      skipWaiting: ...,
     }),
   ],
 };
 ```
 
-A full set of configuration options can be found on
-[this reference page](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-webpack-plugin.GenerateSW.html#GenerateSW).
+This will generate a service worker with precaching setup for all of the webpack assets picked up by your configuration, and the runtime caching rules provided.
+
+A full set of configuration options can be found on [in the reference documentation](/docs/workbox/reference/workbox-build/#type-WebpackGenerateSWOptions).
 
 ## `InjectManifest` Plugin
 
@@ -107,38 +109,19 @@ module.exports = {
   plugins: [
     // Other plugins...
     new InjectManifest({
-      swSrc: './src/sw.js',
+      // These are some common options, and not all are required.
+      // Consult the docs for more info.
+      exclude: [/.../, '...'],
+      maximumFileSizeToCacheInBytes: ...,
+      swSrc: '...',
     }),
   ],
 };
 ```
 
-This will create a precache manifest (a list of webpack assets) and inject it into
-your service worker file via `importScripts()`.
+This will create a precache manifest based on the webpack assets picked up by your configuration and inject it into your bundled and compiled service worker file.
 
-### Full `InjectManifest` Config
-
-You can pass the appropriate configuration as properties of an `Object` to the plugin's constructor.
-
-For example:
-
-```js
-// Inside of webpack.config.js:
-const {InjectManifest} = require('workbox-webpack-plugin');
-
-module.exports = {
-  // Other webpack config...
-  plugins: [
-    // Other plugins...
-    new InjectManifest({
-      option: 'value',
-    }),
-  ],
-};
-```
-
-A full set of configuration options can be found on
-[this reference page](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-webpack-plugin.InjectManifest#InjectManifest).
+A full set of configuration options can be found on [in the reference documentation](/docs/workbox/reference/workbox-build/#type-WebpackInjectManifestOptions).
 
 ## Extra Info
 


### PR DESCRIPTION
R: @malchata 
CC: @tropicadri 

This more of less matches the inline examples we added to the TSDocs in https://github.com/GoogleChrome/workbox/pull/3038, and links to the relevant reference docs for the full configs in a way that's hopefully easier to find.