### PR TITLE
MV3 Update: Extension Architecture overview

### DIFF
--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -12,12 +12,12 @@ platform. Extensions can modify web content that users see and interact with. Th
 and change the behavior of the browser itself. 
 
 This page briefly describes the files that could form part of an extension, how to access these
-files, how to use Chrome APIs, how extension files communicate and how to store
+files, how to use Chrome APIs, how extension files communicate, and how to store
 data.
 
 ## Architecture {: #arch }
 
-An extension's architecture will depend on its functionality, but they are all required to have a
+An extension's architecture will depend on its functionality, but all extensions are required to have a
 [manifest][section-manifest]. The following are other components an extension can include: 
 
 - [Background Script][section-bg]
@@ -58,11 +58,11 @@ as the most important files and the capabilities the extension might use.
 
 Extensions must have an icon that sits in the browser toolbar. Toolbar icons allow easy access and
 keep users aware of which extensions are installed. Most users will interact with an extension that
-uses a [popup][docs-popup] by clicking on the icon, like in the [Getting Started
+uses a [popup][docs-popup] by clicking the icon, like in the [getting started
 example][sample-getting-started].
 
 {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/ku5Z8MMssgw6MKctpJVI.png", alt="Getting started
-Popup", width="187", height="153" %}
+popup", width="187", height="153" %}
 <!-- TODO: Show examples of the MV3 getting started tutorial extensions -->
 
 ### Background service worker {: #background_script }
@@ -73,7 +73,7 @@ the instructed logic; it is only loaded when it is needed and unloaded when it g
 background script has access to all the [Chrome APIs][section-apis], as long it declares the
 required permissions in the `manifest.json`.
 
-See [Manage events with Service Workers][docs-service-worker] to learn more. 
+See [Manage events with service workers][docs-service-worker] to learn more. 
 
 ### Content scripts {: #contentScripts }
 
@@ -87,7 +87,7 @@ and storing values using the [storage][api-storage] API.
 {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/466ftDp0EXB4E1XeaGh0.png", alt="Shows a communication
 path between the content script and the parent extension", height="316", width="388" %}
 
-See [Understanding Content scripts][docs-content-scripts] to learn more.
+See [Understanding content scripts][docs-content-scripts] to learn more.
 
 ### UI elements {: #pages }
 
@@ -122,9 +122,9 @@ extension toolbar. The following is an example of the Google Dictionary extensio
 
 <figure>
 {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/Mz7GV76tFkzxRlb7Pq6e.png", 
-alt="Options page link in UI", width="800", height="299" %}
+alt="Options page link in the UI", width="800", height="299" %}
   <figcaption>
-    Link to Options page.
+    Link to the Options page.
   </figcaption>
 </figure>
 
@@ -137,7 +137,7 @@ alt="Options page link in UI", width="800", height="299" %}
 alt="Context Menu Options page", width="357", height="222" %}
 
   <figcaption>
-    Options page in extension's context menu.
+    Options page in the extension's context menu.
   </figcaption>
 </figure>
 
@@ -153,8 +153,8 @@ You can display other HTML files present in the extension that are not declared 
 These HTML files can access the same [Chrome APIs][section-apis] as the popup or other extension
 files. 
 
-You can open these pages using the web api [window.open()][mdn-window-open] or the Chrome APIs
-[windows.create()][api-window-create] or [tabs.create()][api-create-tab].
+You can open these pages using the web api [window.open()][mdn-window-open], the Chrome APIs
+[windows.create()][api-window-create], or [tabs.create()][api-create-tab].
 
 ## Extension files {: #files }
 <!-- TODO: Intro -->
@@ -167,7 +167,7 @@ pages** can also reference extension assets using relative paths.
 <img src="images/my_image.png">
 ```
 
-To access an extension file from a **content script**, you can
+To access an extension file from a **content script**, you can call
 [`chrome.runtime.getURL()`][api-get-url] to get the _absolute URL_ of your extension asset.
 
 ``` js
@@ -206,7 +206,7 @@ All assets that content scripts and websites want to access must be declared as 
 ### Web accesible resources {: #web-resources }
 
 Web-accessible resources are files (images, HTML, CSS, Javascript) inside an extension that can be
-accessed by a content script, web pages or other extensions. 
+accessed by a content script, web pages, or other extensions. 
 
 In Manifest Version 3, you can declare which resources are exposed and to what origins in the
 manifest:
@@ -298,7 +298,8 @@ checking its API reference page.
 
 ```js
 // Promise
-chrome.tabs.query(queryOptions).then((tabs) => {
+chrome.tabs.query(queryOptions)
+.then((tabs) => {
   chrome.tabs.update(tabs[0].id, {url: newUrl});
   someOtherFunction();
 });
@@ -331,7 +332,7 @@ the same channel.
 ## Saving data {: #data}
 
 The chrome storage API has been optimized to meet the specific storage needs of extensions. For
-example, whenever data is updated, you can use the onChanged() event to track these changes. All
+example, whenever data is updated, you can use the `onChanged()` event to track these changes. All
 extension components have access to this API. An extension can also store data using the web API
 [indexedDB][mdn-indexeddb].
 
@@ -348,13 +349,13 @@ See [Saving data in incognito mode][incognito-data] to understand how to protect
 
 ## Take the next step {: #next-steps }
 
-After reading the overview and completing the [Getting Started][docs-get-started] tutorial, you
+After reading the overview and completing the [Getting started][docs-get-started] tutorial, you
 should be ready to start writing your own extensions! Dive deeper into the world of custom Chrome
 with the following resources:
 
-- Learn about how to debug Extensions in the [debugging tutorial][docs-debugging].
+- Learn how to debug Extensions in the [debugging tutorial][docs-debugging].
 - Chrome Extensions have access to powerful APIs above and beyond what's available on the open web.
-  The [chrome.\* APIs documentation][api-reference] will walk through each API.
+  The [chrome APIs documentation][api-reference] will walk through each API.
 - The [developer's guide][docs-dev-guide] has dozens of additional links to pieces of documentation
   relevant to advanced extension creation.
 

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -122,7 +122,7 @@ or enhance the browsing experience without distracting from it.
 Most extensions run when the user clicks the toolbar icon [action][api-action] or display a
 [popup][docs-popup], but can also contain any of the following:
 
-- A [context menus][docs-context-menu]
+- A [context menu][docs-context-menu]
 - An [omnibox][docs-omnibox]
 - A [keyboard shortcut][docs-commands].
 
@@ -137,7 +137,7 @@ An extension using a popup can use the [declarative content API][api-dec-content
 the background script for when the popup is available to users. When the conditions are met, the
 background script communicates with the popup to make it's icon clickable to users.
 
-An extension can [override][docs-override] and replace the History, New Tab, or Bookmarks web page
+Extensions can also [override][docs-override] and replace the History, New Tab, or Bookmarks web page
 with a custom HTML file.
 
 ### Content scripts {: #contentScripts }
@@ -258,7 +258,7 @@ anything with the results of the update.
 #### Promises
 
 With the introduction of Manifest V3, many extension API methods now return promises. Not all
-methods in extensions APIs support promises. You can check whether a method supports promises by
+methods in extensions APIs support promises. You can verify whether a method supports promises by
 checking its API reference page. See [Using promises][docs-promises] to learn more.
 
 #### Synchronous methods
@@ -311,8 +311,7 @@ After reading the overview and completing the [Getting Started][docs-get-started
 should be ready to start writing your own extensions! Dive deeper into the world of custom Chrome
 with the following resources:
 
-- Learn about the options available for debugging Extensions in the [debugging
-  tutorial][docs-debugging].
+- Learn about how to debug Extensions in the [debugging tutorial][docs-debugging].
 - Chrome Extensions have access to powerful APIs above and beyond what's available on the open web.
   The [chrome.\* APIs documentation][api-reference] will walk through each API.
 - The [developer's guide][docs-dev-guide] has dozens of additional links to pieces of documentation
@@ -340,6 +339,7 @@ with the following resources:
 [docs-messages]: /docs/extensions/mv3/messaging
 [docs-omnibox]: /docs/extensions/mv3/user_interface/#omnibox
 [docs-options]: /docs/extensions/mv3/options
+[docs-override]: /docs/extensions/mv3/override/
 [docs-popup]: /docs/extensions/mv3/user_interface#popup
 [docs-promises]: /docs/extensions/mv3/promises/
 [docs-service-worker]: /docs/extensions/mv3/service_workers

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -337,6 +337,15 @@ extension components have access to this API. An extension can also store data u
 
 See [storage API][api-storage] for usage and examples.
 
+## Incognito mode {: #incognito}
+
+Extensions don't run in incognito windows unless the user manually allows it in the extension's
+settings page. By default, normal and incognito windows run in a single shared process. However,
+extensions can run incognito windows in their own separate process or not support incognito windows
+at all. You can specify this behavior in the ["incognito"][manifest-incognito] key in the manifest.
+
+See [Saving data in incognito mode][incognito-data] to understand how to protect user privacy.
+
 ## Take the next step {: #next-steps }
 
 After reading the overview and completing the [Getting Started][docs-get-started] tutorial, you
@@ -383,7 +392,8 @@ with the following resources:
 [mdn-web-apis]: https://developer.mozilla.org/docs/Web/API
 [mdn-indexeddb]: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API
 [mdn-window-open]: https://developer.mozilla.org/docs/Web/API/Window/open
-[sample-getting-started]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/tutorials/getting-started
+[sample-getting-started]:
+    https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/tutorials/getting-started
 [section-apis]: #apis
 [section-bg]: #background_script
 [section-cs]: #contentScripts
@@ -392,3 +402,5 @@ with the following resources:
 [section-options]: #optionsPage
 [section-ui]: #pages
 [section-web-res]: #web-resources
+[incognito-data]: /docs/extensions/mv3/user_privacy/#data-incognito
+[manifest-incognito]: /docs/extensions/mv3/manifest/incognito/

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -2,7 +2,7 @@
 layout: "layouts/doc-post.njk"
 title: "Architecture overview"
 date: 2012-09-18
-updated: 2022-04-01
+updated: 2022-04-05
 description: A high-level explanation of the software architecture of Chrome Extensions.
 subhead: A high-level explanation of the components and structure of a Chrome Extension.
 ---
@@ -196,7 +196,7 @@ on the Chrome Web Store.
 During development, a new ID is generated when an [_unpacked extension_][docs-unpacked] is loaded,
 unless the `"key"` property is set in the manifest.
 
-See xyz to learn how to set this key.
+See [Keeping a consistent key][docs-key] to learn how to set this key.
 
 {% Aside 'caution' %}
 
@@ -387,6 +387,7 @@ with the following resources:
 [docs-ext-pages]: /docs/extensions/mv3/user_interface/#pages
 [docs-get-started]: /docs/extensions/mv3/getstarted
 [docs-key]: /docs/extensions/mv3/manifest/key/
+[docs-key]: /docs/extensions/mv3/tut_oauth/#keep-consistent-id
 [docs-link-options]: /docs/extensions/mv3/options/#linking
 [docs-manifest]: /docs/extensions/mv3/manifest
 [docs-messages]: /docs/extensions/mv3/messaging

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -118,26 +118,20 @@ goes idle.
 An [extension's user interface][docs-ui] should be purposeful and minimal. The UI should customize
 or enhance the browsing experience without distracting from it. 
 
-Most extensions run when the user clicks the toolbar icon [action][api-action] or display a
-[popup][docs-popup], but can also contain any of the following:
+The following is a list of most common UI examples:
 
-- A [context menu][docs-context-menu]
+- An [action click][docs-click] event.
+- A [popup][docs-popup].
+- A [context menu][docs-context-menu].
 - An [omnibox][docs-omnibox]
 - A [keyboard shortcut][docs-commands].
+- Desktop [notifications][api-notif].
+- [Text-to-speech][api-tts].
+- Inject a custom UI [into a page][docs-content-scripts].
+- [Override Chrome pages][docs-override] (History page, New Tab, or Bookmarks).
+- Open a dedicated [tab][api-create-tab] or [window][api-window-create].
 
-Extension UI pages, such as a [popup][docs-popup], can contain ordinary HTML pages with JavaScript
-logic. Extensions can also call [tabs.create][api-create-tab] or `window.open()` to display
-additional HTML files present in the extension.
-
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/8oLwFaq0VFIQtw4mcA91.png", alt="A browser window
-containing a page action displaying a popup", height="316", width="325" %}
-
-An extension using a popup can use the [declarative content API][api-dec-content] to set rules in
-the background script for when the popup is available to users. When the conditions are met, the
-background script communicates with the popup to make it's icon clickable to users.
-
-Extensions can also [override][docs-override] and replace the History, New Tab, or Bookmarks web page
-with a custom HTML file.
+See [Design the UI][docs-ui] for UI and design guidelines for Chrome Extensions.  
 
 ### Content scripts {: #contentScripts }
 
@@ -320,12 +314,14 @@ with the following resources:
 [api-create-tab]: /docs/extensions/reference/tabs#method-create
 [api-dec-content]: /docs/extensions/reference/declarativeContent
 [api-get-url]: /docs/extensions/reference/runtime#method-getURL
+[api-notif]: /docs/extensions/reference/notifications/
 [api-reference]: /docs/extensions/reference
 [api-storage]: /docs/extensions/reference/storage
 [api-tab]: /docs/extensions/reference/tabs#type-Tab
-[api-tabs-create]: /docs/extensions/reference/tabs#method-create
 [api-tabs-query]: /docs/extensions/reference/tabs#method-query
-[api-window]: /docs/extensions/reference/windows#type-Window
+[api-tts]: /docs/extensions/reference/tts/
+[api-window-create]: /docs/extensions/reference/windows/#method-create
+[docs-click]: /docs/extensions/mv3/user_interface/#click-event
 [docs-commands]: /docs/extensions/mv3/user_interface/#commands
 [docs-content-scripts]: /docs/extensions/mv3/content_scripts
 [docs-context-menu]: /docs/extensions/mv3/user_interface/#context_menu

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -188,25 +188,14 @@ method instead.
 
 ### Asynchronous vs. synchronous methods {: #sync }
 
+#### Callbacks
+
 Most Chrome API methods are asynchronous: they return immediately without waiting for the operation
 to finish. If an extension needs to know the outcome of an asynchronous operation it can pass a
 callback function into the method. The callback is executed later, potentially much later, after the
 method returns.
 
-If the extension needed to navigate the user's currently selected tab to a new URL, it would need to
-get the current tab's ID and then update that tab's address to the new URL.
-
-If the [tabs.query][api-tabs-query] method were synchronous, it may look something like below.
-
-```js
-//THIS CODE DOESN'T WORK
-var tab = chrome.tabs.query({'active': true}); //WRONG!!!
-chrome.tabs.update(tab.id, {url:newUrl});
-someOtherFunction();
-```
-
-This approach will fail because `query()` is asynchronous. It returns without waiting for the work
-to complete, and does not return a value. A method is asynchronous when the callback parameter is
+A method is asynchronous when the callback parameter is
 available in its signature.
 
 ```js
