### PR TITLE
Add heart-like functionality (to test post)

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -1,0 +1,14 @@
+{
+  "rules": {
+    "dcc-likes": {
+      "$item": {
+        "likesCount": {
+           ".read": "true",
+           ".write": "true",
+           ".validate": "newData.isNumber() && newData.val() >= 0"
+        },
+        "$other": { ".validate": false }
+      }
+    }
+  }
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,7 +14,11 @@ import {terser} from 'rollup-plugin-terser';
 import copy from 'rollup-plugin-copy';
 
 const devConfig = {
-  input: 'site/_js/main.js',
+  input: [
+    'site/_js/main.js',
+    // Scripts used on /100 page
+    'site/_js/100.js',
+  ],
   output: {
     dir: 'dist/js',
     format: 'esm',
@@ -36,7 +40,7 @@ const devConfig = {
 };
 
 const productionConfig = {
-  input: 'site/_js/main.js',
+  input: ['site/_js/main.js', 'site/_js/100.js'],
   output: {
     dir: 'dist/js',
     format: 'esm',

--- a/server/index.js
+++ b/server/index.js
@@ -47,7 +47,7 @@ const cspHandler = (_req, res, next) => {
   res.setHeader(
     'Content-Security-Policy-Report-Only',
     "object-src 'none'; " +
-      "script-src 'self' 'unsafe-inline' https://www.google-analytics.com https://cdnjs.cloudflare.com https://www.gstatic.com; " +
+      "script-src 'self' 'unsafe-inline' https://www.google-analytics.com https://www.gstatic.com; " +
       "base-uri 'none'; " +
       "frame-ancestors 'self'; " +
       'report-uri https://csp.withgoogle.com/csp/chrome-apps-doc'

--- a/server/index.js
+++ b/server/index.js
@@ -47,7 +47,7 @@ const cspHandler = (_req, res, next) => {
   res.setHeader(
     'Content-Security-Policy-Report-Only',
     "object-src 'none'; " +
-      "script-src 'self' 'unsafe-inline' https://www.google-analytics.com https://www.gstatic.com; " +
+      "script-src 'self' 'unsafe-inline' https://www.google-analytics.com https://www.gstatic.com https://www.google.com;" +
       "base-uri 'none'; " +
       "frame-ancestors 'self'; " +
       'report-uri https://csp.withgoogle.com/csp/chrome-apps-doc'

--- a/server/index.js
+++ b/server/index.js
@@ -47,7 +47,7 @@ const cspHandler = (_req, res, next) => {
   res.setHeader(
     'Content-Security-Policy-Report-Only',
     "object-src 'none'; " +
-      "script-src 'self' 'unsafe-inline' https://www.google-analytics.com; " +
+      "script-src 'self' 'unsafe-inline' https://www.google-analytics.com https://cdnjs.cloudflare.com https://www.gstatic.com; " +
       "base-uri 'none'; " +
       "frame-ancestors 'self'; " +
       'report-uri https://csp.withgoogle.com/csp/chrome-apps-doc'

--- a/site/_js/100.js
+++ b/site/_js/100.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// These are components that appear on /100 page.
+import './web-components/like-icon';

--- a/site/_js/web-components/like-icon.js
+++ b/site/_js/web-components/like-icon.js
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview A component for displaying a "like" icon. Persist the likes
+ * to the LocalStorage and to Firebase Datastore.
+ */
+import {BaseElement} from './base-element';
+import {html} from 'lit-element';
+
+/* eslint-disable node/no-missing-import */
+// @ts-ignore
+import {initializeApp} from 'https://www.gstatic.com/firebasejs/9.6.10/firebase-app.js';
+import {
+  getDatabase,
+  connectDatabaseEmulator,
+  ref,
+  set,
+  onValue,
+  // @ts-ignore
+} from 'https://www.gstatic.com/firebasejs/9.6.10/firebase-database.js';
+
+// Local emulator configuration
+const config = {
+  projectId: 'devnook-playground-1b315',
+};
+const storagePrefix = 'dcc-like-icon';
+
+export class LikeIcon extends BaseElement {
+  static get properties() {
+    return {
+      item: {type: String, reflect: true},
+      likes: {type: Number},
+      liked: {type: Boolean},
+    };
+  }
+
+  constructor() {
+    super();
+    this.item = '';
+    this.itemId = '';
+    this.onClick = this.onClick.bind(this);
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.addEventListener('click', this.onClick);
+
+    this.itemId = `${storagePrefix}-${this.item}`;
+
+    // Read like status from local storage
+    const item = localStorage.getItem(this.itemId);
+    this.liked = item === 'true';
+
+    // Read likes from Firebase DB
+    const app = initializeApp(config);
+    this.db = getDatabase(app);
+    if (location.hostname === 'localhost') {
+      // Point to the DB emulator running on localhost
+      connectDatabaseEmulator(this.db, 'localhost', 9000);
+    }
+    this.likesRef = ref(this.db, 'dcc-likes/' + this.itemId + '/likesCount');
+    this.unsubscribe = onValue(this.likesRef, snapshot => {
+      const data = snapshot.val();
+      if (!data) {
+        set(this.likesRef, 0);
+      }
+      this.likes = data ? data : 0;
+    });
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.removeEventListener('click', this.onClick);
+    this.unsubscribe();
+  }
+
+  onClick(e) {
+    e.preventDefault();
+
+    // Save to local storage.
+    this.liked = !this.liked;
+    localStorage.setItem(this.itemId, this.liked);
+
+    // Save to store.
+    const likes = this.liked ? this.likes + 1 : this.likes - 1;
+    set(this.likesRef, Math.max(likes, 0));
+  }
+
+  render() {
+    // prettier-ignore
+    return html`<a href="#"
+        class="ga-event"
+        data-ga-label="${this.itemId}"
+        data-ga-category="action"
+        data-ga-action="dcc-like"
+        data-liked="${this.liked}"
+      >
+        <svg width="20" height="19" viewBox="0 0 20 19" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M8.88659 16.6603L8.88587 16.6596C6.30081 14.3155 4.19567 12.4057 2.73078 10.6147C1.27162 8.83074 0.5 7.22576 0.5 5.5C0.5 2.69614 2.69614 0.5 5.5 0.5C7.08861 0.5 8.62112 1.24197 9.61932 2.41417L10 2.8612L10.3807 2.41417C11.3789 1.24197 12.9114 0.5 14.5 0.5C17.3039 0.5 19.5 2.69614 19.5 5.5C19.5 7.22577 18.7284 8.83077 17.2691 10.6161C15.8065 12.4055 13.7058 14.3144 11.1265 16.6584L11.1148 16.669L11.1137 16.67L10.0013 17.675L8.88659 16.6603Z" stroke="currentColor" class="fill-like">
+        </svg> ${this.likes}
+      </a>
+    `;
+  }
+}
+customElements.define('like-icon', LikeIcon);

--- a/site/_js/web-components/like-icon.js
+++ b/site/_js/web-components/like-icon.js
@@ -33,11 +33,16 @@ import {
   increment,
   // @ts-ignore
 } from 'https://www.gstatic.com/firebasejs/9.6.10/firebase-database.js';
+// @ts-ignore
+import { initializeAppCheck, ReCaptchaV3Provider } from 'https://www.gstatic.com/firebasejs/9.6.10/firebase-app-check.js';
 
 // Local emulator configuration
 const config = {
-  projectId: 'devnook-playground-1b315',
+  apiKey: "AIzaSyBO19CVJtI2lRZQWCjfv3FnGqStHvP4xwU",
+  projectId: "devnook-playground-1b315",
+  appId: "1:353904485142:web:1af58ee02b74215c29a637"
 };
+const recaptchaPublicKey = '6LdDPCMfAAAAACPU7H4hn1uaV3_i9vkfIIIhX4LS';
 const storagePrefix = 'dcc-like-icon';
 
 export class LikeIcon extends BaseElement {
@@ -72,6 +77,12 @@ export class LikeIcon extends BaseElement {
     if (location.hostname === 'localhost') {
       // Point to the DB emulator running on localhost
       connectDatabaseEmulator(db, 'localhost', 9000);
+    } else {
+      // App check does not work against emulator.
+      initializeAppCheck(app, {
+        provider: new ReCaptchaV3Provider(recaptchaPublicKey),
+        isTokenAutoRefreshEnabled: true
+      });
     }
     this.likesRef = ref(db, 'dcc-likes/' + this.itemId + '/likesCount');
     this.unsubscribe = onValue(this.likesRef, snapshot => {

--- a/site/_js/web-components/like-icon.js
+++ b/site/_js/web-components/like-icon.js
@@ -33,14 +33,17 @@ import {
   increment,
   // @ts-ignore
 } from 'https://www.gstatic.com/firebasejs/9.6.10/firebase-database.js';
-// @ts-ignore
-import { initializeAppCheck, ReCaptchaV3Provider } from 'https://www.gstatic.com/firebasejs/9.6.10/firebase-app-check.js';
+import {
+  initializeAppCheck,
+  ReCaptchaV3Provider,
+  // @ts-ignore
+} from 'https://www.gstatic.com/firebasejs/9.6.10/firebase-app-check.js';
 
 // Local emulator configuration
 const config = {
-  apiKey: "AIzaSyBO19CVJtI2lRZQWCjfv3FnGqStHvP4xwU",
-  projectId: "devnook-playground-1b315",
-  appId: "1:353904485142:web:1af58ee02b74215c29a637"
+  apiKey: 'AIzaSyBO19CVJtI2lRZQWCjfv3FnGqStHvP4xwU',
+  projectId: 'devnook-playground-1b315',
+  appId: '1:353904485142:web:1af58ee02b74215c29a637',
 };
 const recaptchaPublicKey = '6LdDPCMfAAAAACPU7H4hn1uaV3_i9vkfIIIhX4LS';
 const storagePrefix = 'dcc-like-icon';
@@ -81,7 +84,7 @@ export class LikeIcon extends BaseElement {
       // App check does not work against emulator.
       initializeAppCheck(app, {
         provider: new ReCaptchaV3Provider(recaptchaPublicKey),
-        isTokenAutoRefreshEnabled: true
+        isTokenAutoRefreshEnabled: true,
       });
     }
     this.likesRef = ref(db, 'dcc-likes/' + this.itemId + '/likesCount');

--- a/site/_js/web-components/like-icon.js
+++ b/site/_js/web-components/like-icon.js
@@ -30,6 +30,7 @@ import {
   ref,
   set,
   onValue,
+  increment,
   // @ts-ignore
 } from 'https://www.gstatic.com/firebasejs/9.6.10/firebase-database.js';
 
@@ -96,8 +97,8 @@ export class LikeIcon extends BaseElement {
     localStorage.setItem(this.itemId, this.liked);
 
     // Save to store.
-    const likes = this.liked ? this.likes + 1 : this.likes - 1;
-    set(this.likesRef, Math.max(likes, 0));
+    const delta = this.liked ? 1 : -1;
+    set(this.likesRef, increment(delta));
   }
 
   render() {

--- a/site/_js/web-components/like-icon.js
+++ b/site/_js/web-components/like-icon.js
@@ -48,6 +48,19 @@ const config = {
 const recaptchaPublicKey = '6LdDPCMfAAAAACPU7H4hn1uaV3_i9vkfIIIhX4LS';
 const storagePrefix = 'dcc-like-icon';
 
+const app = initializeApp(config);
+const db = getDatabase(app);
+if (location.hostname === 'localhost') {
+  // Point to the DB emulator running on localhost
+  connectDatabaseEmulator(db, 'localhost', 9000);
+} else {
+  // App check does not work against emulator.
+  initializeAppCheck(app, {
+    provider: new ReCaptchaV3Provider(recaptchaPublicKey),
+    isTokenAutoRefreshEnabled: true,
+  });
+}
+
 export class LikeIcon extends BaseElement {
   static get properties() {
     return {
@@ -75,18 +88,6 @@ export class LikeIcon extends BaseElement {
     this.liked = item === 'true';
 
     // Read likes from Firebase DB
-    const app = initializeApp(config);
-    const db = getDatabase(app);
-    if (location.hostname === 'localhost') {
-      // Point to the DB emulator running on localhost
-      connectDatabaseEmulator(db, 'localhost', 9000);
-    } else {
-      // App check does not work against emulator.
-      initializeAppCheck(app, {
-        provider: new ReCaptchaV3Provider(recaptchaPublicKey),
-        isTokenAutoRefreshEnabled: true,
-      });
-    }
     this.likesRef = ref(db, 'dcc-likes/' + this.itemId + '/likesCount');
     this.unsubscribe = onValue(this.likesRef, snapshot => {
       const data = snapshot.val();

--- a/site/_js/web-components/like-icon.js
+++ b/site/_js/web-components/like-icon.js
@@ -67,12 +67,12 @@ export class LikeIcon extends BaseElement {
 
     // Read likes from Firebase DB
     const app = initializeApp(config);
-    this.db = getDatabase(app);
+    const db = getDatabase(app);
     if (location.hostname === 'localhost') {
       // Point to the DB emulator running on localhost
-      connectDatabaseEmulator(this.db, 'localhost', 9000);
+      connectDatabaseEmulator(db, 'localhost', 9000);
     }
-    this.likesRef = ref(this.db, 'dcc-likes/' + this.itemId + '/likesCount');
+    this.likesRef = ref(db, 'dcc-likes/' + this.itemId + '/likesCount');
     this.unsubscribe = onValue(this.likesRef, snapshot => {
       const data = snapshot.val();
       if (!data) {

--- a/site/_scss/blocks/like-icon.scss
+++ b/site/_scss/blocks/like-icon.scss
@@ -1,0 +1,29 @@
+like-icon {
+  height: 20px;
+  width: 60px;
+
+  a {
+    text-decoration: none;
+  }
+
+  a:hover,
+  a:active,
+  a:visited {
+    color: #000;
+  }
+
+  svg,
+  [data-liked='false'] svg {
+    color: #000;
+    fill: none;
+    height: 20px;
+    margin-top: -3px;
+    vertical-align: middle;
+    width: 20px;
+  }
+
+  [data-liked='true'] svg {
+    color: #fff;
+    fill: #f00;
+  }
+}

--- a/site/_scss/main.scss
+++ b/site/_scss/main.scss
@@ -18,6 +18,7 @@
 @import 'blocks/button';
 @import 'blocks/banner';
 @import 'blocks/icon';
+@import 'blocks/like-icon';
 @import 'blocks/table';
 @import 'blocks/code';
 @import 'blocks/scaffold';

--- a/site/en/docs/handbook/test-post/index.md
+++ b/site/en/docs/handbook/test-post/index.md
@@ -66,7 +66,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin dictum a massa
 sit amet ullamcorper. Suspendisse auctor ultrices ante, nec tempus nibh varius
 at. Cras ligula lacus, porta vitae maximus a, ultrices a mauris. Vestibulum
 
-<like-icon item='aaaa'></like-icon>
+<like-icon item='some-id'></like-icon>
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin dictum a massa
 sit amet ullamcorper. Suspendisse auctor ultrices ante, nec tempus nibh varius

--- a/site/en/docs/handbook/test-post/index.md
+++ b/site/en/docs/handbook/test-post/index.md
@@ -68,6 +68,8 @@ at. Cras ligula lacus, porta vitae maximus a, ultrices a mauris. Vestibulum
 
 <like-icon item='some-id'></like-icon>
 
+<like-icon item='some-other-id'></like-icon>
+
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin dictum a massa
 sit amet ullamcorper. Suspendisse auctor ultrices ante, nec tempus nibh varius
 at. Cras ligula lacus, porta vitae maximus a, ultrices a mauris. Vestibulum

--- a/site/en/docs/handbook/test-post/index.md
+++ b/site/en/docs/handbook/test-post/index.md
@@ -58,7 +58,15 @@ alt: A description of the hero image for screen reader users.
 tags:
   - privacy
   - security
+pageScripts:
+  - /js/100.js
 ---
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin dictum a massa
+sit amet ullamcorper. Suspendisse auctor ultrices ante, nec tempus nibh varius
+at. Cras ligula lacus, porta vitae maximus a, ultrices a mauris. Vestibulum
+
+<like-icon item='aaaa'></like-icon>
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin dictum a massa
 sit amet ullamcorper. Suspendisse auctor ultrices ante, nec tempus nibh varius


### PR DESCRIPTION
Local url to test: http://localhost:8080/docs/handbook/test-post/
Assumes local firebase emulator running on port 9000 `firebase emulators:start --only database`

Usage:

```
<like-icon item='some-item-id'></like-icon>
```

The likes are stored with REaltime Database, because it looks like firestore has a limit of the frequency of udates (around 1 update per second without the use of shards, which might be too low for our use case)