### PR TITLE
Add parity components from web.dev

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -19,8 +19,11 @@ const {toc} = require('./site/_filters/toc');
 const {updateSvgForInclude} = require('webdev-infra/filters/svg');
 
 // Shortcodes
+const {Blockquote} = require('webdev-infra/shortcodes/Blockquote');
+const {Codepen} = require('webdev-infra/shortcodes/Codepen');
 const {Details} = require('./site/_shortcodes/Details');
 const {DetailsSummary} = require('./site/_shortcodes/DetailsSummary');
+const {Empty} = require('./site/_shortcodes/Empty');
 const {IFrame} = require('./site/_shortcodes/IFrame');
 const {Glitch} = require('./site/_shortcodes/Glitch');
 const {Hreflang} = require('./site/_shortcodes/Hreflang');
@@ -119,6 +122,7 @@ module.exports = eleventyConfig => {
   eleventyConfig.addFilter('typeof', x => typeof x);
 
   // Add shortcodes
+  eleventyConfig.addShortcode('Codepen', Codepen);
   eleventyConfig.addShortcode('IFrame', IFrame);
   eleventyConfig.addShortcode('Glitch', Glitch);
   eleventyConfig.addShortcode('Hreflang', Hreflang);
@@ -126,6 +130,7 @@ module.exports = eleventyConfig => {
   eleventyConfig.addShortcode('Video', Video);
   eleventyConfig.addShortcode('YouTube', YouTube);
   eleventyConfig.addShortcode('includeRaw', includeRaw);
+  eleventyConfig.addPairedShortcode('Blockquote', Blockquote);
   eleventyConfig.addPairedShortcode('Details', Details);
   eleventyConfig.addPairedShortcode('DetailsSummary', DetailsSummary);
   eleventyConfig.addPairedShortcode('Columns', Columns);
@@ -134,6 +139,12 @@ module.exports = eleventyConfig => {
   eleventyConfig.addPairedShortcode('CompareCaption', CompareCaption);
   eleventyConfig.addPairedShortcode('Aside', Aside);
   eleventyConfig.addShortcode('LanguageList', LanguageList);
+
+  // Empty shortcodes. They are added for backward compatibility with web.dev.
+  // They will not render any html, but will prevent the build from failing.
+  eleventyConfig.addShortcode('Widget', Empty);
+  eleventyConfig.addShortcode('BrowserCompat', Empty);
+  eleventyConfig.addShortcode('CodePattern', Empty);
 
   // Add transforms
   eleventyConfig.addTransform('domTransformer', domTransformer);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1058,11 +1058,11 @@
       "dev": true
     },
     "@imgix/js-core": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@imgix/js-core/-/js-core-3.2.1.tgz",
-      "integrity": "sha512-Evw7rDybGuOH8sU39JIZUmDue1IjV6SXqrv4f52rb9SzIow/uV+L7ch+3dCFiFTU3YXg5qodP6snIzXCj3gZvQ==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@imgix/js-core/-/js-core-3.5.1.tgz",
+      "integrity": "sha512-5gfOuyC0drq9TdEVR0+fR/PRZx4MqymsiTY38ZJoTXHz5D5IpnQhreroj7F4+VBKLdv96aCU9UyPGVjzSlzYIw==",
       "requires": {
-        "js-base64": "~3.6.0",
+        "js-base64": "~3.7.0",
         "md5": "^2.2.1"
       }
     },
@@ -1138,9 +1138,9 @@
       "dev": true
     },
     "@justinribeiro/lite-youtube": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@justinribeiro/lite-youtube/-/lite-youtube-0.9.1.tgz",
