### PR TITLE
Restructured table of contents of DevTools docs: list of tools

### DIFF
--- a/site/_data/docs/devtools/toc.yml
+++ b/site/_data/docs/devtools/toc.yml
@@ -8,91 +8,94 @@
 - url: /tags/devtools-engineering/
   title: i18n.docs.devtools.blog
   description: i18n.docs.devtools.blog_description
-- title: i18n.docs.devtools.css
+- title: i18n.docs.devtools.commands_shortcuts
   sections:
+    - url: /docs/devtools/command-menu
+    - url: /docs/devtools/javascript/disable/
+    - url: /docs/devtools/shortcuts/
+- url: /docs/devtools/device-mode/
+- description: 'Tools'
+- title: i18n.docs.devtools.elements
+  sections:
+    - url: /docs/devtools/dom/
     - url: /docs/devtools/css/
-    - url: /docs/devtools/css/reference/
-    - url: /docs/devtools/css-overview/
-    - url: /docs/devtools/css/animations/
     - url: /docs/devtools/css/grid/
     - url: /docs/devtools/css/flexbox/
-    - url: /docs/devtools/css/print-preview/
-- url: /docs/devtools/dom/
+    - url: /docs/devtools/css/reference/
 - title: i18n.docs.devtools.console
   sections:
     - url: /docs/devtools/console/
     - url: /docs/devtools/console/log/
     - url: /docs/devtools/console/javascript/
+    - url: /docs/devtools/console/live-expressions/
     - url: /docs/devtools/console/format-style/
     - url: /docs/devtools/console/reference/
     - url: /docs/devtools/console/api/
     - url: /docs/devtools/console/utilities/
-    - url: /docs/devtools/console/live-expressions/
-- url: /docs/devtools/coverage/
+- title: i18n.docs.devtools.sources
+  sections:
+    - url: /docs/devtools/javascript/sources/
+    - url: /docs/devtools/javascript/
+    - url: /docs/devtools/javascript/breakpoints/
+    - url: /docs/devtools/javascript/snippets/
+    - url: /docs/devtools/workspaces/
+    - url: /docs/devtools/javascript/reference/
 - title: i18n.docs.devtools.network
   sections:
     - url: /docs/devtools/network/
     - url: /docs/devtools/network/reference/
-- title: i18n.docs.devtools.storage
-  sections:
-    - url: /docs/devtools/storage/cookies/
-    - url: /docs/devtools/storage/localstorage/
-    - url: /docs/devtools/storage/indexeddb/
-    - url: /docs/devtools/storage/sessionstorage/
-    - url: /docs/devtools/storage/applicationcache/
-    - url: /docs/devtools/storage/websql/
-    - url: /docs/devtools/storage/cache/
-- url: /docs/devtools/issues/
-- url: /docs/devtools/command-menu
-- title: i18n.docs.devtools.mobile
-  sections:
-    - url: /docs/devtools/device-mode/
-    - url: /docs/devtools/device-mode/override-user-agent/
-    - url: /docs/devtools/device-mode/geolocation/
-    - url: /docs/devtools/device-mode/orientation/
-- title: i18n.docs.devtools.javascript
-  sections:
-    - url: /docs/devtools/javascript/
-    - url: /docs/devtools/javascript/breakpoints/
-    - url: /docs/devtools/javascript/reference/
-    - url: /docs/devtools/javascript/snippets/
-    - url: /docs/devtools/javascript/sources/
-    - url: /docs/devtools/javascript/background-services/
-    - url: /docs/devtools/javascript/ignore-chrome-extension-scripts/
-    - url: /docs/devtools/javascript/disable/
+    - url: /docs/devtools/resources/
 - title: i18n.docs.devtools.performance
   sections:
     - url: /docs/devtools/evaluate-performance/
-    - url: /docs/devtools/speed/get-started/
     - url: /docs/devtools/evaluate-performance/reference/
     - url: /docs/devtools/evaluate-performance/performance-reference/
