### PR TITLE
Show tags under headlines in doc posts

### DIFF
--- a/site/_data/i18n/tags.yml
+++ b/site/_data/i18n/tags.yml
@@ -1,6 +1,9 @@
 # The top-level keys in this file are used to generate tag pages under /tags/<tag>, presuming
 # they have at least one matching post.
 
+memory:
+  en: Memory
+
 news:
   en: News
   es: Noticias

--- a/site/_includes/layouts/doc-post.njk
+++ b/site/_includes/layouts/doc-post.njk
@@ -19,7 +19,7 @@
         <div class="stack flow-space-200">
           {% include 'partials/post-headline.njk' %}
         </div>
-
+        {% include 'partials/tags.njk' %}
         {% if authors %}
           <div class="stack-exception-600 lg:stack-exception-700">
             {% include 'partials/post-authors.njk' %}


### PR DESCRIPTION
Show tags under headlines in doc posts.

Only the handbook and the following two doc posts affected:
- https://developer.chrome.com/docs/lighthouse/performance/dom-size
- https://developer.chrome.com/docs/lighthouse/performance/bootup-time
These two posts use the memory tag that was undeclared. Declaring.

Tested locally.