@@ -214,21 +203,51 @@ available in its signature.
 chrome.tabs.query(object queryInfo, function callback)
 ```
 
+If the extension needed to navigate the user's currently selected tab to a new URL, it would need to
+get the current tab's ID and then update that tab's address to the new URL.
+
+
+If the [tabs.query][api-tabs-query] method were synchronous, it may look something like below.
+
+{% Compare 'worse' %}
+```js
+var tab = chrome.tabs.query({'active': true}); //WRONG!!!
+chrome.tabs.update(tab.id, {url:newUrl});
+someOtherFunction();
+```
+{% CompareCaption %}
+
+This approach will fail because `query()` is asynchronous. It returns without waiting for the work
+to complete, and does not return a value.
+
+{% endCompareCaption %}
+
+{% endCompare %}
+
 To correctly query a tab and update its URL the extension must use the callback parameter.
 
+{% Compare 'better' %}
 ```js
-//THIS CODE WORKS
 chrome.tabs.query({'active': true}, function(tabs) {
   chrome.tabs.update(tabs[0].id, {url: newUrl});
 });
 someOtherFunction();
 ```
 
+{% endCompare %}
+
 In the above code, the lines are executed in the following order: 1, 4, 2. The callback function
 specified to `query()` is called and then executes line 2, but only after information about the
 currently selected tab is available. This happens sometime after `query()` returns. Although
 `update()` is asynchronous the code doesn't use a callback parameter, since the extension doesn't do
 anything with the results of the update.
+
+
+#### Promises
+
+With the introduction of Manifest V3, many extension API methods now return promises. Not all methods in extensions APIs support promises. You can check whether a method supports promises by checking its API reference page. See [Using promises][docs-promises] to learn more.
+
+#### Synchronous methods
 
 ```js
 // Synchronous methods have no callback option and returns a type of string
@@ -239,7 +258,7 @@ This method synchronously returns the URL as a `string` and performs no other as
 
 ### More details {: #chrome-more }
 
-For more information, explore the [Chrome API reference docs][api-reference] and watch the following video.
+For more information, explore the [Chrome API reference docs][api-reference].
 
 ## Communication between pages {: #pageComm }
 

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -2,7 +2,7 @@
 layout: "layouts/doc-post.njk"
 title: "Architecture overview"
 date: 2012-09-18
-updated: 2021-05-12
+updated: 2022-03-12
 description: A high-level explanation of the software architecture of Chrome Extensions.
 ---
 
@@ -54,7 +54,8 @@ Extensions must have an icon that sits in the browser toolbar. Toolbar icons all
 keep users aware of which extensions are installed. Most users will interact with an extension that
 uses a [popup][docs-popup] by clicking on the icon, like in the [Getting Started example][sample-getting-started].
 
-{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/ku5Z8MMssgw6MKctpJVI.png", alt="Getting started Popup", width="187", height="153" %}
+{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/ku5Z8MMssgw6MKctpJVI.png", 
+alt="Getting started Popup", width="187", height="153" %}
 
 <!-- TODO: Show examples of the MV3 getting started tutorial extensions -->
 
@@ -82,7 +83,8 @@ generates. The extension ID's are displayed in the Extension management page
 **chrome://extensions**. The <var>PATH_TO_FILE</var> is the location of the file under the
 extension's top folder; it matches the relative URL.
 
-{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/GemDxnaBjzDiY0uwNiVT.png", alt="Extension ID in the Extension management page", width="400", height="21" %}
+{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/GemDxnaBjzDiY0uwNiVT.png", 
+alt="Extension ID in the Extension management page", width="400", height="21" %}
 
 While working on an unpacked extension, if the [`key`][docs-key] has not been specified in the manifest, then the extension ID can change. For example, when the extension is loaded from a different directory, packed or uploaded to the Chrome Web Store.
 
@@ -126,7 +128,13 @@ Extensions can also call [tabs.create][api-create-tab] or `window.open()` to dis
 present in the extension.
 
 {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/8oLwFaq0VFIQtw4mcA91.png",
-       alt="A browser window containing a page action displaying a popup", height="316", width="325" %}
+alt="A browser window containing a page action displaying a popup", height="316", width="325" %}
+
+An extension using a popup can use the [declarative content API][api-dec-content] to set rules in
+the background script for when the popup is available to users. When the conditions are met, the
+background script communicates with the popup to make it's icon clickable to users.
+
+An extension can [override][docs-override] and replace the History, New Tab, or Bookmarks web page with a custom HTML file.
 
 ### Content scripts {: #contentScripts }
 
@@ -135,13 +143,13 @@ contains JavaScript that executes in the contexts of a page that has been loaded
 Content scripts read and modify the DOM of web pages the browser visits.
 
 {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/CNDAVsTnJeSskIXVnSQV.png",
-       alt="A browser window with a page action and a content script", height="316", width="388" %}
+alt="A browser window with a page action and a content script", height="316", width="388" %}
 
 Content scripts can communicate with their parent extension by exchanging [messages][docs-messages] and storing
 values using the [storage][api-storage] API.
 
 {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/466ftDp0EXB4E1XeaGh0.png",
-       alt="Shows a communication path between the content script and the parent extension", height="316", width="388" %}
+alt="Shows a communication path between the content script and the parent extension", height="316", width="388" %}
 
 ### Options page {: #optionsPage }
 
