### PR TITLE
Tweak to redirect logic for top-level invalid URLs

### DIFF
--- a/server/not-found.js
+++ b/server/not-found.js
@@ -64,15 +64,19 @@ const getNonLocalizedURL = (
     // This throws if the path is invalid, and returns undefined if it's valid.
     // (existsSync() is deprecated.)
     fs.accessSync(possibleIndexPath);
-    // We have a valid file!
     // Setting the first item to '' will remove the default locale prefix from
     // the URL we redirect to, while ensuring the URL starts with '/'.
     pathParts[0] = '';
-    return pathParts.join('/');
+    // If there's at least one valid string, join it with '/' and redirect.
+    if (pathParts.some(part => part !== '')) {
+      return pathParts.join('/');
+    }
   } catch (err) {
     // There was no index.html at the default locale path.
-    return null;
   }
+
+  // If we get here, return null to indicate there's no non-localized URL.
+  return null;
 };
 
 /**

--- a/tests/server/fixtures/en/index.html
+++ b/tests/server/fixtures/en/index.html
@@ -1,0 +1,3 @@
+<html>
+  <!-- ignored -->
+</html>

--- a/tests/server/getNonLocalizedURL.js
+++ b/tests/server/getNonLocalizedURL.js
@@ -29,6 +29,11 @@ test('returns null if no redirect is possible, with an index.html suffix', t => 
   t.is(result, null);
 });
 
+test('returns null if no redirect is possible, without a trailing /', t => {
+  const result = getNonLocalizedURL('/doesnotexist', ROOT_DIR, DEFAULT_LOCALE);
+  t.is(result, null);
+});
+
 test('returns null if the URL starts with the default locale', t => {
   const result = getNonLocalizedURL('/en/ignored/', ROOT_DIR, DEFAULT_LOCALE);
   t.is(result, null);


### PR DESCRIPTION
Follow-up to #2412, to address the bug that URLs like https://developer.chrome.com/badurl (i.e. invalid URLs whose pathname does not contain multiple `/`) are currently returning an HTTP 302 with an empty `Location:` response header, when they should be returning an HTTP 404.