### PR TITLE
[Chrome 100] Fixes wording in "PWAs on desktop OS" item

### DIFF
--- a/site/_includes/partials/chrome-100-card-section.njk
+++ b/site/_includes/partials/chrome-100-card-section.njk
@@ -1262,7 +1262,7 @@
                 {% Img src="image/x1Los57vDga6OEMNi1dIJwZ0qvp2/dh8CuKvNIfkb8Bz00Th4.svg", alt="Arrow", class="right-arrow", width="16", height="12" %}
               </a>
             </div>
-            <p class="card-description">Installability available across all major desktop browsers.</p>
+            <p class="card-description">Installability available across all major desktop operating systems.</p>
             <div class="display-flex gap-top-200 logos">
               {% Img src="image/x1Los57vDga6OEMNi1dIJwZ0qvp2/2SWyoN1Cflu2i9ds1fan.svg", alt="Celebration tag", class="tags gap-top-100", width="119", height="15" %}
               <like-icon item="100-card-74"></like-icon>


### PR DESCRIPTION
Fixes #2478

Instead of the suggestion "desktop OSes", I went with "desktop operating systems", because a) I don't think "OSes" is the correct pluralization, and b) there is room in the card for the unabbreviated text.

<img width="494" alt="Screen Shot 2022-03-30 at 9 37 23 AM" src="https://user-images.githubusercontent.com/1749548/160848827-5c926f1e-c310-48ba-93be-4d3f232dc97c.png">