### PR TITLE
Fix href URLs created by Hreflang shortcode

### DIFF
--- a/site/_shortcodes/Hreflang.js
+++ b/site/_shortcodes/Hreflang.js
@@ -1,6 +1,5 @@
 const {findByUrl} = require('../_data/lib/find');
 const {getLocalizedPaths} = require('../_filters/urls');
-const path = require('path');
 
 /**
  * Outputs a list of <link hreflang=""> tags with alternate language versions

--- a/site/_shortcodes/Hreflang.js
+++ b/site/_shortcodes/Hreflang.js
@@ -17,10 +17,10 @@ function Hreflang(url, site, collections) {
     findByUrl(collections.all, hreflang[0])
   );
   const links = hreflangs.map(hreflang => {
-    return `<link href="${path.join(
-      site.url,
-      hreflang[0]
-    )}" rel="alternate" hreflang="${hreflang[1]}">`;
+    return (
+      `<link href="${site.url}${hreflang[0]}" ` +
+      `rel="alternate" hreflang="${hreflang[1]}">`
+    );
   });
   return links.length > 1 ? links.join('\n') : '';
 }


### PR DESCRIPTION
The URLs output by the `Hreflang.js` shortcode are all invalid, because `path.join()` is used to concatenate `site.url` with the localized pathnames. `path.join()` isn't appropriate for joining URL parts, though, since it will make optimizations that are specific to directory paths—like translating the `//` to `/`, resulting in `https:/...`. (It also won't work at all on Windows systems?) This results in invalid URLs, as identified in an [HTML Validator](https://validator.w3.org/nu/?doc=https%3A%2F%2Fdeveloper.chrome.com%2Fes%2Fblog%2Fnew-in-devtools-97%2F).

I am pretty sure that we're safe just doing straight string concatenation here, based on the inputs I've seen, but if we really wanted to be correct we should probably create a `URL` object—that's probably overkill, so I'm not doing it here.