### PR TITLE
Add Chrome Dev Insider redirect

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -375,8 +375,8 @@ redirects:
     - /docs/apps/...
 
 # Temporary Chrome Dev Insider collection page placeholder
-- from: /blog/insider-april-2022/
-  to: /insider/
+- from: /insider/
+  to: /blog/insider-april-2022/
 
 # DO NOT REMOVE. This seems pointless but we rewrite "." to "_" inside our server's code, so if the
 # URL is fine for all but incorrect syntax, we'll fix it up.

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -374,6 +374,10 @@ redirects:
     - /docs/apps/manifest/...
     - /docs/apps/...
 
+# Temporary Chrome Dev Insider collection page placeholder
+- from: /blog/insider-april-2022/
+  to: /insider/
+
 # DO NOT REMOVE. This seems pointless but we rewrite "." to "_" inside our server's code, so if the
 # URL is fine for all but incorrect syntax, we'll fix it up.
 - from: /...


### PR DESCRIPTION
Related to #2584 

As discussed with @harleenkbatra08 we will use the /blog/insider-april-2022 post as a temporary landing lage for the Chrome Dev Insider initiative.