### PR TITLE
async worker pool for CSS purge + minification

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -38,13 +38,13 @@ const {LanguageList} = require('./site/_shortcodes/LanguageList');
 
 // Transforms
 const {domTransformer} = require('./site/_transforms/dom-transformer-pool');
-const {purifyCss} = require('./site/_transforms/purify-css');
+const {purifyCss} = require('./site/_transforms/purify-css-pool');
 const {minifyHtml} = require('./site/_transforms/minify-html');
 
 // Plugins
 const md = require('./site/_plugins/markdown');
 const rssPlugin = require('@11ty/eleventy-plugin-rss');
-const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
+const syntaxHighlight = require('@11ty/eleventy-plugin-syntaxhighlight');
 
 // Supported locales
 const locales = require('./site/_data/site.json').locales;
@@ -88,17 +88,19 @@ module.exports = eleventyConfig => {
   eleventyConfig.addPlugin(syntaxHighlight);
 
   // Add collections
-  locales.forEach(locale => eleventyConfig.addCollection(`blog-${locale}`, collections => {
-    let blogCollection = collections
-      .getFilteredByGlob(`./site/${locale}/blog/*/*.md`)
-      .filter(filterOutDrafts)
-      .reverse();
-    // If we're running inside of Percy then just show the first six blog posts.
-    if (process.env.PERCY_BRANCH) {
-      blogCollection = blogCollection.slice(blogCollection.length - 6);
-    }
-    return blogCollection;
-  }));
+  locales.forEach(locale =>
+    eleventyConfig.addCollection(`blog-${locale}`, collections => {
+      let blogCollection = collections
+        .getFilteredByGlob(`./site/${locale}/blog/*/*.md`)
+        .filter(filterOutDrafts)
+        .reverse();
+      // If we're running inside of Percy then just show the first six blog posts.
+      if (process.env.PERCY_BRANCH) {
+        blogCollection = blogCollection.slice(blogCollection.length - 6);
+      }
+      return blogCollection;
+    })
+  );
   eleventyConfig.addCollection('algolia', algoliaCollection);
   eleventyConfig.addCollection('feeds', feedsCollection);
   eleventyConfig.addCollection('tags', tagsCollection);
@@ -159,7 +161,6 @@ module.exports = eleventyConfig => {
     eleventyConfig.addTransform('purifyCss', purifyCss);
     eleventyConfig.addTransform('minifyHtml', minifyHtml);
   }
-
 
   return {
     markdownTemplateEngine: 'njk',

--- a/site/_transforms/purify-css-pool.js
+++ b/site/_transforms/purify-css-pool.js
@@ -1,0 +1,22 @@
+const path = require('path');
+
+// This works around: https://github.com/mysticatea/eslint-plugin-node/issues/244
+// eslint-disable-next-line node/no-missing-require
+const {pool: buildWorkerPool} = require('async-transforms/worker');
+
+/** @type {(content: string, outputPath: string) => Promise<string>} */
+let purifyCSSPool;
+
+/**
+ * This wraps "purify-css.js" which is rather slow, and can be parallelized.
+ */
+const purifyCss = (content, outputPath) => {
+  if (purifyCSSPool === undefined) {
+    // Lazily create the worker pool if needed.
+    const script = path.join(__dirname, './purify-css.js');
+    purifyCSSPool = buildWorkerPool(script);
+  }
+  return purifyCSSPool(content, outputPath);
+};
+
+module.exports = {purifyCss};

--- a/site/_transforms/purify-css.js
+++ b/site/_transforms/purify-css.js
@@ -73,4 +73,4 @@ const purifyCss = async (content, outputPath) => {
   return content;
 };
 
-module.exports = {purifyCss};
+module.exports = purifyCss;


### PR DESCRIPTION
This will hopefully offer some improvements for #2556, by using the same worker pool approach we already use for our DOM transforms when implementing our CSS purging.

I would still like to find a way to move off of per-file CSS purging in general, so I want to keep #2556 open, but given that this PR should improve things with minimal changes, I wanted to implement it first.