### PR TITLE
Fix broken links to Match Patterns page

### DIFF
--- a/site/en/docs/extensions/mv3/content_scripts/index.md
+++ b/site/en/docs/extensions/mv3/content_scripts/index.md
@@ -172,6 +172,7 @@ They can include JavaScript files, CSS files, or both. All auto-run content scri
 </table>
 
 {% if false %}
+
 ### Inject with dynamic declarations {: #dynamic-declarative }
 
 {% Aside 'caution' %}

--- a/site/en/docs/extensions/mv3/content_scripts/index.md
+++ b/site/en/docs/extensions/mv3/content_scripts/index.md
@@ -129,9 +129,9 @@ They can include JavaScript files, CSS files, or both. All auto-run content scri
     <tr id="matches">
       <td><code>matches</code></td>
       <td>array of strings</td>
-      <td><em>Required.</em> Specifies which pages this content script will be injected into. See <a
-          href="match_patterns">Match Patterns</a> for more details on the syntax of these strings
-        and <a href="#matchAndGlob">Match patterns and globs</a> for information on how to exclude
+      <td><em>Required.</em> Specifies which pages this content script will be injected into. See
+        [Match Patterns][19] for more details on the syntax of these strings and
+        <a href="#matchAndGlob">Match patterns and globs</a> for information on how to exclude
         URLs.</td>
     </tr>
     <tr id="css">
@@ -305,8 +305,7 @@ registration.
       <td><code>exclude_matches</code></td>
       <td>array of strings</td>
       <td><em>Optional.</em> Excludes pages that this content script would otherwise be injected
-        into. See <a href="match_patterns">Match Patterns</a> for more details on the syntax of
-        these strings.</td>
+        into. See [Match Patterns][21] for more details on the syntax of these strings.</td>
     </tr>
     <tr id="include_globs">
       <td><code>include_globs</code></td>


### PR DESCRIPTION
References #281 (_doesn't fully resolve it so I changed "Fixes" to not auto-close that issue_)

Changes proposed in this pull request:

- Update the links to the Match Patterns page to use the url references in the footer of the doc
  - Looks like the footer links were auto-generated but didn't get automatically linked up in a migration (I'm guessing)

CLA was signed today under Giles Wells