### PR TITLE
Fixing some markdown nits in the fenced frames articles.

### DIFF
--- a/site/en/blog/embed-content/index.md
+++ b/site/en/blog/embed-content/index.md
@@ -49,7 +49,7 @@ to a contact page, and displaying ads.
 
 Each iframe has its own browsing context, with its own session history and
 [document](https://developer.mozilla.org/docs/Web/API/Document). The context
-that embeds the iframe is referred to as the _parent _browsing context.
+that embeds the iframe is referred to as the _parent_ browsing context.
 
 Third-party content displayed in an iframe can interact with the parent site
 through `postMessage()`. This allows developers to send arbitrary values between
@@ -87,9 +87,8 @@ sandbox attribute.
 ```
 
 There are a number of possible values for the [`sandbox`
-specification](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-ifram
--sandbox), including `allow-forms`, `allow-same-origin`, `allow-popups`, and
-more.
+specification](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-ifram-sandbox),
+including `allow-forms`, `allow-same-origin`, `allow-popups`, and more.
 
 
 ### Permissions Policy
@@ -177,7 +176,7 @@ rendered both the `<object>` and `<applet>` elements obsolete.
 
 Although `<object>` and `<embed>` are not officially deprecated yet, it's best
 to avoid them, especially since they have some [strange
-behaviors](https://github.com/whatwg/html/issues?q=is%3Aopen+is%3Aissue+label%3A%22topic%3A+embed+and+object%22)).
+behaviors](https://github.com/whatwg/html/issues?q=is%3Aopen+is%3Aissue+label%3A%22topic%3A+embed+and+object%22).
 `<applet>` was [removed from the HTML
 specification](https://github.com/whatwg/html/pull/1399) in 2017. 
 

--- a/site/en/docs/privacy-sandbox/fenced-frame/index.md
+++ b/site/en/docs/privacy-sandbox/fenced-frame/index.md
@@ -172,7 +172,7 @@ Current candidates for this combination include:
    storage](https://github.com/shivanigithub/fenced-frame/blob/master/explainer/modes.md#unpartitioned-storage).
 
 For more details, refer to the [Fenced Frames
-explainer](https://github.com/shivanigithub/fenced-frame/blob/master/explainer/modes.md)).
+explainer](https://github.com/shivanigithub/fenced-frame/blob/master/explainer/modes.md).
 
 
 ### Examples


### PR DESCRIPTION
Fixes #2600

Changes proposed in this pull request:

+ _parent _ - I checked the source doc to make sure italic was correct.
+ sandbox specification link was word wrapped and breaking (it's still longer than line limt)
+ removed superflous ")" from some markdown links
