### PR TITLE
Update deploy Cloud Build task

### DIFF
--- a/.cloudbuild/deploy.yaml
+++ b/.cloudbuild/deploy.yaml
@@ -1,20 +1,23 @@
+# This deploys the site. Roughly equivalent to
+# https://github.com/GoogleChrome/web.dev/blob/main/.cloudbuild/deploy.yaml
+
 timeout: 2700s # set build timeout to 45 mins
 steps:
-  - name: node
+  - name: node:16.14.2
     entrypoint: npm
     args: ['ci']
 
-  - name: node
+  - name: node:16.14.2
     entrypoint: npm
     args: ['run', 'cloud-secrets']
 
-  - name: node
+  - name: node:16.14.2
     entrypoint: npm
     args: ['run', 'production']
     env:
-      - 'NODE_OPTIONS="--max_old_space_size=4096"' # https://github.com/GoogleChrome/developer.chrome.com/issues/2439
+      - 'NODE_OPTIONS="--max_old_space_size=8192"' # https://github.com/GoogleChrome/developer.chrome.com/issues/2439
 
-  - name: node
+  - name: node:16.14.2
     entrypoint: npm
     args: ['run', 'algolia']
 
@@ -32,7 +35,6 @@ substitutions:
   _EXTRA_GCLOUD_ARGS: # default empty
 
 options:
-  machineType: 'E2_HIGHCPU_8' # yolo
+  machineType: 'E2_HIGHCPU_32'
   env:
-    - 'NODE_OPTIONS=--unhandled-rejections=strict'
     - 'PROJECT_ID=$PROJECT_ID'


### PR DESCRIPTION
This brings our d.c.c. `deploy` task in line with how we have web.dev's [`deploy` configured](https://github.com/GoogleChrome/web.dev/blob/main/.cloudbuild/deploy.yaml) configured.

- Explicitly request `node:16.14.2`. Right now, the generic `node` alias resolves to a Docker container using node v17.9.0, which I don't think anyone on the team uses during regular development.
- Request `E2_HIGHCPU_32` instead of `E2_HIGHCPU_8`. That beefier VM is what we use in web.dev already.
- Bumps up `max_old_space_size` from 4gb to 8gb, since we have the extra RAM and under the impression that fewer garbage collections will lead to a faster build.