### PR TITLE
Link leads to 404 error

### DIFF
--- a/site/en/docs/devtools/open/index.md
+++ b/site/en/docs/devtools/open/index.md
@@ -60,4 +60,4 @@ on, every new tab will automatically open DevTools until the user fully quits
 Chrome.
 
 [1]: /docs/devtools/css
-[2]: /docs/devtools/console/get-started
+[2]: /docs/devtools/console


### PR DESCRIPTION
The "Get Started With The Console" link leads to a 404 error

- Changes the "Get Started With The Console" anchor tag's link from "https://developer.chrome.com/docs/devtools/console/get-started/" to "https://developer.chrome.com/docs/devtools/console/"