### PR TITLE
Updates a few more reference docs links from d.g.c to d.c.c.

### DIFF
--- a/site/en/docs/workbox/modules/workbox-precaching/index.md
+++ b/site/en/docs/workbox/modules/workbox-precaching/index.md
@@ -25,7 +25,7 @@ the API and ensuring assets are downloaded efficiently.
 When a web app is loaded for the first time, `workbox-precaching` will look at all
 the assets you want to download, remove any duplicates and hook up the relevant
 service worker events to download and store the assets. URLs that
-[already include](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build#parameter_2:~:text=index.-,dontCacheBustURLsMatching)
+[already include](/docs/workbox/reference/workbox-build/#property-BasePartial-dontCacheBustURLsMatching)
 versioning information (like a content hash) are used as cache keys without any
 further modification. URLs that don't include versioning information have an extra
 URL query parameter appended to their cache key representing a hash of their content

--- a/site/en/docs/workbox/modules/workbox-sw/index.md
+++ b/site/en/docs/workbox/modules/workbox-sw/index.md
@@ -110,7 +110,7 @@ self.addEventListener('fetch', event => {
 
 If you need to write code that would otherwise run afoul of this restriction, you can explicitly
 trigger the `importScripts()` call outside of the event handler by using the
-[`workbox.loadModule()`](https://developers.google.com/web/tools/workbox/reference-docs/latest/workbox#.loadModule) method:
+`workbox.loadModule()` method:
 
 ```js
 importScripts(

--- a/site/en/docs/workbox/precaching-with-workbox/index.md
+++ b/site/en/docs/workbox/precaching-with-workbox/index.md
@@ -19,7 +19,7 @@ Precaching is one of the most common things you'll do in a service worker, and W
 On the other hand, if you use `workbox-build` or `workbox-cli`, only HTML, CSS and JavaScript assets read from the local filesystem will be precached by default. Configuration-wise, you have to specify `swDest` and [the globDirectoryoption in the [`generateSW` config](/docs/workbox/reference/workbox-build/#method-generateSW) for precaching to work. Chances are, you'll want to configure additional options affecting your service worker behavior as well, so take a look through the documentation.
 
 {% Aside 'warning' %}
-If too many assets in your project are precached with the default settings, use one of the glob options to exclude resources in the `generateSW` configuration. When using `workbox-webpack-plugin`, consult the plugin's [`GenerateSW` documentation](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-webpack-plugin.GenerateSW) to find out how to prevent unwanted assets from being precached, as its configuration differs from `generateSW`.
+If too many assets in your project are precached with the default settings, use one of the glob options to exclude resources in the `generateSW` configuration. When using `workbox-webpack-plugin`, consult the plugin's [`GenerateSW` documentation](/docs/workbox/reference/workbox-webpack-plugin/#type-GenerateSW) to find out how to prevent unwanted assets from being precached, as its configuration differs from `generateSW`.
 {% endAside %}
 
 ## Precaching with `injectManifest`

--- a/site/en/docs/workbox/troubleshooting-and-logging/index.md
+++ b/site/en/docs/workbox/troubleshooting-and-logging/index.md
@@ -58,7 +58,7 @@ While bundlers are great, not every project needs them. If you find yourself in 
 
 The `workbox-sw` module simplifies loading other Workbox modules (e.g., `workbox-routing`, `workbox-precaching`, etc) from a CDN. Whether it loads the development or production bundles depends on the URL used to access your web app. By default, `workbox-sw` loads the development version of Workbox if your web app is running on `http://localhost`, and the production version at all other times.
 
-You can override the default behavior by calling Workbox's [`setConfig` method](https://developers.google.com/web/tools/workbox/reference-docs/latest/workbox#.setConfig) to set the `debug` option to `true`:
+You can override the default behavior by calling Workbox's `setConfig` method to set the `debug` option to `true`:
 
 ```js
 // Load workbox-sw from a CDN

--- a/site/en/docs/workbox/troubleshooting-and-logging/index.md
+++ b/site/en/docs/workbox/troubleshooting-and-logging/index.md
@@ -50,7 +50,7 @@ Bundlers are tools that take code from individual modules and create JavaScript 
 - In webpack, the [`mode` configuration option](https://webpack.js.org/configuration/mode/) can be set to `'production'` or `'development'`. `workbox-webpack-plugin` will use the production or development logging in Workbox based on this value.
 - For Rollup, [`rollup-plugin-workbox`](https://www.npmjs.com/package/rollup-plugin-workbox) accepts a `mode` configuration option that also affects whether Workbox logs anything to the console. If you're using Rollup without the Workbox-specific plugin, you'll need to configure [`@rollup/plugin-replace`](https://www.npmjs.com/package/@rollup/plugin-replace) to substitute `process.env.NODE_ENV` with `'development'` or `'production'`.
 
-Suppose the default logging behavior must be overridden in development. In that case, the appropriate Workbox plugin for your bundler should allow you to hardcode a preference for debugging logs in its configuration. For example, you could disable logging in Workbox via `workbox-webpack-plugin`'s `mode` option for the [`GenerateSW` method](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-webpack-plugin.GenerateSW#GenerateSW).
+Suppose the default logging behavior must be overridden in development. In that case, the appropriate Workbox plugin for your bundler should allow you to hardcode a preference for debugging logs in its configuration. For example, you could disable logging in Workbox via `workbox-webpack-plugin`'s `mode` option for the [`GenerateSW` method](/docs/workbox/reference/workbox-webpack-plugin/#type-GenerateSW).
 
 ### Without a bundler
 


### PR DESCRIPTION
As the title says, this PR updates a few reference docs links that point to the old reference docs on d.g.c. to the new docs on d.c.c.