### PR TITLE
Set type: doc in Algolia for localized docs pages

### DIFF
--- a/site/de/docs/docs.11tydata.js
+++ b/site/de/docs/docs.11tydata.js
@@ -1,0 +1,3 @@
+module.exports = {
+  type: 'doc',
+};

--- a/site/es/docs/docs.11tydata.js
+++ b/site/es/docs/docs.11tydata.js
@@ -1,0 +1,3 @@
+module.exports = {
+  type: 'doc',
+};

--- a/site/fr/docs/docs.11tydata.js
+++ b/site/fr/docs/docs.11tydata.js
@@ -1,0 +1,3 @@
+module.exports = {
+  type: 'doc',
+};

--- a/site/ja/docs/docs.11tydata.js
+++ b/site/ja/docs/docs.11tydata.js
@@ -1,0 +1,3 @@
+module.exports = {
+  type: 'doc',
+};

--- a/site/ko/docs/docs.11tydata.js
+++ b/site/ko/docs/docs.11tydata.js
@@ -1,0 +1,3 @@
+module.exports = {
+  type: 'doc',
+};

--- a/site/pt/docs/docs.11tydata.js
+++ b/site/pt/docs/docs.11tydata.js
@@ -1,0 +1,3 @@
+module.exports = {
+  type: 'doc',
+};

--- a/site/ru/docs/docs.11tydata.js
+++ b/site/ru/docs/docs.11tydata.js
@@ -1,0 +1,3 @@
+module.exports = {
+  type: 'doc',
+};

--- a/site/zh/docs/docs.11tydata.js
+++ b/site/zh/docs/docs.11tydata.js
@@ -1,0 +1,3 @@
+module.exports = {
+  type: 'doc',
+};


### PR DESCRIPTION
Fixes #2494 by ensuring that `type: doc` metadata is set on all of the non-`en` documentation pages when ingested into Algolia. This will, in turn, ensure that they are surfaced in our site search results.

CC: @agektmr 