### PR TITLE
remove nested `<name>` inside `<author>` in the feed template

### DIFF
--- a/site/feed.njk
+++ b/site/feed.njk
@@ -32,7 +32,7 @@ pagination:
       <author>
         <name>
           {%- if author -%}
-            <name>{{ author.title | i18n(locale) }}</name>
+            {{ author.title | i18n(locale) }}
           {%- else -%}
             {{ authorId }}
           {%- endif -%}


### PR DESCRIPTION
Fixes #2541

Changes proposed in this pull request:

- remove the `<name>` element inside `<name>`