### PR TITLE
[Private Network Access] Mention delay in preflight blog post.

### DIFF
--- a/site/en/blog/private-network-access-preflight/index.md
+++ b/site/en/blog/private-network-access-preflight/index.md
@@ -6,13 +6,23 @@ authors:
   - agektmr
 description: Chrome is deprecating access to private network endpoints from non-secure public websites as part of the Private Network Access specification. Read on for recommended actions.
 date: 2022-01-06
-updated: 2022-02-11
+updated: 2022-03-07
 hero: image/VbsHyyQopiec0718rMq2kTE1hke2/iqanYAE91Ab6BsgwhBjq.jpg
 alt: An airplane in the sky
 tags:
   - chrome-98
   - security
 ---
+
+**Updates**
+
+- **March 7, 2022**: The experiment in Chrome 98 has been rolled back due to
+  stability and compatibility issues discovered during the rollout to Chrome
+  stable. These issues will be fixed before the experiment is tried again, no
+  earlier than in Chrome 101. See the
+  [blink-dev@chromium.org Intent to Ship email
+  thread](https://groups.google.com/a/chromium.org/g/blink-dev/c/72CK2mxD47c)
+  for more details.
 
 ## Introduction
 
@@ -39,7 +49,8 @@ Chrome will roll this change out in two phases to give websites time to notice
 the change and adjust accordingly.
 
 1. In Chrome 98:
-    * Chrome sends preflight requests ahead of private network subresource
+    * Chrome experiments by sending preflight requests ahead of private network
+      subresource
       requests.
     * Preflight failures only display warnings in DevTools, without otherwise
       affecting the private network requests.

--- a/site/en/blog/private-network-access-preflight/index.md
+++ b/site/en/blog/private-network-access-preflight/index.md
@@ -19,9 +19,9 @@ tags:
 - **March 7, 2022**: The experiment in Chrome 98 has been rolled back due to
   stability and compatibility issues discovered during the rollout to Chrome
   stable. These issues will be fixed before the experiment is tried again, no
-  earlier than in Chrome 101. See the
-  [blink-dev@chromium.org Intent to Ship email
-  thread](https://groups.google.com/a/chromium.org/g/blink-dev/c/72CK2mxD47c)
+  earlier than in Chrome 101. See the [blink-dev@chromium.org Intent to Ship
+  email
+  thread](https://groups.google.com/a/chromium.org/g/blink-dev/c/72CK2mxD47c/m/d835CNGtAAAJ)
   for more details.
 
 ## Introduction

--- a/site/en/blog/private-network-access-preflight/index.md
+++ b/site/en/blog/private-network-access-preflight/index.md
@@ -16,7 +16,7 @@ tags:
 
 **Updates**
 
-- **March 7, 2022**: The experiment in Chrome 98 has been rolled back due to
+- **March 7, 2022**: The experiment in Chrome 98 was rolled back due to
   stability and compatibility issues discovered during the rollout to Chrome
   stable. These issues will be fixed before the experiment is tried again, no
   earlier than in Chrome 101. See the [blink-dev@chromium.org Intent to Ship

--- a/site/en/blog/private-network-access-preflight/index.md
+++ b/site/en/blog/private-network-access-preflight/index.md
@@ -14,15 +14,16 @@ tags:
   - security
 ---
 
-**Updates**
+{% Aside 'warning' %}
 
 - **March 7, 2022**: The experiment in Chrome 98 was rolled back due to
-  stability and compatibility issues discovered during the rollout to Chrome
+  stability and compatibility issues discovered in the rollout to Chrome
   stable. These issues will be fixed before the experiment is tried again, no
-  earlier than in Chrome 101. See the [blink-dev@chromium.org Intent to Ship
+  earlier than in Chrome 101. Learn more in the [blink-dev@chromium.org Intent to Ship
   email
   thread](https://groups.google.com/a/chromium.org/g/blink-dev/c/72CK2mxD47c/m/d835CNGtAAAJ)
   for more details.
+{% endAside %}
 
 ## Introduction
 
@@ -274,10 +275,10 @@ Affected preflight requests can also be viewed and diagnosed in the network pane
    width="800", height="265"
 %}
 
-Note that if your request would have triggered a regular CORS preflight were it
-not for Private Network Access rules, then two preflights may appear in the
+If your request would have triggered a regular CORS preflight without
+Private Network Access rules, then two preflights may appear in the
 network panel, with the first one always appearing to have failed. This is a
-[known quirk](https://crbug.com/1290390), and you may safely ignore it.
+[known bug](https://crbug.com/1290390), and you can safely ignore it.
 
 {% Img
    src="image/I8XwjL2ZK8fUPQRJMwrRzjyKAar1/MaBNk7572rWNybez1FHH.png",

--- a/site/en/blog/private-network-access-preflight/index.md
+++ b/site/en/blog/private-network-access-preflight/index.md
@@ -274,6 +274,18 @@ Affected preflight requests can also be viewed and diagnosed in the network pane
    width="800", height="265"
 %}
 
+Note that if your request would have triggered a regular CORS preflight were it
+not for Private Network Access rules, then two preflights may appear in the
+network panel, with the first one always appearing to have failed. This is a
+[known quirk](https://crbug.com/1290390), and you may safely ignore it.
+
+{% Img
+   src="image/I8XwjL2ZK8fUPQRJMwrRzjyKAar1/MaBNk7572rWNybez1FHH.png",
+   alt="A spurious failed preflight request ahead of a successful preflight in
+   the DevTools Network panel.",
+   width="800", height="316"
+%}
+
 To review what happens if preflight success was enforced, you can
 [pass the following command-line argument](https://www.chromium.org/developers/how-tos/run-chromium-with-flags),
 starting in Chrome 98:


### PR DESCRIPTION
See the [Intent to Ship thread](https://groups.google.com/a/chromium.org/g/blink-dev/c/72CK2mxD47c/m/d835CNGtAAAJ). Preflights have been rolled back in Chrome 98, and we are working on resolving issues.

Also mention the spurious failed preflight seen in https://crbug.com/1290390.

Preview: https://deploy-preview-2243--developer-chrome-com.netlify.app/blog/private-network-access-preflight/