### PR TITLE
Update formatting specifier in console.log documentation

### DIFF
--- a/site/en/docs/devtools/console/format-style/index.md
+++ b/site/en/docs/devtools/console/format-style/index.md
@@ -57,7 +57,7 @@ Here is the list of [format specifiers](https://console.spec.whatwg.org/#formatt
       <td>Formats the value as an expandable DOM element</td>
     </tr>
     <tr>
-      <td><code>%0</code></td>
+      <td><code>%O</code></td>
       <td>Formats the value as an expandable JavaScript object</td>
     </tr>
     <tr>


### PR DESCRIPTION
This pull request updates a mistake in `site/en/docs/devtools/console/format-style/index.md`. The documentation says to use `%0` when in fact it should be `%O`.