-      "integrity": "sha512-IgcpHnovzZGxU4Ec+0c7sSLhrJWflvYliQUmdcwBgyVkGw0ZL9Y8IU/m09NPk9EzIk2HAOWUGLywTVpB785egA=="
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@justinribeiro/lite-youtube/-/lite-youtube-0.9.2.tgz",
+      "integrity": "sha512-ni+E5jbVVrN7D7xfB7qzXjMq5rhSh20dILHfQl02GrySpdT+9KZp1acs8bZtBgmIqhOBkjk8+fTX30nq1UraGg=="
     },
     "@lhci/cli": {
       "version": "0.7.2",
@@ -4184,7 +4184,8 @@
         "get-stream": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "optional": true
         },
         "got": {
           "version": "8.3.2",
@@ -4255,6 +4256,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
           "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+          "optional": true,
           "requires": {
             "p-finally": "^1.0.0"
           }
@@ -4300,6 +4302,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "optional": true,
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -4308,12 +4311,14 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "optional": true
         },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -4328,6 +4333,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -4662,6 +4668,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "optional": true,
       "requires": {
         "buffer-alloc-unsafe": "^1.1.0",
         "buffer-fill": "^1.0.0"
@@ -4670,7 +4677,8 @@
     "buffer-alloc-unsafe": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "optional": true
     },
     "buffer-crc32": {
       "version": "0.2.13",
@@ -4690,7 +4698,8 @@
     "buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+      "optional": true
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -4901,6 +4910,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/caw/-/caw-2.0.1.tgz",
       "integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
+      "optional": true,
       "requires": {
         "get-proxy": "^2.0.0",
         "isurl": "^1.0.0-alpha5",
@@ -6416,6 +6426,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
       "integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
+      "optional": true,
       "requires": {
         "decompress-tar": "^4.0.0",
         "decompress-tarbz2": "^4.0.0",
@@ -6431,6 +6442,7 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
           "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+          "optional": true,
           "requires": {
             "pify": "^3.0.0"
           },
@@ -6438,7 +6450,8 @@
             "pify": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+              "optional": true
             }
           }
         }
@@ -6456,6 +6469,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
       "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+      "optional": true,
       "requires": {
         "file-type": "^5.2.0",
         "is-stream": "^1.1.0",
@@ -6465,7 +6479,8 @@
         "file-type": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
-          "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
+          "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
+          "optional": true
         }
       }
     },
@@ -6473,6 +6488,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
       "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
+      "optional": true,
       "requires": {
         "decompress-tar": "^4.1.0",
         "file-type": "^6.1.0",
@@ -6484,7 +6500,8 @@
         "file-type": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
-          "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg=="
+          "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
+          "optional": true
         }
       }
     },
@@ -6492,6 +6509,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
       "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
+      "optional": true,
       "requires": {
         "decompress-tar": "^4.1.1",
         "file-type": "^5.2.0",
@@ -6501,7 +6519,8 @@
         "file-type": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
-          "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
+          "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
+          "optional": true
         }
       }
     },
@@ -6509,6 +6528,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
       "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
+      "optional": true,
       "requires": {
         "file-type": "^3.8.0",
         "get-stream": "^2.2.0",
@@ -6519,12 +6539,14 @@
         "file-type": {
           "version": "3.9.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-          "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
+          "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
+          "optional": true
         },
         "get-stream": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
+          "optional": true,
           "requires": {
             "object-assign": "^4.0.1",
             "pinkie-promise": "^2.0.0"
@@ -6892,7 +6914,8 @@
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "optional": true
         }
       }
     },
