### PR TITLE
Link to Workbox GH project

### DIFF
--- a/site/_data/docs/workbox/toc.yml
+++ b/site/_data/docs/workbox/toc.yml
@@ -37,3 +37,6 @@
 - url: /docs/workbox/reference
   title: i18n.docs.workbox.reference
   description: i18n.docs.workbox.reference_description
+- url: https://github.com/GoogleChrome/workbox
+  title: i18n.docs.workbox.github
+  description: i18n.docs.workbox.github_description

--- a/site/_data/i18n/docs/workbox.yml
+++ b/site/_data/i18n/docs/workbox.yml
@@ -1,30 +1,35 @@
 intro:
-  en: "Introduction to Workbox and service workers"
+  en: 'Introduction to Workbox and service workers'
 intro_description:
   en: |
     To do.
 know:
-  en: "What you need to know"
+  en: 'What you need to know'
 know_description:
   en: |
     To do.
 ways:
-  en: "Ways to use Workbox"
+  en: 'Ways to use Workbox'
 ways_description:
   en: |
     To do.
 uses:
-  en: "Use cases and recipes"
+  en: 'Use cases and recipes'
 uses_description:
   en: |
     To do.
 modules:
-  en: "Workbox Modules"
+  en: 'Workbox Modules'
 modules_description:
   en: |
     Dig deeper into specific Workbox modules.
 reference:
-  en: "API Reference"
+  en: 'API Reference'
 reference_description:
   en: |
     Browse the API reference to get information on available methods in the Workbox API, broken down by module.
+github:
+  en: 'Workbox on GitHub'
+github_description:
+  en: |
+    File issues, read release notes, and browse the source code.

--- a/site/en/docs/workbox/workbox.11tydata.js
+++ b/site/en/docs/workbox/workbox.11tydata.js
@@ -15,7 +15,7 @@
  */
 
 /**
- * @fileoverview Exists while Workbox is being ported across. Don't index pages on Algolia.
+ * @fileoverview Default metadata for Workbox pages.
  */
 
 /**


### PR DESCRIPTION
I think @petele had mentioned that it would be a good idea to link back to the GitHub project from the Workbox docs landing page.

<img width="853" alt="Screen Shot 2022-03-08 at 3 55 19 PM" src="https://user-images.githubusercontent.com/1749548/157323417-c3cc595d-ed2c-46e9-9390-c6c18f68adc4.png">