### PR TITLE
Blob URL clarification in extensions docs

### DIFF
--- a/site/en/docs/extensions/mv3/content_scripts/index.md
+++ b/site/en/docs/extensions/mv3/content_scripts/index.md
@@ -213,7 +213,7 @@ Use programmatic injection for content scripts that need to run in response to e
 occasions.
 
 In order to inject a content script programmatically, your extension needs host permissions for
-the page it's trying to inject scripts into. Host permissions can either be granted either by
+the page it's trying to inject scripts into. Host permissions can either be granted by
 requesting them as part of your extension's manifest (see [`host_permissions`][33]) or temporarily
 via [activeTab][15].
 
@@ -579,8 +579,8 @@ themselves match the script's specified patterns.
 
 This is the case when an extension wants to inject in frames with URLs that
 have `about:`, `data:`, `blob:`, and `filesystem:` schemes. In these cases, the
-URL will not match the content script's pattern (and, in the case of `about:`,
-`data:`, and `blob:`, do not even include the parent URL or origin in the URL
+URL will not match the content script's pattern (and, in the case of `about:` and
+`data:`, do not even include the parent URL or origin in the URL
 at all, as in `about:blank` or `data:text/html,<html>Hello, World!</html>`).
 However, these frames can still be associated with the creating frame.
 


### PR DESCRIPTION
The extension content script docs mention that Blob URLs "do not even include the parent URL or origin in the URL", but they do include the parent origin (Ex: `blob:http://chromium.org:35419/95cbb8b1-c3f5-42eb-85b8-e9715baa4f4f`)

Also, fix a minor grammatical issue

These both seem like minor edits but I'm happy to open a corresponding issue if you'd like. Thanks!