### PR TITLE
Fixes typo in method name in the 'Using Plugins' doc.

### DIFF
--- a/site/en/docs/workbox/using-plugins/index.md
+++ b/site/en/docs/workbox/using-plugins/index.md
@@ -1,5 +1,5 @@
 ---
-layout: "layouts/doc-post.njk"
+layout: 'layouts/doc-post.njk'
 title: Using plugins
 date: 2022-02-02
 description: >
@@ -36,9 +36,9 @@ registerRoute(
     plugins: [
       new ExpirationPlugin({
         maxEntries: 60,
-        maxAgeSeconds: 30 * 24 * 60 * 60 // 30 Days
-      })
-    ]
+        maxAgeSeconds: 30 * 24 * 60 * 60, // 30 Days
+      }),
+    ],
   })
 );
 ```
@@ -58,7 +58,7 @@ A Workbox plugin needs to implement one or more callback functions. When you add
 - [`handlerWillRespond`](/docs/workbox/reference/workbox-core/#method-HandlerWillRespondCallback): Called before the strategy's [`handle()` method](/docs/workbox/reference/workbox-strategies/#method-CacheFirst-handle) returns a response, which is helpful if you need to modify a response before returning it to a [`RouteHandler`](/docs/workbox/reference/workbox-core/#type-RouteHandler) or other custom logic.
 - [`handlerDidRespond`](/docs/workbox/reference/workbox-core/#method-HandlerDidRespondCallback): Called after the strategy's [`handle()` method](/docs/workbox/reference/workbox-strategies/#method-CacheFirst-handle) returns a response. This is when it might be useful to record any final response details (for example, after changes made by other plugins).
 - [`handlerDidComplete`](/docs/workbox/reference/workbox-core/#method-HandlerDidCompleteCallback): Called after all [extend lifetime promises](https://w3c.github.io/ServiceWorker/#extendableevent-extend-lifetime-promises) added to the event from the invocation of the strategy have settled. This is helpful if you need to report on any data that needs to wait until the handler is done in order to calculate stuff like cache hit status, cache latency, network latency, and other useful information.
-- [`handleDidError`](/docs/workbox/reference/workbox-core/#method-HandlerDidErrorCallback): Called if the handler can't provide a valid response from from _any_ source, which is the optimal time to provide some sort of fallback response as an alternative to failing outright.
+- [`handlerDidError`](/docs/workbox/reference/workbox-core/#method-HandlerDidErrorCallback): Called if the handler can't provide a valid response from from _any_ source, which is the optimal time to provide some sort of fallback response as an alternative to failing outright.
 
 All of these callback are [`async`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/async_function), and therefore will require `await` to be used whenever a cache or fetch event reaches the relevant point for the callback concerned.
 
@@ -70,7 +70,14 @@ const myPlugin = {
     // Return `response`, a different `Response` object, or `null`.
     return response;
   },
-  cacheDidUpdate: async ({cacheName, request, oldResponse, newResponse, event, state}) => {
+  cacheDidUpdate: async ({
+    cacheName,
+    request,
+    oldResponse,
+    newResponse,
+    event,
+    state,
+  }) => {
     // No return expected
     // Note: `newResponse.bodyUsed` is `true` when this is called,
     // meaning the body has already been read. If you need access to
@@ -84,7 +91,14 @@ const myPlugin = {
     // Returning the original `request` will make this a no-op.
     return request;
   },
-  cachedResponseWillBeUsed: async ({cacheName, request, matchOptions, cachedResponse, event, state}) => {
+  cachedResponseWillBeUsed: async ({
+    cacheName,
+    request,
+    matchOptions,
+    cachedResponse,
+    event,
+    state,
+  }) => {
     // Return `cachedResponse`, a different `Response` object, or null.
     return cachedResponse;
   },
@@ -123,7 +137,7 @@ const myPlugin = {
   handlerDidError: async ({request, event, error, state}) => {
     // Return `response`, a different `Response` object as a fallback, or `null`.
     return response;
-  }
+  },
 };
 ```
 


### PR DESCRIPTION
Fixes a minor typo in the [Using Plugins](https://developer.chrome.com/docs/workbox/using-plugins/) doc, where the `handlerDidError` plugin method was mistyped as `handleDidError`.