-- title: i18n.docs.devtools.accessibility
+- title: i18n.docs.devtools.memory
   sections:
-    - url: /docs/devtools/accessibility/reference/
-    - url: /docs/devtools/accessibility/navigation/
-    - url: /docs/devtools/accessibility/focus/
+    - url: /docs/devtools/memory-problems/memory-101/
+    - url: /docs/devtools/memory-problems/
+    - url: /docs/devtools/memory-problems/heap-snapshots/
+    - url: /docs/devtools/memory-problems/allocation-profiler/
+- title: i18n.docs.devtools.application
+  sections:
+    - url: /docs/devtools/javascript/background-services/
+    - url: /docs/devtools/progressive-web-apps/
+    - url: /docs/devtools/storage/cookies/
+    - url: /docs/devtools/storage/localstorage/
+    - url: /docs/devtools/storage/sessionstorage/
+    - url: /docs/devtools/storage/indexeddb/
+    - url: /docs/devtools/storage/applicationcache/
+    - url: /docs/devtools/storage/websql/
+    - url: /docs/devtools/storage/cache/
+- url: /docs/devtools/speed/get-started/
+- url: /docs/devtools/css/animations/
+- url: /docs/devtools/coverage/
+- url: /docs/devtools/css-overview/
+- url: /docs/devtools/issues/
+- url: /docs/devtools/media-panel/
+- url: /docs/devtools/memory-inspector/
+- url: /docs/devtools/device-mode/override-user-agent/
+- url: /docs/devtools/recorder/
+- url: /docs/devtools/css/print-preview/
+- url: /docs/devtools/security/
+- title: i18n.docs.devtools.sensors
+  sections:
+    - url: /docs/devtools/device-mode/geolocation/
+    - url: /docs/devtools/device-mode/orientation/
+- url: /docs/devtools/webauthn/
 - title: i18n.docs.devtools.remotedebug
   sections:
     - url: /docs/devtools/remote-debugging/
     - url: /docs/devtools/remote-debugging/local-server/
     - url: /docs/devtools/remote-debugging/webviews/
-- title: i18n.docs.devtools.memory
+- title: i18n.docs.devtools.accessibility
   sections:
-    - url: /docs/devtools/memory-inspector/
-    - url: /docs/devtools/memory-problems/
-    - url: /docs/devtools/memory-problems/memory-101/
-    - url: /docs/devtools/memory-problems/heap-snapshots/
-    - url: /docs/devtools/memory-problems/allocation-profiler/
-- url: /docs/devtools/recorder/
-- url: /docs/devtools/media-panel/
-- url: /docs/devtools/webauthn/
-- url: /docs/devtools/workspaces/
-- url: /docs/devtools/progressive-web-apps/
-- url: /docs/devtools/security/
-- url: /docs/devtools/shortcuts/
-- url: /docs/devtools/resources/
+    - url: /docs/devtools/accessibility/reference/
+    - url: /docs/devtools/accessibility/navigation/
+    - url: /docs/devtools/accessibility/focus/ 
 - title: i18n.docs.devtools.customization
   sections:
     - url: /docs/devtools/customize/
     - url: /docs/devtools/customize/dark-theme/
     - url: /docs/devtools/customize/placement/
+    - url: /docs/devtools/javascript/ignore-chrome-extension-scripts/

--- a/site/_data/docs/devtools/toc.yml
+++ b/site/_data/docs/devtools/toc.yml
@@ -14,7 +14,6 @@
     - url: /docs/devtools/javascript/disable/
     - url: /docs/devtools/shortcuts/
 - url: /docs/devtools/device-mode/
-- description: 'Tools'
 - title: i18n.docs.devtools.elements
   sections:
     - url: /docs/devtools/dom/

--- a/site/_data/i18n/docs/devtools.yml
+++ b/site/_data/i18n/docs/devtools.yml
@@ -26,6 +26,18 @@ accessibility:
 memory:
   en: 'Memory'
 customization:
-  en: 'Customization'
+  en: 'Settings and customization'
 remotedebug:
   en: 'Remote debugging'