@@ -7872,6 +7895,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
       "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "optional": true,
       "requires": {
         "cross-spawn": "^6.0.0",
         "get-stream": "^4.0.0",
@@ -8157,6 +8181,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
       "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
+      "optional": true,
       "requires": {
         "mime-db": "^1.28.0"
       }
@@ -8165,6 +8190,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
       "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
+      "optional": true,
       "requires": {
         "ext-list": "^2.0.0",
         "sort-keys-length": "^1.0.0"
@@ -8445,12 +8471,14 @@
     "filename-reserved-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
-      "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
+      "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik=",
+      "optional": true
     },
     "filenamify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz",
       "integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
+      "optional": true,
       "requires": {
         "filename-reserved-regex": "^2.0.0",
         "strip-outer": "^1.0.0",
@@ -9021,6 +9049,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz",
       "integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
+      "optional": true,
       "requires": {
         "npm-conf": "^1.1.0"
       }
@@ -9028,7 +9057,8 @@
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "optional": true
     },
     "get-stream": {
       "version": "4.1.0",
@@ -9129,7 +9159,8 @@
         "path-key": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "optional": true
         },
         "pump": {
           "version": "3.0.0",
@@ -9778,7 +9809,8 @@
     "graceful-readlink": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "optional": true
     },
     "gray-matter": {
       "version": "4.0.3",
@@ -10589,7 +10621,8 @@
     "has-symbol-support-x": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
-      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
+      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
+      "optional": true
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -10600,6 +10633,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+      "optional": true,
       "requires": {
         "has-symbol-support-x": "^1.4.1"
       }
@@ -11054,6 +11088,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "optional": true,
       "requires": {
         "repeating": "^2.0.0"
       }
@@ -11451,7 +11486,8 @@
     "is-finite": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
-      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w=="
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+      "optional": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -11525,7 +11561,8 @@
     "is-natural-number": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
-      "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
+      "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=",
+      "optional": true
     },
     "is-negated-glob": {
       "version": "1.0.0",
@@ -11568,7 +11605,8 @@
     "is-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "optional": true
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -11667,7 +11705,8 @@
     "is-retry-allowed": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
+      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
+      "optional": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -11946,6 +11985,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
       "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+      "optional": true,
       "requires": {
         "has-to-string-tag-x": "^1.2.0",
         "is-object": "^1.0.1"
@@ -11990,9 +12030,9 @@
       "integrity": "sha512-ru1HWKek8octvUHFHvE5ZzQ1yAsJmIvRdGWvSoKV52XKyuyYA437QWDttXT8eZXDSbuMpHlLzPDZUPd6idIz+Q=="
     },
     "js-base64": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.6.1.tgz",
-      "integrity": "sha512-Frdq2+tRRGLQUIQOgsIGSCd1VePCS2fsddTG5dTCqR0JHgltXWfsxnY0gIXPoMeRmdom6Oyq+UMOFg5suduOjQ=="
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
+      "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ=="
     },
     "js-beautify": {
       "version": "1.13.4",
@@ -12718,7 +12758,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.2.tgz",
       "integrity": "sha512-gDBO4aHNZS6coiZCKVhSNh43F9ioIL4JwRjLZPkoLIY4yZFwg264Y5lu2x6rb1Js42Gh6Yqm2f6L2AJcnkzinQ==",
-      "dev": true,
       "requires": {
         "uc.micro": "^1.0.1"
       }
@@ -13982,6 +14021,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
       "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
+      "optional": true,
       "requires": {
         "config-chain": "^1.1.11",
         "pify": "^3.0.0"
@@ -13990,7 +14030,8 @@
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "optional": true
         }
       }
     },
@@ -18504,6 +18545,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "optional": true,
       "requires": {
         "is-finite": "^1.0.0"
       }
@@ -18945,6 +18987,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
       "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
+      "optional": true,
       "requires": {
         "commander": "~2.8.1"
       },
@@ -18953,6 +18996,7 @@
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+          "optional": true,
           "requires": {
             "graceful-readlink": ">= 1.0.0"
           }
@@ -19655,6 +19699,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+      "optional": true,
       "requires": {
         "is-plain-obj": "^1.0.0"
       }
@@ -19663,6 +19708,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
       "integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
+      "optional": true,
       "requires": {
         "sort-keys": "^1.0.0"
       }
@@ -20084,6 +20130,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
       "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+      "optional": true,
       "requires": {
         "is-natural-number": "^4.0.1"
       }
@@ -20117,6 +20164,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
       "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "optional": true,
       "requires": {
         "escape-string-regexp": "^1.0.2"
       },
@@ -20124,7 +20172,8 @@
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "optional": true
         }
       }
     },
@@ -20842,6 +20891,7 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
       "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+      "optional": true,
       "requires": {
         "bl": "^1.0.0",
         "buffer-alloc": "^1.2.0",
@@ -20855,12 +20905,14 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "optional": true
         },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -20875,6 +20927,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -20920,12 +20973,14 @@
     "temp-dir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
-      "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0="
+      "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
+      "optional": true
     },
     "tempfile": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz",
       "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
