### PR TITLE
Remove reference to performance benefit

### DIFF
--- a/site/en/blog/new-in-chrome-90/index.md
+++ b/site/en/blog/new-in-chrome-90/index.md
@@ -86,8 +86,7 @@ that works similarly to `hidden`.
 Using `overflow: clip` makes it possible for you to prevent any type of
 scrolling for the box, including programmatic scrolling. That means the box
 is not considered a scroll container; it does not start a new formatting
-context, which gives it better performance than `overflow: hidden`. And if
-you need it, you can apply clipping to a single axis via `overflow-x`
+context. If you need it, you can apply clipping to a single axis via `overflow-x`
 and `overflow-y`.
 
 Oh, and FYI - there's also `overflow-clip-margin`, which allows you to expand


### PR DESCRIPTION
There isn't really a measurable performance benefit here, but folks are using this post to recommend switching to `overflow: clip` for performance reasons.

https://twitter.com/Steve8708/status/1503864654329958400

Changes proposed in this pull request: Remove reference to performance benefit where there isn't really one