+commands_shortcuts:
+  en: 'Commands and shortcuts'
+elements:
+  en: 'Elements'
+sources:
+  en: 'Sources'
+application:
+  en: 'Application'
+lighthouse:
+  en: 'Lighthouse'
+sensors:
+  en: 'Sensors'

--- a/site/en/docs/devtools/coverage/index.md
+++ b/site/en/docs/devtools/coverage/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Find Unused JavaScript And CSS With The Coverage Tab"
+title: "Coverage: Find unused JavaScript and CSS"
 authors:
   - kaycebasques
 date: 2019-07-09

--- a/site/en/docs/devtools/css-overview/index.md
+++ b/site/en/docs/devtools/css-overview/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Identify potential CSS improvements"
+title: "CSS Overview: Identify potential CSS improvements"
 authors:
   - jecelynyeen
 date: 2021-10-21

--- a/site/en/docs/devtools/css/animations/index.md
+++ b/site/en/docs/devtools/css/animations/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Inspect animations"
+title: "Animations: Inspect and modify CSS animation effects"
 authors:
   - kaycebasques
 date: 2016-05-02

--- a/site/en/docs/devtools/css/print-preview/index.md
+++ b/site/en/docs/devtools/css/print-preview/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Force print preview mode"
+title: "Rendering: Force print preview mode"
 authors:
   - kaycebasques
 date: 2018-12-14

--- a/site/en/docs/devtools/customize/index.md
+++ b/site/en/docs/devtools/customize/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Customization"
+title: "Customize"
 authors:
   - kaycebasques
   - jecelynyeen

--- a/site/en/docs/devtools/device-mode/override-user-agent/index.md
+++ b/site/en/docs/devtools/device-mode/override-user-agent/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Override the user agent string"
+title: "Network conditions: Override the user agent string"
 authors:
   - kaycebasques
 date: 2018-12-14

--- a/site/en/docs/devtools/issues/index.md
+++ b/site/en/docs/devtools/issues/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Find and fix problems with the Issues tab"
+title: "Issues: Find and fix problems"
 authors:
   - samdutton
 date: 2020-05-14

--- a/site/en/docs/devtools/media-panel/index.md
+++ b/site/en/docs/devtools/media-panel/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "View and debug media players information"
+title: "Media: View and debug media players information"
 authors:
   - jecelynyeen
 date: 2020-08-20

--- a/site/en/docs/devtools/memory-inspector/index.md
+++ b/site/en/docs/devtools/memory-inspector/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Inspect JavaScript ArrayBuffer with the Memory inspector"
+title: "Memory Inspector: Inspect JavaScript ArrayBuffer"
 authors:
   - jecelynyeen
 date: 2020-08-20

--- a/site/en/docs/devtools/recorder/index.md
+++ b/site/en/docs/devtools/recorder/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Record, replay and measure user flows"
+title: "Recorder: Record, replay and measure user flows"
 authors:
   - jecelynyeen
 date: 2021-11-02

--- a/site/en/docs/devtools/security/index.md
+++ b/site/en/docs/devtools/security/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Understand security issues"
+title: "Security: Understand security issues"
 authors:
   - kaycebasques
 date: 2015-12-21

--- a/site/en/docs/devtools/speed/get-started/index.md
+++ b/site/en/docs/devtools/speed/get-started/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Optimize website speed"
+title: "Lighthouse: Optimize website speed"
 authors:
   - kaycebasques
 date: 2018-06-18

--- a/site/en/docs/devtools/webauthn/index.md
+++ b/site/en/docs/devtools/webauthn/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Emulate authenticators and debug WebAuthn"
+title: "WebAuthn: Emulate authenticators"
 authors:
   - fawazm
   - jecelynyeen


### PR DESCRIPTION
When users open DevTools for the first time, the first question they often ask is "What do all those tabs do"?
Therefore, it makes perfect sense to have reference-style documentation and to structure the table of contents as a list of sections about tools.
