### PR TITLE
Add "Discovery on the Chrome Web Store" document

### DIFF
--- a/site/_data/docs/webstore/toc.yml
+++ b/site/_data/docs/webstore/toc.yml
@@ -30,6 +30,7 @@
     - url: /docs/webstore/cws-dashboard-privacy/
     - url: /docs/webstore/cws-dashboard-distribution/
     - url: /docs/webstore/cws-enterprise/
+- url: /docs/webstore/discovery/
 - title: i18n.docs.webstore.policies
   sections:
     - url: /docs/webstore/terms/

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -16,12 +16,17 @@ updated: 2022-02-17
 Check this page often to learn about changes to the Chrome extensions platform, its documentation,
 and related policy or other changes.
 
+### Docs update: Chrome Web Store item discovery {: #cws-discoevery-doc }
+
+[Discovery on Chrome Web Store](/docs/webstore/discovery/) gives an overview of how users find items
+on the Chrome Web Store and how our editors select items to feature.
+
 ### Chrome 100: native messaging port keeps service worker alive {: #m100-native-msg-lifetime }
 
 February 9, 2022
 
 Connecting to a native messaging host using `chrome.runtime.connectNative()` in an extension's
-service worker will keep the service worker alive as long as the port is open. 
+service worker will keep the service worker alive as long as the port is open.
 
 ### Chrome 100: omnibox.setDefaultSuggestion() supports promises and callbacks {: #m100-omnibox-setdefault }
 

--- a/site/en/docs/webstore/discovery/index.md
+++ b/site/en/docs/webstore/discovery/index.md
@@ -42,7 +42,7 @@ being featured on the homepage is to build a useful, high-quality extension that
 {% Img src="image/WlD8wC6g8khYWPJUsQceQkhXSlv1/iCX0CN92abOKmENf8Co5.png", width="800", height="571",
   class="screenshot", alt="Screenshot of the Chrome Web Store homepage." %}
 
-# Editors' Picks
+## Editors' Picks
 
 Chrome editors handpick items to be featured as Editors' Picks to inspire users and recognize
 exceptional extensions. Editors' Picks items are featured in the Editors' Picks collection on the

--- a/site/en/docs/webstore/discovery/index.md
+++ b/site/en/docs/webstore/discovery/index.md
@@ -39,7 +39,7 @@ but there is no set checklist developers can follow to guarantee being featured.
 pay to be featured on the homepage. The best thing a developer can do to increase their chances of
 being featured on the homepage is to build a useful, high-quality extension that is a joy to use.
 
-{% Img src="image/WlD8wC6g8khYWPJUsQceQkhXSlv1/iCX0CN92abOKmENf8Co5.png", width="800", height="571",
+{% Img src="image/WlD8wC6g8khYWPJUsQceQkhXSlv1/O4HjVbAcyIvYCxmCRB9H.png", width="800", height="571",
   class="screenshot", alt="Screenshot of the Chrome Web Store homepage." %}
 
 ## Editors' Picks {: #editors-picks }

--- a/site/en/docs/webstore/discovery/index.md
+++ b/site/en/docs/webstore/discovery/index.md
@@ -9,24 +9,24 @@ description: >
 ---
 
 We strive to make it easy for users to discover great items on the Chrome Web Store. A positive
-discovery experience means making it simple for our users to find the items they know and love, as
+discovery experience means making it simple for users to find the items they know and love, as
 well as new and undiscovered items. From browsing the homepage to searching by title, we want users
 to find the best item to fit their needs. Learn more about discovery on the Chrome Web Store below.
 
 ## Search {: #search }
 
-Chrome Web Store search is a key tool for users to find relevant and popular items. When users
+Chrome Web Store search is a key tool for helping users find relevant and popular items. When users
 search for an item, search returns a list of items that are ranked based on a number of criteria,
 including metadata from your item's listing page. Making sure that your store listing page is
-complete, accurate and optimized is important to ensuring your item is discoverable through search.
+complete, accurate, and optimized is important to ensuring your item is discoverable through search.
 Learn more about [crafting a great listing page][best-listing].
 
 ## Categories {: #categories }
 
 Categories on the Chrome Web Store organize items based on their main function. Users can browse
-category pages, like Shopping, Productivity or Fun, to find relevant items to install. Developers
-select a category for their item in the Developer Dashboard, which determines which category it will
-appear under in the store. Categories are only available for extensions at this time.
+category pages, like Shopping, Productivity, or Fun, to find relevant items to install. To determine
+which category an item will appear under, developers can select one on the Developer Dashboard.
+Categories are only available for extensions at this time.
 
 ## Extensions Homepage {: #homepage }
 
@@ -37,15 +37,15 @@ of factors including performance, design, usefulness, relevancy and breadth of a
 featured on the homepage must follow our general [best practices][best-practices] to be considered,
 but there is no set checklist developers can follow to guarantee being featured. Developers cannot
 pay to be featured on the homepage. The best thing a developer can do to increase their chances of
-being featured on the homepage is to build a useful, high-quality extension that is a joy to use.
+being featured on the home page is to build a useful, high-quality extension that is a joy to use.
 
 {% Img src="image/WlD8wC6g8khYWPJUsQceQkhXSlv1/O4HjVbAcyIvYCxmCRB9H.png", width="800", height="571",
-  class="screenshot", alt="Screenshot of the Chrome Web Store homepage." %}
+  class="screenshot", alt="Screenshot of the Chrome Web Store home page." %}
 
 ## Editors' Picks {: #editors-picks }
 
