### PR TITLE
ContentMigrationAuthors#2

### DIFF
--- a/site/_data/authorsData.json
+++ b/site/_data/authorsData.json
@@ -1,4 +1,120 @@
 {
+  "mustaqahmed": {
+    "github": "mustaqahmed"
+  },
+  "tomgreenaway": {
+    "twitter": "tcmg",
+    "github": "tcmg"
+  },
+  "kinukoyasuda": {
+    "twitter": "kinu",
+    "github": "kinu"
+  },
+  "tdresser": {
+    "twitter": "tdresser"
+  },
+  "victorcostan": {
+    "twitter": "pwnall",
+    "github": "pwnall"
+  },
+  "jeremywagner": {
+    "homepage": "https://jeremywagner.me/",
+    "twitter": "malchata",
+    "github": "malchata"
+  },
+  "majidvp": {
+    "homepage": "http://zgrs.ca/",
+    "twitter": "majido",
+    "github": "majido"
+  },
+  "yangguo": {
+    "twitter": "hashseed",
+    "github": "hashseed"
+  },
+  "jgruber": {
+    "twitter": "schuay",
+    "github": "schuay"
+  },
+  "dtapuska": {
+    "twitter": "dtapuska"
+  },
+  "bokan": {
+    "twitter": "david_bokan"
+  },
+  "mcasas": {
+    "twitter": "yellowdoge",
+    "github": "yellowdoge"
+  },
+  "sgomes": {
+    "twitter": "sergiomdgomes"
+  },
+  "ericlawrence": {
+    "homepage": "https://textslashplain.com/",
+    "twitter": "ericlaw",
+    "github": "ericlaw1979"
+  },
+  "mco": {
+    "homepage": "https://about.me/marc1",
+    "twitter": "marcacohen"
+  },
+  "owencm": {
+    "homepage": "http://www.owencampbellmoore.com/",
+    "twitter": "owencm"
+  },
+  "wdenniss": {
+    "twitter": "williamdenniss"
+  },
+  "kenchris": {
+    "twitter": "kennethrohde"
+  },
+  "emilystark": {
+    "homepage": "https://www.emilymstark.com/",
+    "twitter": "estark37"
+  },
+  "heathermahan": {
+    "homepage": "https://github.com/heatheramahan",
+    "twitter": "heatheramahan"
+  },
+  "ewagasperowicz": {
+    "twitter": "devnook"
+  },
+  "addyosmani": {
+    "twitter": "addyosmani"
+  },
+  "paullewis": {
+    "homepage": "https://aerotwist.com/",
+    "twitter": "aerotwist"
+  },
+  "chriswilson": {
+    "twitter": "cwilso"
+  },
+  "renatomangini": {
+    "homepage": "http://www.renatomangini.com/",
+    "twitter": "renatomangini"
+  },
+  "ilmariheikkinen": {
+    "homepage": "http://fhtr.org/",
+    "twitter": "ilmarihei"
+  },
+  "alexdanilo": {
+    "twitter": "alexanderdanilo"
+  },
+  "borissmus": {
+    "homepage": "http://smus.com/",
+    "twitter": "borismus"
+  },
+  "greenido": {
+    "homepage": "https://greenido.wordpress.com/",
+    "twitter": "greenido"
+  },
+  "sethladd": {
+    "homepage": "https://sethladd.com/",
+    "twitter": "sethladd"
+  },
+  "mikemahemoff": {
+    "homepage": "https://github.com/mahemoff",
+    "twitter": "mahemoff"
+  },
   "mikewest": {
     "homepage": "https://mikewest.org/",
     "twitter": "mikewest"

--- a/site/_data/i18n/authors.yaml
+++ b/site/_data/i18n/authors.yaml
@@ -1,3 +1,193 @@
+mustaqahmed:
+  title:
+    en: 'Mustaq Ahmed'
+  description:
+    en: 'Mustaq is a contributor to WebFundamentals'
+shampson:
+  title:
+    en: 'Seth Hampson'
+  description:
+    en: 'Software Engineer at Google working on WebRTC'
+mlamouri:
+  title:
+    en: 'Mounir Lamouri'
+  description:
+    en: 'Software Engineer for Web Media Experience'
+tomgreenaway:
+  title:
+    en: 'Tom Greenaway'
+  description:
+    en: 'Chrome & Web Developer Relations Games Lead'
+kinukoyasuda:
+  title:
+    en: 'Kinuko Yasuda'
+  description:
+    en: 'Software Engineer at Google working on the web platform'
+tdresser:
+  title:
+    en: 'Tim Dresser'
+  description:
+    en: 'Software Engineer working on performance metrics at Google'
+victorcostan:
+  title:
+    en: 'Victor Costan'
+  description:
+    en: 'Tech Lead, Chrome Storage'
+rezaali:
+  title:
+    en: 'Reza Ali'
+  description:
+    en: 'Reza is a software developer'
+jeremywagner:
+  title:
+    en: 'Jeremy Wagner'
+  description:
+    en: 'Jeremy is a contributor to WebFundamentals'
+sunyunjia:
+  title:
+    en: 'Sandra Sun'
+  description:
+    en: 'Software Engineer working on Chromium'
+majidvp:
+  title:
+    en: 'Majid Valipour'
+  description:
+    en: 'Software Engineer working on Chromium'
+yangguo:
+  title:
+    en: 'Yang Guo'
+  description:
+    en: 'Yang is an engineer working on V8'
+jgruber:
+  title:
+    en: 'Jakob Gruber'
+  description:
+    en: 'Jakob is an engineer working on V8'
+smcgruer:
+  title:
+    en: 'Stephen McGruer'
+  description:
+    en: 'Stephen is a contributor to WebFundamentals'
+dtapuska:
+  title:
+    en: 'Dave Tapuska'
+  description:
+    en: 'Dave is a contributor to WebFundamentals'
+bokan:
+  title:
+    en: 'David Bokan'
+  description:
+    en: 'David is a contributor to WebFundamentals'
+mcasas:
+  title:
+    en: 'Miguel Casas-Sanchez'
+  description:
+    en: 'Miguel is an engineer in the Chrome team'
+sgomes:
+  title:
+    en: 'Sérgio Gomes'
+  description:
+    en: 'Web DevRel at Google'
+ericlawrence:
+  title:
+    en: 'Eric Lawrence'
+  description:
+    en: 'Eric is a contributor to WebFundamentals'
+flackr:
+  title:
+    en: 'Robert Flack'
+  description:
+    en: 'Robert is a contributor to WebFundamentals'
+mco:
+  title:
+    en: 'Marc Cohen'
+  description:
+    en: 'Eng Manager, Web Developer Relations'
+owencm:
+  title:
+    en: 'Owen Campbell-Moore'
+  description:
+    en: 'Owen is a contributor to WebFundamentals'
+wdenniss:
+  title:
+    en: 'William Denniss'
+  description:
+    en: 'Google Identity Product Manager'
+kenchris:
+  title:
+    en: 'Kenneth Christiansen'
+  description:
+    en: 'Kenneth is an Engineer at Intel'
+emilystark:
+  title:
+    en: 'Emily Stark'
+  description:
+    en: 'Emily is a contributor to WebFundamentals'
+heathermahan:
+  title:
+    en: 'Heather Mahan'
+  description:
+    en: 'Heather Mahan is a developer'
+ewagasperowicz:
+  title:
+    en: 'Ewa Gasperowicz'
+  description:
+    en: 'Ewa is a contributor to WebFundamentals'
+addyosmani:
+  title:
+    en: 'Addy Osmani'
+  description:
+    en: 'Eng Manager, Web Developer Relations'
+paullewis:
+  title:
+    en: 'Paul Lewis'
+  description:
+    en: 'Paul is a Design and Perf Advocate'
+glenshires:
+  title:
+    en: 'Glen Shires'
+  description:
+    en: 'Glen is a contributor to WebFundamentals'
+tomwiltzius:
+  title:
+    en: 'Tom Wiltzius'
+  description:
+    en: 'Tom is a contributor to WebFundamentals'
+chriswilson:
+  title:
+    en: 'Chris Wilson'
+  description:
+    en: 'Chris is a contributor to WebFundamentals'
+renatomangini:
+  title:
+    en: 'Renato Mangini'
+  description:
+    en: 'Renato is a contributor to WebFundamentals'
+ilmariheikkinen:
+  title:
+    en: 'Ilmari Heikkinen'
+  description:
+    en: 'Ilmari is a contributor to WebFundamentals'
+alexdanilo:
+  title:
+    en: 'Alex Danilo'
+  description:
+    en: 'Alex is a contributor to WebFundamentals'
+borissmus:
+  title:
+    en: 'Boris Smus'
+  description:
+    en: 'Boris is a contributor to WebFundamentals'
+sethladd:
+  title:
+    en: 'Seth Ladd'
+  description:
+    en: 'Seth is a contributor to WebFundamentals'
+mikemahemoff:
+  title:
+    en: 'Michael Mahemoff'
+  description:
+    en: 'Michael is a contributor to WebFundamentals'
 mikewest:
   title:
     en: 'Mike West'

--- a/site/_data/i18n/authors.yaml
+++ b/site/_data/i18n/authors.yaml
@@ -2,7 +2,7 @@ mustaqahmed:
   title:
     en: 'Mustaq Ahmed'
   description:
-    en: 'Mustaq is a contributor to WebFundamentals'
+    en: 'Mustaq is a contributor to Chrome Developers'
 shampson:
   title:
     en: 'Seth Hampson'
@@ -42,7 +42,7 @@ jeremywagner:
   title:
     en: 'Jeremy Wagner'
   description:
-    en: 'Jeremy is a contributor to WebFundamentals'
+    en: 'Jeremy is a contributor to Chrome Developers'
 sunyunjia:
   title:
     en: 'Sandra Sun'
@@ -67,17 +67,17 @@ smcgruer:
   title:
     en: 'Stephen McGruer'
   description:
-    en: 'Stephen is a contributor to WebFundamentals'
+    en: 'Stephen is a contributor to Chrome Developers'
 dtapuska:
   title:
     en: 'Dave Tapuska'
   description:
-    en: 'Dave is a contributor to WebFundamentals'
+    en: 'Dave is a contributor to Chrome Developers'
 bokan:
   title:
     en: 'David Bokan'
   description:
-    en: 'David is a contributor to WebFundamentals'
+    en: 'David is a contributor to Chrome Developers'
 mcasas:
   title:
     en: 'Miguel Casas-Sanchez'
@@ -92,12 +92,12 @@ ericlawrence:
   title:
     en: 'Eric Lawrence'
   description:
-    en: 'Eric is a contributor to WebFundamentals'
+    en: 'Eric is a contributor to Chrome Developers'
 flackr:
   title:
     en: 'Robert Flack'
   description:
-    en: 'Robert is a contributor to WebFundamentals'
+    en: 'Robert is a contributor to Chrome Developers'
 mco:
   title:
     en: 'Marc Cohen'
@@ -107,7 +107,7 @@ owencm:
   title:
     en: 'Owen Campbell-Moore'
   description:
-    en: 'Owen is a contributor to WebFundamentals'
+    en: 'Owen is a contributor to Chrome Developers'
 wdenniss:
   title:
     en: 'William Denniss'
@@ -122,7 +122,7 @@ emilystark:
   title:
     en: 'Emily Stark'
   description:
-    en: 'Emily is a contributor to WebFundamentals'
+    en: 'Emily is a contributor to Chrome Developers'
 heathermahan:
   title:
     en: 'Heather Mahan'
@@ -132,7 +132,7 @@ ewagasperowicz:
   title:
     en: 'Ewa Gasperowicz'
   description:
-    en: 'Ewa is a contributor to WebFundamentals'
+    en: 'Ewa is a contributor to Chrome Developers'
 addyosmani:
   title:
     en: 'Addy Osmani'
@@ -147,52 +147,52 @@ glenshires:
   title:
     en: 'Glen Shires'
   description:
-    en: 'Glen is a contributor to WebFundamentals'
+    en: 'Glen is a contributor to Chrome Developers'
 tomwiltzius:
   title:
     en: 'Tom Wiltzius'
   description:
-    en: 'Tom is a contributor to WebFundamentals'
+    en: 'Tom is a contributor to Chrome Developers'
 chriswilson:
   title:
     en: 'Chris Wilson'
   description:
-    en: 'Chris is a contributor to WebFundamentals'
+    en: 'Chris is a contributor to Chrome Developers'
 renatomangini:
   title:
     en: 'Renato Mangini'
   description:
-    en: 'Renato is a contributor to WebFundamentals'
+    en: 'Renato is a contributor to Chrome Developers'
 ilmariheikkinen:
   title:
     en: 'Ilmari Heikkinen'
   description:
-    en: 'Ilmari is a contributor to WebFundamentals'
+    en: 'Ilmari is a contributor to Chrome Developers'
 alexdanilo:
   title:
     en: 'Alex Danilo'
   description:
-    en: 'Alex is a contributor to WebFundamentals'
+    en: 'Alex is a contributor to Chrome Developers'
 borissmus:
   title:
     en: 'Boris Smus'
   description:
-    en: 'Boris is a contributor to WebFundamentals'
+    en: 'Boris is a contributor to Chrome Developers'
 sethladd:
   title:
     en: 'Seth Ladd'
   description:
-    en: 'Seth is a contributor to WebFundamentals'
+    en: 'Seth is a contributor to Chrome Developers'
 mikemahemoff:
   title:
     en: 'Michael Mahemoff'
   description:
-    en: 'Michael is a contributor to WebFundamentals'
+    en: 'Michael is a contributor to Chrome Developers'
 mikewest:
   title:
     en: 'Mike West'
   description:
-    en: 'Mike is a contributor to WebFundamentals'
+    en: 'Mike is a contributor to Chrome Developers'
 johannes:
   title:
     en: 'Johannes Henkel'
@@ -222,7 +222,7 @@ katiehempenius:
   title:
     en: 'Katie Hempenius'
   description:
-    en: 'Katie is a contributor to WebFundamentals'
+    en: 'Katie is a contributor to Chrome Developers'
 ossu:
   title:
     en: 'Oskar Sundbom'
@@ -242,12 +242,12 @@ paulirish:
   title:
     en: 'Paul Irish'
   description:
-    en: 'Paul is a contributor to WebFundamentals'
+    en: 'Paul is a contributor to Chrome Developers'
 rviscomi:
   title:
     en: 'Rick Viscomi'
   description:
-    en: 'Rick is a contributor to WebFundamentals'
+    en: 'Rick is a contributor to Chrome Developers'
 ilyagrigorik:
   title:
     en: 'Ilya Grigorik'
@@ -272,7 +272,7 @@ mattgaunt:
   title:
     en: 'Matt Gaunt'
   description:
-    en: 'Matt is a contributor to WebFundamentals'
+    en: 'Matt is a contributor to Chrome Developers'
 kosamari:
   title:
     en: 'Mariko Kosaka'
@@ -282,7 +282,7 @@ mscales:
   title:
     en: 'Mat Scales'
   description:
-    en: 'Mat is a contributor to WebFundamentals'
+    en: 'Mat is a contributor to Chrome Developers'
 ericbidelman:
   title:
     en: 'Eric Bidelman'


### PR DESCRIPTION
Added all the missing authors of the articles newly labelled as DCC in the ContentMigration Sheet

@rachelandrew 