### PR TITLE
Add basic /robots.txt

### DIFF
--- a/site/robots.njk
+++ b/site/robots.njk
@@ -1,0 +1,4 @@
+---
+permalink: "/robots.txt"
+---
+sitemap: {{site.url}}/sitemap.xml


### PR DESCRIPTION
This PR should address https://github.com/GoogleChrome/developer.chrome.com/pull/2412#pullrequestreview-930591644, by adding in a `/robots.txt` file, containing only

```
sitemap: https://developer.chrome.com/sitemap.xml
```

This is roughy what we have at https://github.com/GoogleChrome/web.dev/blob/main/src/site/content/robots.njk, except there we have one `disallow` rule.

Without any `allow`/`disallow` rules, [everything is indexable by default](https://www.robotstxt.org/robotstxt.html).