### PR TITLE
"Emulate CSS media type" to match DevTools UI

### DIFF
--- a/site/en/docs/devtools/css/print-preview/index.md
+++ b/site/en/docs/devtools/css/print-preview/index.md
@@ -21,7 +21,7 @@ preview mode:
     **Figure 1**. The **Command Menu**
 
 2.  Type `rendering`, select **Show Rendering**, and then press <kbd>Enter</kbd>.
-3.  Under **Emulate CSS media** select **print**.
+3.  Under **Emulate CSS media type** select **print**.
 
     {% Img src="image/admin/F5e5z6N1lhwERU1TrX8c.png", alt="Print preview mode.", width="800", height="588" %}
 


### PR DESCRIPTION
Fixes #2308

Small fix to add a missing word to match the current DevTools UI.