### PR TITLE
Documented @support and properties on hover

### DIFF
--- a/site/en/docs/devtools/css/reference/index.md
+++ b/site/en/docs/devtools/css/reference/index.md
@@ -4,6 +4,7 @@ title: "CSS features reference"
 authors:
   - kaycebasques
   - jecelynyeen
+  - sofiayem
 date: 2017-06-09
 #updated: YYYY-MM-DD
 description: "Discover new workflows for viewing and changing CSS in Chrome DevTools."

--- a/site/en/docs/devtools/css/reference/index.md
+++ b/site/en/docs/devtools/css/reference/index.md
@@ -87,6 +87,39 @@ Use the **Computed** tab. See [View only the CSS that's actually applied to an e
 Check the **Show All** checkbox in the **Computed** tab. See [View only the CSS that's actually
 applied to an element][6].
 
+### View `@supports` at-rules {: #supports }
+
+The **Styles** tab shows you the `@supports` CSS at-rules if they are applied to an element. For example, inspect the following element:
+
+<div class="box"></div>
+<style>
+  .box {
+  width: 300px;
+  height: 30px;
+  text-align: center;
+}
+@supports (background: lab(0% 0 0)) {
+  .box {
+    background: lab(90% -44 55);
+  }
+  .box::after { content: "I support CIELAB color space!" }
+}
+@supports not (background: lab(0% 0 0)) {
+  .box {
+    background:#c9b1d6;
+  }
+  .box::after { content: "I don\'t support CIELAB color space :(" }
+}
+</style>
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Lw1ZveiO2lxVFDgylmnC.png", alt="View @supports at-rules", width="800", height="453" %}
+
+If your browser supports the `lab()` function, the element is green, otherwise it's purple.
+
+{% Aside %}
+**Note**: At the time of writing, only Safari [supports the CIELAB color space](https://caniuse.com/?search=lab).
+{% endAside %}
+
 ### View an element's box model {: #box-model }
 
 To view [the box model][7] of an element, go to the **Styles** tab. If your DevTools window is

--- a/site/en/docs/devtools/javascript/reference/index.md
+++ b/site/en/docs/devtools/javascript/reference/index.md
@@ -23,6 +23,12 @@ Set a breakpoint so that you can pause your code in the middle of its execution.
 
 See [Pause Your Code With Breakpoints][2] to learn how to set breakpoints.
 
+### Preview class/function properties on hover {: #properties }
+
+While the execution is paused, hover over a class or function name to preview its properties.
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/wP0xZMDPcIGvz5xE8PAF.png", alt="Preview class/function properties on hover", width="800", height="629" %}
+
 ## Step through code {: #stepping }
 
 Once your code is paused, step through it, one line at a time, investigating control flow and


### PR DESCRIPTION
Documented:

- Elements > Styles > @supports at-rules: https://developer.chrome.com/blog/new-in-devtools-100/#supports
- Sources > debug > preview class/func properties on hover: https://developer.chrome.com/blog/new-in-devtools-100/#properties

Don't merge until Mar 29, the 100 stable release date.

