### PR TITLE
Add MV3 samples to Design the User Interface

### DIFF
--- a/site/en/docs/extensions/mv3/user_interface/index.md
+++ b/site/en/docs/extensions/mv3/user_interface/index.md
@@ -22,14 +22,14 @@ After installation, by default, these appear in the extensions menu (the puzzle 
 
 {% Column %}
 {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/iouvm1a3lsQWGyg6fSMS.png", 
-alt="Unpinned extension", width="340", height="174" %}
+alt="Unpinned extension", width="300", height="174" %}
 
 **Unpinned**
 {% endColumn %}
 
 {% Column %}
 {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/KS09fVoCj3YWuIoH5EFn.png", 
-alt="Pinned extension", width="338", height="182" %}
+alt="Pinned extension", width="300", height="182" %}
 
 **Pinned**
 {% endColumn %}
@@ -51,10 +51,22 @@ The `"action"` field is registered in the manifest.
 }
 ```
 
-## Define rules for activating the extension{: #activate_pages }
+## Define rules for activating the extension {: #activate_pages }
 
-It's possible to use [declarativeContent][api-declarativecontent] to enable and disable the action based on the current URL being shown.
-See the [example as part of declarativeContent][docs-emulating-page-actions].
+The [declarativeContent][api-declarativecontent] API allows you to enable and disable the action
+based on the current URL being shown. 
+
+When an extension is disabled, the icon will be greyscale. If the user clicks on the action icon, they will see the extension's context menu.
+<figure>
+{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/hlYsQJPFsF7WBAjJZ6DS.png", 
+alt="Clicked Disabled extension", width="252", height="180" %}  
+
+<figcaption>
+    Disabled extension.
+  </figcaption>
+</figure>
+
+See the [Emulating pageActions with declarativeContent][docs-emulating-page-actions] for a code sample.
 
 ## Provide the extension icons
 

--- a/site/en/docs/extensions/mv3/user_interface/index.md
+++ b/site/en/docs/extensions/mv3/user_interface/index.md
@@ -17,7 +17,7 @@ to implement different UI elements within an extension.
 
 ## Allow the extension on all pages {: #action }
 
-Use an [action][1] when an extension's features are functional in most situations.
+Use an [action][docs-action] when an extension's features are functional in most situations.
 It will be displayed to the right of the user's URL bar, hidden under the Extensions overflow menu by default, and a user can 'pin' it to be always visible.
 
 ### Register browser action {: #browser }
@@ -43,7 +43,7 @@ users.
 Badges display a colored banner with up to four characters on top of the browser icon. They can only
 be used by extensions that declare `"action"` in their manifest.
 
-Use badges to indicate the state of the extension. The [Drink Water Event][2] sample displays a
+Use badges to indicate the state of the extension. The [Drink Water Event][sample-drink] sample displays a
 badge with "ON" to show the user they successfully set an alarm and displays nothing when the
 extension is idle.
 
@@ -53,8 +53,8 @@ extension is idle.
 {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/pNz8UgfTBMmcf7fE9wja.png",
        alt="Badge Off", height="72", width="72" %}
 
-Set the text of the badge by calling [`chrome.action.setBadgeText`][3] and the banner color
-by calling [`chrome.action.setBadgeBackgroundColor`][4] .
+Set the text of the badge by calling [`chrome.action.setBadgeText`][action-setbadgetext] and the banner color
+by calling [`chrome.action.setBadgeBackgroundColor`][action-setbadgebackgroundcolor] .
 
 ```js
 chrome.action.setBadgeText({text: 'ON'});
@@ -63,8 +63,8 @@ chrome.action.setBadgeBackgroundColor({color: '#4688F1'});
 
 ## Define rules for activating the extension{: #activate_pages }
 
