### PR TITLE
fix WebKit casing in the Chrome 100 page

### DIFF
--- a/site/_includes/partials/chrome-100-card-section.njk
+++ b/site/_includes/partials/chrome-100-card-section.njk
@@ -213,7 +213,7 @@
                 {% Img src="image/x1Los57vDga6OEMNi1dIJwZ0qvp2/dh8CuKvNIfkb8Bz00Th4.svg", alt="Arrow", class="right-arrow", width="16", height="12" %}
               </a>
             </div>
-            <p class="card-description">Open-source and built upon Webkit's Inspector.</p>
+            <p class="card-description">Open-source and built upon WebKit's Inspector.</p>
             <div class="display-flex gap-top-200 logos">
               {% Img src="image/x1Los57vDga6OEMNi1dIJwZ0qvp2/2SWyoN1Cflu2i9ds1fan.svg", alt="Celebration tag", class="tags gap-top-100", width="119", height="15" %}
               <like-icon item="100-card-9"></like-icon>
@@ -1608,7 +1608,7 @@
         <div class="card gap-bottom-300">
           <div class="card-info card-top">
             <div class="arrow-wrapper">
-              <a href="https://webkit.org/blog/12257/the-file-system-access-api-with-origin-private-file-system/" target="_blank" rel="noopener noreferrer" class="card-heading ga-event" data-ga-event="click" data-ga-category="card heading" data-ga-label="File System API Webkit support" aria-label="File System API Webkit support">File System API Webkit support
+              <a href="https://webkit.org/blog/12257/the-file-system-access-api-with-origin-private-file-system/" target="_blank" rel="noopener noreferrer" class="card-heading ga-event" data-ga-event="click" data-ga-category="card heading" data-ga-label="File System API WebKit support" aria-label="File System API WebKit support">File System API WebKit support
                 {% Img src="image/x1Los57vDga6OEMNi1dIJwZ0qvp2/dh8CuKvNIfkb8Bz00Th4.svg", alt="Arrow", class="right-arrow", width="16", height="12" %}
               </a>
             </div>


### PR DESCRIPTION
Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- replace "Webkit" with "WebKit" in https://developer.chrome.com/100/ , just like #2471 does to "GitHub"