+      "optional": true,
       "requires": {
         "temp-dir": "^1.0.0",
         "uuid": "^3.0.1"
@@ -21152,7 +21207,8 @@
     "to-buffer": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
+      "optional": true
     },
     "to-fast-properties": {
       "version": "1.0.3",
@@ -21304,6 +21360,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+      "optional": true,
       "requires": {
         "escape-string-regexp": "^1.0.2"
       },
@@ -21311,7 +21368,8 @@
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "optional": true
         }
       }
     },
@@ -21975,7 +22033,8 @@
     "url-to-options": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
-      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
+      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
+      "optional": true
     },
     "use": {
       "version": "3.1.1",
@@ -22391,18 +22450,30 @@
       }
     },
     "webdev-infra": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.28.tgz",
-      "integrity": "sha512-SM7izeZAKq1LWBXUdq3VH/lnzwm/5iUecYFDf8kyGT26BwvRGf59cCxr0socs+EzZPR1H9stxn06PwUACa3Zlg==",
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.31.tgz",
+      "integrity": "sha512-Z+8Z4UB8SjJJDX2FRdmNBuGlQ1ezcm37s1kCgwI2IczryGDqgP1Soxa5idPOfFwbOPh/wyh2hO3EQTlgzAkxZg==",
       "requires": {
         "@imgix/js-core": "^3.1.3",
         "@justinribeiro/lite-youtube": "^0.9.1",
         "browser-media-mime-type": "^1.0.0",
         "common-tags": "^1.8.0",
         "lit-element": "^2.5.1",
+        "markdown-it": "^12.3.2",
+        "querystring": "^0.2.1",
         "striptags": "^3.1.1"
       },
       "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
+        "entities": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+          "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
+        },
         "lit-element": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.5.1.tgz",
@@ -22410,6 +22481,23 @@
           "requires": {
             "lit-html": "^1.1.1"
           }
+        },
+        "markdown-it": {
+          "version": "12.3.2",
+          "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+          "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+          "requires": {
+            "argparse": "^2.0.1",
+            "entities": "~2.1.0",
+            "linkify-it": "^3.0.1",
+            "mdurl": "^1.0.1",
+            "uc.micro": "^1.0.5"
+          }
+        },
+        "querystring": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
+          "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "typedoc": "^0.22.7",
     "typescript": "^4.4.4",
     "unistore": "^3.5.2",
-    "webdev-infra": "^1.0.28"
+    "webdev-infra": "^1.0.31"
   },
   "devDependencies": {
     "@11ty/eleventy-plugin-syntaxhighlight": "^3.0.4",

--- a/site/_includes/icons/download.svg
+++ b/site/_includes/icons/download.svg
@@ -1,0 +1,1 @@
+<svg style="width:24px;height:24px" viewBox="0 0 24 24"><path fill="currentColor" d="M5,20H19V18H5M19,9H15V3H9V9H5L12,16L19,9Z" /></svg>

--- a/site/_scss/blocks/_button.scss
+++ b/site/_scss/blocks/_button.scss
@@ -4,6 +4,10 @@
   border: 0;
   cursor: pointer;
   text-decoration: none;
+
+  svg {
+    vertical-align: middle;
+  }
 }
 
 %material-button,

