### PR TITLE
Normalize casing of "Manifest V3"

### DIFF
--- a/site/en/blog/new-in-chrome-88/index.md
+++ b/site/en/blog/new-in-chrome-88/index.md
@@ -24,7 +24,7 @@ Chrome 88 is starting to roll out to stable now.
 
 Here's what you need to know:
 
-* You can now upload extensions using [manifest v3](#mv3) to the Chrome Web
+* You can now upload extensions using [manifest V3](#mv3) to the Chrome Web
   Store.
 * The [`aspect-ratio`](#aspect-ratio) CSS property makes it easy to set the
   aspect ratio on any element.
@@ -37,10 +37,10 @@ Here's what you need to know:
 I'm [Pete LePage](https://petelepage.com/), working, and shooting
 from home, let's dive in and see what's new for developers in Chrome 88!
 
-## Manifest v3 {: #mv3 }
+## Manifest V3 {: #mv3 }
 
-Chrome 88 now supports extensions built with manifest v3, and you
-can upload them to the Chrome Web Store. Manifest v3 is a new extension
+Chrome 88 now supports extensions built with Manifest V3, and you
+can upload them to the Chrome Web Store. Manifest V3 is a new extension
 platform, that makes Chrome extensions more secure, performant, and privacy
 respecting, by default.
 
@@ -59,7 +59,7 @@ share their data, in a future release we will be adopting a new install flow
 that allows users to withhold sensitive permissions at install time.
 
 Check out [developer.chrome.com](/docs/extensions/mv3/)
-for complete details, and how to migrate your current extension to manifest v3.
+for complete details, and how to migrate your current extension to Manifest V3.
 
 <br style="clear:both;">
 


### PR DESCRIPTION
In [this comment](https://github.com/GoogleChrome/developer.chrome.com/pull/2557#discussion_r847387114) @jpmedley noted that we have some inconsistent casing for "Manifest V3". This PR addresses the inconsistencies I could find. 