### PR TITLE
Translate Topics description in Japanese

### DIFF
--- a/site/ja/docs/privacy-sandbox/topics/index.md
+++ b/site/ja/docs/privacy-sandbox/topics/index.md
@@ -2,9 +2,9 @@
 layout: 'layouts/doc-post.njk'
 title: 'Topics API'
 subhead: >
-  Enable interest-based advertising, without having to resort to tracking the sites a user visits.
+  ユーザーが訪問するサイトをトラッキングすることなく、興味 / 関心に基づく広告を可能にします。
 description: >
- A proposal for a mechanism to enable interest-based advertising without having to resort to tracking the sites a user visits.
+  ユーザーが訪問するサイトをトラッキングすることなく、興味 / 関心に基づく広告を実現する手法の提案です。
 date: 2022-02-14
 updated: 2022-02-14
 authors:


### PR DESCRIPTION
At the Privacy Sandbox top page in Japanese, everything else except Topics API part is translated.
This pull request fixes it.

This is a time-sensitive request to be merged before 6th April 2022.