### PR TITLE
Increase node heap size in deploy builds

### DIFF
--- a/.cloudbuild/deploy.yaml
+++ b/.cloudbuild/deploy.yaml
@@ -11,6 +11,8 @@ steps:
   - name: node
     entrypoint: npm
     args: ['run', 'production']
+    env:
+      - 'NODE_OPTIONS="--max_old_space_size=4096"' # https://github.com/GoogleChrome/developer.chrome.com/issues/2439
 
   - name: node
     entrypoint: npm
@@ -19,18 +21,18 @@ steps:
   - name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'bash'
     args:
-    - '-c'
-    - |
-      # This snippet lets us pass additional args via the Cloud Build console
-      # in the _EXTRA_GCLOUD_ARGS var.
-      # nb. We don't have to specify --project; it's part of the environment.
-      gcloud app deploy ${_EXTRA_GCLOUD_ARGS}
+      - '-c'
+      - |
+        # This snippet lets us pass additional args via the Cloud Build console
+        # in the _EXTRA_GCLOUD_ARGS var.
+        # nb. We don't have to specify --project; it's part of the environment.
+        gcloud app deploy ${_EXTRA_GCLOUD_ARGS}
 
 substitutions:
-  _EXTRA_GCLOUD_ARGS:  # default empty
+  _EXTRA_GCLOUD_ARGS: # default empty
 
 options:
-  machineType: 'E2_HIGHCPU_8'  # yolo
+  machineType: 'E2_HIGHCPU_8' # yolo
   env:
-  - 'NODE_OPTIONS=--unhandled-rejections=strict'
-  - 'PROJECT_ID=$PROJECT_ID'
+    - 'NODE_OPTIONS=--unhandled-rejections=strict'
+    - 'PROJECT_ID=$PROJECT_ID'


### PR DESCRIPTION
R: @devnook 

This is related to #2439, but does not address the long-term issue.

Our web.dev production build uses [8gb of heap size](https://github.com/GoogleChrome/web.dev/blob/9a197fd63a3c87249eb5145736ba35f291b58ccd/.cloudbuild/deploy.yaml#L23), but we also have it configured to [use `E2_HIGHCPU_32`](https://github.com/GoogleChrome/web.dev/blob/9a197fd63a3c87249eb5145736ba35f291b58ccd/.cloudbuild/deploy.yaml#L35).

I'm guessing we can't safely configure more than 4gb of explicit heap size if our current configuration for d.c.c. is `E2_HIGHCPU_8` (i.e. and 8gb machine). I'm not sure what the implication would be if we switched over to `E2_HIGHCPU_32` in this PR, and the `# yolo` comment for the current VM configuration doesn't give me a huge amount of confidence...