### PR TITLE
Remove Workbox preview banner, make the docs indexable

### DIFF
--- a/site/en/docs/workbox/modules/modules.11tydata.js
+++ b/site/en/docs/workbox/modules/modules.11tydata.js
@@ -22,7 +22,6 @@
  * @return {EleventyData}
  */
 module.exports = {
-  noindex: true,
   // This is the default hero image for all Workbox pages.
   hero: 'image/QMjXarRXcMarxQddwrEdPvHVM242/ZUBXF0hK0jo9q4RvELUs.png',
   eleventyComputed: {

--- a/site/en/docs/workbox/workbox.11tydata.js
+++ b/site/en/docs/workbox/workbox.11tydata.js
@@ -22,16 +22,6 @@
  * @return {EleventyData}
  */
 module.exports = {
-  noindex: true,
   // This is the default hero image for all Workbox pages.
   hero: 'image/QMjXarRXcMarxQddwrEdPvHVM242/ZUBXF0hK0jo9q4RvELUs.png',
-  banner: {
-    text: "This is a preview of Workbox's new documentation.",
-    actions: [
-      {
-        text: 'Need to see older docs?',
-        href: 'https://developers.google.com/web/tools/workbox',
-      },
-    ],
-  },
 };


### PR DESCRIPTION
R: @malchata 
CC: @tropicadri 

This will effectively "launch" the new docs site.

Redirects from https://developers.google.com/web/tools/workbox/ will follow in separate PRs to another repo.