### PR TITLE
Add "optional_host_permissions" to manifest.json

### DIFF
--- a/site/en/docs/extensions/mv3/manifest/index.md
+++ b/site/en/docs/extensions/mv3/manifest/index.md
@@ -74,6 +74,7 @@ discusses each field.
   <span class="token property">"<a href="/docs/extensions/reference/omnibox">omnibox</a>"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
     <span class="token property">"keyword"</span><span class="token operator">:</span> <span class="token string">"aString"</span>
   <span class="token punctuation">}</span><span class="token punctuation">,</span>
+  <span class="token property">"<a href="/docs/extensions/reference/permissions">optional_host_permissions</a>"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token string">"..."</span><span class="token punctuation">]</span><span class="token punctuation">,</span>
   <span class="token property">"<a href="/docs/extensions/reference/permissions">optional_permissions</a>"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token string">"tabs"</span><span class="token punctuation">]</span><span class="token punctuation">,</span>
   <span class="token property">"<a href="/docs/extensions/mv3/options">options_page</a>"</span><span class="token operator">:</span> <span class="token string">"options.html"</span><span class="token punctuation">,</span>
   <span class="token property">"<a href="/docs/extensions/mv3/options">options_ui</a>"</span><span class="token operator">:</span> <span class="token punctuation">{</span>


### PR DESCRIPTION
This PR adds the new "optional_host_permissions" key to the Manifest V3 documentation for manifest.json. The announcement of this change is handled in #2557. 

[Preview page](https://deploy-preview-2572--developer-chrome-com.netlify.app/docs/extensions/mv3/manifest#:~:text=%22optional_host_permissions%22)