-It's possible to use [declarativeContent](/docs/extensions/reference/declarativeContent/) to enable and disable the action based on the current URL being shown.
-See the [example as part of declarativeContent](docs/extensions/reference/action/#emulating-pageactions-with-declarativecontent).
+It's possible to use [declarativeContent][api-declarativecontent] to enable and disable the action based on the current URL being shown.
+See the [example as part of declarativeContent][docs-emulating-page-actions].
 
 ## Provide the extension icons
 
@@ -74,7 +74,7 @@ visual results, although any format supported by WebKit including BMP, GIF, ICO,
 ### Designate toolbar icons {: #icons }
 
 Icons specific to the toolbar are registered in the `"default_icon"` field under
-[`action`][15]  in the manifest. Including multiple sizes is
+[`action`][api-action]  in the manifest. Including multiple sizes is
 encouraged to scale for the 16-dip space. At minimum, 16x16 and 32x32 sizes are recommended.
 
 ```json
@@ -124,7 +124,7 @@ A popup is an HTML file that is displayed in a special window when the user clic
 A popup works very similarly to a web page; it can contain links to stylesheets and script tags, but
 does not allow inline JavaScript.
 
-The [Drink Water Event][17] example popup displays available timer options. Users set an alarm by
+The [Drink Water Event][sample-drink] example popup displays available timer options. Users set an alarm by
 clicking one of the provided buttons.
 
 {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/JVduBMXnyUorfNjFZmue.png",
@@ -159,8 +159,7 @@ The popup can be registered in the manifest under the `"action"` key.
 }
 ```
 
-Popups can also be set dynamically by calling [`action.setPopup`][18] or
-[`action.setPopup`][19].
+Popups can also be set dynamically by calling [`action.setPopup`][action-setpopup].
 
 ```js
 chrome.storage.local.get('signed_in', (data) => {
@@ -194,9 +193,9 @@ in the manifest.
 }
 ```
 
-Tooltips can also be set or updated by calling [`action.setTitle`][22].
+Tooltips can also be set or updated by calling [`action.setTitle`][action-settitle].
 
-Specialized locale strings are implemented with [Internationalization][24]. Create directories to
+Specialized locale strings are implemented with [Internationalization][api-i18n]. Create directories to
 house language specific messages within a folder called `_locales`, like this:
 
 * `_locales/en/messages.json`
@@ -237,7 +236,7 @@ Include the name of the message in the tooltip field instead of the message to e
 
 ### Click Event
 
-It's possible to install a click handler for when the user clicks the action item.
+It's possible to install a [click handler][action-onclicked] for when the user clicks the action item.
 However, this won't fire if the action has a popup (default or otherwise).
 
 ```js
@@ -248,8 +247,8 @@ chrome.action.onClicked.addListener(function(tab) {
 
 ### Omnibox {: #omnibox }
 
-Users can invoke extension functionality through the [omnibox][26]. Include the `"omnibox"` field in
-the manifest and designate a keyword. The [Omnibox New Tab Search][27] sample extension uses "nt" as
+Users can invoke extension functionality through the [omnibox][api-omnibox]. Include the `"omnibox"` field in
+the manifest and designate a keyword. The [Omnibox New Tab Search][sample-new-tab-search] sample extension uses "nt" as
 the keyword.
 
 ```json/3
@@ -271,7 +270,7 @@ it grayscales the provided 16x16 icon and includes it in the omnibox next to the
 {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/T0jCZDUVfuEANigPV6bY.png",
        alt="Active Omnibox Extension", height="70", width="576" %}
 
-The extension listens to the [`omnibox.onInputEntered`][28] event. After it's triggered, the
+The extension listens to the [`omnibox.onInputEntered`][omnibox-inputentered] event. After it's triggered, the
 extension opens a new tab containing a Google search for the user's entry.
 
 ```js
@@ -284,7 +283,7 @@ chrome.omnibox.onInputEntered.addListener(function(text) {
 
 ### Context menu {: #context_menu }
 
-Add new [context menu][29] options by granting the `"contextMenus"` permission in the manifest.
+Add new [context menu][api-context-menu] options by granting the `"contextMenus"` permission in the manifest.
 
 ```json/4
 {
@@ -308,10 +307,11 @@ The 16x16 icon is displayed next to the new menu entry.
 {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/jpA0DLCg2sEnwIf4FkLp.png",
        alt="Context Menu Icon", height="500", width="500" %}
 
-Create a context menu by calling [`contextMenus.create`][30] in the [background script][31]. This
-should be done under the [`runtime.onInstalled`][32] listener event.
+Create a context menu by calling [`contextMenus.create`][contextmenu-create] in the background script. This
+should be done under the [`runtime.onInstalled`][runtime-oninstalled] listener event.
 
 ```js
+// background.js
 chrome.runtime.onInstalled.addListener(function() {
   for (const key of Object.keys(kLocales)) {
     chrome.contextMenus.create({
@@ -342,7 +342,7 @@ const kLocales = {
 ```
 
 The Global Google Search context menu example creates multiple options from the list in
-[locales.js][33]. When an extension contains more than one context menu, Google Chrome
+`locales.js`. When an extension contains more than one context menu, Google Chrome
 automatically collapses them into a single parent menu.
 
 {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/LhrliaEhN82maJmeNp7f.png",
@@ -350,8 +350,8 @@ automatically collapses them into a single parent menu.
 
 ### Commands {: #commands }
 
-Extensions can define specific [commands][34] and bind them to a key combination. Register one or
-more commands in the manifest under the `"commands"` field.
+Extensions can define specific [commands][api-commands] and bind them to a key combination. Register one or
+more commands in the manifest under the `"commands"` key.
 
 ```json
 {
@@ -377,11 +377,13 @@ more commands in the manifest under the `"commands"` field.
 }
 ```
 
-Commands can be used to provide new or alternative browser shortcuts. The [Tab Flipper][35] sample
-extension listens to the [`commands.onCommand`][36] event in the [background script][37] and defines
+Commands can be used to provide new or alternative browser shortcuts. The [Tab Flipper][sample-tab-flipper] sample
+extension listens to the [`commands.onCommand`][commands-oncommand] event in the [background script][docs-background] and defines
 functionality for each registered combination.
 
 ```js
+// background.js 
+
 chrome.commands.onCommand.addListener(command => {
   // command will be "flip-tabs-forward" or "flip-tabs-backwards"
 
@@ -403,8 +405,8 @@ chrome.commands.onCommand.addListener(command => {
 
 ### Override pages {: #override }
 
-An extension can [override][42] and replace the History, New Tab, or Bookmarks web page with a
-custom HTML file. Like a [popup][43], it can include specialized logic and style, but does not allow
+An extension can [override][docs-override] and replace the History, New Tab, or Bookmarks web page with a
+custom HTML file. Like a [popup][section-popup], it can include specialized logic and style, but does not allow
 inline JavaScript. A single extension is limited to overriding only one of the three possible pages.
 
 Register an override page in the manifest under the `"chrome_url_overrides"` field.
@@ -436,44 +438,30 @@ pages.
 </html>
 ```
 
-[1]: /docs/extensions/reference/action
-[2]: /docs/extensions/mv3/samples#search:drink
-[3]: /docs/extensions/reference/action#method-setBadgeText
-[4]: /docs/extensions/reference/action#method-setBadgeBackgroundColor
-[5]: /docs/extensions/reference/action
-[6]: /docs/extensions/reference/declarativeContent
-[7]: /docs/extensions/reference/runtime#event-onInstalled
-[8]: /docs/extensions/mv3/background_pages
-[10]: /docs/extensions/reference/action#method-show
-[11]: /docs/extensions/reference/action#method-show
-[12]: /docs/extensions/reference/action#method-hide
-[13]: /docs/extensions/mv3/samples#search:mappy
-[15]: /docs/extensions/reference/action
-[16]: /docs/extensions/reference/action
-[17]: /docs/extensions/mv3/samples#search:drink
-[18]: /docs/extensions/reference/action#method-setPopup
-[19]: /docs/extensions/reference/action#method-setPopup
-[20]: /docs/extensions/reference/action
-[21]: /docs/extensions/reference/action
-[22]: /docs/extensions/reference/action#method-setTitle
-[23]: /docs/extensions/reference/action#method-setTitle
-[24]: /docs/extensions/reference/i18n
-[25]: /docs/extensions/mv3/i18n-messages
-[26]: /docs/extensions/reference/omnibox
-[27]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api/omnibox/new-tab-search
-[28]: /docs/extensions/reference/omnibox#event-onInputEntered
-[29]: /docs/extensions/reference/contextMenus
-[30]: /docs/extensions/reference/contextMenus#method-create
-[31]: /docs/extensions/mv3/migrating_to_service_workers
-[32]: /docs/extensions/reference/runtime#event-onInstalled
-[33]: /docs/extensions/examples/api/contextMenus/global_context_search/locales.js
-[34]: /docs/extensions/reference/commands
-[35]: /docs/extensions/mv3/samples#search:tab%20flipper
-[36]: /docs/extensions/reference/commands#event-onCommand
-[37]: /docs/extensions/mv3/migrating_to_service_workers
-[38]: /docs/extensions
-[39]: /docs/extensions/mv3/user_interface#browser
-[40]: /docs/extensions/mv3/migrating_to_service_workers
-[42]: /docs/extensions/mv3/override
-[43]: /docs/extensions/mv3/user_interface/#popup
+[action-hide]: /docs/extensions/reference/action#method-hide
+[action-onclicked]: /docs/extensions/reference/action/#event-onClicked
+[action-setbadgebackgroundcolor]: /docs/extensions/reference/action#method-setBadgeBackgroundColor
+[action-setbadgetext]: /docs/extensions/reference/action#method-setBadgeText
+[action-setpopup]: /docs/extensions/reference/action#method-setPopup
+[action-settitle]: /docs/extensions/reference/action#method-setTitle
+[action-show]: /docs/extensions/reference/action#method-show
+[api-action]: /docs/extensions/reference/action
+[api-commands]: /docs/extensions/reference/commands
+[api-context-menu]: /docs/extensions/reference/contextMenus
+[api-declarativecontent]: /docs/extensions/reference/declarativeContent
+[api-i18n]: /docs/extensions/reference/i18n
+[api-messages]: /docs/extensions/mv3/i18n-messages
+[api-omnibox]: /docs/extensions/reference/omnibox
+[commands-oncommand]: /docs/extensions/reference/commands#event-onCommand
+[contextmenu-create]: /docs/extensions/reference/contextMenus#method-create
+[docs-background]: /docs/extensions/mv3/background_pages
+[docs-emulating-page-actions]: /docs/extensions/reference/action/#emulating-pageactions-with-declarativecontent
+[docs-override]: /docs/extensions/mv3/override
+[omnibox-inputentered]: /docs/extensions/reference/omnibox#event-onInputEntered
+[runtime-oninstalled]: /docs/extensions/reference/runtime#event-onInstalled
+[sample-drink]: /docs/extensions/mv3/samples#search:drink
+[sample-mappy]: /docs/extensions/mv3/samples#search:mappy
+[sample-new-tab-search]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api/omnibox/new-tab-search
+[sample-tab-flipper]: /docs/extensions/mv3/samples#search:tab%20flipper
+[section-popup]: #popup
 

--- a/site/en/docs/extensions/mv3/user_interface/index.md
+++ b/site/en/docs/extensions/mv3/user_interface/index.md
@@ -102,11 +102,11 @@ generic one to the toolbar with the first letter of the extension name.
 
 Include additional icons in the following sizes for uses outside of the toolbar.
 
-| Icon Size | Icon Use                                                                                       |
-|-----------|------------------------------------------------------------------------------------------------|
-| 16x16     | favicon on the extension's pages                                                               |
+| Icon Size | Icon Use                                                                                   |
+|-----------|--------------------------------------------------------------------------------------------|
+| 16x16     | favicon on the extension's pages and context menu icon                                    |
 | 32x32     | Windows often uses size. Chrome will choose this size instead of shrinking a 48-pixel icon |
-| 48x48     | displays on the extension management page                                                     |
+| 48x48     | displays on the extension management page                                                  |
 | 128x128   | displays on installation and in the Chrome Web Store                                            |
 
 
@@ -147,7 +147,7 @@ chrome.action.setBadgeBackgroundColor({color: '#4688F1'});
 
 A popup is an HTML file that is displayed in a special window when the user clicks the toolbar icon.
 A popup works very similarly to a web page; it can contain links to stylesheets and script tags, but
-does not allow inline JavaScript.
+does not allow inline JavaScript. The popup cannot be smaller than 25x25 and cannot be larger than 800x600.
 
 The [Drink Water Event][sample-drink] example popup displays available timer options. Users set an alarm by
 clicking one of the provided buttons.
@@ -198,8 +198,8 @@ chrome.storage.local.get('signed_in', (data) => {
 
 ### Tooltip {: #tooltip }
 
-Use a tooltip to give short descriptions or instructions to users when hovering over the browser
-icon.
+Use a tooltip to give short descriptions or instructions to users when hovering over the action
+icon. By default, the tootip displays the name of the extension.
 
 {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/Go8aQg0vd0f2hkOFElLK.png",
        alt="A screenshot of an example tooltip", height="157", width="519" %}
@@ -432,7 +432,14 @@ chrome.commands.onCommand.addListener(command => {
 
 An extension can [override][docs-override] and replace the History, New Tab, or Bookmarks web page with a
 custom HTML file. Like a [popup][section-popup], it can include specialized logic and style, but does not allow
-inline JavaScript. A single extension is limited to overriding only one of the three possible pages.
+inline JavaScript. 
+
+{% Aside %}
+
+A single extension is limited to overriding **only one** of the three possible pages.
+
+{% endAside %}
+
 
 Register an override page in the manifest under the `"chrome_url_overrides"` field.
 
@@ -492,4 +499,3 @@ pages.
 [sample-tab-flipper]: /docs/extensions/mv3/samples#search:tab%20flipper
 [section-popup]: #popup
 [section-onclick]: #click
-

--- a/site/en/docs/extensions/mv3/user_interface/index.md
+++ b/site/en/docs/extensions/mv3/user_interface/index.md
@@ -71,9 +71,9 @@ See the [Emulating pageActions with declarativeContent][docs-emulating-page-acti
 ## Provide the extension icons
 
 An extension requires at least one icon to represent it. Provide icons in PNG format for the best
-visual results, although any format supported by WebKit including BMP, GIF, ICO, and JPEG is accepted. 
+visual results, although any format supported by WebKit including BMP, GIF, ICO, and JPEG is accepted (SVG is not supported).
 
-See [Supplying images][docs-icon-guidelines] for guidelines on how to design your icon.
+Ensure your icon follows the [extension icon best practices][docs-icon-guidelines].
 
 ### Designate toolbar icons {: #icons }
 
@@ -485,6 +485,7 @@ pages.
 [docs-override]: /docs/extensions/mv3/override
 [omnibox-inputentered]: /docs/extensions/reference/omnibox#event-onInputEntered
 [runtime-oninstalled]: /docs/extensions/reference/runtime#event-onInstalled
+[sample-action-api]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api/action
 [sample-drink]: /docs/extensions/mv3/samples#search:drink
 [sample-mappy]: /docs/extensions/mv3/samples#search:mappy
 [sample-new-tab-search]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api/omnibox/new-tab-search

--- a/site/en/docs/extensions/mv3/user_interface/index.md
+++ b/site/en/docs/extensions/mv3/user_interface/index.md
@@ -83,6 +83,7 @@ encouraged to scale for the 16-dip space. At minimum, 16x16 and 32x32 sizes are 
 
 ```json
 {
+    "name": "My Awesome Extension",
   ...
   "action": {
     "default_icon": {
@@ -101,7 +102,13 @@ generic one to the toolbar with the first letter of the extension name.
 
 Include additional icons in the following sizes for uses outside of the toolbar.
 
-<table><tbody><tr><th>Icon Size</th><th>Icon Use</th></tr><tr><td>16x16</td><td>favicon on the extension's pages</td></tr><tr></tr><tr><td>32x32</td><td>Windows computers often require this size. Providing this option will prevent size distortion from shrinking the 48x48 option.</td></tr><tr></tr><tr><td>48x48</td><td>displays on the extensions management page</td></tr><tr></tr><tr><td>128x128</td><td>displays on installation and in the Chrome Webstore</td></tr><tr></tr></tbody></table>
+| Icon Size | Icon Use                                                                                       |
+|-----------|------------------------------------------------------------------------------------------------|
+| 16x16     | favicon on the extension's pages                                                               |
+| 32x32     | Windows often uses size. Chrome will choose this size instead of shrinking a 48-pixel icon |
+| 48x48     | displays on the extension management page                                                     |
+| 128x128   | displays on installation and in the Chrome Web Store                                            |
+
 
 Register icons in the manifest under the `"icons"` field.
 
@@ -126,15 +133,7 @@ Register icons in the manifest under the `"icons"` field.
 Badges display a colored banner with up to four characters on top of the action icon. They can only
 be used by extensions that declare `"action"` in their manifest.
 
-Use badges to indicate the state of the extension. The [Drink Water Event][sample-drink] sample displays a
-badge with "ON" to show the user they successfully set an alarm and displays nothing when the
-extension is idle.
-
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/nXwAHSWLBEgT8099ITT0.png",
-       alt="Badge On", height="72", width="72" %}
-
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/pNz8UgfTBMmcf7fE9wja.png",
-       alt="Badge Off", height="72", width="72" %}
+Use badges to indicate the state of the extension. See the action API
 
 Set the text of the badge by calling [`chrome.action.setBadgeText`][action-setbadgetext] and the banner color
 by calling [`chrome.action.setBadgeBackgroundColor`][action-setbadgebackgroundcolor] .

--- a/site/en/docs/extensions/mv3/user_interface/index.md
+++ b/site/en/docs/extensions/mv3/user_interface/index.md
@@ -51,29 +51,6 @@ The `"action"` field is registered in the manifest.
 }
 ```
 
-### Add a badge {: #badge }
-
-Badges display a colored banner with up to four characters on top of the browser icon. They can only
-be used by extensions that declare `"action"` in their manifest.
-
-Use badges to indicate the state of the extension. The [Drink Water Event][sample-drink] sample displays a
-badge with "ON" to show the user they successfully set an alarm and displays nothing when the
-extension is idle.
-
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/nXwAHSWLBEgT8099ITT0.png",
-       alt="Badge On", height="72", width="72" %}
-
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/pNz8UgfTBMmcf7fE9wja.png",
-       alt="Badge Off", height="72", width="72" %}
-
-Set the text of the badge by calling [`chrome.action.setBadgeText`][action-setbadgetext] and the banner color
-by calling [`chrome.action.setBadgeBackgroundColor`][action-setbadgebackgroundcolor] .
-
-```js
-chrome.action.setBadgeText({text: 'ON'});
-chrome.action.setBadgeBackgroundColor({color: '#4688F1'});
-```
-
 ## Define rules for activating the extension{: #activate_pages }
 
 It's possible to use [declarativeContent][api-declarativecontent] to enable and disable the action based on the current URL being shown.
@@ -130,6 +107,29 @@ Register icons in the manifest under the `"icons"` field.
 ```
 
 ## Additional UI features {: #additional_features }
+
+### Add a badge {: #badge }
+
+Badges display a colored banner with up to four characters on top of the action icon. They can only
+be used by extensions that declare `"action"` in their manifest.
+
+Use badges to indicate the state of the extension. The [Drink Water Event][sample-drink] sample displays a
+badge with "ON" to show the user they successfully set an alarm and displays nothing when the
+extension is idle.
+
+{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/nXwAHSWLBEgT8099ITT0.png",
+       alt="Badge On", height="72", width="72" %}
+
+{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/pNz8UgfTBMmcf7fE9wja.png",
+       alt="Badge Off", height="72", width="72" %}
+
+Set the text of the badge by calling [`chrome.action.setBadgeText`][action-setbadgetext] and the banner color
+by calling [`chrome.action.setBadgeBackgroundColor`][action-setbadgebackgroundcolor] .
+
+```js
+chrome.action.setBadgeText({text: 'ON'});
+chrome.action.setBadgeBackgroundColor({color: '#4688F1'});
+```
 
 ### Popup {: #popup }
 

--- a/site/en/docs/extensions/mv3/user_interface/index.md
+++ b/site/en/docs/extensions/mv3/user_interface/index.md
@@ -2,7 +2,7 @@
 layout: "layouts/doc-post.njk"
 title: "Design the user interface"
 date: 2018-03-16
-updated: 2021-08-18
+updated: 2022-03-25
 description: UI and design guidelines for Chrome Extensions.
 ---
 
@@ -14,25 +14,24 @@ to implement different UI elements within an extension.
 
 ## The action icon {: #action }
 
-The [action][api-action] API controls the toolbar icon for your extension. It can open a [popup][section-popup] or trigger some functionality when it's [clicked][section-onclick]. The action icons are displayed in the browser toolbar to the right of the user's URL bar. 
+The [action][api-action] API controls the toolbar icon for your extension. It can open a
+[popup][section-popup] or trigger some functionality when it's [clicked][section-onclick]. The
+action icons are displayed in the browser toolbar to the right of the user's URL bar. 
 
-After installation, by default, these appear in the extensions menu (the puzzle piece). Users can choose to 'pin' your extension icon to the toolbar.
+After installation, by default, these appear in the extensions menu (the puzzle piece). Users can
+choose to 'pin' your extension icon to the toolbar.
 
 {% Columns %}
 
-{% Column %}
-{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/iouvm1a3lsQWGyg6fSMS.png", 
-alt="Unpinned extension", width="300", height="174" %}
+{% Column %} {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/iouvm1a3lsQWGyg6fSMS.png", alt="Unpinned
+extension", width="300", height="174" %}
 
-**Unpinned**
-{% endColumn %}
+**Unpinned** {% endColumn %}
 
-{% Column %}
-{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/KS09fVoCj3YWuIoH5EFn.png", 
-alt="Pinned extension", width="300", height="182" %}
+{% Column %} {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/KS09fVoCj3YWuIoH5EFn.png", alt="Pinned
+extension", width="300", height="182" %}
 
-**Pinned**
-{% endColumn %}
+**Pinned** {% endColumn %}
 
 {% endColumns %}
 
@@ -56,7 +55,8 @@ The `"action"` field is registered in the manifest.
 The [declarativeContent][api-declarativecontent] API allows you to enable and disable the action
 based on the current URL being shown. 
 
-When an extension is disabled, the icon will be greyscale. If the user clicks on the action icon, they will see the extension's context menu.
+When an extension is disabled, the icon will be greyscale. If the user clicks on the action icon,
+they will see the extension's context menu.
 <figure>
 {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/hlYsQJPFsF7WBAjJZ6DS.png", 
 alt="Clicked Disabled extension", width="252", height="180" %}  
@@ -66,24 +66,25 @@ alt="Clicked Disabled extension", width="252", height="180" %}
   </figcaption>
 </figure>
 
-See the [Emulating pageActions with declarativeContent][docs-emulating-page-actions] for a code sample.
+See [Emulating pageActions with declarativeContent][docs-emulating-page-actions] to learn more.
 
 ## Provide the extension icons
 
 An extension requires at least one icon to represent it. Provide icons in PNG format for the best
-visual results, although any format supported by WebKit including BMP, GIF, ICO, and JPEG is accepted (SVG is not supported).
+visual results, although any format supported by WebKit including BMP, GIF, ICO, and JPEG is
+accepted (SVG is not supported).
 
 Ensure your icon follows the [extension icon best practices][docs-icon-guidelines].
 
 ### Designate toolbar icons {: #icons }
 
 Icons specific to the toolbar are registered in the `"default_icon"` field under
-[`action`][api-action]  in the manifest. Including multiple sizes is
-encouraged to scale for the 16-dip space. At minimum, 16x16 and 32x32 sizes are recommended.
+[`action`][api-action]  in the manifest. Including multiple sizes is encouraged to scale for the
+16-dip space. At minimum, 16x16 and 32x32 sizes are recommended.
 
 ```json
 {
-    "name": "My Awesome Extension",
+  "name": "My Awesome Extension",
   ...
   "action": {
     "default_icon": {
@@ -104,10 +105,10 @@ Include additional icons in the following sizes for uses outside of the toolbar.
 
 | Icon Size | Icon Use                                                                                   |
 |-----------|--------------------------------------------------------------------------------------------|
-| 16x16     | favicon on the extension's pages and context menu icon                                    |
-| 32x32     | Windows often uses size. Chrome will choose this size instead of shrinking a 48-pixel icon |
+| 16x16     | favicon on the extension's pages and context menu icon                                     |
+| 32x32     | In Windows, Chrome will choose this prefered size instead of shrinking a 48-pixel icon     |
 | 48x48     | displays on the extension management page                                                  |
-| 128x128   | displays on installation and in the Chrome Web Store                                            |
+| 128x128   | displays on installation and in the Chrome Web Store                                       |
 
 
 Register icons in the manifest under the `"icons"` field.
@@ -135,8 +136,8 @@ be used by extensions that declare `"action"` in their manifest.
 
 Use badges to indicate the state of the extension. See the action API
 
-Set the text of the badge by calling [`chrome.action.setBadgeText`][action-setbadgetext] and the banner color
-by calling [`chrome.action.setBadgeBackgroundColor`][action-setbadgebackgroundcolor] .
+Set the text of the badge by calling [`chrome.action.setBadgeText`][action-setbadgetext] and the
+banner color by calling [`chrome.action.setBadgeBackgroundColor`][action-setbadgebackgroundcolor].
 
 ```js
 chrome.action.setBadgeText({text: 'ON'});
@@ -147,13 +148,14 @@ chrome.action.setBadgeBackgroundColor({color: '#4688F1'});
 
 A popup is an HTML file that is displayed in a special window when the user clicks the toolbar icon.
 A popup works very similarly to a web page; it can contain links to stylesheets and script tags, but
-does not allow inline JavaScript. The popup cannot be smaller than 25x25 and cannot be larger than 800x600.
+does not allow inline JavaScript. The popup cannot be smaller than 25x25 and cannot be larger than
+800x600.
 
-The [Drink Water Event][sample-drink] example popup displays available timer options. Users set an alarm by
-clicking one of the provided buttons.
+The [Drink Water Event][sample-drink] example popup displays available timer options. Users set an
+alarm by clicking one of the provided buttons.
 
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/JVduBMXnyUorfNjFZmue.png",
-       alt="Popup sample screenshot", height="561", width="413" %}
+{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/JVduBMXnyUorfNjFZmue.png", alt="Popup sample
+       screenshot", height="561", width="413" %}
 
 ```html
 <html>
@@ -171,7 +173,7 @@ clicking one of the provided buttons.
 </html>
 ```
 
-The popup can be registered in the manifest under the `"action"` key.
+The popup is registered in the manifest under the `"action"` key.
 
 ```json
 {
@@ -201,11 +203,10 @@ chrome.storage.local.get('signed_in', (data) => {
 Use a tooltip to give short descriptions or instructions to users when hovering over the action
 icon. By default, the tootip displays the name of the extension.
 
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/Go8aQg0vd0f2hkOFElLK.png",
-       alt="A screenshot of an example tooltip", height="157", width="519" %}
+{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/Go8aQg0vd0f2hkOFElLK.png", alt="A screenshot of an
+       example tooltip", height="157", width="519" %}
 
-Tooltips are registered in the `"default_title"` field under the `"action"` key.
-in the manifest.
+Tooltips are registered in the `"default_title"` field under the `"action"` key. in the manifest.
 
 ```json
 {
@@ -220,49 +221,10 @@ in the manifest.
 
 Tooltips can also be set or updated by calling [`action.setTitle`][action-settitle].
 
-Specialized locale strings are implemented with [Internationalization][api-i18n]. Create directories to
-house language specific messages within a folder called `_locales`, like this:
-
-* `_locales/en/messages.json`
-* `_locales/es/messages.json`
-
-[Format messages][25] inside of each language's `messages.json`.
-
-```json
-{
-  "__MSG_tooltip__": {
-    "message": "Hello!",
-    "description": "Tooltip Greeting."
-  }
-}
-```
-
-```json
-{
-  "__MSG_tooltip__": {
-    "message": "Hola!",
-    "description": "Tooltip Greeting."
-  }
-}
-```
-
-Include the name of the message in the tooltip field instead of the message to enable localization.
-
-```json
-{
-" name": "Tab Flipper",
-  ...
-  "action": {
-    "default_title": "__MSG_tooltip__"
-  }
-...
-}
-```
-
 ### Click Event {: #click}
 
-It's possible to install a [click handler][action-onclicked] for when the user clicks the action item.
-However, this won't fire if the action has a popup (default or otherwise).
+It's possible to install a [click handler][action-onclicked] for when the user clicks the action
+item. However, this won't fire if the action has a popup (default or otherwise).
 
 ```js
 chrome.action.onClicked.addListener(function(tab) {
@@ -272,9 +234,9 @@ chrome.action.onClicked.addListener(function(tab) {
 
 ### Omnibox {: #omnibox }
 
-Users can invoke extension functionality through the [omnibox][api-omnibox]. Include the `"omnibox"` field in
-the manifest and designate a keyword. The [Omnibox New Tab Search][sample-new-tab-search] sample extension uses "nt" as
-the keyword.
+Users can invoke extension functionality through the [omnibox][api-omnibox]. Include the `"omnibox"`
+field in the manifest and designate a keyword. The [Omnibox New Tab Search][sample-new-tab-search]
+sample extension uses "nt" as the keyword.
 
 ```json/3
 {
@@ -292,11 +254,11 @@ the keyword.
 When the user types "nt" into the omnibox, it activates the extension. To signal this to the user,
 it grayscales the provided 16x16 icon and includes it in the omnibox next to the extension name.
 
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/T0jCZDUVfuEANigPV6bY.png",
-       alt="Active Omnibox Extension", height="70", width="576" %}
+{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/T0jCZDUVfuEANigPV6bY.png", alt="Active Omnibox
+       Extension", height="70", width="576" %}
 
-The extension listens to the [`omnibox.onInputEntered`][omnibox-inputentered] event. After it's triggered, the
-extension opens a new tab containing a Google search for the user's entry.
+The extension listens to the [`omnibox.onInputEntered`][omnibox-inputentered] event. After it's
+triggered, the extension opens a new tab containing a Google search for the user's entry.
 
 ```js
 chrome.omnibox.onInputEntered.addListener(function(text) {
@@ -308,7 +270,8 @@ chrome.omnibox.onInputEntered.addListener(function(text) {
 
 ### Context menu {: #context_menu }
 
-Add new [context menu][api-context-menu] options by granting the `"contextMenus"` permission in the manifest.
+Add new [context menu][api-context-menu] options by granting the `"contextMenus"` permission in the
+manifest.
 
 ```json/4
 {
@@ -329,11 +292,11 @@ Add new [context menu][api-context-menu] options by granting the `"contextMenus"
 
 The 16x16 icon is displayed next to the new menu entry.
 
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/jpA0DLCg2sEnwIf4FkLp.png",
-       alt="Context Menu Icon", height="500", width="500" %}
+{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/jpA0DLCg2sEnwIf4FkLp.png", alt="Context Menu Icon",
+       height="500", width="500" %}
 
-Create a context menu by calling [`contextMenus.create`][contextmenu-create] in the background script. This
-should be done under the [`runtime.onInstalled`][runtime-oninstalled] listener event.
+Create a context menu by calling [`contextMenus.create`][contextmenu-create] in the background
+script. This should be done under the [`runtime.onInstalled`][runtime-oninstalled] listener event.
 
 ```js
 // background.js
@@ -367,16 +330,16 @@ const kLocales = {
 ```
 
 The Global Google Search context menu example creates multiple options from the list in
-`locales.js`. When an extension contains more than one context menu, Google Chrome
-automatically collapses them into a single parent menu.
+`locales.js`. When an extension contains more than one context menu, Google Chrome automatically
+collapses them into a single parent menu.
 
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/LhrliaEhN82maJmeNp7f.png",
-       alt="Multiple Context Menus will Collapse", height="606", width="800" %}
+{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/LhrliaEhN82maJmeNp7f.png", alt="Multiple Context
+       Menus will Collapse", height="606", width="800" %}
 
 ### Commands {: #commands }
 
-Extensions can define specific [commands][api-commands] and bind them to a key combination. Register one or
-more commands in the manifest under the `"commands"` key.
+Extensions can define specific [commands][api-commands] and bind them to a key combination. Register
+one or more commands in the manifest under the `"commands"` key.
 
 ```json
 {
@@ -402,9 +365,10 @@ more commands in the manifest under the `"commands"` key.
 }
 ```
 
-Commands can be used to provide new or alternative browser shortcuts. The [Tab Flipper][sample-tab-flipper] sample
-extension listens to the [`commands.onCommand`][commands-oncommand] event in the [background script][docs-background] and defines
-functionality for each registered combination.
+Commands can be used to provide new or alternative browser shortcuts. The [Tab
+Flipper][sample-tab-flipper] sample extension listens to the
+[`commands.onCommand`][commands-oncommand] event in the [background script][docs-background] and
+defines functionality for each registered combination.
 
 ```js
 // background.js 
@@ -430,9 +394,9 @@ chrome.commands.onCommand.addListener(command => {
 
 ### Override pages {: #override }
 
-An extension can [override][docs-override] and replace the History, New Tab, or Bookmarks web page with a
-custom HTML file. Like a [popup][section-popup], it can include specialized logic and style, but does not allow
-inline JavaScript. 
+An extension can [override][docs-override] and replace the History, New Tab, or Bookmarks web page
+with a custom HTML file. Like a [popup][section-popup], it can include specialized logic and style,
+but does not allow inline JavaScript. 
 
 {% Aside %}
 
@@ -470,6 +434,64 @@ pages.
 </html>
 ```
 
+## Internationalize the UI {: #localize }
+
+You can use the [`chrome.i18n`][api-i18n] API to internationalize your extension. Create directories
+to house language specific messages within a folder called `_locales`, like this:
+
+- `_locales/en/messages.json`
+- `_locales/es/messages.json`
+
+[Format messages][docs-locale-messages] inside of each language's `messages.json`. For example, the
+following code localizes the tooltip:
+
+{% Columns %}
+
+{% Column %}
+
+```json
+// _locales/en/messages.json
+{
+  "__MSG_tooltip__": {
+    "message": "Hello!",
+    "description": "Tooltip"
+  }
+}
+```
+
+{% endColumn %}
+
+{% Column %}
+
+```json
+// _locales/es/messages.json
+{
+  "__MSG_tooltip__": {
+    "message": "Hola!",
+    "description": "Tooltip"
+  }
+}
+```
+
+{% endColumn %}
+
+{% endColumns %}
+
+Specify the name of the message in the `"default_title"` field. The `"default_locale"` field must be
+defined.
+
+```json
+{
+  "name": "Tab Flipper",
+  ...
+  "action": {
+    "default_title": "__MSG_tooltip__"
+  },
+  "default_locale": "en"
+  ...
+}
+```
+
 [action-hide]: /docs/extensions/reference/action#method-hide
 [action-onclicked]: /docs/extensions/reference/action/#event-onClicked
 [action-setbadgebackgroundcolor]: /docs/extensions/reference/action#method-setBadgeBackgroundColor
@@ -489,6 +511,7 @@ pages.
 [docs-background]: /docs/extensions/mv3/background_pages
 [docs-emulating-page-actions]: /docs/extensions/reference/action/#emulating-pageactions-with-declarativecontent
 [docs-icon-guidelines]: /docs/webstore/images/#icons
+[docs-locale-messages]: /docs/extensions/mv3/i18n-messages/
 [docs-override]: /docs/extensions/mv3/override
 [omnibox-inputentered]: /docs/extensions/reference/omnibox#event-onInputEntered
 [runtime-oninstalled]: /docs/extensions/reference/runtime#event-onInstalled
@@ -497,5 +520,5 @@ pages.
 [sample-mappy]: /docs/extensions/mv3/samples#search:mappy
 [sample-new-tab-search]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api/omnibox/new-tab-search
 [sample-tab-flipper]: /docs/extensions/mv3/samples#search:tab%20flipper
-[section-popup]: #popup
 [section-onclick]: #click
+[section-popup]: #popup

--- a/site/en/docs/extensions/mv3/user_interface/index.md
+++ b/site/en/docs/extensions/mv3/user_interface/index.md
@@ -71,7 +71,9 @@ See the [Emulating pageActions with declarativeContent][docs-emulating-page-acti
 ## Provide the extension icons
 
 An extension requires at least one icon to represent it. Provide icons in PNG format for the best
-visual results, although any format supported by WebKit including BMP, GIF, ICO, and JPEG is accepted.
+visual results, although any format supported by WebKit including BMP, GIF, ICO, and JPEG is accepted. 
+
+See [Supplying images][docs-icon-guidelines] for guidelines on how to design your icon.
 
 ### Designate toolbar icons {: #icons }
 
@@ -81,7 +83,6 @@ encouraged to scale for the 16-dip space. At minimum, 16x16 and 32x32 sizes are 
 
 ```json
 {
-  "name": "My Awesome page_action Extension",
   ...
   "action": {
     "default_icon": {
@@ -94,7 +95,7 @@ encouraged to scale for the 16-dip space. At minimum, 16x16 and 32x32 sizes are 
 ```
 
 All icons should be square or they may be distorted. If no icons are supplied, Chrome will add a
-generic one to the toolbar.
+generic one to the toolbar with the first letter of the extension name. 
 
 ### Create and register additional icons {: #icon_size }
 
@@ -481,6 +482,7 @@ pages.
 [contextmenu-create]: /docs/extensions/reference/contextMenus#method-create
 [docs-background]: /docs/extensions/mv3/background_pages
 [docs-emulating-page-actions]: /docs/extensions/reference/action/#emulating-pageactions-with-declarativecontent
+[docs-icon-guidelines]: /docs/webstore/images/#icons
 [docs-override]: /docs/extensions/mv3/override
 [omnibox-inputentered]: /docs/extensions/reference/omnibox#event-onInputEntered
 [runtime-oninstalled]: /docs/extensions/reference/runtime#event-onInstalled

--- a/site/en/docs/extensions/mv3/user_interface/index.md
+++ b/site/en/docs/extensions/mv3/user_interface/index.md
@@ -6,21 +6,37 @@ updated: 2021-08-18
 description: UI and design guidelines for Chrome Extensions.
 ---
 
-<!-- Note to editors: this is largely identical to the Manifest V2 version, but removes
-    browser_action and page_action in favor of action -->
-
 The extension user interface should be purposeful and minimal. Just like extensions themselves, the
 UI should customize or enhance the browsing experience without distracting from it.
 
 This guide explores required and optional user interface features. Use it to understand how and when
 to implement different UI elements within an extension.
 
-## Allow the extension on all pages {: #action }
+## The action icon {: #action }
 
-Use an [action][docs-action] when an extension's features are functional in most situations.
-It will be displayed to the right of the user's URL bar, hidden under the Extensions overflow menu by default, and a user can 'pin' it to be always visible.
+The [action][api-action] API controls the toolbar icon for your extension. It can open a [popup][section-popup] or trigger some functionality when it's [clicked][section-onclick]. The action icons are displayed in the browser toolbar to the right of the user's URL bar. 
 
-### Register browser action {: #browser }
+After installation, by default, these appear in the extensions menu (the puzzle piece). Users can choose to 'pin' your extension icon to the toolbar.
+
+{% Columns %}
+
+{% Column %}
+{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/iouvm1a3lsQWGyg6fSMS.png", 
+alt="Unpinned extension", width="340", height="174" %}
+
+**Unpinned**
+{% endColumn %}
+
+{% Column %}
+{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/KS09fVoCj3YWuIoH5EFn.png", 
+alt="Pinned extension", width="338", height="182" %}
+
+**Pinned**
+{% endColumn %}
+
+{% endColumns %}
+
+### Register the action {: #browser }
 
 The `"action"` field is registered in the manifest.
 
@@ -34,9 +50,6 @@ The `"action"` field is registered in the manifest.
   ...
 }
 ```
-
-Declaring `"action"` keeps the icon colorized, indicating the extension is available to
-users.
 
 ### Add a badge {: #badge }
 
@@ -234,7 +247,7 @@ Include the name of the message in the tooltip field instead of the message to e
 }
 ```
 
-### Click Event
+### Click Event {: #click}
 
 It's possible to install a [click handler][action-onclicked] for when the user clicks the action item.
 However, this won't fire if the action has a popup (default or otherwise).
@@ -464,4 +477,5 @@ pages.
 [sample-new-tab-search]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api/omnibox/new-tab-search
 [sample-tab-flipper]: /docs/extensions/mv3/samples#search:tab%20flipper
 [section-popup]: #popup
+[section-onclick]: #click
 

--- a/site/en/docs/extensions/mv3/user_interface/index.md
+++ b/site/en/docs/extensions/mv3/user_interface/index.md
@@ -6,6 +6,7 @@ updated: 2022-03-25
 description: UI and design guidelines for Chrome Extensions.
 ---
 
+<!-- TODO: Extension sample links need to be updated, once the samples are approved -->
 The extension user interface should be purposeful and minimal. Just like extensions themselves, the
 UI should customize or enhance the browsing experience without distracting from it.
 
@@ -14,7 +15,7 @@ to implement different UI elements within an extension.
 
 ## The action icon {: #action }
 
-The [action][api-action] API controls the toolbar icon for your extension. It can open a
+The [action][api-action] API controls the extension's action icon (toolbar icon). It can open a
 [popup][section-popup] or trigger some functionality when it's [clicked][section-onclick]. The
 action icons are displayed in the browser toolbar to the right of the user's URL bar. 
 
@@ -23,15 +24,23 @@ choose to 'pin' your extension icon to the toolbar.
 
 {% Columns %}
 
-{% Column %} {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/iouvm1a3lsQWGyg6fSMS.png", alt="Unpinned
-extension", width="300", height="174" %}
+{% Column %} 
 
-**Unpinned** {% endColumn %}
+{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/iouvm1a3lsQWGyg6fSMS.png", 
+alt="Unpinned extension", width="400", height="374" %}
 
-{% Column %} {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/KS09fVoCj3YWuIoH5EFn.png", alt="Pinned
-extension", width="300", height="182" %}
+**Unpinned** 
 
-**Pinned** {% endColumn %}
+{% endColumn %}
+
+{% Column %} 
+
+{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/KS09fVoCj3YWuIoH5EFn.png", 
+alt="Pinned extension", width="400", height="382" %}
+
+**Pinned** 
+
+{% endColumn %}
 
 {% endColumns %}
 
@@ -53,20 +62,23 @@ The `"action"` field is registered in the manifest.
 ## Define rules for activating the extension {: #activate_pages }
 
 The [declarativeContent][api-declarativecontent] API allows you to enable and disable the action
-based on the current URL being shown. 
+based on the current URL being shown and the CSS selectors its content matches.
 
-When an extension is disabled, the icon will be greyscale. If the user clicks on the action icon,
-they will see the extension's context menu.
+When an extension is disabled, the icon is grayscaled. If the user clicks on the action icon while
+disabled, the extension's context menu will appear.
+
 <figure>
 {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/hlYsQJPFsF7WBAjJZ6DS.png", 
-alt="Clicked Disabled extension", width="252", height="180" %}  
+alt="Clicked Disabled extension", width="252", height="180", class="screenshot"%}  
 
 <figcaption>
     Disabled extension.
   </figcaption>
 </figure>
 
-See [Emulating pageActions with declarativeContent][docs-emulating-page-actions] to learn more.
+See [Emulating pageActions with declarativeContent][docs-emulating-page-actions] for an example on
+how to disable the action by default and use declarativeContent to enable the action on specific
+sites.
 
 ## Provide the extension icons
 
@@ -76,7 +88,7 @@ accepted (SVG is not supported).
 
 Ensure your icon follows the [extension icon best practices][docs-icon-guidelines].
 
-### Designate toolbar icons {: #icons }
+### Designate action icons {: #icons }
 
 Icons specific to the toolbar are registered in the `"default_icon"` field under
 [`action`][api-action]  in the manifest. Including multiple sizes is encouraged to scale for the
@@ -103,12 +115,12 @@ generic one to the toolbar with the first letter of the extension name.
 
 Include additional icons in the following sizes for uses outside of the toolbar.
 
-| Icon Size | Icon Use                                                                                   |
-|-----------|--------------------------------------------------------------------------------------------|
-| 16x16     | favicon on the extension's pages and context menu icon                                     |
-| 32x32     | In Windows, Chrome will choose this prefered size instead of shrinking a 48-pixel icon     |
-| 48x48     | displays on the extension management page                                                  |
-| 128x128   | displays on installation and in the Chrome Web Store                                       |
+| Icon Size | Icon Use                                               |
+|-----------|--------------------------------------------------------|
+| 16x16     | favicon on the extension's pages and context menu icon |
+| 32x32     | Windows computers often require this size.             |
+| 48x48     | displays on the extension management page              |
+| 128x128   | displays on installation and in the Chrome Web Store   |
 
 
 Register icons in the manifest under the `"icons"` field.
@@ -146,16 +158,16 @@ chrome.action.setBadgeBackgroundColor({color: '#4688F1'});
 
 ### Popup {: #popup }
 
-A popup is an HTML file that is displayed in a special window when the user clicks the toolbar icon.
+A popup is an HTML file that is displayed in a special window when the user clicks the action icon.
 A popup works very similarly to a web page; it can contain links to stylesheets and script tags, but
-does not allow inline JavaScript. The popup cannot be smaller than 25x25 and cannot be larger than
-800x600.
+does not allow inline JavaScript. The popup cannot be smaller than 25x25 px and cannot be larger than
+800x600 px.
 
 The [Drink Water Event][sample-drink] example popup displays available timer options. Users set an
 alarm by clicking one of the provided buttons.
 
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/JVduBMXnyUorfNjFZmue.png", alt="Popup sample
-       screenshot", height="561", width="413" %}
+{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/JVduBMXnyUorfNjFZmue.png", 
+alt="Popup sample screenshot", height="361", width="213" %}
 
 ```html
 <html>
@@ -203,10 +215,10 @@ chrome.storage.local.get('signed_in', (data) => {
 Use a tooltip to give short descriptions or instructions to users when hovering over the action
 icon. By default, the tootip displays the name of the extension.
 
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/Go8aQg0vd0f2hkOFElLK.png", alt="A screenshot of an
-       example tooltip", height="157", width="519" %}
+{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/Go8aQg0vd0f2hkOFElLK.png", 
+alt="A screenshot of an example tooltip", height="157", width="419" %}
 
-Tooltips are registered in the `"default_title"` field under the `"action"` key. in the manifest.
+Tooltips are registered in the `"default_title"` field under the `"action"` key in the manifest.
 
 ```json
 {
@@ -254,8 +266,8 @@ sample extension uses "nt" as the keyword.
 When the user types "nt" into the omnibox, it activates the extension. To signal this to the user,
 it grayscales the provided 16x16 icon and includes it in the omnibox next to the extension name.
 
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/T0jCZDUVfuEANigPV6bY.png", alt="Active Omnibox
-       Extension", height="70", width="576" %}
+{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/T0jCZDUVfuEANigPV6bY.png", 
+alt="Active Omnibox Extension", height="70", width="476" %}
 
 The extension listens to the [`omnibox.onInputEntered`][omnibox-inputentered] event. After it's
 triggered, the extension opens a new tab containing a Google search for the user's entry.
@@ -292,19 +304,19 @@ manifest.
 
 The 16x16 icon is displayed next to the new menu entry.
 
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/jpA0DLCg2sEnwIf4FkLp.png", alt="Context Menu Icon",
-       height="500", width="500" %}
+{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/jpA0DLCg2sEnwIf4FkLp.png", 
+alt="Context Menu Icon", height="300", width="300" %}
 
 Create a context menu by calling [`contextMenus.create`][contextmenu-create] in the background
 script. This should be done under the [`runtime.onInstalled`][runtime-oninstalled] listener event.
 
 ```js
 // background.js
-chrome.runtime.onInstalled.addListener(function() {
-  for (const key of Object.keys(kLocales)) {
+chrome.runtime.onInstalled.addListener(async () => {
+  for (let [tld, locale] of Object.entries(tldLocales)) {
     chrome.contextMenus.create({
-      id: key,
-      title: kLocales[key],
+      id: tld,
+      title: locale,
       type: 'normal',
       contexts: ['selection'],
     });
@@ -313,7 +325,7 @@ chrome.runtime.onInstalled.addListener(function() {
 ```
 
 ```js
-const kLocales = {
+const tldLocales = {
   'com.au': 'Australia',
   'com.br': 'Brazil',
   'ca': 'Canada',
@@ -333,13 +345,13 @@ The Global Google Search context menu example creates multiple options from the 
 `locales.js`. When an extension contains more than one context menu, Google Chrome automatically
 collapses them into a single parent menu.
 
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/LhrliaEhN82maJmeNp7f.png", alt="Multiple Context
-       Menus will Collapse", height="606", width="800" %}
+{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/LhrliaEhN82maJmeNp7f.png", 
+alt="Multiple Context Menus will Collapse", height="306", width="500" %}
 
 ### Commands {: #commands }
 
 Extensions can define specific [commands][api-commands] and bind them to a key combination. Register
-one or more commands in the manifest under the `"commands"` key.
+one or more shortcuts in the manifest under the `"commands"` key.
 
 ```json
 {
@@ -403,7 +415,6 @@ but does not allow inline JavaScript.
 A single extension is limited to overriding **only one** of the three possible pages.
 
 {% endAside %}
-
 
 Register an override page in the manifest under the `"chrome_url_overrides"` field.
 
@@ -491,6 +502,10 @@ defined.
   ...
 }
 ```
+## Learn more
+
+See the [Action API example][sample-action] for a complete demonstration of the action APIs
+capabilities.
 
 [action-hide]: /docs/extensions/reference/action#method-hide
 [action-onclicked]: /docs/extensions/reference/action/#event-onClicked
@@ -516,8 +531,8 @@ defined.
 [omnibox-inputentered]: /docs/extensions/reference/omnibox#event-onInputEntered
 [runtime-oninstalled]: /docs/extensions/reference/runtime#event-onInstalled
 [sample-action-api]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api/action
+[sample-action]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api/action
 [sample-drink]: /docs/extensions/mv3/samples#search:drink
-[sample-mappy]: /docs/extensions/mv3/samples#search:mappy
 [sample-new-tab-search]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api/omnibox/new-tab-search
 [sample-tab-flipper]: /docs/extensions/mv3/samples#search:tab%20flipper
 [section-onclick]: #click


### PR DESCRIPTION
Fixes #2382 

Changes proposed in this pull request:

- Restructure content
- Add links to MV3 examples
- Add link to action demo example

TODO:
- [ ] Add links to MV3 example repos when PRs are merged

https://github.com/GoogleChrome/chrome-extensions-samples/pull/678
https://github.com/GoogleChrome/chrome-extensions-samples/pull/679
https://github.com/GoogleChrome/chrome-extensions-samples/pull/680