### PR TITLE
Re-add chromeOsOnly metadata to generated Chrome types

### DIFF
--- a/external/build/lib/dts-parse.js
+++ b/external/build/lib/dts-parse.js
@@ -708,6 +708,9 @@ class Transform {
       channel: 'stable',
     };
 
+    // See https://github.com/GoogleChrome/developer.chrome.com/issues/2298
+    let chromeOsOnly = undefined;
+
     tags.forEach(({tag, text}) => {
       text = text.trim(); // some show up with extra \n
 
@@ -749,8 +752,23 @@ class Transform {
         case 'chrome-disallow-service-workers':
           out.disallowServiceWorkers = true;
           break;
+        case 'chrome-platform':
+          // If chromeos is the platform, and chromeOsOnly is undefined because
+          // we haven't seen any other platforms, this might be chromeOsOnly.
+          if (text === 'chromeos' && chromeOsOnly === undefined) {
+            chromeOsOnly = true;
+          } else {
+            // The first time we see a platform that's not chromeos, we know the
+            // feature isn't chromeOsOnly.
+            chromeOsOnly = false;
+          }
+          break;
       }
     });
+
+    if (chromeOsOnly === true) {
+      out.chromeOsOnly = true;
+    }
 
     return out;
   }

--- a/site/_includes/layouts/namespace-reference.njk
+++ b/site/_includes/layouts/namespace-reference.njk
@@ -51,7 +51,6 @@
           </div>
         {% endif %}
 
-        {# TODO: unsupported #}
         {% if f.chromeOsOnly %}
           {# There are some historic cases of multi-platform support in Platform Apps, but
               the only restriction these days is CrOS vs everywhere. #}

--- a/types/site/_data/types.d.ts
+++ b/types/site/_data/types.d.ts
@@ -47,12 +47,14 @@ declare global {
     channel: string;
     permissions?: string[];
     manifestKeys?: string[];
+    chromeOsOnly?: true;
   }
 
   /**
    * This is something referencing another type, so include a {@link _href} where possible.
    */
-  export interface ExtendedReferenceType extends typedoc.JSONOutput.ReferenceType {
+  export interface ExtendedReferenceType
+    extends typedoc.JSONOutput.ReferenceType {
     _href?: string;
   }
 
@@ -60,7 +62,8 @@ declare global {
    * Contains extended information about a DeclarationReflection that makes it easy to render by
    * our Nunjucks templates.
    */
-  export interface ExtendedReflection extends typedoc.JSONOutput.DeclarationReflection {
+  export interface ExtendedReflection
+    extends typedoc.JSONOutput.DeclarationReflection {
     _name: string;
     _feature: FeatureInfo;
 
@@ -108,7 +111,7 @@ declare global {
   }
 
   export interface TypesEnumPair {
-    value: string|number;
+    value: string | number;
     description: string;
   }
 }


### PR DESCRIPTION
Fixes #2298, fixes #2542

This adds `chromeOsOnly: true` metadata to a given Chrome feature if, when parsing its TypeScript docs, there is only one `@chrome-platform` tag, and it's set to `@chrome-platform chromeos`.

You can see an example of such as feature at, e.g., lines 6720-6726 of https://unpkg.com/browse/chrome-types@0.1.94/_all.d.ts:

```js
/**
 * Use this API to expose certificates to the platform which can use these certificates for TLS authentications.
 *
 * @since Chrome 46
 * @chrome-permission certificateProvider
 * @chrome-platform chromeos
 */
```

There are a handful of other features, beyond `chrome.certificateProvider`, that are flagged as well.

The rendering looks like:

<img width="1263" alt="Screen Shot 2022-03-15 at 10 47 33 AM" src="https://user-images.githubusercontent.com/1749548/158404345-7989ac6a-abf4-474a-8f12-d484d9f6cc6b.png">
