### PR TITLE
Change a verb for the sake of the consistency

### DIFF
--- a/site/en/docs/extensions/mv3/declare_permissions/index.md
+++ b/site/en/docs/extensions/mv3/declare_permissions/index.md
@@ -93,7 +93,7 @@ The following table lists the currently available permissions:
     </tr>
     <tr id="clipboardWrite">
       <td><code>"clipboardWrite"</code></td>
-      <td>Indicates the extension uses <code>document.execCommand('copy')</code> or
+      <td>Required if the extension uses <code>document.execCommand('copy')</code> or
         <code>document.execCommand('cut')</code>.
     </tr>
     <tr id="contentSettings">


### PR DESCRIPTION
[Staged link](https://deploy-preview-2506--developer-chrome-com.netlify.app/docs/extensions/mv3/declare_permissions/#:~:text=required%20if%20the%20extension%20uses%20document.execcommand('copy')%20or%20document.execcommand('cut').)