### PR TITLE
Fix a few broken links in extensions documentation

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -233,6 +233,9 @@ redirects:
 - from: /extensions/crx
   to: /docs/extensions/mv3/hosting
 
+- from: /extensions/event_pages/
+  to: /docs/extensions/mv2/background_pages/
+
 - from: /extensions/getstarted_arc
   to: https://developer.android.com/chrome-os/intro.html
 

--- a/site/en/docs/apps/event_pages/index.md
+++ b/site/en/docs/apps/event_pages/index.md
@@ -23,4 +23,4 @@ Scripts][3] for clarification and best practices.
 
 [1]: https://blog.chromium.org/2020/08/changes-to-chrome-app-support-timeline.html
 [2]: /apps/migration
-[3]: /background_pages
+[3]: /docs/extensions/mv2/background_pages/

--- a/site/en/docs/extensions/mv3/devtools/index.md
+++ b/site/en/docs/extensions/mv3/devtools/index.md
@@ -11,9 +11,8 @@ description: How to create a Chrome Extension that adds functionality to Chrome 
 ## Overview {: #overview }
 
 A DevTools extension adds functionality to the Chrome DevTools. It can add new UI panels and
-sidebars, interact with the inspected page, get information about network requests, and more. 
-DevTools extensions have access to an additional set of
-DevTools-specific extension APIs:
+sidebars, interact with the inspected page, get information about network requests, and more.
+DevTools extensions have access to an additional set of DevTools-specific extension APIs:
 
 - [`devtools.inspectedWindow`][api-inspectedwindow]
 - [`devtools.network`][api-network]
@@ -42,9 +41,10 @@ DevTools APIs and a limited set of extension APIs. Specifically, the DevTools pa
 - Get information about network requests using the [`devtools.network`][api-network] APIs.
 
 The DevTools page cannot use most of the extensions APIs directly. It has access to the same subset
-of the [`extension`][api-extension] and [`runtime`][api-runtime] APIs that a content script has access to. Like a content
-script, a DevTools page can communicate with the background page using [Message Passing][doc-message-passing]. For an
-example, see [Injecting a Content Script][header-injecting].
+of the [`extension`][api-extension] and [`runtime`][api-runtime] APIs that a content script has
+access to. Like a content script, a DevTools page can communicate with the background page using
+[Message Passing][doc-message-passing]. For an example, see [Injecting a Content
+Script][header-injecting].
 
 ## Creating a DevTools extension {: #creating }
 
