### PR TITLE
Add example collection landing page

### DIFF
--- a/site/_data/docs/handbook/toc.yml
+++ b/site/_data/docs/handbook/toc.yml
@@ -5,6 +5,7 @@
     - url: /docs/handbook/how-to/add-a-doc
     - url: /docs/handbook/how-to/add-a-blog-post
     - url: /docs/handbook/how-to/add-an-api
+    - url: /docs/handbook/how-to/add-a-collection-page
     - url: /docs/handbook/how-to/add-media
     - url: /docs/handbook/how-to/add-an-author
     - url: /docs/handbook/how-to/add-a-tag

--- a/site/_includes/layouts/collection-landing.njk
+++ b/site/_includes/layouts/collection-landing.njk
@@ -21,7 +21,7 @@
       </div>
 
       <nav class="pagination gap-top-300 pad-left-400 pad-right-400">
-        <span></span>
+        <span><!-- pagination elements expects to always have 2 children, therefore this empty span --></span>
         <a class="pagination__button type--small gap-left-200 text-align-center" href="/tags/{{ collection_tag }}/">
           <span>{{ 'i18n.common.see_all_articles' | i18n(locale) }}</span>
           {{ icon('arrow-forward', {hidden: true}) }}

--- a/site/_includes/layouts/collection-landing.njk
+++ b/site/_includes/layouts/collection-landing.njk
@@ -1,0 +1,31 @@
+{% extends "layouts/base.njk" %}
+
+{% from 'macros/cards/hero-card.njk' import heroCard with context %}
+{% from 'macros/icon.njk' import icon with context %}
+{% from 'macros/cards/blog-card.njk' import blogCard with context %}
+
+{% block content %}
+    <div class="measure-1280 width-full center-margin pad-400">
+      {{ heroCard(title, description) }}
+
+      <div class="pad-top-400">
+        {{ content | safe }}
+      <div>
+
+      <div class="blog-grid pad-top-400">
+        {% for post in collections.tags[collection_tag].posts.en %}
+          {% if loop.index0 < 6 %}
+            {{ blogCard(post) }}
+          {% endif %}
+        {% endfor %}
+      </div>
+
+      <nav class="pagination gap-top-300 pad-left-400 pad-right-400">
+        <span></span>
+        <a class="pagination__button type--small gap-left-200 text-align-center" href="/tags/{{ collection_tag }}/">
+          <span>{{ 'i18n.common.see_all_articles' | i18n(locale) }}</span>
+          {{ icon('arrow-forward', {hidden: true}) }}
+        </a>
+      </nav>
+    </div>
+{% endblock %}

--- a/site/_includes/layouts/home.njk
+++ b/site/_includes/layouts/home.njk
@@ -9,7 +9,14 @@
 {% block content %}
   <div class="home-container width-full center-margin pad-400">
 
-    {{ heroCard() }}
+    {{ heroCard(
+        'Welcome!',
+        "This is Chrome's official site to help you build Extensions, publish on the Chrome Web Store, optimize your website, and more.",
+        "Start building",
+         "/docs/",
+        "image/QMjXarRXcMarxQddwrEdPvHVM242/uyy9OtWHTcxH5sK5VuRA.png",
+        "Construction crane lifting a resource into a Chrome tab"
+        ) }}
     <div class="gap-top-500 grid-gap-500 display-flex direction-column masonry:direction-row align-center masonry:align-start">
       <div class="display-flex direction-column grid-gap-500">
         {% set blog = 'blog-' + locale %}

--- a/site/_includes/macros/cards/hero-card.njk
+++ b/site/_includes/macros/cards/hero-card.njk
@@ -1,29 +1,33 @@
 {% from 'macros/icon.njk' import icon with context %}
 
-{% macro heroCard() %}
+{% macro heroCard(title, text, actionText, actionLink, imgSrc, imgAlt) %}
 <div class="hero-card width-full rounded-lg bg-blue-lighter pad-400 masonry:pad-right-500 masonry:pad-top-1000 masonry:pad-bottom-1000 masonry:pad-left-500">
   <div class="hero-card__inner">
     <div>
       <h1 class="type--h1 color-blue-darkest">
-        Welcome!
+        {{ title }}
       </h1>
       <p class="gap-top-300">
-        This is Chrome's official site to help you build Extensions, publish on the Chrome Web Store, optimize your website, and more.
+        {{ text }}
       </p>
-      <a href="/docs/" class="material-button button-filled button-round display-inline-flex color-bg bg-primary gap-top-400">
-        Start building
-      </a>
+      {% if actionText %}
+        <a href="{{ actionLink }}" class="material-button button-filled button-round display-inline-flex color-bg bg-primary gap-top-400">
+          {{ actionText }}
+        </a>
+      {% endif %}
     </div>
