### PR TITLE
docs: update broken links

### DIFF
--- a/site/en/docs/devtools/overview/index.md
+++ b/site/en/docs/devtools/overview/index.md
@@ -192,7 +192,7 @@ DevTools also has a Slack channel, but the team doesn't monitor it consistently.
 [3]: /docs/devtools/dom
 [4]: /docs/devtools/css
 [5]: /docs/devtools/javascript
-[6]: /docs/devtools/console/get-started
+[6]: /docs/devtools/console
 [7]: /docs/devtools/speed/get-started
 [8]: /docs/devtools/network
 [9]: /docs/devtools/device-mode
@@ -205,14 +205,14 @@ DevTools also has a Slack channel, but the team doesn't monitor it consistently.
 [16]: /docs/devtools/dom/#edit
 [17]: /docs/devtools/css/animations
 [18]: /docs/devtools/coverage
-[19]: /docs/devtools/console/get-started
+[19]: /docs/devtools/console
 [20]: /docs/devtools/console
 [21]: /docs/devtools/console/utilities
 [22]: /docs/devtools/console/api
 [23]: /docs/devtools/javascript
 [24]: /docs/devtools/javascript/breakpoints
 [25]: /docs/devtools/workspaces
-[26]: /docs/devtools/snippets
+[26]: /docs/devtools/javascript/snippets
 [27]: /docs/devtools/javascript/reference
 [28]: /blog/new-in-devtools-65#overrides
 [29]: /docs/devtools/coverage


### PR DESCRIPTION
Fixes #1889 + 2 previously unnoticed broken links

Changes proposed in this pull request:

Three occurrences of broken links are fixed on https://developer.chrome.com/docs/devtools/overview/
- ["View Messages and Run JavaScript in the Console"](https://developer.chrome.com/docs/devtools/console/get-started/) :x: --> `/docs/devtools/console` ✅ (#1889)
- ["Get Started With The Console"](https://developer.chrome.com/docs/devtools/console/get-started/) :x: --> `/docs/devtools/console` ✅ 
- ["Run Snippets Of Code From Any Page"](https://developer.chrome.com/docs/devtools/snippets/) :x: --> `/docs/devtools/javascript/snippets` ✅ 