### PR TITLE
Tweak the footer of Chrome 100 page

### DIFF
--- a/site/_includes/partials/chrome-100-footer-section.njk
+++ b/site/_includes/partials/chrome-100-footer-section.njk
@@ -9,7 +9,7 @@
     <p class="footer-info">On 29 March 2022, Chrome launched its 100th release. Since our first iteration in 2008, our goal has been to improve the experience for our users and help developers build amazing things. We've grown together with the needs of the platform and its ecosystem. And it's been quite a ride.</p>
     <p class="footer-info">If there's anything we've missed or you'd like fixed, tweet us <a href="https://twitter.com/ChromiumDev" target="_blank" rel="noreferrer noopener">@Chromiumdev</a> with #100CoolWebMoments and we'll try to address it.
     </p>
-    <p class="gap-top-300"><i>Acknowledgements</i>: Inspired by <a href="https://thehistoryoftheweb.com/" target="_blank" rel="noopener noreferrer">The History of the Web</a> by <a href="https://twitter.com/jay_hoffmann/" target="_blank" rel="noopener noreferrer">Jay Hoffman</a>.</p>
+    <p class="gap-top-300">Inspired by <a href="https://thehistoryoftheweb.com/" target="_blank" rel="noopener noreferrer">The History of the Web</a> by <a href="https://twitter.com/jay_hoffmann/" target="_blank" rel="noopener noreferrer">Jay Hoffman</a>.</p>
 
   </div>
   <div class="display-flex justify-content-center gap-top-400">


### PR DESCRIPTION
This removes the word _Acknowledgements_ from the https://developer.chrome.com/100/ footer.