-Chrome editors handpick items to be featured as Editors' Picks to inspire users and recognize
-exceptional extensions. Editors' Picks items are featured in the Editors' Picks collection on the
+Chrome editors hand pick items to be featured as Editors' Picks to inspire users and recognize
+exceptional extensions. Editors' Picks are featured in the Editors' Picks collection on the
 homepage. We look for high-quality items that offer consistent, best-in-class experiences to users.
 Like the homepage, items chosen for Editors' Picks must follow our general [best
 practices][best-practices] to be considered, but there is no set checklist of requirements to

--- a/site/en/docs/webstore/discovery/index.md
+++ b/site/en/docs/webstore/discovery/index.md
@@ -39,8 +39,8 @@ but there is no set checklist developers can follow to guarantee being featured.
 pay to be featured on the homepage. The best thing a developer can do to increase their chances of
 being featured on the homepage is to build a useful, high-quality extension that is a joy to use.
 
-<!-- { % Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/pgzFlq6rxiKFQ5NjYlBi.svg", alt="Diagram of group
-publishing process", width="800", height="395" % } -->
+{% Img src="image/WlD8wC6g8khYWPJUsQceQkhXSlv1/iCX0CN92abOKmENf8Co5.png", width="800", height="571",
+  class="screenshot", alt="Screenshot of the Chrome Web Store homepage." %}
 
 # Editors' Picks
 

--- a/site/en/docs/webstore/discovery/index.md
+++ b/site/en/docs/webstore/discovery/index.md
@@ -1,0 +1,55 @@
+---
+layout: "layouts/doc-post.njk"
+title: Discovery on the Chrome Web Store
+date: 2022-03-21
+#updated: 2022-03-21
+description: >
+  An overview of how users find items on the Chrome Web Store, and how our editors select items to
+  feature.
+---
+
+We strive to make it easy for users to discover great items on the Chrome Web Store. A positive
+discovery experience means making it simple for our users to find the items they know and love, as
+well as new and undiscovered items. From browsing the homepage to searching by title, we want users
+to find the best item to fit their needs. Learn more about discovery on the Chrome Web Store below.
+
+## Search
+
+Chrome Web Store search is a key tool for users to find relevant and popular items. When users
+search for an item, search returns a list of items that are ranked based on a number of criteria,
+including metadata from your item's listing page. Making sure that your store listing page is
+complete, accurate and optimized is important to ensuring your item is discoverable through search.
+Learn more about [crafting a great listing page][best-listing].
+
+## Categories
+
+Categories on the Chrome Web Store organize items based on their main function. Users can browse
+category pages, like Shopping, Productivity or Fun, to find relevant items to install. Developers
+select a category for their item in the Developer Dashboard, which determines which category it will
+appear under in the store. Categories are only available for extensions at this time.
+
+## Extensions Homepage
+
+The homepage is where we highlight great extensions and themes that we think users will love. Users
+come to this page to find new and interesting items recommended by our editors. Chrome editors
+curate items to be featured in merchandised collections and the rotating marquee based on a variety
+of factors including performance, design, usefulness, relevancy and breadth of appeal. Items
+featured on the homepage must follow our general [best practices][best-practices] to be considered,
+but there is no set checklist developers can follow to guarantee being featured. Developers cannot
+pay to be featured on the homepage. The best thing a developer can do to increase their chances of
+being featured on the homepage is to build a useful, high-quality extension that is a joy to use.
+
+<!-- { % Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/pgzFlq6rxiKFQ5NjYlBi.svg", alt="Diagram of group
+publishing process", width="800", height="395" % } -->
+
+# Editors' Picks
+
+Chrome editors handpick items to be featured as Editors' Picks to inspire users and recognize
+exceptional extensions. Editors' Picks items are featured in the Editors' Picks collection on the
+homepage. We look for high-quality items that offer consistent, best-in-class experiences to users.
+Like the homepage, items chosen for Editors' Picks must follow our general [best
+practices][best-practices] to be considered, but there is no set checklist of requirements to
+guarantee being featured. Developers cannot pay to be featured as an Editors' Pick.
+
+[best-practices]: https://developer.chrome.com/docs/webstore/best_practices/
+[best-listing]: https://developer.chrome.com/docs/webstore/best_listing/

--- a/site/en/docs/webstore/discovery/index.md
+++ b/site/en/docs/webstore/discovery/index.md
@@ -13,7 +13,7 @@ discovery experience means making it simple for our users to find the items they
 well as new and undiscovered items. From browsing the homepage to searching by title, we want users
 to find the best item to fit their needs. Learn more about discovery on the Chrome Web Store below.
 
-## Search
+## Search {: #search }
 
 Chrome Web Store search is a key tool for users to find relevant and popular items. When users
 search for an item, search returns a list of items that are ranked based on a number of criteria,
@@ -21,14 +21,14 @@ including metadata from your item's listing page. Making sure that your store li
 complete, accurate and optimized is important to ensuring your item is discoverable through search.
 Learn more about [crafting a great listing page][best-listing].
 
-## Categories
+## Categories {: #categories }
 
 Categories on the Chrome Web Store organize items based on their main function. Users can browse
 category pages, like Shopping, Productivity or Fun, to find relevant items to install. Developers
 select a category for their item in the Developer Dashboard, which determines which category it will
 appear under in the store. Categories are only available for extensions at this time.
 
-## Extensions Homepage
+## Extensions Homepage {: #homepage }
 
 The homepage is where we highlight great extensions and themes that we think users will love. Users
 come to this page to find new and interesting items recommended by our editors. Chrome editors
@@ -42,7 +42,7 @@ being featured on the homepage is to build a useful, high-quality extension that
 {% Img src="image/WlD8wC6g8khYWPJUsQceQkhXSlv1/iCX0CN92abOKmENf8Co5.png", width="800", height="571",
   class="screenshot", alt="Screenshot of the Chrome Web Store homepage." %}
 
-## Editors' Picks
+## Editors' Picks {: #editors-picks }
 
 Chrome editors handpick items to be featured as Editors' Picks to inspire users and recognize
 exceptional extensions. Editors' Picks items are featured in the Editors' Picks collection on the

--- a/site/en/docs/webstore/discovery/index.md
+++ b/site/en/docs/webstore/discovery/index.md
@@ -9,9 +9,9 @@ description: >
 ---
 
 We strive to make it easy for users to discover great items on the Chrome Web Store. A positive
-discovery experience means making it simple for users to find the items they know and love, as
-well as new and undiscovered items. From browsing the homepage to searching by title, we want users
-to find the best item to fit their needs. Learn more about discovery on the Chrome Web Store below.
+discovery experience means making it simple for users to find the items they know and love, as well
+as new and undiscovered items. From browsing the home page to searching by title, we want users to
+find the best item to fit their needs. Learn more about discovery on the Chrome Web Store below.
 
 ## Search {: #search }
 
@@ -28,15 +28,15 @@ category pages, like Shopping, Productivity, or Fun, to find relevant items to i
 which category an item will appear under, developers can select one on the Developer Dashboard.
 Categories are only available for extensions at this time.
 
-## Extensions Homepage {: #homepage }
+## Extensions home page {: #home-page }
 
-The homepage is where we highlight great extensions and themes that we think users will love. Users
+The home page is where we highlight great extensions and themes that we think users will love. Users
 come to this page to find new and interesting items recommended by our editors. Chrome editors
 curate items to be featured in merchandised collections and the rotating marquee based on a variety
 of factors including performance, design, usefulness, relevancy and breadth of appeal. Items
-featured on the homepage must follow our general [best practices][best-practices] to be considered,
+featured on the home page must follow our general [best practices][best-practices] to be considered,
 but there is no set checklist developers can follow to guarantee being featured. Developers cannot
-pay to be featured on the homepage. The best thing a developer can do to increase their chances of
+pay to be featured on the home page. The best thing a developer can do to increase their chances of
 being featured on the home page is to build a useful, high-quality extension that is a joy to use.
 
 {% Img src="image/WlD8wC6g8khYWPJUsQceQkhXSlv1/O4HjVbAcyIvYCxmCRB9H.png", width="800", height="571",
@@ -45,9 +45,9 @@ being featured on the home page is to build a useful, high-quality extension tha
 ## Editors' Picks {: #editors-picks }
 
 Chrome editors hand pick items to be featured as Editors' Picks to inspire users and recognize
-exceptional extensions. Editors' Picks are featured in the Editors' Picks collection on the
-homepage. We look for high-quality items that offer consistent, best-in-class experiences to users.
-Like the homepage, items chosen for Editors' Picks must follow our general [best
+exceptional extensions. Editors' Picks are featured in the Editors' Picks collection on the home
+page. We look for high-quality items that offer consistent, best-in-class experiences to users. Like
+the home page, items chosen for Editors' Picks must follow our general [best
 practices][best-practices] to be considered, but there is no set checklist of requirements to
 guarantee being featured. Developers cannot pay to be featured as an Editors' Pick.
 


### PR DESCRIPTION
This document provides a high level overview of the discovery tools available to extension developers when publishing to the Chrome Web Store.

- [Discovery on the Chrome Web Store](https://deploy-preview-2399--developer-chrome-com.netlify.app/docs/webstore/discovery/)
- [Webstore index](https://deploy-preview-2399--developer-chrome-com.netlify.app/docs/webstore/)