--- a/site/_scss/blocks/_figure.scss
+++ b/site/_scss/blocks/_figure.scss
@@ -1,0 +1,43 @@
+/// COMPONENT LIBRARY LOCATION
+/// https://web.dev/design-system/component/figure
+figure {
+  display: block;
+  width: 100%;
+
+  > *:not(figcaption) {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  > figcaption {
+    display: block;
+    max-width: 100%;
+    text-align: center;
+  }
+}
+
+figure[data-float] {
+  width: auto;
+  margin-bottom: get-size(200);
+}
+
+figure[data-float='left'] {
+  float: left;
+  margin-inline-end: get-size(300);
+}
+
+figure[data-float='right'] {
+  float: right;
+  margin-inline-start: get-size(300);
+}
+
+figure[data-size='full'] {
+  > * {
+    width: 100%;
+  }
+}
+
+figure[data-screenshot] {
+  border: 1px solid var(--color-hairline);
+}

--- a/site/_scss/blocks/_figure.scss
+++ b/site/_scss/blocks/_figure.scss
@@ -18,8 +18,8 @@ figure {
 }
 
 figure[data-float] {
-  width: auto;
   margin-bottom: get-size(200);
+  width: auto;
 }
 
 figure[data-float='left'] {

--- a/site/_scss/blocks/_switcher.scss
+++ b/site/_scss/blocks/_switcher.scss
@@ -1,28 +1,13 @@
-/// SWITCHER
-/// More info: https://every-layout.dev/layouts/switcher/
-/// A layout that allows you to lay **2** items next to each other
-/// until there is not enough horizontal space to allow that.
-
-/// CUSTOM PROPERTIES AND CONFIGURATION
-/// --gutter ($global-gutter): This defines the space
-/// between each item
-
-/// --switcher-target-container-width (40rem): How large the container
-/// needs to be to allow items to sit inline with each other
-
-/// --switcher-vertical-alignment How items should align vertically.
-/// Can be any acceptable flexbox alignment value.
-
 .switcher {
+  align-items: flex-start;
   display: flex;
   flex-wrap: wrap;
   gap: get-size(300);
-  align-items: flex-start;
 }
 
 .switcher > * {
-  flex-grow: 1;
   flex-basis: 0;
+  flex-grow: 1;
 }
 
 /// Max 2 items, so we target everything *after* those

--- a/site/_scss/blocks/_switcher.scss
+++ b/site/_scss/blocks/_switcher.scss
@@ -1,0 +1,32 @@
+/// SWITCHER
+/// More info: https://every-layout.dev/layouts/switcher/
+/// A layout that allows you to lay **2** items next to each other
+/// until there is not enough horizontal space to allow that.
+
+/// CUSTOM PROPERTIES AND CONFIGURATION
+/// --gutter ($global-gutter): This defines the space
+/// between each item
+
+/// --switcher-target-container-width (40rem): How large the container
+/// needs to be to allow items to sit inline with each other
+
+/// --switcher-vertical-alignment How items should align vertically.
+/// Can be any acceptable flexbox alignment value.
+
+.switcher {
+  display: flex;
+  flex-wrap: wrap;
+  gap: get-size(300);
+  align-items: flex-start;
+}
+
+.switcher > * {
+  flex-grow: 1;
+  flex-basis: 0;
+}
+
+/// Max 2 items, so we target everything *after* those
+.switcher > :nth-last-child(n + 3),
+.switcher > :nth-last-child(n + 3) ~ * {
+  flex-basis: 100%;
+}

--- a/site/_scss/main.scss
+++ b/site/_scss/main.scss
@@ -72,6 +72,8 @@
 @import 'blocks/devtools';
 @import 'blocks/select-loader';
 @import 'blocks/social-icon';
+@import 'blocks/figure';
+@import 'blocks/switcher';
 
 // Utilities
 @import 'utilities/center-margin';

--- a/site/_shortcodes/Aside.js
+++ b/site/_shortcodes/Aside.js
@@ -14,7 +14,9 @@ const icons = {
   caution: loadIcon('error'),
   warning: loadIcon('warning'),
   success: loadIcon('done'),
+  objective: loadIcon('done'),
   gotchas: loadIcon('lightbulb-outline'),
+  important: loadIcon('lightbulb-outline'),
   'key-term': loadIcon('ink-highlighter'),
   codelab: loadIcon('code'),
 };

--- a/site/_shortcodes/Empty.js
+++ b/site/_shortcodes/Empty.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This is an emoty shortcode. It can be used as a substitute for missing
+ * (uncritical) components when moving external content to dcc.
+ *
+ * @return {string}
+ */
+const Empty = () => {
+  return '<p>This shortcode is not supported</p>';
+};
+
+module.exports = {Empty};

--- a/site/en/docs/handbook/test-post/index.md
+++ b/site/en/docs/handbook/test-post/index.md
@@ -1,6 +1,6 @@
 ---
 layout: 'layouts/blog-post.njk'
-title: An example blog post used for screenshot testing.
+title: An example post for testing prose elements
 subhead: |
   A catchy subhead that previews the content and is a bit wordy to test what
   happens when a subhead wraps.
@@ -58,17 +58,7 @@ alt: A description of the hero image for screen reader users.
 tags:
   - privacy
   - security
-pageScripts:
-  - /js/100.js
 ---
-
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin dictum a massa
-sit amet ullamcorper. Suspendisse auctor ultrices ante, nec tempus nibh varius
-at. Cras ligula lacus, porta vitae maximus a, ultrices a mauris. Vestibulum
-
-<like-icon item='some-id'></like-icon>
-
-<like-icon item='some-other-id'></like-icon>
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin dictum a massa
 sit amet ullamcorper. Suspendisse auctor ultrices ante, nec tempus nibh varius
@@ -90,7 +80,7 @@ sit amet ullamcorper. Suspendisse auctor ultrices ante, nec tempus nibh varius
 at. Cras ligula lacus, porta vitae maximus a, ultrices a mauris. Vestibulum
 porta dolor erat, vel molestie dolor posuere in. Nam vel elementum augue. Nam
 quis enim blandit, posuere justo dignissim, scelerisque diam. Fusce aliquet urna
-ac blandit ullamcorper. Proin et semper nibh, sit amet imperdiet velit. Morbi at
+ac blandit ullamcorper. Proin et semper nibh, sit amet imperdiet velit. Morbi
 quam sem. Integer et erat ac mi scelerisque suscipit et vitae nulla. Aliquam
 scelerisque efficitur ante ut facilisis. Aenean et risus fringilla, hendrerit
 sapien et, tincidunt orci. Aenean sed tellus aliquam, consectetur metus in,
@@ -460,6 +450,32 @@ quis enim blandit, posuere justo dignissim, scelerisque diam. Fusce aliquet urna
 ac blandit ullamcorper. Proin et semper nibh, sit amet imperdiet velit. Morbi at
 quam sem.
 
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin dictum a massa
+sit amet ullamcorper. Suspendisse auctor ultrices ante, nec tempus nibh varius
+at. Cras ligula lacus, porta vitae maximus a, ultrices a mauris. Vestibulum
+porta dolor erat, vel molestie dolor posuere in. Nam vel elementum augue. Nam
+quis enim blandit, posuere justo dignissim, scelerisque diam. Fusce aliquet urna
+ac blandit ullamcorper. Proin et semper nibh, sit amet imperdiet velit. Morbi at
+quam sem.
+
+{% Blockquote 'Jon Doe' %}
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin dictum
+  a massa sit amet ullamcorper.
+{% endBlockquote %}
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin dictum a massa
+sit amet ullamcorper. Suspendisse auctor ultrices ante, nec tempus nibh varius
+at. Cras ligula lacus, porta vitae maximus a, ultrices a mauris. Vestibulum
+porta dolor erat, vel molestie dolor posuere in. Nam vel elementum augue. Nam
+quis enim blandit, posuere justo dignissim, scelerisque diam. Fusce aliquet urna
+ac blandit ullamcorper. Proin et semper nibh, sit amet imperdiet velit. Morbi at
+quam sem.
+
+{% Blockquote 'Jon Doe', 'pullquote' %}
+[Lorem ipsum](#) dolor sit amet, consectetur adipiscing elit. Proin dictum
+a massa sit amet ullamcorper.
+{% endBlockquote %}
+
 {% if site.percy %}
 <div style="background: aquamarine; width: 400px; height: 400px;">
   Glitch iframe placeholder
@@ -482,6 +498,60 @@ porta dolor erat, vel molestie dolor posuere in. Nam vel elementum augue. Nam
 quis enim blandit, posuere justo dignissim, scelerisque diam. Fusce aliquet urna
 ac blandit ullamcorper. Proin et semper nibh, sit amet imperdiet velit. Morbi at
 quam sem.
+
+{% Codepen {
+  user: 'robdodson',
+  id: 'GRroyyX',
+  height: 300,
+  theme: 'dark',
+  tab: 'css,result',
+  allow: ['geolocation']
+} %}
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin dictum a massa
+sit amet ullamcorper. Suspendisse auctor ultrices ante, nec tempus nibh varius
+at. Cras ligula lacus, porta vitae maximus a, ultrices a mauris. Vestibulum
+porta dolor erat, vel molestie dolor posuere in. Nam vel elementum augue. Nam
+quis enim blandit, posuere justo dignissim, scelerisque diam. Fusce aliquet urna
+ac blandit ullamcorper. Proin et semper nibh, sit amet imperdiet velit. Morbi at
+quam sem.
+
+<div class="switcher">
+  <figure>
+    {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/amwrx4HVBEVTEzQspIWw.png", alt="", width="800", height="155" %}
+    <figcaption>
+      Small image.
+    </figcaption>
+  </figure>
+  <figure>
+    {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/amwrx4HVBEVTEzQspIWw.png", alt="", width="800", height="155" %}
+    <figcaption>
+      Small image.
+    </figcaption>
+  </figure>
+</div>
+
+{% Compare 'worse' %}
+```text
+Bad code example
+```
+
+{% CompareCaption %}
+Explanation of why `example` is bad.
+{% endCompareCaption %}
+
+{% endCompare %}
+
+{% Compare 'better' %}
+```text
+Good code example
+```
+
+{% CompareCaption %}
+Explanation of why `example` is good.
+{% endCompareCaption %}
+
+{% endCompare %}
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin dictum a massa
 sit amet ullamcorper. Suspendisse auctor ultrices ante, nec tempus nibh varius
@@ -509,10 +579,64 @@ quam sem.
 <div class="all-center">
   <p>
     <a href="https://example.com/some.pdf" class="button">
+      {% include "icons/download.svg" %}
       Download case study
     </a>
   </p>
 </div>
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin dictum a massa
+sit amet ullamcorper. Suspendisse auctor ultrices ante, nec tempus nibh varius
+at. Cras ligula lacus, porta vitae maximus a, ultrices a mauris. Vestibulum
+porta dolor erat, vel molestie dolor posuere in. Nam vel elementum augue. Nam
+quis enim blandit, posuere justo dignissim, scelerisque diam. Fusce aliquet urna
+ac blandit ullamcorper. Proin et semper nibh, sit amet imperdiet velit. Morbi at
+quam sem.
+
+{% Widget 'example-set/graph', 540 %}
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin dictum a massa
+sit amet ullamcorper. Suspendisse auctor ultrices ante, nec tempus nibh varius
+at. Cras ligula lacus, porta vitae maximus a, ultrices a mauris. Vestibulum
+porta dolor erat, vel molestie dolor posuere in. Nam vel elementum augue. Nam
+quis enim blandit, posuere justo dignissim, scelerisque diam. Fusce aliquet urna
+ac blandit ullamcorper. Proin et semper nibh, sit amet imperdiet velit. Morbi at
+quam sem.
+
+{% Details %}
+
+{% DetailsSummary %}
+Details _summary_
+{% endDetailsSummary %}
+
+This is an optional preview. Make your preview text match the first paragraph
+of your panel text.
+
+Lorem ipsum [dolor sit amet](#), consectetur adipiscing elit. Proin dictum a massa
+sit amet ullamcorper. `Suspendisse` auctor ultrices ante, nec tempus nibh varius
+at.
+
+{% endDetails %}
+
+{% Details %}
+
+{% DetailsSummary %}
+Details _summary_
+{% endDetailsSummary %}
+
+Lorem ipsum [dolor sit amet](#), consectetur adipiscing elit. Proin dictum a massa
+sit amet ullamcorper. `Suspendisse` auctor ultrices ante, nec tempus nibh varius
+at.
+
+{% endDetails %}
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin dictum a massa
+sit amet ullamcorper. Suspendisse auctor ultrices ante, nec tempus nibh varius
+at. Cras ligula lacus, porta vitae maximus a, ultrices a mauris. Vestibulum
+porta dolor erat, vel molestie dolor posuere in. Nam vel elementum augue. Nam
+quis enim blandit, posuere justo dignissim, scelerisque diam. Fusce aliquet urna
+ac blandit ullamcorper. Proin et semper nibh, sit amet imperdiet velit. Morbi at
+quam sem.
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin dictum a massa
 sit amet ullamcorper. Suspendisse auctor ultrices ante, nec tempus nibh varius


### PR DESCRIPTION
+ Bump the webdev-infra to 1.0.31 to get access to new components
+ Update /test-post to list stae-of-the-art prose components
+ Add missing styles to dcc
+ Provide a fallback "Empty" component so that copying a file from web.dev with a not-supported component will not break the build