### PR TITLE
Remove interest-cohort from Browsing Topics API

### DIFF
--- a/site/en/docs/privacy-sandbox/topics/index.md
+++ b/site/en/docs/privacy-sandbox/topics/index.md
@@ -439,12 +439,6 @@ header:
 Permissions-Policy: browsing-topics=()
 ```
 
-{% Aside %}
-
-The existing Permissions-Policy `interest-cohort=()` from FLOC will also forbid topic calculation.
-
-{% endAside %}
-
 ### User opt-out
 
 The Topics API explainer [proposes](https://github.com/jkarlin/topics#:~:text=empty) that the list


### PR DESCRIPTION
Chromium removed interest-cohort Permissions-Polic directive in this commit:
https://github.com/chromium/chromium/commit/9255aecd4114c0b3da4016f641316367112adb53

Fixes #2296.

Changes proposed in this pull request:

- Remove note about `interest-cohort` directive