-    <div class="justify-self-end gap-top-300 masonry:gap-top-0">
-      {% Img
-        class="width-full",
-        src="image/QMjXarRXcMarxQddwrEdPvHVM242/uyy9OtWHTcxH5sK5VuRA.png",
-        alt="Construction crane lifting a resource into a Chrome tab",
-        width="264",
-        height="132",
-        sizes="(min-width: 592px) 597px, calc(100vw - 96px)"
-      %}
-    </div>
+    {% if imgSrc %}
+      <div class="justify-self-end gap-top-300 masonry:gap-top-0">
+        {% Img
+          class="width-full",
+          src=imgSrc,
+          alt=imgAlt,
+          width="264",
+          height="132",
+          sizes="(min-width: 592px) 597px, calc(100vw - 96px)"
+        %}
+      </div>
+    {% endif %}
   </div>
 </div>
 {% endmacro %}

--- a/site/en/capabilities/index.md
+++ b/site/en/capabilities/index.md
@@ -1,0 +1,11 @@
+---
+title: 'Capabilities'
+description: 'A landing page for the Capabilities project'
+layout: 'layouts/collection-landing.njk'
+collection_tag: 'extensions'
+draft: true
+---
+
+This is a content of the landing page. It can contain shortcodes and custom
+markup, if needed. Below the content we display 6 last articles with the
+relevant collection tag.

--- a/site/en/capabilities/index.md
+++ b/site/en/capabilities/index.md
@@ -4,6 +4,7 @@ description: 'A landing page for the Capabilities project'
 layout: 'layouts/collection-landing.njk'
 collection_tag: 'extensions'
 noindex: true
+draft: true
 ---
 
 This is a content of the landing page. It can contain shortcodes and custom

--- a/site/en/capabilities/index.md
+++ b/site/en/capabilities/index.md
@@ -3,7 +3,7 @@ title: 'Capabilities'
 description: 'A landing page for the Capabilities project'
 layout: 'layouts/collection-landing.njk'
 collection_tag: 'extensions'
-draft: true
+noindex: true
 ---
 
 This is a content of the landing page. It can contain shortcodes and custom

--- a/site/en/docs/handbook/how-to/add-a-collection-page/index.md
+++ b/site/en/docs/handbook/how-to/add-a-collection-page/index.md
@@ -1,0 +1,51 @@
+---
+layout: 'layouts/doc-post.njk'
+title: Add a collection page
+description: 'Add a landing page for a project or initiative.'
+date: 2022-03-08
+---
+
+## Choose a tag for your collection
+
+Choose a tag for your collection. It will become the `<COLLECTION_NAME>`. You can use an
+[existing tag](https://github.com/GoogleChrome/developer.chrome.com/blob/main/site/_data/i18n/tags.yml)
+or [create a new one](/docs/handbook/how-to/add-a-tag/).
+
+## Tag content
+
+Make sure all posts / articles / docs that will be bart of the collection are
+tagged with the chosen tag (e.g. `tags: [“capabilities”]`).
+
+## Create collection landing page
+
+Create a new page in the `site/en` directory:
+
+```bash
+├── site
+│   ├── en
+│   │   ├── <COLLECTION_NAME>
+│   │   │   └── index.md
+```
+
+## Configure the page
+
+Add the following frontmatter to the `index.md` file:
+
+```bash
+---
+title: '<COLLECTION_NAME_OR_CUSTOM_TITLE>'
+description: '<COLLECTION_DESCRIPTION>'
+layout: 'layouts/collection-landing.njk'
+collection_tag: '<COLLECTION_NAME>'
+---
+```
+
+You can leave the content of the `index.md` empty, or add custom markup as needed.
+
+Content supports markdown syntax with some additional features and shortcodes.
+See the [components guide](/docs/handbook/components/) for a full list of supported elements.
+
+We use an image CDN and GCS bucket to ensure that images and
+videos are served in a performant, responsive manner.
+Take a look at the guide on [uploading media](/docs/handbook/how-to/add-media)
+to learn how to add images and videos to your docs.


### PR DESCRIPTION
Example landing page: https://deploy-preview-2245--developer-chrome-com.netlify.app/capabilities
Docs on how to create a landing page: https://deploy-preview-2245--developer-chrome-com.netlify.app/docs/handbook/how-to/add-a-collection-page/

<img width="1111" alt="Screenshot 2022-03-08 at 12 08 34" src="https://user-images.githubusercontent.com/1914261/157226853-1a68faa3-a491-47ce-b4a3-4b70497c0d66.png">

The landing page consists of 3 sections:

1. Hero card with title, description, optional image and optional action button (like on the homepage)
2. Freeform content (accepts markdown and shortcodes). This area can be used to develop custom widgets needed by particular landing pages (similarly to "releases card" or "twitter card" on homepage).
3. List of last 6 pieces of content with link to see more (selected by a tag, e.g. "capabilities").

We can use this as a basis to identify and develop more sophisticated landing page widgets if needed.