@@ -149,7 +157,8 @@ Just as extensions allow users to customize the Chrome browser, the [options pag
 customization of the extension. Options can be used to enable features and allow users to choose
 what functionality is relevant to their needs.
 
-Users can access the options page via [direct link][docs-link-options] or in the context menu of the extension toolbar. The following is an example of the Google Dictionary extension. 
+Users can access the options page via [direct link][docs-link-options] or in the context menu of the
+extension toolbar. The following is an example of the Google Dictionary extension. 
 
 {% Columns %}
 
@@ -328,6 +337,7 @@ following resources.
 [docs-omnibox]: /docs/extensions/mv3/user_interface/#omnibox
 [docs-options]: /docs/extensions/mv3/options
 [docs-popup]: /docs/extensions/mv3/user_interface#popup
+[docs-promises]: /docs/extensions/mv3/promises/
 [docs-service-worker]: /docs/extensions/mv3/service_workers
 [docs-ui]: /docs/extensions/mv3/user_interface
 [sample-getting-started]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/tutorials/getting-started

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -21,6 +21,8 @@ Extensions vary in types of files and amount of directories, but they are all re
 [manifest][docs-manifest]. Some basic, but useful, extensions may consist of just the manifest and its toolbar
 icon.
 
+### The manifest {: #manifest }
+
 The manifest file, titled `manifest.json`, gives the browser information about the extension, such
 as the most important files and the capabilities the extension might use.
 
@@ -39,7 +41,7 @@ as the most important files and the capabilities the extension might use.
   "background": {
     "service_worker": "background.js"
   },
-  "permissions": ["activeTab"],
+  "permissions": ["storage"],
   "host_permissions": ["*://*.example.com/*"],
   "action": {
     "default_icon": "icon_16.png",
@@ -48,19 +50,13 @@ as the most important files and the capabilities the extension might use.
 }
 ```
 
+### Toolbar icon {: #icons }
+
 Extensions must have an icon that sits in the browser toolbar. Toolbar icons allow easy access and
 keep users aware of which extensions are installed. Most users will interact with an extension that
-uses a [popup][docs-popup] by clicking on the icon.
+uses a [popup][docs-popup] by clicking on the icon, like in the [Getting Started extension][sample-get-started].
 
-This Manifest V2 [Google Mail Checker extension][sample-gmail] uses a [browser action][4]:
-
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/mG1Uyd3uzcP7sSyKXWkh.png",
-       alt="A screenshot of the Google Mail Checker extension", height="79", width="90" %}
-
-This Manifest V2 [Mappy extension][sample-mappy] uses a [page action][6] and [content script][7]:
-
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/LrHTrkZVBN96DqNQjtyF.png",
-       alt="A screenshot of the Mappy extension", height="103", width="90" %}
+{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/ku5Z8MMssgw6MKctpJVI.png", alt="Getting started Popup", width="187", height="153" %}
 
 ### Referring to files {: #relative-urls }
 
@@ -275,8 +271,7 @@ following resources.
 [docs-popup]: /docs/extensions/mv3/user_interface#popup
 [docs-service-worker]: /docs/extensions/mv3/service_workers
 [docs-ui]: /docs/extensions/mv3/user_interface
-[sample-gmail]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/mv2-archive/extensions/gmail
-[sample-mappy]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/mv2-archive/extensions/mappy
+[sample-getting-started]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/tutorials/getting-started
 [section-bg]: #background_script
 [section-cs]: #contentScripts
 [section-options]: #optionsPage

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -115,7 +115,7 @@ goes idle.
 
 ### UI elements {: #pages }
 
-An [extension's user interface][docs-ui] should be purposeful and minimal. The UI should customize
+An extension's user interface should be purposeful and minimal. The UI should customize
 or enhance the browsing experience without distracting from it. 
 
 The following is a list of most common UI examples:
@@ -135,9 +135,9 @@ See [Design the UI][docs-ui] for UI and design guidelines for Chrome Extensions.
 
 ### Content scripts {: #contentScripts }
 
-Extensions that read or write to web pages utilize a [content script][docs-content-scripts]. The
+[Content scripts][docs-content-scripts] allow extensions to inject script into a page in order to read and modify its contents. The
 content script contains JavaScript that executes in the contexts of a page that has been loaded into
-the browser. Content scripts read and modify the DOM of web pages the browser visits.
+the browser.
 
 {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/CNDAVsTnJeSskIXVnSQV.png", alt="A browser window with
 a page action and a content script", height="316", width="388" %}

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -4,20 +4,18 @@ title: "Architecture overview"
 date: 2012-09-18
 updated: 2022-03-25
 description: A high-level explanation of the software architecture of Chrome Extensions.
+subhead: Overview of Chrome extensions components and capabilities.
 ---
 
 Extensions are zipped bundles of HTML, CSS, JavaScript, images, and other files used in the web
-platform, that customize the Google Chrome browsing experience. Extensions are built using web
-technology and can use the same APIs the browser provides to the open web.
+platform. Extensions can modify web content that users see and interact with. They can also extend and change the behavior of
+the browser itself. 
 
-Extensions have a wide range of functional possibilities. They can modify web content users see and
-interact with or extend and change the behavior of the browser itself.
-
-Consider extensions the gateway to making the Chrome browser the most personalized browser.
+This page briefly describes the files that could form part of an extension, how to access these files, how to use the Chrome APIs, how these pages communicate with each other and how to store data.
 
 ## Extension files {: #files }
 
-Extensions vary in types of files and amount of directories, but they are all required to have a
+Extensions may contain many files or directories, but they are all required to have a
 [manifest][docs-manifest].
 
 ### The manifest {: #manifest }
@@ -97,6 +95,8 @@ All assets accessed by content scripts must be declared as a
 
 {% endAside %}
 
+### Web accesible resources
+
 ## Architecture {: #arch }
 
 An extension's architecture will depend on its functionality, but many robust extensions will
@@ -130,10 +130,11 @@ The following is a list of most common UI examples:
 - Desktop [notifications][api-notif].
 - [Extension pages][docs-ext-pages].
 - [Text-to-speech][api-tts].
-- Inject a custom UI [into a page][docs-content-scripts].
+- A custom UI injected [into a page][docs-content-scripts].
+<!-- Rewrite -->
 - [Override Chrome pages][docs-override] (History page, New Tab, or Bookmarks).
 
-See [Design the UI][docs-ui] for UI and design guidelines for Chrome Extensions.  
+To learn more, see the [Design the UI of a Ch][docs-ui].  
 
 ### Content scripts {: #contentScripts }
 

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -113,17 +113,17 @@ when it goes idle.
 ### UI elements {: #pages }
 
 An [extension's user interface][docs-ui] should be purposeful and minimal. The UI should customize or
-enhance the browsing experience without distracting from it. Most extensions have a [browser
-action][16] or [page action][17], but can contain other forms of UI, such as [context menus][docs-context-menu],
-use of the [omnibox][docs-omnibox], or creation of a [keyboard shortcut][docs-commands].
+enhance the browsing experience without distracting from it. 
 
-Extension UI pages, such as a [popup][21], can contain ordinary HTML pages with JavaScript logic.
-Extensions can also call [tabs.create][22] or `window.open()` to display additional HTML files
+Most extensions run when the user clicks the toolbar icon [action][api-action] or display a [popup][docs-popup], but can also contain any of the following:
+
+- A [context menus][docs-context-menu]
+- An [omnibox][docs-omnibox]
+- A [keyboard shortcut][docs-commands].
+
+Extension UI pages, such as a [popup][docs-popup], can contain ordinary HTML pages with JavaScript logic.
+Extensions can also call [tabs.create][api-create-tab] or `window.open()` to display additional HTML files
 present in the extension.
-
-An extension using a page action and a popup can use the [declarative content][api-dec-content] API to set rules
-in the background script for when the popup is available to users. When the conditions are met, the
-background script communicates with the popup to make it's icon clickable to users.
 
 {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/8oLwFaq0VFIQtw4mcA91.png",
        alt="A browser window containing a page action displaying a popup", height="316", width="325" %}
@@ -257,6 +257,7 @@ following resources.
 - The [developer's guide][docs-dev-guide] has dozens of additional links to pieces of documentation relevant to
   advanced extension creation.
 
+[api-action]: /docs/extensions/reference/action/
 [api-create-tab]: /docs/extensions/reference/tabs#method-create
 [api-dec-content]: /docs/extensions/reference/declarativeContent
 [api-get-url]: /docs/extensions/reference/runtime#method-getURL
@@ -277,7 +278,6 @@ following resources.
 [docs-messages]: /docs/extensions/mv3/messaging
 [docs-omnibox]: /docs/extensions/mv3/user_interface/#omnibox
 [docs-options]: /docs/extensions/mv3/options
-[docs-popup]: /docs/extensions/mv3/user_interface#popup
 [docs-popup]: /docs/extensions/mv3/user_interface#popup
 [docs-service-worker]: /docs/extensions/mv3/service_workers
 [docs-ui]: /docs/extensions/mv3/user_interface

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -128,10 +128,10 @@ The following is a list of most common UI examples:
 - An [omnibox][docs-omnibox]
 - A [keyboard shortcut][docs-commands].
 - Desktop [notifications][api-notif].
+- [Extension pages][docs-ext-pages].
 - [Text-to-speech][api-tts].
 - Inject a custom UI [into a page][docs-content-scripts].
 - [Override Chrome pages][docs-override] (History page, New Tab, or Bookmarks).
-- Open a dedicated [tab][api-create-tab] or [window][api-window-create].
 
 See [Design the UI][docs-ui] for UI and design guidelines for Chrome Extensions.  
 
@@ -351,6 +351,7 @@ with the following resources:
 [docs-manifest]: /docs/extensions/mv3/manifest
 [docs-messages]: /docs/extensions/mv3/messaging
 [docs-omnibox]: /docs/extensions/mv3/user_interface/#omnibox
+[docs-ext-pages]: /docs/extensions/mv3/user_interface/#pages
 [docs-options]: /docs/extensions/mv3/options
 [docs-override]: /docs/extensions/mv3/override/
 [docs-popup]: /docs/extensions/mv3/user_interface#popup

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -271,16 +271,12 @@ For more information, explore the [Chrome API reference docs][api-reference].
 
 ## Communication between pages {: #pageComm }
 
-Different components in an extension often need to communicate with each other. Different HTML pages
-can find each other by using the [`chrome.extension`][32] methods, such as `getViews()` and
-`getBackgroundPage()`. Once a page has a reference to other extension pages the first one can invoke
-functions on the other pages and manipulate their DOMs. Additionally, all components of the
-extension can access values stored using the [storage][33] API and communicate through [message
-passing][34].
+Different components in an extension can communicate with each other using [message passing][docs-messages]. Either side can listen for messages sent from the other end, and respond on the same channel. Additionally, all components of the
+extension can access values stored using the [storage][api-storage] API.
 
 ## Saving data and incognito mode {: #incognito }
 
-Extensions can save data using the [storage][api-storage] API, the HTML5 [web storage API][36] , or by making
+Extensions can save data using the [storage][api-storage] API, or by making
 server requests that result in saving data. When the extension needs to save something, first
 consider if it's from an incognito window. By default, extensions don't run in incognito windows.
 

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -156,8 +156,6 @@ files.
 You can open these pages using the web api [window.open()][mdn-window-open] or the Chrome APIs
 [windows.create()][api-window-create] or [tabs.create()][api-create-tab].
 
-<!-- TODO: See Extension pages to learn more. -->
-
 ## Extension files {: #files }
 <!-- TODO: Intro -->
 ### Referencing extension files {: #ref-files }

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -103,11 +103,11 @@ include multiple components:
 - [Content Script][section-cs]
 - [Options Page][section-options]
 
-### Background script {: #background_script }
+### Background service worker {: #background_script }
 
-The [background script][docs-service-worker] is the extension's event handler; it contains listeners for browser
+The [background service worker][docs-service-worker] is the extension's event handler; it contains listeners for browser
 events that are important to the extension. It lies dormant until an event is fired then performs
-the instructed logic. An effective background script is only loaded when it is needed and unloaded
+the instructed logic; it is only loaded when it is needed and unloaded
 when it goes idle.
 
 ### UI elements {: #pages }

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -326,33 +326,14 @@ This method synchronously returns the URL as a `string` and performs no other as
 
 Different components in an extension can communicate with each other using [message
 passing][docs-messages]. Either side can listen for messages sent from the other end, and respond on
-the same channel. Additionally, all components of the extension can access values stored using the
-[storage][api-storage] API.
+the same channel. 
 
-## Saving data and incognito mode {: #incognito }
-<!-- TODO: Would like to move this section to Protect User Privacy docs -->
-Extensions can save data using the [storage][api-storage] API, or by making server requests that
-result in saving data. When the extension needs to save something, first consider if it's from an
-incognito window. By default, extensions don't run in incognito windows.
+## Saving data {: #data}
 
-_Incognito mode_ promises that the window will leave no tracks. When dealing with data from
-incognito windows, extensions should honor this promise. If an extension normally saves browsing
-history, don't save history from incognito windows. However, extensions can store setting
-preferences from any window, incognito or not.
+The chrome storage API has been optimized to meet the specific storage needs of extensions. For example, whenever data is updated, you can use the onChanged() event to track these changes. All extension components have access to this API. An extension can also store data using the web API [indexedDB][mdn-indexeddb].
 
-To detect whether a window is in incognito mode, check the `incognito` property of the relevant
-[tabs.Tab][api-tab] or [windows.Window][api-window] object.
+See [storage API][api-storage] for usage and examples.
 
-```js
-function saveTabData(tab) {
-  if (tab.incognito) {
-    return;
-  } else {
-    chrome.storage.local.set({data: tab.url});
-  }
-}
-```
-'
 ## Take the next step {: #next-steps }
 
 After reading the overview and completing the [Getting Started][docs-get-started] tutorial, you
@@ -398,6 +379,7 @@ with the following resources:
 [docs-unpacked]: /docs/extensions/mv3/getstarted/#unpacked
 [docs-web-acc-res]: /docs/extensions/mv3/manifest/web_accessible_resources/
 [mdn-web-apis]: https://developer.mozilla.org/docs/Web/API
+[mdn-indexeddb]: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API
 [mdn-window-open]: https://developer.mozilla.org/docs/Web/API/Window/open
 [sample-getting-started]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/tutorials/getting-started
 [section-apis]: #apis

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -149,9 +149,38 @@ Just as extensions allow users to customize the Chrome browser, the [options pag
 customization of the extension. Options can be used to enable features and allow users to choose
 what functionality is relevant to their needs.
 
+Users can access the options page via [direct link][docs-link-options] or in the context menu of the extension toolbar. The following is an example of the Google Dictionary extension. 
+
+{% Columns %}
+
+{% Column %}
+
+<figure>
+{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/Mz7GV76tFkzxRlb7Pq6e.png", alt="Options page link in UI", width="800", height="299" %}
+  <figcaption>
+    Link to Options page.
+  </figcaption>
+</figure>
+
+{% endColumn %}
+
+{% Column %}
+
+<figure>
+{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/BM11QeGCThsUNTlsZbAe.png", alt="Context Menu Options page", width="357", height="222" %}
+
+  <figcaption>
+    Options page in extension's context menu.
+  </figcaption>
+</figure>
+
+{% endColumn %}
+
+{% endColumns %}
+
 ## Using Chrome APIs {: #apis }
 
-In addition to having access to the same APIs as web pages, extensions can also use
+In addition to having access to the same web APIs as web pages, extensions can also use
 [extension-specific APIs][api-reference] that create tight integration with the browser. Extensions and
 webpages can both access the standard `window.open()` method to open a URL, but extensions can
 specify which window that URL should be displayed in by using the Chrome API [tabs.create][api-tabs-create]
@@ -272,8 +301,9 @@ following resources.
 [docs-context-menu]: /docs/extensions/mv3/user_interface/#context_menu
 [docs-debugging]: /docs/extensions/mv3/tut_debugging
 [docs-dev-guide]: /docs/extensions/mv3/devguide
-[docs-key]: /docs/extensions/mv3/manifest/key/
 [docs-get-started]: /docs/extensions/mv3/getstarted
+[docs-key]: /docs/extensions/mv3/manifest/key/
+[docs-link-options]: /docs/extensions/mv3/options/#linking
 [docs-manifest]: /docs/extensions/mv3/manifest
 [docs-messages]: /docs/extensions/mv3/messaging
 [docs-omnibox]: /docs/extensions/mv3/user_interface/#omnibox

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -73,29 +73,27 @@ pages can also reference assets in the extension using relative paths.
 
 #### Absolute URL {: #absolute-urls }
 
-Additionally, each file can also be accessed using an absolute URL.
-
-```text
-chrome-extension://EXTENSION_ID/PATH_TO_FILE
-```
-
-In the absolute URL, the <code><var>EXTENSION_ID</var></code> is a unique identifier that the extension system
-generates. The extension ID's are displayed in the Extension management page
-**chrome://extensions**. The <code><var>PATH_TO_FILE</var></code> is the location of the file under the
-extension's top folder; it matches the relative URL.
-
-{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/GemDxnaBjzDiY0uwNiVT.png", alt="Extension ID in the
-Extension management page", width="400", height="21" %}
-
-While working on an unpacked extension, if the [`key`][docs-key] has not been specified in the
-manifest, then the extension ID can change. For example, when the extension is loaded from a
-different director or uploaded to the Chrome Web Store.
-
-You can use the [`chrome.runtime.getURL()`][api-get-url] method to avoid hardcoding the ID.
+To access a file in a content script, you can use the [`chrome.runtime.getURL()`][api-get-url] method. 
 
 ``` js
 let image = chrome.runtime.getURL("images/my_image.png")
 ```
+
+It will return an absolute URL for the asset in your extension, that looks like this:
+
+```text
+chrome-extension://EXTENSION_ID/RELATIVE_PATH
+```
+
+The <code><var>EXTENSION_ID</var></code> is a unique identifier that the browser generates. You can view these IDs in the Extension management page
+**chrome://extensions**. The <code><var>RELATIVE_PATH</var></code> is the file path relative to the
+extension's top folder.
+
+{% Aside 'caution' %}
+
+All assets accessed by content scripts must be declared as a [`web_accessible_resource`][docs-web-acc-res] in the manifest.
+
+{% endAside %}
 
 ## Architecture {: #arch }
 
@@ -345,6 +343,7 @@ with the following resources:
 [docs-promises]: /docs/extensions/mv3/promises/
 [docs-service-worker]: /docs/extensions/mv3/service_workers
 [docs-ui]: /docs/extensions/mv3/user_interface
+[docs-web-acc-res]: /docs/extensions/mv3/manifest/web_accessible_resources/
 [mdn-web-apis]: https://developer.mozilla.org/en-US/docs/Web/API
 [sample-getting-started]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/tutorials/getting-started
 [section-bg]: #background_script

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -330,7 +330,10 @@ the same channel.
 
 ## Saving data {: #data}
 
-The chrome storage API has been optimized to meet the specific storage needs of extensions. For example, whenever data is updated, you can use the onChanged() event to track these changes. All extension components have access to this API. An extension can also store data using the web API [indexedDB][mdn-indexeddb].
+The chrome storage API has been optimized to meet the specific storage needs of extensions. For
+example, whenever data is updated, you can use the onChanged() event to track these changes. All
+extension components have access to this API. An extension can also store data using the web API
+[indexedDB][mdn-indexeddb].
 
 See [storage API][api-storage] for usage and examples.
 
@@ -365,7 +368,6 @@ with the following resources:
 [docs-dev-guide]: /docs/extensions/mv3/devguide
 [docs-ext-pages]: /docs/extensions/mv3/user_interface/#pages
 [docs-get-started]: /docs/extensions/mv3/getstarted
-[docs-key]: /docs/extensions/mv3/manifest/key/
 [docs-key]: /docs/extensions/mv3/tut_oauth/#keep-consistent-id
 [docs-link-options]: /docs/extensions/mv3/options/#linking
 [docs-manifest]: /docs/extensions/mv3/manifest

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -216,7 +216,7 @@ If the [tabs.query][api-tabs-query] method were synchronous, it may look somethi
 
 {% Compare 'worse' %}
 ```js
-var tab = chrome.tabs.query({'active': true}); //WRONG!!!
+var tab = chrome.tabs.query(queryOptions); //WRONG!!!
 chrome.tabs.update(tab.id, {url:newUrl});
 someOtherFunction();
 ```
@@ -233,7 +233,7 @@ To correctly query a tab and update its URL the extension must use the callback 
 
 {% Compare 'better' %}
 ```js
-chrome.tabs.query({'active': true}, function(tabs) {
+chrome.tabs.query(queryOptions, function(tabs) {
   chrome.tabs.update(tabs[0].id, {url: newUrl});
 });
 someOtherFunction();
@@ -253,6 +253,22 @@ anything with the results of the update.
 With the introduction of Manifest V3, many extension API methods now return promises. Not all
 methods in extensions APIs support promises. You can verify whether a method supports promises by
 checking its API reference page. See [Using promises][docs-promises] to learn more.
+
+```js
+// Promise
+chrome.tabs.query(queryOptions).then((tabs) => {
+  chrome.tabs.update(tabs[0].id, {url: newUrl});
+  someOtherFunction();
+});
+
+// async-await
+async function queryTab() {
+  let tabs = await chrome.tabs.query(queryOptions});
+  chrome.tabs.update(tabs[0].id, {url: newUrl});
+  someOtherFunction();
+}
+
+```
 
 #### Synchronous methods
 

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -2,7 +2,7 @@
 layout: "layouts/doc-post.njk"
 title: "Architecture overview"
 date: 2012-09-18
-updated: 2022-04-05
+updated: 2022-05-13
 description: A high-level explanation of the software architecture of Chrome Extensions.
 subhead: A high-level explanation of the components and structure of a Chrome Extension.
 ---
@@ -17,13 +17,13 @@ data.
 
 ## Architecture {: #arch }
 
-An extension's architecture will depend on its functionality, but all extensions are required to have a
+An extension's architecture will depend on its functionality, but all extensions must have a
 [manifest][section-manifest]. The following are other components an extension can include: 
 
-- [Background service worker][section-bg]
+- [Service worker][section-bg]
 - [Toolbar icon][section-icons]
 - [UI elements][section-ui]
-- [Content acript][section-cs]
+- [Content script][section-cs]
 - [Options page][section-options]
 
 ### The manifest {: #manifest }
@@ -65,20 +65,20 @@ example][sample-getting-started].
 popup", width="187", height="153" %}
 <!-- TODO: Show examples of the MV3 getting started tutorial extensions -->
 
-### Background service worker {: #background_script }
+### Service worker {: #background_script }
 
-The background service worker is the extension's event handler; it contains listeners for browser
+The extension service worker is the extension's event handler; it contains listeners for browser
 events that are important to the extension. It lies dormant until an event is fired then performs
 the instructed logic; it is only loaded when it is needed and unloaded when it goes idle. The
-background script has access to all the [Chrome APIs][section-apis], as long it declares the
+service worker has access to all the [Chrome APIs][section-apis], as long it declares the
 required permissions in the `manifest.json`.
 
 See [Manage events with service workers][docs-service-worker] to learn more. 
 
 ### Content scripts {: #contentScripts }
 
-Content scripts allow extensions to inject script into a page in order to read and modify its
-contents. The content script contains JavaScript that executes in the contexts of a page that has
+Content scripts allow extensions to inject logic into a page in order to read and modify its
+contents. A content script contains JavaScript that executes in the context of a page that has
 been loaded into the browser.
 
 Content scripts can communicate with their parent extension by exchanging [messages][docs-messages]
@@ -94,12 +94,12 @@ See [Understanding content scripts][docs-content-scripts] to learn more.
 An extension's user interface should be purposeful and minimal. The UI should customize or enhance
 the browsing experience without distracting from it. 
 
-The following is a list of most common UI examples:
+The following is a list of the most common UI examples:
 
 - An [action click][docs-click] event.
 - A [popup][docs-popup].
 - A [context menu][docs-context-menu].
-- An [omnibox][docs-omnibox]
+- An [omnibox][docs-omnibox].
 - A [keyboard shortcut][docs-commands].
 - Desktop [notifications][api-notif].
 - [Text-to-speech][api-tts].
@@ -157,7 +157,7 @@ You can open these pages using the web api [window.open()][mdn-window-open], the
 [windows.create()][api-window-create], or [tabs.create()][api-create-tab].
 
 ## Extension files {: #files }
-<!-- TODO: Intro -->
+
 ### Referencing extension files {: #ref-files }
 
 Just as HTML pages on the web can include files on the same site with _relative URLs_, **extension
@@ -186,29 +186,27 @@ extension's top folder.
 
 {% Aside 'key-term' %}
 
-The **extension ID** is a 32 character alpha string that identifies an extension in the browser and
+The **extension ID** is a 32-character alpha string that identifies an extension in the browser and
 on the Chrome Web Store.
 
 {% endAside %}
 
 During development, a new ID is generated when an [_unpacked extension_][docs-unpacked] is loaded,
-unless the `"key"` property is set in the manifest.
-
-See [Keeping a consistent key][docs-key] to learn how to set this key.
+unless the `"key"` property is [set in the manifest][docs-key].
 
 {% Aside 'caution' %}
 
-All assets that content scripts and websites want to access must be declared as a
-[`web_accessible_resources`][section-web-res] in the manifest.
+All assets that content scripts and websites want to access must be declared under
+[`web_accessible_resources`][section-web-res] key in the manifest.
 
 {% endAside %}
 
-### Web accesible resources {: #web-resources }
+### Web-accesible resources {: #web-resources }
 
 Web-accessible resources are files (images, HTML, CSS, Javascript) inside an extension that can be
 accessed by a content script, web pages, or other extensions. 
 
-In Manifest Version 3, you can declare which resources are exposed and to what origins in the
+You can declare which resources are exposed and to what origins in the
 manifest:
 
 ```json
@@ -224,7 +222,7 @@ manifest:
 }
 ```
 
-See [Web accesible resources][docs-web-acc-res] to learn more.
+See [Web-accesible resources][docs-web-acc-res] for usage information.
 
 ## Using Chrome APIs {: #apis }
 

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -18,7 +18,7 @@ Consider extensions the gateway to making the Chrome browser the most personaliz
 ## Extension files {: #files }
 
 Extensions vary in types of files and amount of directories, but they are all required to have a
-[manifest][1]. Some basic, but useful, extensions may consist of just the manifest and its toolbar
+[manifest][docs-manifest]. Some basic, but useful, extensions may consist of just the manifest and its toolbar
 icon.
 
 The manifest file, titled `manifest.json`, gives the browser information about the extension, such
@@ -50,7 +50,7 @@ as the most important files and the capabilities the extension might use.
 
 Extensions must have an icon that sits in the browser toolbar. Toolbar icons allow easy access and
 keep users aware of which extensions are installed. Most users will interact with an extension that
-uses a [popup][2] by clicking on the icon.
+uses a [popup][docs-popup] by clicking on the icon.
 
 This Manifest V2 [Google Mail Checker extension][sample-gmail] uses a [browser action][4]:
 
@@ -85,38 +85,38 @@ extension's top folder; it matches the relative URL.
 While working on an unpacked extension the extension ID can change. Specifically, the ID of an
 unpacked extension will change if the extension is loaded from a different directory; the ID will
 change again when the extension is packaged. If an extension's code relies on an absolute URL, it
-can use the [`chrome.runtime.getURL()`][8] method to avoid hardcoding the ID during development.
+can use the [`chrome.runtime.getURL()`][api-get-url] method to avoid hardcoding the ID during development.
 
 ## Architecture {: #arch }
 
 An extension's architecture will depend on its functionality, but many robust extensions will
 include multiple components:
 
-- [Manifest][9]
-- [Background Script][10]
-- [UI Elements][11]
-- [Content Script][12]
-- [Options Page][13]
+- [Manifest][docs-manifest]
+- [Background Script][section-bg]
+- [UI Elements][section-ui]
+- [Content Script][section-cs]
+- [Options Page][section-options]
 
 ### Background script {: #background_script }
 
-The [background script][14] is the extension's event handler; it contains listeners for browser
+The [background script][docs-service-worker] is the extension's event handler; it contains listeners for browser
 events that are important to the extension. It lies dormant until an event is fired then performs
 the instructed logic. An effective background script is only loaded when it is needed and unloaded
 when it goes idle.
 
 ### UI elements {: #pages }
 
-An [extension's user interface][15] should be purposeful and minimal. The UI should customize or
+An [extension's user interface][docs-ui] should be purposeful and minimal. The UI should customize or
 enhance the browsing experience without distracting from it. Most extensions have a [browser
-action][16] or [page action][17], but can contain other forms of UI, such as [context menus][18],
-use of the [omnibox][19], or creation of a [keyboard shortcut][20].
+action][16] or [page action][17], but can contain other forms of UI, such as [context menus][docs-context-menu],
+use of the [omnibox][docs-omnibox], or creation of a [keyboard shortcut][docs-commands].
 
 Extension UI pages, such as a [popup][21], can contain ordinary HTML pages with JavaScript logic.
 Extensions can also call [tabs.create][22] or `window.open()` to display additional HTML files
 present in the extension.
 
-An extension using a page action and a popup can use the [declarative content][23] API to set rules
+An extension using a page action and a popup can use the [declarative content][api-dec-content] API to set rules
 in the background script for when the popup is available to users. When the conditions are met, the
 background script communicates with the popup to make it's icon clickable to users.
 
@@ -125,31 +125,31 @@ background script communicates with the popup to make it's icon clickable to use
 
 ### Content scripts {: #contentScripts }
 
-Extensions that read or write to web pages utilize a [content script][24]. The content script
+Extensions that read or write to web pages utilize a [content script][docs-content-scripts]. The content script
 contains JavaScript that executes in the contexts of a page that has been loaded into the browser.
 Content scripts read and modify the DOM of web pages the browser visits.
 
 {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/CNDAVsTnJeSskIXVnSQV.png",
        alt="A browser window with a page action and a content script", height="316", width="388" %}
 
-Content scripts can communicate with their parent extension by exchanging [messages][25] and storing
-values using the [storage][26] API.
+Content scripts can communicate with their parent extension by exchanging [messages][docs-messages] and storing
+values using the [storage][api-storage] API.
 
 {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/466ftDp0EXB4E1XeaGh0.png",
        alt="Shows a communication path between the content script and the parent extension", height="316", width="388" %}
 
 ### Options page {: #optionsPage }
 
-Just as extensions allow users to customize the Chrome browser, the [options page][27] enables
+Just as extensions allow users to customize the Chrome browser, the [options page][docs-options] enables
 customization of the extension. Options can be used to enable features and allow users to choose
 what functionality is relevant to their needs.
 
 ## Using Chrome APIs {: #apis }
 
 In addition to having access to the same APIs as web pages, extensions can also use
-[extension-specific APIs][28] that create tight integration with the browser. Extensions and
+[extension-specific APIs][api-reference] that create tight integration with the browser. Extensions and
 webpages can both access the standard `window.open()` method to open a URL, but extensions can
-specify which window that URL should be displayed in by using the Chrome API [tabs.create][29]
+specify which window that URL should be displayed in by using the Chrome API [tabs.create][api-tabs-create]
 method instead.
 
 ### Asynchronous vs. synchronous methods {: #sync }
@@ -162,7 +162,7 @@ method returns.
 If the extension needed to navigate the user's currently selected tab to a new URL, it would need to
 get the current tab's ID and then update that tab's address to the new URL.
 
-If the [tabs.query][30] method were synchronous, it may look something like below.
+If the [tabs.query][api-tabs-query] method were synchronous, it may look something like below.
 
 ```js
 //THIS CODE DOESN'T WORK
@@ -205,7 +205,7 @@ This method synchronously returns the URL as a `string` and performs no other as
 
 ### More details {: #chrome-more }
 
-For more information, explore the [Chrome API reference docs][31] and watch the following video.
+For more information, explore the [Chrome API reference docs][api-reference] and watch the following video.
 
 ## Communication between pages {: #pageComm }
 
@@ -218,7 +218,7 @@ passing][34].
 
 ## Saving data and incognito mode {: #incognito }
 
-Extensions can save data using the [storage][35] API, the HTML5 [web storage API][36] , or by making
+Extensions can save data using the [storage][api-storage] API, the HTML5 [web storage API][36] , or by making
 server requests that result in saving data. When the extension needs to save something, first
 consider if it's from an incognito window. By default, extensions don't run in incognito windows.
 
@@ -228,7 +228,7 @@ history, don't save history from incognito windows. However, extensions can stor
 preferences from any window, incognito or not.
 
 To detect whether a window is in incognito mode, check the `incognito` property of the relevant
-[tabs.Tab][37] or [windows.Window][38] object.
+[tabs.Tab][api-tab] or [windows.Window][api-window] object.
 
 ```js
 function saveTabData(tab) {
@@ -242,58 +242,42 @@ function saveTabData(tab) {
 
 ## Take the next step {: #next-steps }
 
-After reading the overview and completing the [Getting Started][39] tutorial, developers should be
+After reading the overview and completing the [Getting Started][docs-get-started] tutorial, developers should be
 ready to start writing their own extensions! Dive deeper into the world of custom Chrome with the
 following resources.
 
-- Learn about the options available for debugging Extensions in the [debugging tutorial][40].
+- Learn about the options available for debugging Extensions in the [debugging tutorial][docs-debugging].
 - Chrome Extensions have access to powerful APIs above and beyond what's available on the open web.
-  The [chrome.\* APIs documentation][41] will walk through each API.
-- The [developer's guide][42] has dozens of additional links to pieces of documentation relevant to
+  The [chrome.\* APIs documentation][api-reference] will walk through each API.
+- The [developer's guide][docs-dev-guide] has dozens of additional links to pieces of documentation relevant to
   advanced extension creation.
 
-[1]: /docs/extensions/mv3/manifest
-[2]: /docs/extensions/mv3/user_interface#popup
-[3]: /docs/extensions/mv3/samples#search:google%20mail%20checker
-[4]: /docs/extensions/reference/browserAction
-[5]: /docs/extensions/mv3/samples#search:mappy
-[6]: /docs/extensions/reference/pageAction
-[7]: #contentScripts
-[8]: /docs/extensions/reference/runtime#method-getURL
-[9]: /docs/extensions/mv3/manifest
-[10]: #background_script
-[11]: #pages
-[12]: #contentScripts
-[13]: #optionsPage
-[14]: /docs/extensions/mv3/background_pages
-[15]: /docs/extensions/mv3/user_interface
-[16]: /docs/extensions/reference/browserAction
-[17]: /docs/extensions/reference/pageAction
-[18]: /docs/extensions/reference/contextMenus
-[19]: /docs/extensions/reference/omnibox
-[20]: /docs/extensions/reference/commands
-[21]: /docs/extensions/mv3/user_interface#popup
-[22]: /docs/extensions/reference/tabs#method-create
-[23]: /docs/extensions/reference/declarativeContent
-[24]: /docs/extensions/mv3/content_scripts
-[25]: /docs/extensions/mv3/messaging
-[26]: /docs/extensions/reference/storage
-[27]: /docs/extensions/mv3/options
-[28]: /docs/extensions/reference
-[29]: /docs/extensions/reference/tabs#method-create
-[30]: /docs/extensions/reference/tabs#method-query
-[31]: /docs/extensions/reference
-[32]: /docs/extensions/reference/extension
-[33]: /docs/extensions/reference/storage
-[34]: /docs/extensions/mv3/messaging
-[35]: /docs/extensions/reference/storage
-[36]: https://html.spec.whatwg.org/multipage/webstorage.html
-[37]: /docs/extensions/reference/tabs#type-Tab
-[38]: /docs/extensions/reference/windows#type-Window
-[39]: /docs/extensions/mv3/getstarted
-[40]: /docs/extensions/mv3/tut_debugging
-[41]: /docs/extensions/reference
-[42]: /docs/extensions/mv3/devguide
-
+[api-create-tab]: /docs/extensions/reference/tabs#method-create
+[api-dec-content]: /docs/extensions/reference/declarativeContent
+[api-get-url]: /docs/extensions/reference/runtime#method-getURL
+[api-reference]: /docs/extensions/reference
+[api-storage]: /docs/extensions/reference/storage
+[api-tab]: /docs/extensions/reference/tabs#type-Tab
+[api-tabs-create]: /docs/extensions/reference/tabs#method-create
+[api-tabs-query]: /docs/extensions/reference/tabs#method-query
+[api-window]: /docs/extensions/reference/windows#type-Window
+[docs-commands]: /docs/extensions/mv3/user_interface/#commands
+[docs-content-scripts]: /docs/extensions/mv3/content_scripts
+[docs-context-menu]: /docs/extensions/mv3/user_interface/#context_menu
+[docs-debugging]: /docs/extensions/mv3/tut_debugging
+[docs-dev-guide]: /docs/extensions/mv3/devguide
+[docs-get-started]: /docs/extensions/mv3/getstarted
+[docs-manifest]: /docs/extensions/mv3/manifest
+[docs-messages]: /docs/extensions/mv3/messaging
+[docs-omnibox]: /docs/extensions/mv3/user_interface/#omnibox
+[docs-options]: /docs/extensions/mv3/options
+[docs-popup]: /docs/extensions/mv3/user_interface#popup
+[docs-popup]: /docs/extensions/mv3/user_interface#popup
+[docs-service-worker]: /docs/extensions/mv3/service_workers
+[docs-ui]: /docs/extensions/mv3/user_interface
 [sample-gmail]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/mv2-archive/extensions/gmail
 [sample-mappy]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/mv2-archive/extensions/mappy
+[section-bg]: #background_script
+[section-cs]: #contentScripts
+[section-options]: #optionsPage
+[section-ui]: #pages

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -52,10 +52,11 @@ as the most important files and the capabilities the extension might use.
 
 Extensions must have an icon that sits in the browser toolbar. Toolbar icons allow easy access and
 keep users aware of which extensions are installed. Most users will interact with an extension that
-uses a [popup][docs-popup] by clicking on the icon, like in the [Getting Started example][sample-getting-started].
+uses a [popup][docs-popup] by clicking on the icon, like in the [Getting Started
+example][sample-getting-started].
 
-{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/ku5Z8MMssgw6MKctpJVI.png", 
-alt="Getting started Popup", width="187", height="153" %}
+{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/ku5Z8MMssgw6MKctpJVI.png", alt="Getting started
+Popup", width="187", height="153" %}
 
 <!-- TODO: Show examples of the MV3 getting started tutorial extensions -->
 
@@ -63,8 +64,7 @@ alt="Getting started Popup", width="187", height="153" %}
 
 #### Relative URL {: #relative-urls }
 
-An extension's files can be referred to by using a relative URL, just like in an ordinary HTML
-page.
+An extension's files can be referred to by using a relative URL, just like in an ordinary HTML page.
 
 ```html
 <img src="images/my_image.png">
@@ -83,10 +83,12 @@ generates. The extension ID's are displayed in the Extension management page
 **chrome://extensions**. The <var>PATH_TO_FILE</var> is the location of the file under the
 extension's top folder; it matches the relative URL.
 
-{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/GemDxnaBjzDiY0uwNiVT.png", 
-alt="Extension ID in the Extension management page", width="400", height="21" %}
+{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/GemDxnaBjzDiY0uwNiVT.png", alt="Extension ID in the
+Extension management page", width="400", height="21" %}
 
-While working on an unpacked extension, if the [`key`][docs-key] has not been specified in the manifest, then the extension ID can change. For example, when the extension is loaded from a different directory, packed or uploaded to the Chrome Web Store.
+While working on an unpacked extension, if the [`key`][docs-key] has not been specified in the
+manifest, then the extension ID can change. For example, when the extension is loaded from a
+different directory, packed or uploaded to the Chrome Web Store.
 
 You can use the [`chrome.runtime.getURL()`][api-get-url] method to avoid hardcoding the ID.
 
@@ -107,55 +109,57 @@ include multiple components:
 
 ### Background service worker {: #background_script }
 
-The [background service worker][docs-service-worker] is the extension's event handler; it contains listeners for browser
-events that are important to the extension. It lies dormant until an event is fired then performs
-the instructed logic; it is only loaded when it is needed and unloaded
-when it goes idle.
+The [background service worker][docs-service-worker] is the extension's event handler; it contains
+listeners for browser events that are important to the extension. It lies dormant until an event is
+fired then performs the instructed logic; it is only loaded when it is needed and unloaded when it
+goes idle.
 
 ### UI elements {: #pages }
 
-An [extension's user interface][docs-ui] should be purposeful and minimal. The UI should customize or
-enhance the browsing experience without distracting from it. 
+An [extension's user interface][docs-ui] should be purposeful and minimal. The UI should customize
+or enhance the browsing experience without distracting from it. 
 
-Most extensions run when the user clicks the toolbar icon [action][api-action] or display a [popup][docs-popup], but can also contain any of the following:
+Most extensions run when the user clicks the toolbar icon [action][api-action] or display a
+[popup][docs-popup], but can also contain any of the following:
 
 - A [context menus][docs-context-menu]
 - An [omnibox][docs-omnibox]
 - A [keyboard shortcut][docs-commands].
 
-Extension UI pages, such as a [popup][docs-popup], can contain ordinary HTML pages with JavaScript logic.
-Extensions can also call [tabs.create][api-create-tab] or `window.open()` to display additional HTML files
-present in the extension.
+Extension UI pages, such as a [popup][docs-popup], can contain ordinary HTML pages with JavaScript
+logic. Extensions can also call [tabs.create][api-create-tab] or `window.open()` to display
+additional HTML files present in the extension.
 
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/8oLwFaq0VFIQtw4mcA91.png",
-alt="A browser window containing a page action displaying a popup", height="316", width="325" %}
+{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/8oLwFaq0VFIQtw4mcA91.png", alt="A browser window
+containing a page action displaying a popup", height="316", width="325" %}
 
 An extension using a popup can use the [declarative content API][api-dec-content] to set rules in
 the background script for when the popup is available to users. When the conditions are met, the
 background script communicates with the popup to make it's icon clickable to users.
 
-An extension can [override][docs-override] and replace the History, New Tab, or Bookmarks web page with a custom HTML file.
+An extension can [override][docs-override] and replace the History, New Tab, or Bookmarks web page
+with a custom HTML file.
 
 ### Content scripts {: #contentScripts }
 
-Extensions that read or write to web pages utilize a [content script][docs-content-scripts]. The content script
-contains JavaScript that executes in the contexts of a page that has been loaded into the browser.
-Content scripts read and modify the DOM of web pages the browser visits.
+Extensions that read or write to web pages utilize a [content script][docs-content-scripts]. The
+content script contains JavaScript that executes in the contexts of a page that has been loaded into
+the browser. Content scripts read and modify the DOM of web pages the browser visits.
 
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/CNDAVsTnJeSskIXVnSQV.png",
-alt="A browser window with a page action and a content script", height="316", width="388" %}
+{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/CNDAVsTnJeSskIXVnSQV.png", alt="A browser window with
+a page action and a content script", height="316", width="388" %}
 
-Content scripts can communicate with their parent extension by exchanging [messages][docs-messages] and storing
-values using the [storage][api-storage] API.
+Content scripts can communicate with their parent extension by exchanging [messages][docs-messages]
+and storing values using the [storage][api-storage] API.
 
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/466ftDp0EXB4E1XeaGh0.png",
-alt="Shows a communication path between the content script and the parent extension", height="316", width="388" %}
+{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/466ftDp0EXB4E1XeaGh0.png", alt="Shows a communication
+path between the content script and the parent extension", height="316", width="388" %}
 
 ### Options page {: #optionsPage }
 
-Just as extensions allow users to customize the Chrome browser, the [options page][docs-options] enables
-customization of the extension. Options can be used to enable features and allow users to choose
-what functionality is relevant to their needs.
+Just as extensions allow users to customize the Chrome browser, the [options page][docs-options]
+enables customization of the extension. Options can be used to enable features and allow users to
+choose what functionality is relevant to their needs.
 
 Users can access the options page via [direct link][docs-link-options] or in the context menu of the
 extension toolbar. The following is an example of the Google Dictionary extension. 
@@ -189,11 +193,11 @@ extension toolbar. The following is an example of the Google Dictionary extensio
 
 ## Using Chrome APIs {: #apis }
 
-In addition to having access to the same web APIs as web pages, extensions can also use
-[extension-specific APIs][api-reference] that create tight integration with the browser. Extensions and
-webpages can both access the standard `window.open()` method to open a URL, but extensions can
-specify which window that URL should be displayed in by using the Chrome API [tabs.create][api-tabs-create]
-method instead.
+In addition to having access to the same [web APIs][mdn-web-apis] as web pages, extensions can also
+use [extension-specific APIs][api-reference] that create tight integration with the browser.
+Extensions and webpages can both access the standard `window.open()` method to open a URL, but
+extensions can specify which window that URL should be displayed in by using
+[chrome.tabs.create()][api-tabs-create] instead.
 
 ### Asynchronous vs. synchronous methods {: #sync }
 
@@ -204,8 +208,7 @@ to finish. If an extension needs to know the outcome of an asynchronous operatio
 callback function into the method. The callback is executed later, potentially much later, after the
 method returns.
 
-A method is asynchronous when the callback parameter is
-available in its signature.
+A method is asynchronous when the callback parameter is available in its signature.
 
 ```js
 // Signature for an asynchronous method
@@ -254,7 +257,9 @@ anything with the results of the update.
 
 #### Promises
 
-With the introduction of Manifest V3, many extension API methods now return promises. Not all methods in extensions APIs support promises. You can check whether a method supports promises by checking its API reference page. See [Using promises][docs-promises] to learn more.
+With the introduction of Manifest V3, many extension API methods now return promises. Not all
+methods in extensions APIs support promises. You can check whether a method supports promises by
+checking its API reference page. See [Using promises][docs-promises] to learn more.
 
 #### Synchronous methods
 
@@ -271,14 +276,16 @@ For more information, explore the [Chrome API reference docs][api-reference].
 
 ## Communication between pages {: #pageComm }
 
-Different components in an extension can communicate with each other using [message passing][docs-messages]. Either side can listen for messages sent from the other end, and respond on the same channel. Additionally, all components of the
-extension can access values stored using the [storage][api-storage] API.
+Different components in an extension can communicate with each other using [message
+passing][docs-messages]. Either side can listen for messages sent from the other end, and respond on
+the same channel. Additionally, all components of the extension can access values stored using the
+[storage][api-storage] API.
 
 ## Saving data and incognito mode {: #incognito }
 
-Extensions can save data using the [storage][api-storage] API, or by making
-server requests that result in saving data. When the extension needs to save something, first
-consider if it's from an incognito window. By default, extensions don't run in incognito windows.
+Extensions can save data using the [storage][api-storage] API, or by making server requests that
+result in saving data. When the extension needs to save something, first consider if it's from an
+incognito window. By default, extensions don't run in incognito windows.
 
 _Incognito mode_ promises that the window will leave no tracks. When dealing with data from
 incognito windows, extensions should honor this promise. If an extension normally saves browsing
@@ -300,15 +307,16 @@ function saveTabData(tab) {
 
 ## Take the next step {: #next-steps }
 
-After reading the overview and completing the [Getting Started][docs-get-started] tutorial, developers should be
-ready to start writing their own extensions! Dive deeper into the world of custom Chrome with the
-following resources.
+After reading the overview and completing the [Getting Started][docs-get-started] tutorial, you
+should be ready to start writing your own extensions! Dive deeper into the world of custom Chrome
+with the following resources:
 
-- Learn about the options available for debugging Extensions in the [debugging tutorial][docs-debugging].
+- Learn about the options available for debugging Extensions in the [debugging
+  tutorial][docs-debugging].
 - Chrome Extensions have access to powerful APIs above and beyond what's available on the open web.
   The [chrome.\* APIs documentation][api-reference] will walk through each API.
-- The [developer's guide][docs-dev-guide] has dozens of additional links to pieces of documentation relevant to
-  advanced extension creation.
+- The [developer's guide][docs-dev-guide] has dozens of additional links to pieces of documentation
+  relevant to advanced extension creation.
 
 [api-action]: /docs/extensions/reference/action/
 [api-create-tab]: /docs/extensions/reference/tabs#method-create
@@ -336,6 +344,7 @@ following resources.
 [docs-promises]: /docs/extensions/mv3/promises/
 [docs-service-worker]: /docs/extensions/mv3/service_workers
 [docs-ui]: /docs/extensions/mv3/user_interface
+[mdn-web-apis]: https://developer.mozilla.org/en-US/docs/Web/API
 [sample-getting-started]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/tutorials/getting-started
 [section-bg]: #background_script
 [section-cs]: #contentScripts

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -2,7 +2,7 @@
 layout: "layouts/doc-post.njk"
 title: "Architecture overview"
 date: 2012-09-18
-updated: 2022-03-12
+updated: 2022-03-25
 description: A high-level explanation of the software architecture of Chrome Extensions.
 ---
 
@@ -73,7 +73,8 @@ pages can also reference assets in the extension using relative paths.
 
 #### Absolute URL {: #absolute-urls }
 
-To access a file in a content script, you can use the [`chrome.runtime.getURL()`][api-get-url] method. 
+To access a file in a content script, you can use the [`chrome.runtime.getURL()`][api-get-url]
+method. 
 
 ``` js
 let image = chrome.runtime.getURL("images/my_image.png")
@@ -85,13 +86,14 @@ It will return an absolute URL for the asset in your extension, that looks like 
 chrome-extension://EXTENSION_ID/RELATIVE_PATH
 ```
 
-The <code><var>EXTENSION_ID</var></code> is a unique identifier that the browser generates. You can view these IDs in the Extension management page
-**chrome://extensions**. The <code><var>RELATIVE_PATH</var></code> is the file path relative to the
-extension's top folder.
+The <code><var>EXTENSION_ID</var></code> is a unique identifier that the browser generates. You can
+view these IDs in the Extension management page **chrome://extensions**. The
+<code><var>RELATIVE_PATH</var></code> is the file path relative to the extension's top folder.
 
 {% Aside 'caution' %}
 
-All assets accessed by content scripts must be declared as a [`web_accessible_resource`][docs-web-acc-res] in the manifest.
+All assets accessed by content scripts must be declared as a
+[`web_accessible_resource`][docs-web-acc-res] in the manifest.
 
 {% endAside %}
 
@@ -115,8 +117,8 @@ goes idle.
 
 ### UI elements {: #pages }
 
-An extension's user interface should be purposeful and minimal. The UI should customize
-or enhance the browsing experience without distracting from it. 
+An extension's user interface should be purposeful and minimal. The UI should customize or enhance
+the browsing experience without distracting from it. 
 
 The following is a list of most common UI examples:
 
@@ -135,9 +137,9 @@ See [Design the UI][docs-ui] for UI and design guidelines for Chrome Extensions.
 
 ### Content scripts {: #contentScripts }
 
-[Content scripts][docs-content-scripts] allow extensions to inject script into a page in order to read and modify its contents. The
-content script contains JavaScript that executes in the contexts of a page that has been loaded into
-the browser.
+[Content scripts][docs-content-scripts] allow extensions to inject script into a page in order to
+read and modify its contents. The content script contains JavaScript that executes in the contexts
+of a page that has been loaded into the browser.
 
 {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/CNDAVsTnJeSskIXVnSQV.png", alt="A browser window with
 a page action and a content script", height="316", width="388" %}

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -18,8 +18,7 @@ Consider extensions the gateway to making the Chrome browser the most personaliz
 ## Extension files {: #files }
 
 Extensions vary in types of files and amount of directories, but they are all required to have a
-[manifest][docs-manifest]. Some basic, but useful, extensions may consist of just the manifest and its toolbar
-icon.
+[manifest][docs-manifest].
 
 ### The manifest {: #manifest }
 
@@ -54,9 +53,11 @@ as the most important files and the capabilities the extension might use.
 
 Extensions must have an icon that sits in the browser toolbar. Toolbar icons allow easy access and
 keep users aware of which extensions are installed. Most users will interact with an extension that
-uses a [popup][docs-popup] by clicking on the icon, like in the [Getting Started extension][sample-get-started].
+uses a [popup][docs-popup] by clicking on the icon, like in the [Getting Started example][sample-getting-started].
 
 {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/ku5Z8MMssgw6MKctpJVI.png", alt="Getting started Popup", width="187", height="153" %}
+
+<!-- TODO: Show examples of the MV3 getting started tutorial extensions -->
 
 ### Referring to files {: #relative-urls }
 

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -33,7 +33,6 @@ as the most important files and the capabilities the extension might use.
   "manifest_version": 3,
   "icons": {
     "16": "icon_16.png",
-    "32": "icon_32.png",
     "48": "icon_48.png",
     "128": "icon_128.png"
   },
@@ -59,14 +58,18 @@ uses a [popup][docs-popup] by clicking on the icon, like in the [Getting Started
 
 <!-- TODO: Show examples of the MV3 getting started tutorial extensions -->
 
-### Referring to files {: #relative-urls }
+### Referring to files {: #ref-files }
 
-An extension's files can be referred to by using a relative URL, just as files in an ordinary HTML
+#### Relative URL {: #relative-urls }
+
+An extension's files can be referred to by using a relative URL, just like in an ordinary HTML
 page.
 
 ```html
 <img src="images/my_image.png">
 ```
+
+#### Absolute URL {: #absolute-urls }
 
 Additionally, each file can also be accessed using an absolute URL.
 
@@ -75,14 +78,19 @@ chrome-extension://EXTENSION_ID/PATH_TO_FILE
 ```
 
 In the absolute URL, the <var>EXTENSION_ID</var> is a unique identifier that the extension system
-generates for each extension. The IDs for all loaded extensions can be viewed by going to the URL
+generates. The extension ID's are displayed in the Extension management page
 **chrome://extensions**. The <var>PATH_TO_FILE</var> is the location of the file under the
 extension's top folder; it matches the relative URL.
 
-While working on an unpacked extension the extension ID can change. Specifically, the ID of an
-unpacked extension will change if the extension is loaded from a different directory; the ID will
-change again when the extension is packaged. If an extension's code relies on an absolute URL, it
-can use the [`chrome.runtime.getURL()`][api-get-url] method to avoid hardcoding the ID during development.
+{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/GemDxnaBjzDiY0uwNiVT.png", alt="Extension ID in the Extension management page", width="400", height="21" %}
+
+While working on an unpacked extension, if the [`key`][docs-key] has not been specified in the manifest, then the extension ID can change. For example, when the extension is loaded from a different directory, packed or uploaded to the Chrome Web Store.
+
+You can use the [`chrome.runtime.getURL()`][api-get-url] method to avoid hardcoding the ID.
+
+``` js
+let image = chrome.runtime.getURL("images/my_image.png")
+```
 
 ## Architecture {: #arch }
 
@@ -263,6 +271,7 @@ following resources.
 [docs-context-menu]: /docs/extensions/mv3/user_interface/#context_menu
 [docs-debugging]: /docs/extensions/mv3/tut_debugging
 [docs-dev-guide]: /docs/extensions/mv3/devguide
+[docs-key]: /docs/extensions/mv3/manifest/key/
 [docs-get-started]: /docs/extensions/mv3/getstarted
 [docs-manifest]: /docs/extensions/mv3/manifest
 [docs-messages]: /docs/extensions/mv3/messaging

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -60,11 +60,12 @@ Popup", width="187", height="153" %}
 
 <!-- TODO: Show examples of the MV3 getting started tutorial extensions -->
 
-### Referring to files {: #ref-files }
+### Referencing extension files {: #ref-files }
 
-#### Relative URL {: #relative-urls }
+#### Relative URLs {: #relative-urls }
 
-An extension's files can be referred to by using a relative URL, just like in an ordinary HTML page.
+Just as HTML pages on the web can include files on the same site with relative URLs, extensions
+pages can also reference assets in the extension using relative paths.
 
 ```html
 <img src="images/my_image.png">
@@ -78,9 +79,9 @@ Additionally, each file can also be accessed using an absolute URL.
 chrome-extension://EXTENSION_ID/PATH_TO_FILE
 ```
 
-In the absolute URL, the <var>EXTENSION_ID</var> is a unique identifier that the extension system
+In the absolute URL, the <code><var>EXTENSION_ID</var></code> is a unique identifier that the extension system
 generates. The extension ID's are displayed in the Extension management page
-**chrome://extensions**. The <var>PATH_TO_FILE</var> is the location of the file under the
+**chrome://extensions**. The <code><var>PATH_TO_FILE</var></code> is the location of the file under the
 extension's top folder; it matches the relative URL.
 
 {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/GemDxnaBjzDiY0uwNiVT.png", alt="Extension ID in the
@@ -88,7 +89,7 @@ Extension management page", width="400", height="21" %}
 
 While working on an unpacked extension, if the [`key`][docs-key] has not been specified in the
 manifest, then the extension ID can change. For example, when the extension is loaded from a
-different directory, packed or uploaded to the Chrome Web Store.
+different director or uploaded to the Chrome Web Store.
 
 You can use the [`chrome.runtime.getURL()`][api-get-url] method to avoid hardcoding the ID.
 

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -2,21 +2,29 @@
 layout: "layouts/doc-post.njk"
 title: "Architecture overview"
 date: 2012-09-18
-updated: 2022-03-25
+updated: 2022-04-01
 description: A high-level explanation of the software architecture of Chrome Extensions.
-subhead: Overview of Chrome extensions components and capabilities.
+subhead: A high-level explanation of the components and structure of a Chrome Extension.
 ---
 
 Extensions are zipped bundles of HTML, CSS, JavaScript, images, and other files used in the web
-platform. Extensions can modify web content that users see and interact with. They can also extend and change the behavior of
-the browser itself. 
+platform. Extensions can modify web content that users see and interact with. They can also extend
+and change the behavior of the browser itself. 
 
-This page briefly describes the files that could form part of an extension, how to access these files, how to use the Chrome APIs, how these pages communicate with each other and how to store data.
+This page briefly describes the files that could form part of an extension, how to access these
+files, how to use Chrome APIs, how extension files communicate and how to store
+data.
 
-## Extension files {: #files }
+## Architecture {: #arch }
 
-Extensions may contain many files or directories, but they are all required to have a
-[manifest][docs-manifest].
+An extension's architecture will depend on its functionality, but they are all required to have a
+[manifest][section-manifest]. The following are other components an extension can include: 
+
+- [Background Script][section-bg]
+- [Toolbar icon][section-icons]
+- [UI Elements][section-ui]
+- [Content Script][section-cs]
+- [Options Page][section-options]
 
 ### The manifest {: #manifest }
 
@@ -55,65 +63,31 @@ example][sample-getting-started].
 
 {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/ku5Z8MMssgw6MKctpJVI.png", alt="Getting started
 Popup", width="187", height="153" %}
-
 <!-- TODO: Show examples of the MV3 getting started tutorial extensions -->
-
-### Referencing extension files {: #ref-files }
-
-#### Relative URLs {: #relative-urls }
-
-Just as HTML pages on the web can include files on the same site with relative URLs, extensions
-pages can also reference assets in the extension using relative paths.
-
-```html
-<img src="images/my_image.png">
-```
-
-#### Absolute URL {: #absolute-urls }
-
-To access a file in a content script, you can use the [`chrome.runtime.getURL()`][api-get-url]
-method. 
-
-``` js
-let image = chrome.runtime.getURL("images/my_image.png")
-```
-
-It will return an absolute URL for the asset in your extension, that looks like this:
-
-```text
-chrome-extension://EXTENSION_ID/RELATIVE_PATH
-```
-
-The <code><var>EXTENSION_ID</var></code> is a unique identifier that the browser generates. You can
-view these IDs in the Extension management page **chrome://extensions**. The
-<code><var>RELATIVE_PATH</var></code> is the file path relative to the extension's top folder.
-
-{% Aside 'caution' %}
-
-All assets accessed by content scripts must be declared as a
-[`web_accessible_resource`][docs-web-acc-res] in the manifest.
-
-{% endAside %}
-
-### Web accesible resources
-
-## Architecture {: #arch }
-
-An extension's architecture will depend on its functionality, but many robust extensions will
-include multiple components:
-
-- [Manifest][docs-manifest]
-- [Background Script][section-bg]
-- [UI Elements][section-ui]
-- [Content Script][section-cs]
-- [Options Page][section-options]
 
 ### Background service worker {: #background_script }
 
-The [background service worker][docs-service-worker] is the extension's event handler; it contains
-listeners for browser events that are important to the extension. It lies dormant until an event is
-fired then performs the instructed logic; it is only loaded when it is needed and unloaded when it
-goes idle.
+The background service worker is the extension's event handler; it contains listeners for browser
+events that are important to the extension. It lies dormant until an event is fired then performs
+the instructed logic; it is only loaded when it is needed and unloaded when it goes idle. The
+background script has access to all the [Chrome APIs][section-apis], as long it declares the
+required permissions in the `manifest.json`.
+
+See [Manage events with Service Workers][docs-service-worker] to learn more. 
+
+### Content scripts {: #contentScripts }
+
+Content scripts allow extensions to inject script into a page in order to read and modify its
+contents. The content script contains JavaScript that executes in the contexts of a page that has
+been loaded into the browser.
+
+Content scripts can communicate with their parent extension by exchanging [messages][docs-messages]
+and storing values using the [storage][api-storage] API.
+
+{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/466ftDp0EXB4E1XeaGh0.png", alt="Shows a communication
+path between the content script and the parent extension", height="316", width="388" %}
+
+See [Understanding Content scripts][docs-content-scripts] to learn more.
 
 ### UI elements {: #pages }
 
@@ -128,34 +102,16 @@ The following is a list of most common UI examples:
 - An [omnibox][docs-omnibox]
 - A [keyboard shortcut][docs-commands].
 - Desktop [notifications][api-notif].
-- [Extension pages][docs-ext-pages].
 - [Text-to-speech][api-tts].
 - A custom UI injected [into a page][docs-content-scripts].
-<!-- Rewrite -->
-- [Override Chrome pages][docs-override] (History page, New Tab, or Bookmarks).
 
-To learn more, see the [Design the UI of a Ch][docs-ui].  
-
-### Content scripts {: #contentScripts }
-
-[Content scripts][docs-content-scripts] allow extensions to inject script into a page in order to
-read and modify its contents. The content script contains JavaScript that executes in the contexts
-of a page that has been loaded into the browser.
-
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/CNDAVsTnJeSskIXVnSQV.png", alt="A browser window with
-a page action and a content script", height="316", width="388" %}
-
-Content scripts can communicate with their parent extension by exchanging [messages][docs-messages]
-and storing values using the [storage][api-storage] API.
-
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/466ftDp0EXB4E1XeaGh0.png", alt="Shows a communication
-path between the content script and the parent extension", height="316", width="388" %}
+See [Design the UI of a Chrome extension][docs-ui], to learn more.
 
 ### Options page {: #optionsPage }
 
-Just as extensions allow users to customize the Chrome browser, the [options page][docs-options]
-enables customization of the extension. Options can be used to enable features and allow users to
-choose what functionality is relevant to their needs.
+Just as extensions allow users to customize the Chrome browser, the options page enables
+customization of the extension. Options can be used to enable features and allow users to choose
+what functionality is relevant to their needs.
 
 Users can access the options page via [direct link][docs-link-options] or in the context menu of the
 extension toolbar. The following is an example of the Google Dictionary extension. 
@@ -165,7 +121,8 @@ extension toolbar. The following is an example of the Google Dictionary extensio
 {% Column %}
 
 <figure>
-{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/Mz7GV76tFkzxRlb7Pq6e.png", alt="Options page link in UI", width="800", height="299" %}
+{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/Mz7GV76tFkzxRlb7Pq6e.png", 
+alt="Options page link in UI", width="800", height="299" %}
   <figcaption>
     Link to Options page.
   </figcaption>
@@ -176,7 +133,8 @@ extension toolbar. The following is an example of the Google Dictionary extensio
 {% Column %}
 
 <figure>
-{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/BM11QeGCThsUNTlsZbAe.png", alt="Context Menu Options page", width="357", height="222" %}
+{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/BM11QeGCThsUNTlsZbAe.png", 
+alt="Context Menu Options page", width="357", height="222" %}
 
   <figcaption>
     Options page in extension's context menu.
@@ -187,17 +145,102 @@ extension toolbar. The following is an example of the Google Dictionary extensio
 
 {% endColumns %}
 
+See [Give users options][docs-options] to learn more.
+
+### Additional HTML files {: #html-files}
+
+You can display other HTML files present in the extension that are not declared in the manifest.
+These HTML files can access the same [Chrome APIs][section-apis] as the popup or other extension
+files. 
+
+You can open these pages using the web api [window.open()][mdn-window-open] or the Chrome APIs
+[windows.create()][api-window-create] or [tabs.create()][api-create-tab].
+
+<!-- TODO: See Extension pages to learn more. -->
+
+## Extension files {: #files }
+<!-- TODO: Intro -->
+### Referencing extension files {: #ref-files }
+
+Just as HTML pages on the web can include files on the same site with _relative URLs_, **extension
+pages** can also reference extension assets using relative paths.
+
+```html
+<img src="images/my_image.png">
+```
+
+To access an extension file from a **content script**, you can
+[`chrome.runtime.getURL()`][api-get-url] to get the _absolute URL_ of your extension asset.
+
+``` js
+let image = chrome.runtime.getURL("images/my_image.png")
+```
+
+To access an extension file from a **website**, you will have to construct the URL as follows:
+
+```text
+chrome-extension://EXTENSION_ID/RELATIVE_PATH
+```
+
+You can find the <code><var>EXTENSION_ID</var></code> in the Extension management page
+**chrome://extensions**. The <code><var>RELATIVE_PATH</var></code> is the file path relative to the
+extension's top folder.
+
+{% Aside 'key-term' %}
+
+The **extension ID** is a 32 character alpha string that identifies an extension in the browser and
+on the Chrome Web Store.
+
+{% endAside %}
+
+During development, a new ID is generated when an [_unpacked extension_][docs-unpacked] is loaded,
+unless the `"key"` property is set in the manifest.
+
+See xyz to learn how to set this key.
+
+{% Aside 'caution' %}
+
+All assets that content scripts and websites want to access must be declared as a
+[`web_accessible_resources`][section-web-res] in the manifest.
+
+{% endAside %}
+
+### Web accesible resources {: #web-resources }
+
+Web-accessible resources are files (images, HTML, CSS, Javascript) inside an extension that can be
+accessed by a content script, web pages or other extensions. 
+
+In Manifest Version 3, you can declare which resources are exposed and to what origins in the
+manifest:
+
+```json
+{
+  ...
+  "web_accessible_resources": [
+    {
+      "resources": [ "images/*.png" ],
+      "matches": [ "https://example.com/*" ]
+    }
+  ],
+  ...
+}
+```
+
+See [Web accesible resources][docs-web-acc-res] to learn more.
+
 ## Using Chrome APIs {: #apis }
 
 In addition to having access to the same [web APIs][mdn-web-apis] as web pages, extensions can also
-use [extension-specific APIs][api-reference] that create tight integration with the browser.
-Extensions and webpages can both access the standard `window.open()` method to open a URL, but
-extensions can specify which window that URL should be displayed in by using
-[chrome.tabs.create()][api-tabs-create] instead.
+use [extension-specific APIs][api-reference] that create tight integration with the browser. For
+example, both extensions and webpages can access the standard [`window.open()`][mdn-window-open]
+method to open a URL, but extensions can specify which window that URL should be displayed in by
+using [chrome.tabs.create()][api-create-tab] instead.
+
+For more information, explore the [Chrome API reference docs][api-reference].
 
 ### Asynchronous vs. synchronous methods {: #sync }
 
-#### Callbacks
+#### Callbacks {: #callbacks }
 
 Most Chrome API methods are asynchronous: they return immediately without waiting for the operation
 to finish. If an extension needs to know the outcome of an asynchronous operation it can pass a
@@ -214,19 +257,18 @@ chrome.tabs.query(object queryInfo, function callback)
 If the extension needed to navigate the user's currently selected tab to a new URL, it would need to
 get the current tab's ID and then update that tab's address to the new URL.
 
-
 If the [tabs.query][api-tabs-query] method were synchronous, it may look something like below.
 
 {% Compare 'worse' %}
 ```js
-var tab = chrome.tabs.query(queryOptions); //WRONG!!!
+let tab = chrome.tabs.query(queryOptions); //WRONG!!!
 chrome.tabs.update(tab.id, {url:newUrl});
 someOtherFunction();
 ```
 {% CompareCaption %}
 
-This approach will fail because `query()` is asynchronous. It returns without waiting for the work
-to complete, and does not return a value.
+This approach will fail because `query()` is **asynchronous**. It returns without waiting for the
+work to complete, and does not return a value.
 
 {% endCompareCaption %}
 
@@ -250,12 +292,11 @@ currently selected tab is available. This happens sometime after `query()` retur
 `update()` is asynchronous the code doesn't use a callback parameter, since the extension doesn't do
 anything with the results of the update.
 
-
-#### Promises
+#### Promises {: #async }
 
 With the introduction of Manifest V3, many extension API methods now return promises. Not all
 methods in extensions APIs support promises. You can verify whether a method supports promises by
-checking its API reference page. See [Using promises][docs-promises] to learn more.
+checking its API reference page.
 
 ```js
 // Promise
@@ -270,21 +311,18 @@ async function queryTab() {
   chrome.tabs.update(tabs[0].id, {url: newUrl});
   someOtherFunction();
 }
-
 ```
 
-#### Synchronous methods
+See [Using promises][docs-promises] to learn more.
+
+#### Synchronous methods {: #sync }
 
 ```js
-// Synchronous methods have no callback option and returns a type of string
-string chrome.runtime.getURL()
+// Synchronous methods have no callback
+const imgUrl = chrome.runtime.getURL("images/icon.png")
 ```
 
 This method synchronously returns the URL as a `string` and performs no other asynchronous work.
-
-### More details {: #chrome-more }
-
-For more information, explore the [Chrome API reference docs][api-reference].
 
 ## Communication between pages {: #pageComm }
 
@@ -294,7 +332,7 @@ the same channel. Additionally, all components of the extension can access value
 [storage][api-storage] API.
 
 ## Saving data and incognito mode {: #incognito }
-
+<!-- TODO: Would like to move this section to Protect User Privacy docs -->
 Extensions can save data using the [storage][api-storage] API, or by making server requests that
 result in saving data. When the extension needs to save something, first consider if it's from an
 incognito window. By default, extensions don't run in incognito windows.
@@ -316,7 +354,7 @@ function saveTabData(tab) {
   }
 }
 ```
-
+'
 ## Take the next step {: #next-steps }
 
 After reading the overview and completing the [Getting Started][docs-get-started] tutorial, you
@@ -346,23 +384,28 @@ with the following resources:
 [docs-context-menu]: /docs/extensions/mv3/user_interface/#context_menu
 [docs-debugging]: /docs/extensions/mv3/tut_debugging
 [docs-dev-guide]: /docs/extensions/mv3/devguide
+[docs-ext-pages]: /docs/extensions/mv3/user_interface/#pages
 [docs-get-started]: /docs/extensions/mv3/getstarted
 [docs-key]: /docs/extensions/mv3/manifest/key/
 [docs-link-options]: /docs/extensions/mv3/options/#linking
 [docs-manifest]: /docs/extensions/mv3/manifest
 [docs-messages]: /docs/extensions/mv3/messaging
 [docs-omnibox]: /docs/extensions/mv3/user_interface/#omnibox
-[docs-ext-pages]: /docs/extensions/mv3/user_interface/#pages
 [docs-options]: /docs/extensions/mv3/options
-[docs-override]: /docs/extensions/mv3/override/
 [docs-popup]: /docs/extensions/mv3/user_interface#popup
 [docs-promises]: /docs/extensions/mv3/promises/
 [docs-service-worker]: /docs/extensions/mv3/service_workers
 [docs-ui]: /docs/extensions/mv3/user_interface
+[docs-unpacked]: /docs/extensions/mv3/getstarted/#unpacked
 [docs-web-acc-res]: /docs/extensions/mv3/manifest/web_accessible_resources/
-[mdn-web-apis]: https://developer.mozilla.org/en-US/docs/Web/API
+[mdn-web-apis]: https://developer.mozilla.org/docs/Web/API
+[mdn-window-open]: https://developer.mozilla.org/docs/Web/API/Window/open
 [sample-getting-started]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/tutorials/getting-started
+[section-apis]: #apis
 [section-bg]: #background_script
 [section-cs]: #contentScripts
+[section-icons]: #icons
+[section-manifest]: #manifest
 [section-options]: #optionsPage
 [section-ui]: #pages
+[section-web-res]: #web-resources

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -238,7 +238,7 @@ using [chrome.tabs.create()][api-create-tab] instead.
 
 For more information, explore the [Chrome API reference docs][api-reference].
 
-### Asynchronous vs. synchronous methods {: #sync }
+### Asynchronous vs. synchronous methods {: #async-sync }
 
 #### Callbacks {: #callbacks }
 

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -20,11 +20,11 @@ data.
 An extension's architecture will depend on its functionality, but all extensions are required to have a
 [manifest][section-manifest]. The following are other components an extension can include: 
 
-- [Background Script][section-bg]
+- [Background service worker][section-bg]
 - [Toolbar icon][section-icons]
-- [UI Elements][section-ui]
-- [Content Script][section-cs]
-- [Options Page][section-options]
+- [UI elements][section-ui]
+- [Content acript][section-cs]
+- [Options page][section-options]
 
 ### The manifest {: #manifest }
 

--- a/site/en/docs/extensions/mv3/user_privacy/index.md
+++ b/site/en/docs/extensions/mv3/user_privacy/index.md
@@ -108,6 +108,30 @@ All requested user data should be treated with care. Store and retrieve data in 
 a registered domain. Always use HTTPS to connect and avoid keeping sensitive user data in the client
 side of an extension as extension storage is not encrypted.
 
+## Saving data and incognito mode {: #data-incognito }
+
+Extensions can save data using the [storage][api-storage] API, or by making server requests that
+result in saving data. When the extension needs to save something, first consider if it's from an
+incognito window. By default, extensions don't run in incognito windows.
+
+_Incognito mode_ promises that the window will leave no tracks. When dealing with data from
+incognito windows, extensions should honor this promise. If an extension normally saves browsing
+history, don't save history from incognito windows. However, extensions can store setting
+preferences from any window, incognito or not.
+
+To detect whether a window is in incognito mode, check the `incognito` property of the relevant
+[tabs.Tab][api-tab] or [windows.Window][api-window] object.
+
+```js
+function saveTabData(tab) {
+  if (tab.incognito) {
+    return;
+  } else {
+    chrome.storage.local.set({data: tab.url});
+  }
+}
+```
+
 [1]: /docs/webstore/program_policies#userdata
 [2]: /docs/extensions/mv3/manifest
 [3]: #optional_permissions

--- a/site/en/docs/extensions/mv3/user_privacy/index.md
+++ b/site/en/docs/extensions/mv3/user_privacy/index.md
@@ -120,7 +120,7 @@ history, don't save history from incognito windows. However, extensions can stor
 preferences from any window, incognito or not.
 
 To detect whether a window is in incognito mode, check the `incognito` property of the relevant
-[tabs.Tab][api-tab] or [windows.Window][api-window] object.
+[`tabs.Tab`][api-tab] or [`windows.Window`][api-window] object.
 
 ```js
 function saveTabData(tab) {

--- a/site/en/docs/extensions/mv3/user_privacy/index.md
+++ b/site/en/docs/extensions/mv3/user_privacy/index.md
@@ -138,3 +138,6 @@ function saveTabData(tab) {
 [4]: /docs/extensions/mv3/manifest/activeTab
 [5]: /docs/extensions/reference/permissions#manifest
 [6]: /webstore/user_data
+[api-tab]: /docs/extensions/reference/tabs/#type-Tab
+[api-window]: /docs/extensions/reference/windows/#type-Window
+[api-storage]: /docs/extensions/reference/storage


### PR DESCRIPTION
Fixes #2259 

Changes proposed in this pull request:

- Remove MV2 content
- Convert numbered links to text links
- Update screenshots
- Move the [Saving data in incognito mode](https://developer.chrome.com/docs/extensions/mv3/architecture-overview/#incognito) section, to [Protect User Data](https://developer.chrome.com/docs/extensions/mv3/user_privacy/).

Staged links
[Architecture Overview](https://deploy-preview-2260--developer-chrome-com.netlify.app/docs/extensions/mv3/architecture-overview/)