@@ -91,8 +91,7 @@ DevTools extension can add UI elements to the DevTools window:
   appearance of sidebar panes may not match the image, depending on the version of Chrome you're
   using, and where the DevTools window is docked.)
 
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/TDNgfhI9byR4eeGQ0Xxv.png",
-    class="screenshot",
+{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/TDNgfhI9byR4eeGQ0Xxv.png", class="screenshot",
     alt="DevTools window showing Elements panel and Styles sidebar pane.", height="302", width="770" %}
 
 Each panel is its own HTML file, which can include other resources (JavaScript, CSS, images, and so
@@ -124,8 +123,8 @@ There are several ways to display content in a sidebar pane:
 
 - HTML content. Call [`setPage`][api-panels-setpane] to specify an HTML page to display in the pane.
 - JSON data. Pass a JSON object to [`setObject`][api-panels-setobject].
-- JavaScript expression. Pass an expression to [`setExpression`][api-panels-setexpression]. DevTools evaluates the
-  expression in the context of the inspected page, and displays the return value.
+- JavaScript expression. Pass an expression to [`setExpression`][api-panels-setexpression]. DevTools
+  evaluates the expression in the context of the inspected page, and displays the return value.
 
 For both `setObject` and `setExpression`, the pane displays the value as it would appear in the
 DevTools console. However, `setExpression` lets you display DOM elements and arbitrary JavaScript
@@ -138,15 +137,17 @@ components of a DevTools extension.
 
 ### Injecting a content script {: #injecting }
 
-The DevTools page can't call [`scripting.executeScript`][api-scripting-executescript] directly. To inject a content script from
-the DevTools page, you must retrieve the ID of the inspected window's tab using the
-[`inspectedWindow.tabId`][api-inspectedwindow-tabid] property and send a message to the background page. From the
-background page, call [`scripting.executeScript`][api-scripting-executescript] to inject the script.
+The DevTools page can't call [`scripting.executeScript`][api-scripting-executescript] directly. To
+inject a content script from the DevTools page, you must retrieve the ID of the inspected window's
+tab using the [`inspectedWindow.tabId`][api-inspectedwindow-tabid] property and send a message to
+the background page. From the background page, call
+[`scripting.executeScript`][api-scripting-executescript] to inject the script.
 
 {% Aside %}
 
 If a content script has already been injected, you can add additional context scripts using the
-`eval` method. See [Passing the Selected Element to a Content Script][header-selected-element] for more information.
+`eval` method. See [Passing the Selected Element to a Content Script][header-selected-element] for
+more information.
 
 {% endAside %}
 
@@ -192,15 +193,16 @@ chrome.runtime.onConnect.addListener(function(devToolsConnection) {
 
 ### Evaluating JavaScript in the inspected window {: #evaluating-js }
 
-You can use the [`inspectedWindow.eval`][api-inspectedwindow-eval] method to execute JavaScript code in the context of the
-inspected page. You can invoke the `eval` method from a DevTools page, panel or sidebar pane.
+You can use the [`inspectedWindow.eval`][api-inspectedwindow-eval] method to execute JavaScript code
+in the context of the inspected page. You can invoke the `eval` method from a DevTools page, panel
+or sidebar pane.
 
 By default, the expression is evaluated in the context of the main frame of the page. Now, you may
-be familiar with the DevTools [Console Utilities API][doc-utilities] features like element inspection
-(`inspect(elem)`), breaking on functions (`debug(fn)`), copying to clipboard (`copy()`) and more.
-`inspectedWindow.eval()` uses the same script execution context and options as the code typed at the
-DevTools console, which allows access to these APIs within the eval. For example, [SOAK][gh-soak] uses it
-for inspecting an element:
+be familiar with the DevTools [Console Utilities API][doc-utilities] features like element
+inspection (`inspect(elem)`), breaking on functions (`debug(fn)`), copying to clipboard (`copy()`)
+and more. `inspectedWindow.eval()` uses the same script execution context and options as the code
+typed at the DevTools console, which allows access to these APIs within the eval. For example,
+[SOAK][gh-soak] uses it for inspecting an element:
 
 ```js
 chrome.devtools.inspectedWindow.eval(
@@ -219,21 +221,22 @@ Once the context script context exists, you can use this option to inject additi
 scripts.
 
 The `eval` method is powerful when used in the right context and dangerous when used
-inappropriately. Use the [`scripting.executeScript`][api-scripting-executescript] method if you don't need access to the
-JavaScript context of the inspected page. For detailed cautions and a comparison of the two methods,
-see [`inspectedWindow`][api-inspectedwindow].
+inappropriately. Use the [`scripting.executeScript`][api-scripting-executescript] method if you
+don't need access to the JavaScript context of the inspected page. For detailed cautions and a
+comparison of the two methods, see [`inspectedWindow`][api-inspectedwindow].
 
 ### Passing the selected element to a content script {: #selected-element }
 
 The content script doesn't have direct access to the current selected element. However, any code you
-execute using [`inspectedWindow.eval`][api-inspectedwindow-eval] has access to the DevTools console and Console Utilities APIs.
-For example, in evaluated code you can use `$0` to access the selected element.
+execute using [`inspectedWindow.eval`][api-inspectedwindow-eval] has access to the DevTools console
+and Console Utilities APIs. For example, in evaluated code you can use `$0` to access the selected
+element.
 
 To pass the selected element to a content script:
 
 - Create a method in the content script that takes the selected element as an argument.
-- Call the method from the DevTools page using [`inspectedWindow.eval`][api-inspectedwindow-eval] with the
-  `useContentScriptContext: true` option.
+- Call the method from the DevTools page using [`inspectedWindow.eval`][api-inspectedwindow-eval]
+  with the `useContentScriptContext: true` option.
 
 The code in your content script might look something like this:
 
@@ -255,8 +258,8 @@ same context as the content scripts, so it can access the `setSelectedElement` m
 
 ### Getting a reference panel's `window` {: #panel-window }
 
-To `postMessage` from a devtools panel, you'll need a reference to its `window` object.
-Get a panel's iframe window in from the the [`panel.onShown`][api-panels-onshown] event handler:
+To `postMessage` from a devtools panel, you'll need a reference to its `window` object. Get a
+panel's iframe window in from the the [`panel.onShown`][api-panels-onshown] event handler:
 
 ```js
 onShown.addListener(function callback)
@@ -271,8 +274,8 @@ extensionPanel.onShown.addListener(function (extPanelWindow) {
 Messaging between the DevTools page and content scripts is indirect, by way of the background page.
 
 When sending a message _to_ a content script, the background page can use the
-[`tabs.sendMessage`][api-scripting-sendmessage] method, which directs a message to the content scripts in a specific tab,
-as shown in [Injecting a Content Script][header-injecting].
+[`tabs.sendMessage`][api-scripting-sendmessage] method, which directs a message to the content
+scripts in a specific tab, as shown in [Injecting a Content Script][header-injecting].
 
 When sending a message _from_ a content script, there is no ready-made method to deliver a message
 to the correct DevTools page instance associated with the current tab. As a workaround, you can have
@@ -349,13 +352,15 @@ backgroundPageConnection.postMessage({
 ### Messaging from injected scripts to the DevTools page {: #evaluated-scripts-to-devtools }
 
 While the above solution works for content scripts, code that is injected directly into the page
-(e.g. through appending a `<script>` tag or through [`inspectedWindow.eval`][api-inspectedwindow-eval]) requires a
-different strategy. In this context, [`runtime.sendMessage`][api-runtime-sendmessage] will not pass messages to the
-background script as expected.
+(e.g. through appending a `<script>` tag or through
+[`inspectedWindow.eval`][api-inspectedwindow-eval]) requires a different strategy. In this context,
+[`runtime.sendMessage`][api-runtime-sendmessage] will not pass messages to the background script as
+expected.
 
 As a workaround, you can combine your injected script with a content script that acts as an
-intermediary. To pass messages to the content script, you can use the [`window.postMessage`][mdn-postmessage]
-API. Here's an example, assuming the background script from the previous section:
+intermediary. To pass messages to the content script, you can use the
+[`window.postMessage`][mdn-postmessage] API. Here's an example, assuming the background script from
+the previous section:
 
 ```js
 // injected-script.js
@@ -390,14 +395,16 @@ window.addEventListener('message', function(event) {
 Your message will now flow from the injected script, to the content script, to the background
 script, and finally to the DevTools page.
 
-You can also consider [two alternative message passing techniques outlined here][gh-devtools-messaging].
+You can also consider [two alternative message passing techniques outlined
+here][gh-devtools-messaging].
 
 ### Detecting when DevTools opens and closes {: #detecting-open-close }
 
-If your extension needs to track whether the DevTools window is open, you can add an [onConnect][api-runtime-onconnect]
-listener to the background page, and call [connect][api-runtime-connect] from the DevTools page. Since each tab can
-have its own DevTools window open, you may receive multiple connect events. To track whether any
-DevTools window is open, you need to count the connect and disconnect events as shown below:
+If your extension needs to track whether the DevTools window is open, you can add an
+[onConnect][api-runtime-onconnect] listener to the background page, and call
+[connect][api-runtime-connect] from the DevTools page. Since each tab can have its own DevTools
+window open, you may receive multiple connect events. To track whether any DevTools window is open,
+you need to count the connect and disconnect events as shown below:
 
 ```js
 // background.js
@@ -436,13 +443,15 @@ var backgroundPageConnection = chrome.runtime.connect({
 
 Browse the source of these DevTools extension examples:
 
-- [Polymer Devtools Extension][gh-polymer-dt] - uses many helpers running in the host page to query DOM/JS
-  state to send back to the custom panel.
-- [React DevTools Extension][gh-react-dt] - Uses a submodule of Blink to reuse DevTools UI components.
+- [Polymer Devtools Extension][gh-polymer-dt] - uses many helpers running in the host page to query
+  DOM/JS state to send back to the custom panel.
+- [React DevTools Extension][gh-react-dt] - Uses a submodule of Blink to reuse DevTools UI
+  components.
 - [Ember Inspector][gh-ember-dt] - Shared extension core with adapters for both Chrome and Firefox.
-- [Coquette-inspect][gh-coquette] - A clean React-based extension with a debugging agent injected into the
-  host page.
-- [Sample Extensions][doc-samples] have more worthwhile extensions to install, try out, and learn from.
+- [Coquette-inspect][gh-coquette] - A clean React-based extension with a debugging agent injected
+  into the host page.
+- [Sample Extensions][doc-samples] have more worthwhile extensions to install, try out, and learn
+  from.
 
 ## More information {: #more }
 

--- a/site/en/docs/extensions/mv3/devtools/index.md
+++ b/site/en/docs/extensions/mv3/devtools/index.md
@@ -137,7 +137,7 @@ components of a DevTools extension.
 
 ### Injecting a content script {: #injecting }
 
-The DevTools page can't call [`scripting.executeScript`][api-scripting-executescript] directly. To
+The DevTools page can't call [`scripting.executeScript()`][api-scripting-executescript] directly. To
 inject a content script from the DevTools page, you must retrieve the ID of the inspected window's
 tab using the [`inspectedWindow.tabId`][api-inspectedwindow-tabid] property and send a message to
 the background page. From the background page, call
@@ -146,7 +146,7 @@ the background page. From the background page, call
 {% Aside %}
 
 If a content script has already been injected, you can add additional context scripts using the
-`eval` method. See [Passing the Selected Element to a Content Script][header-selected-element] for
+`eval()` method. See [Passing the Selected Element to a Content Script][header-selected-element] for
 more information.
 
 {% endAside %}
@@ -193,8 +193,8 @@ chrome.runtime.onConnect.addListener(function(devToolsConnection) {
 
 ### Evaluating JavaScript in the inspected window {: #evaluating-js }
 
-You can use the [`inspectedWindow.eval`][api-inspectedwindow-eval] method to execute JavaScript code
-in the context of the inspected page. You can invoke the `eval` method from a DevTools page, panel
+You can use the [`inspectedWindow.eval()`][api-inspectedwindow-eval] method to execute JavaScript code
+in the context of the inspected page. You can invoke the `eval()` method from a DevTools page, panel
 or sidebar pane.
 
 By default, the expression is evaluated in the context of the main frame of the page. Now, you may
@@ -221,21 +221,21 @@ Once the context script context exists, you can use this option to inject additi
 scripts.
 
 The `eval` method is powerful when used in the right context and dangerous when used
-inappropriately. Use the [`scripting.executeScript`][api-scripting-executescript] method if you
+inappropriately. Use the [`scripting.executeScript()`][api-scripting-executescript] method if you
 don't need access to the JavaScript context of the inspected page. For detailed cautions and a
 comparison of the two methods, see [`inspectedWindow`][api-inspectedwindow].
 
 ### Passing the selected element to a content script {: #selected-element }
 
 The content script doesn't have direct access to the current selected element. However, any code you
-execute using [`inspectedWindow.eval`][api-inspectedwindow-eval] has access to the DevTools console
+execute using [`inspectedWindow.eval()`][api-inspectedwindow-eval] has access to the DevTools console
 and Console Utilities APIs. For example, in evaluated code you can use `$0` to access the selected
 element.
 
 To pass the selected element to a content script:
 
 - Create a method in the content script that takes the selected element as an argument.
-- Call the method from the DevTools page using [`inspectedWindow.eval`][api-inspectedwindow-eval]
+- Call the method from the DevTools page using [`inspectedWindow.eval()`][api-inspectedwindow-eval]
   with the `useContentScriptContext: true` option.
 
 The code in your content script might look something like this:
@@ -258,7 +258,7 @@ same context as the content scripts, so it can access the `setSelectedElement` m
 
 ### Getting a reference panel's `window` {: #panel-window }
 
-To `postMessage` from a devtools panel, you'll need a reference to its `window` object. Get a
+To call `postMessage()` from a devtools panel, you'll need a reference to its `window` object. Get a
 panel's iframe window in from the the [`panel.onShown`][api-panels-onshown] event handler:
 
 ```js
@@ -274,7 +274,7 @@ extensionPanel.onShown.addListener(function (extPanelWindow) {
 Messaging between the DevTools page and content scripts is indirect, by way of the background page.
 
 When sending a message _to_ a content script, the background page can use the
-[`tabs.sendMessage`][api-scripting-sendmessage] method, which directs a message to the content
+[`tabs.sendMessage()`][api-scripting-sendmessage] method, which directs a message to the content
 scripts in a specific tab, as shown in [Injecting a Content Script][header-injecting].
 
 When sending a message _from_ a content script, there is no ready-made method to deliver a message
@@ -353,13 +353,13 @@ backgroundPageConnection.postMessage({
 
 While the above solution works for content scripts, code that is injected directly into the page
 (e.g. through appending a `<script>` tag or through
-[`inspectedWindow.eval`][api-inspectedwindow-eval]) requires a different strategy. In this context,
-[`runtime.sendMessage`][api-runtime-sendmessage] will not pass messages to the background script as
+[`inspectedWindow.eval()`][api-inspectedwindow-eval]) requires a different strategy. In this context,
+[`runtime.sendMessage()`][api-runtime-sendmessage] will not pass messages to the background script as
 expected.
 
 As a workaround, you can combine your injected script with a content script that acts as an
 intermediary. To pass messages to the content script, you can use the
-[`window.postMessage`][mdn-postmessage] API. Here's an example, assuming the background script from
+[`window.postMessage()`][mdn-postmessage] method. Here's an example, assuming the background script from
 the previous section:
 
 ```js
@@ -402,7 +402,7 @@ here][gh-devtools-messaging].
 
 If your extension needs to track whether the DevTools window is open, you can add an
 [onConnect][api-runtime-onconnect] listener to the background page, and call
-[connect][api-runtime-connect] from the DevTools page. Since each tab can have its own DevTools
+[connect()][api-runtime-connect] from the DevTools page. Since each tab can have its own DevTools
 window open, you may receive multiple connect events. To track whether any DevTools window is open,
 you need to count the connect and disconnect events as shown below:
 
@@ -443,9 +443,9 @@ var backgroundPageConnection = chrome.runtime.connect({
 
 Browse the source of these DevTools extension examples:
 
-- [Polymer Devtools Extension][gh-polymer-dt] - uses many helpers running in the host page to query
+- [Polymer Devtools Extension][gh-polymer-dt] - Uses many helpers running in the host page to query
   DOM/JS state to send back to the custom panel.
-- [React DevTools Extension][gh-react-dt] - Uses a submodule of Blink to reuse DevTools UI
+- [React DevTools Extension][gh-react-dt] - Uses a submodule of the renderer to reuse DevTools UI
   components.
 - [Ember Inspector][gh-ember-dt] - Shared extension core with adapters for both Chrome and Firefox.
 - [Coquette-inspect][gh-coquette] - A clean React-based extension with a debugging agent injected

--- a/site/en/docs/extensions/mv3/devtools/index.md
+++ b/site/en/docs/extensions/mv3/devtools/index.md
@@ -193,9 +193,9 @@ chrome.runtime.onConnect.addListener(function(devToolsConnection) {
 
 ### Evaluating JavaScript in the inspected window {: #evaluating-js }
 
-You can use the [`inspectedWindow.eval()`][api-inspectedwindow-eval] method to execute JavaScript code
-in the context of the inspected page. You can invoke the `eval()` method from a DevTools page, panel
-or sidebar pane.
+You can use the [`inspectedWindow.eval()`][api-inspectedwindow-eval] method to execute JavaScript
+code in the context of the inspected page. You can invoke the `eval()` method from a DevTools page,
+panel or sidebar pane.
 
 By default, the expression is evaluated in the context of the main frame of the page. Now, you may
 be familiar with the DevTools [Console Utilities API][doc-utilities] features like element
@@ -228,9 +228,9 @@ comparison of the two methods, see [`inspectedWindow`][api-inspectedwindow].
 ### Passing the selected element to a content script {: #selected-element }
 
 The content script doesn't have direct access to the current selected element. However, any code you
-execute using [`inspectedWindow.eval()`][api-inspectedwindow-eval] has access to the DevTools console
-and Console Utilities APIs. For example, in evaluated code you can use `$0` to access the selected
-element.
+execute using [`inspectedWindow.eval()`][api-inspectedwindow-eval] has access to the DevTools
+console and Console Utilities APIs. For example, in evaluated code you can use `$0` to access the
+selected element.
 
 To pass the selected element to a content script:
 
@@ -353,14 +353,14 @@ backgroundPageConnection.postMessage({
 
 While the above solution works for content scripts, code that is injected directly into the page
 (e.g. through appending a `<script>` tag or through
-[`inspectedWindow.eval()`][api-inspectedwindow-eval]) requires a different strategy. In this context,
-[`runtime.sendMessage()`][api-runtime-sendmessage] will not pass messages to the background script as
-expected.
+[`inspectedWindow.eval()`][api-inspectedwindow-eval]) requires a different strategy. In this
+context, [`runtime.sendMessage()`][api-runtime-sendmessage] will not pass messages to the background
+script as expected.
 
 As a workaround, you can combine your injected script with a content script that acts as an
 intermediary. To pass messages to the content script, you can use the
-[`window.postMessage()`][mdn-postmessage] method. Here's an example, assuming the background script from
-the previous section:
+[`window.postMessage()`][mdn-postmessage] method. Here's an example, assuming the background script
+from the previous section:
 
 ```js
 // injected-script.js

--- a/site/en/docs/extensions/mv3/devtools/index.md
+++ b/site/en/docs/extensions/mv3/devtools/index.md
@@ -11,13 +11,13 @@ description: How to create a Chrome Extension that adds functionality to Chrome 
 ## Overview {: #overview }
 
 A DevTools extension adds functionality to the Chrome DevTools. It can add new UI panels and
-sidebars, interact with the inspected page, get information about network requests, and more. View
-[featured DevTools extensions][1]. DevTools extensions have access to an additional set of
+sidebars, interact with the inspected page, get information about network requests, and more. 
+DevTools extensions have access to an additional set of
 DevTools-specific extension APIs:
 
-- [`devtools.inspectedWindow`][2]
-- [`devtools.network`][3]
-- [`devtools.panels`][4]
+- [`devtools.inspectedWindow`][api-inspectedwindow]
+- [`devtools.network`][api-network]
+- [`devtools.panels`][api-panels]
 
 A DevTools extension is structured like any other extension: it can have a background page, content
 scripts, and other items. In addition, each DevTools extension has a DevTools page, which has access
@@ -36,15 +36,15 @@ An instance of the extension's DevTools page is created each time a DevTools win
 DevTools page exists for the lifetime of the DevTools window. The DevTools page has access to the
 DevTools APIs and a limited set of extension APIs. Specifically, the DevTools page can:
 
-- Create and interact with panels using the [`devtools.panels`][5] APIs.
+- Create and interact with panels using the [`devtools.panels`][api-panels] APIs.
 - Get information about the inspected window and evaluate code in the inspected window using the
-  [`devtools.inspectedWindow`][6] APIs.
-- Get information about network requests using the [`devtools.network`][7] APIs.
+  [`devtools.inspectedWindow`][api-inspectedwindow] APIs.
+- Get information about network requests using the [`devtools.network`][api-network] APIs.
 
 The DevTools page cannot use most of the extensions APIs directly. It has access to the same subset
-of the [`extension`][8] and [`runtime`][9] APIs that a content script has access to. Like a content
-script, a DevTools page can communicate with the background page using [Message Passing][10]. For an
-example, see [Injecting a Content Script][11].
+of the [`extension`][api-extension] and [`runtime`][api-runtime] APIs that a content script has access to. Like a content
+script, a DevTools page can communicate with the background page using [Message Passing][doc-message-passing]. For an
+example, see [Injecting a Content Script][header-injecting].
 
 ## Creating a DevTools extension {: #creating }
 
@@ -63,7 +63,7 @@ manifest:
 
 An instance of the `devtools_page` specified in your extension's manifest is created for every
 DevTools window opened. The page may add other extension pages as panels and sidebars to the
-DevTools window using the [`devtools.panels`][12] API.
+DevTools window using the [`devtools.panels`][api-panels] API.
 
 {% Aside %}
 
@@ -78,7 +78,7 @@ window. Content scripts and other extension pages do not have these APIs. Thus, 
 available only through the lifetime of the DevTools window.
 
 There are also some DevTools APIs that are still experimental. Refer to [chrome.experimental.\*
-APIs][13] for the list of experimental APIs and guidelines on how to use them.
+APIs][api-index] for the list of experimental APIs and guidelines on how to use them.
 
 ## DevTools UI elements: panels and sidebar panes {: #devtools-ui }
 
@@ -122,9 +122,9 @@ chrome.devtools.panels.elements.createSidebarPane("My Sidebar",
 
 There are several ways to display content in a sidebar pane:
 
-- HTML content. Call [`setPage`][14] to specify an HTML page to display in the pane.
-- JSON data. Pass a JSON object to [`setObject`][15].
-- JavaScript expression. Pass an expression to [`setExpression`][16]. DevTools evaluates the
+- HTML content. Call [`setPage`][api-panels-setpane] to specify an HTML page to display in the pane.
+- JSON data. Pass a JSON object to [`setObject`][api-panels-setobject].
+- JavaScript expression. Pass an expression to [`setExpression`][api-panels-setexpression]. DevTools evaluates the
   expression in the context of the inspected page, and displays the return value.
 
 For both `setObject` and `setExpression`, the pane displays the value as it would appear in the
@@ -138,15 +138,15 @@ components of a DevTools extension.
 
 ### Injecting a content script {: #injecting }
 
-The DevTools page can't call [`scripting.executeScript`][17] directly. To inject a content script from
+The DevTools page can't call [`scripting.executeScript`][api-scripting-executescript] directly. To inject a content script from
 the DevTools page, you must retrieve the ID of the inspected window's tab using the
-[`inspectedWindow.tabId`][18] property and send a message to the background page. From the
-background page, call [`scripting.executeScript`][19] to inject the script.
+[`inspectedWindow.tabId`][api-inspectedwindow-tabid] property and send a message to the background page. From the
+background page, call [`scripting.executeScript`][api-scripting-executescript] to inject the script.
 
 {% Aside %}
 
 If a content script has already been injected, you can add additional context scripts using the
-`eval` method. See [Passing the Selected Element to a Content Script][20] for more information.
+`eval` method. See [Passing the Selected Element to a Content Script][header-selected-element] for more information.
 
 {% endAside %}
 
@@ -192,14 +192,14 @@ chrome.runtime.onConnect.addListener(function(devToolsConnection) {
 
 ### Evaluating JavaScript in the inspected window {: #evaluating-js }
 
-You can use the [`inspectedWindow.eval`][21] method to execute JavaScript code in the context of the
+You can use the [`inspectedWindow.eval`][api-inspectedwindow-eval] method to execute JavaScript code in the context of the
 inspected page. You can invoke the `eval` method from a DevTools page, panel or sidebar pane.
 
 By default, the expression is evaluated in the context of the main frame of the page. Now, you may
-be familiar with the DevTools [commandline API][22] features like element inspection
+be familiar with the DevTools [Console Utilities API][doc-utilities] features like element inspection
 (`inspect(elem)`), breaking on functions (`debug(fn)`), copying to clipboard (`copy()`) and more.
 `inspectedWindow.eval()` uses the same script execution context and options as the code typed at the
-DevTools console, which allows access to these APIs within the eval. For example, [SOAK][23] uses it
+DevTools console, which allows access to these APIs within the eval. For example, [SOAK][gh-soak] uses it
 for inspecting an element:
 
 ```js
@@ -219,20 +219,20 @@ Once the context script context exists, you can use this option to inject additi
 scripts.
 
 The `eval` method is powerful when used in the right context and dangerous when used
-inappropriately. Use the [`scripting.executeScript`][24] method if you don't need access to the
+inappropriately. Use the [`scripting.executeScript`][api-scripting-executescript] method if you don't need access to the
 JavaScript context of the inspected page. For detailed cautions and a comparison of the two methods,
-see [`inspectedWindow`][25].
+see [`inspectedWindow`][api-inspectedwindow].
 
 ### Passing the selected element to a content script {: #selected-element }
 
 The content script doesn't have direct access to the current selected element. However, any code you
-execute using [`inspectedWindow.eval`][26] has access to the DevTools console and command-line APIs.
+execute using [`inspectedWindow.eval`][api-inspectedwindow-eval] has access to the DevTools console and Console Utilities APIs.
 For example, in evaluated code you can use `$0` to access the selected element.
 
 To pass the selected element to a content script:
 
 - Create a method in the content script that takes the selected element as an argument.
-- Call the method from the DevTools page using [`inspectedWindow.eval`][27] with the
+- Call the method from the DevTools page using [`inspectedWindow.eval`][api-inspectedwindow-eval] with the
   `useContentScriptContext: true` option.
 
 The code in your content script might look something like this:
@@ -256,7 +256,7 @@ same context as the content scripts, so it can access the `setSelectedElement` m
 ### Getting a reference panel's `window` {: #panel-window }
 
 To `postMessage` from a devtools panel, you'll need a reference to its `window` object.
-Get a panel's iframe window in from the the [`panel.onShown`][28] event handler:
+Get a panel's iframe window in from the the [`panel.onShown`][api-panels-onshown] event handler:
 
 ```js
 onShown.addListener(function callback)
@@ -271,8 +271,8 @@ extensionPanel.onShown.addListener(function (extPanelWindow) {
 Messaging between the DevTools page and content scripts is indirect, by way of the background page.
 
 When sending a message _to_ a content script, the background page can use the
-[`tabs.sendMessage`][29] method, which directs a message to the content scripts in a specific tab,
-as shown in [Injecting a Content Script][30].
+[`tabs.sendMessage`][api-scripting-sendmessage] method, which directs a message to the content scripts in a specific tab,
+as shown in [Injecting a Content Script][header-injecting].
 
 When sending a message _from_ a content script, there is no ready-made method to deliver a message
 to the correct DevTools page instance associated with the current tab. As a workaround, you can have
@@ -349,12 +349,12 @@ backgroundPageConnection.postMessage({
 ### Messaging from injected scripts to the DevTools page {: #evaluated-scripts-to-devtools }
 
 While the above solution works for content scripts, code that is injected directly into the page
-(e.g. through appending a `<script>` tag or through [`inspectedWindow.eval`][31]) requires a
-different strategy. In this context, [`runtime.sendMessage`][32] will not pass messages to the
+(e.g. through appending a `<script>` tag or through [`inspectedWindow.eval`][api-inspectedwindow-eval]) requires a
+different strategy. In this context, [`runtime.sendMessage`][api-runtime-sendmessage] will not pass messages to the
 background script as expected.
 
 As a workaround, you can combine your injected script with a content script that acts as an
-intermediary. To pass messages to the content script, you can use the [`window.postMessage`][33]
+intermediary. To pass messages to the content script, you can use the [`window.postMessage`][mdn-postmessage]
 API. Here's an example, assuming the background script from the previous section:
 
 ```js
@@ -390,12 +390,12 @@ window.addEventListener('message', function(event) {
 Your message will now flow from the injected script, to the content script, to the background
 script, and finally to the DevTools page.
 
-You can also consider [two alternative message passing techniques here][34].
+You can also consider [two alternative message passing techniques outlined here][gh-devtools-messaging].
 
 ### Detecting when DevTools opens and closes {: #detecting-open-close }
 
-If your extension needs to track whether the DevTools window is open, you can add an [onConnect][35]
-listener to the background page, and call [connect][36] from the DevTools page. Since each tab can
+If your extension needs to track whether the DevTools window is open, you can add an [onConnect][api-runtime-onconnect]
+listener to the background page, and call [connect][api-runtime-connect] from the DevTools page. Since each tab can
 have its own DevTools window open, you may receive multiple connect events. To track whether any
 DevTools window is open, you need to count the connect and disconnect events as shown below:
 
@@ -436,69 +436,51 @@ var backgroundPageConnection = chrome.runtime.connect({
 
 Browse the source of these DevTools extension examples:
 
-- [Polymer Devtools Extension][37] - uses many helpers running in the host page to query DOM/JS
+- [Polymer Devtools Extension][gh-polymer-dt] - uses many helpers running in the host page to query DOM/JS
   state to send back to the custom panel.
-- [React DevTools Extension][38] - Uses a submodule of Blink to reuse DevTools UI components.
-- [Ember Inspector][39] - Shared extension core with adapters for both Chrome and Firefox.
-- [Coquette-inspect][40] - A clean React-based extension with a debugging agent injected into the
+- [React DevTools Extension][gh-react-dt] - Uses a submodule of Blink to reuse DevTools UI components.
+- [Ember Inspector][gh-ember-dt] - Shared extension core with adapters for both Chrome and Firefox.
+- [Coquette-inspect][gh-coquette] - A clean React-based extension with a debugging agent injected into the
   host page.
-- our [DevTools Extension Gallery][41] and [Sample Extensions][42] have more worthwhile extensions to
-  install, try out, and learn from.
+- [Sample Extensions][doc-samples] have more worthwhile extensions to install, try out, and learn from.
 
 ## More information {: #more }
 
-For information on the standard APIs that extensions can use, see [chrome.\* APIs][43].
+For information on the standard APIs that extensions can use, see [chrome.\* APIs][api-index].
 
-[Give us feedback!][45] Your comments and suggestions help us improve the APIs.
+[Give us feedback!][group-devtools] Your comments and suggestions help us improve the APIs.
 
 ## Examples {: #examples }
 
-You can find examples that use DevTools APIs in [Samples][46].
+You can find examples that use DevTools APIs in [Samples][doc-samples].
 
-[1]: /docs/devtools/docs/extensions-gallery
-[2]: /docs/extensions/mv3/devtools.inspectedWindow
-[3]: /docs/extensions/mv3/devtools.network
-[4]: /docs/extensions/mv3/devtools.panels
-[5]: /docs/extensions/mv3/devtools.panels
-[6]: /docs/extensions/mv3/devtools.inspectedWindow
-[7]: /docs/extensions/mv3/devtools.network
-[8]: /docs/extensions/extension
-[9]: /docs/extensions/runtime
-[10]: /docs/extensions/mv3/messaging
-[11]: #injecting
-[12]: /docs/extensions/mv3/devtools.panels
-[13]: /docs/extensions/reference
-[14]: /docs/extensions/mv3/devtools.panels#method-ExtensionSidebarPane-setPage
-[15]: /docs/extensions/mv3/devtools.panels#method-ExtensionSidebarPane-setObject
-[16]:
-  /extensions/devtools.panels#method-ExtensionSidebarPane-setExpression
-[17]: /docs/extensions/scripting#method-executeScript
-[18]: /docs/extensions/mv3/devtools.inspectedWindow#property-tabId
-[19]: /docs/extensions/scripting#method-executeScript
-[20]: #selected-element
-[21]: /docs/extensions/mv3/devtools.inspectedWindow#method-eval
-[22]: /docs/devtools/docs/commandline-api
-[23]:
-  https://github.com/RedRibbon/SOAK/blob/ffdfad68ffb6051fa2d4e9db0219b3d234ac1ae8/pages/devtools.js#L6-L8
-[24]: /docs/extensions/scripting#method-executeScript
-[25]: /docs/extensions/mv3/devtools.inspectedWindow
-[26]: /docs/extensions/mv3/devtools.inspectedWindow#method-eval
-[27]: /docs/extensions/mv3/devtools.inspectedWindow#method-eval
-[28]: /docs/extensions/reference/devtools_panels#event-ExtensionPanel-onShown
-[29]: /docs/extensions/scripting#method-sendMessage
-[30]: #injecting
-[31]: /docs/extensions/mv3/devtools.inspectedWindow#method-eval
-[32]: /docs/extensions/runtime#method-sendMessage
-[33]: https://developer.mozilla.org/docs/Web/API/Window.postMessage
-[34]: https://github.com/GoogleChrome/devtools-docs/issues/143
-[35]: /docs/extensions/runtime#event-onConnect
-[36]: /docs/extensions/runtime#method-connect
-[37]: https://github.com/PolymerLabs/polymer-devtools-extension
-[38]: https://github.com/facebook/react-devtools
-[39]: https://github.com/emberjs/ember-inspector
-[40]: https://github.com/thomasboyt/coquette-inspect
-[41]: /docs/devtools/docs/extensions-gallery
-[42]: /docs/devtools/docs/sample-extensions
-[43]: /docs/extensions/reference
-[45]: http://groups.google.com/group/google-chrome-developer-tools/topics
-[46]: /extensions/samples#devtools
+[api-extension]: /docs/extensions/reference/extension
+[api-index]: /docs/extensions/reference
+[api-inspectedwindow-eval]: /docs/extensions/reference/devtools_inspectedWindow#method-eval
+[api-inspectedwindow-tabid]: /docs/extensions/reference/devtools_inspectedWindow#property-tabId
+[api-inspectedwindow]: /docs/extensions/reference/devtools_inspectedWindow
+[api-network]: /docs/extensions/reference/devtools_network
+[api-panels-onshown]: /docs/extensions/reference/devtools_panels#event-ExtensionPanel-onShown
+[api-panels-setexpression]: /docs/extensions/reference/devtools_panels#method-ExtensionSidebarPane-setExpression
+[api-panels-setobject]: /docs/extensions/reference/devtools_panels#method-ExtensionSidebarPane-setObject
+[api-panels-setpane]: /docs/extensions/reference/devtools_panels#method-ExtensionSidebarPane-setPage
+[api-panels]: /docs/extensions/reference/devtools_panels
+[api-runtime-connect]: /docs/extensions/reference/runtime#method-connect
+[api-runtime-onconnect]: /docs/extensions/reference/runtime#event-onConnect
+[api-runtime-sendmessage]: /docs/extensions/reference/runtime#method-sendMessage
+[api-runtime]: /docs/extensions/reference/runtime
+[api-scripting-executescript]: /docs/extensions/reference/scripting#method-executeScript
+[api-scripting-sendmessage]: /docs/extensions/reference/scripting#method-sendMessage
+[doc-message-passing]: /docs/extensions/mv3/messaging
+[doc-samples]: /docs/extensions/mv3/samples#devtools
+[doc-utilities]: /docs/devtools/console/utilities/
+[gh-coquette]: https://github.com/thomasboyt/coquette-inspect
+[gh-devtools-messaging]: https://github.com/GoogleChrome/devtools-docs/issues/143
+[gh-ember-dt]: https://github.com/emberjs/ember-inspector
+[gh-polymer-dt]: https://github.com/PolymerLabs/polymer-devtools-extension
+[gh-react-dt]: https://github.com/facebook/react/tree/main/scripts/devtools
+[gh-soak]: https://github.com/RedRibbon/SOAK/blob/ffdfad68ffb6051fa2d4e9db0219b3d234ac1ae8/pages/devtools.js#L6-L8
+[group-devtools]: https://groups.google.com/g/google-chrome-developer-tools
+[header-injecting]: #injecting
+[header-selected-element]: #selected-element
+[mdn-postmessage]: https://developer.mozilla.org/docs/Web/API/Window.postMessage


### PR DESCRIPTION
This PR address two issues I stumbled across today

1. `/docs/extensions/mv3/devtools` prominently features three links near the top of the page to for `devtools.inspectedWindow`, `devtools.network`, and `devtools.panels`. All three links 404. Interestingly the MV2 version of the same page did not have the same issue.
2. Attempting to visit `/extensions/event_pages` redirects to `/docs/apps/event_pages`. That page contains a "Background pages" link (`/background_pages`) that 404s.  

In addition to updating the targets for the devtools API links, this PR also replaces the numeric footer links with named footer links, rewraps the page content at 100 characters, updates some of the external URLs used, and drops references to the "extensions gallery". 