### PR TITLE
Docs: Fix link path

### DIFF
--- a/site/en/docs/extensions/mv3/user_interface/index.md
+++ b/site/en/docs/extensions/mv3/user_interface/index.md
@@ -64,7 +64,7 @@ chrome.action.setBadgeBackgroundColor({color: '#4688F1'});
 ## Define rules for activating the extension{: #activate_pages }
 
 It's possible to use [declarativeContent](/docs/extensions/reference/declarativeContent/) to enable and disable the action based on the current URL being shown.
-See the [example as part of declarativeContent](docs/extensions/reference/action/#emulating-pageactions-with-declarativecontent).
+See the [example as part of declarativeContent](/docs/extensions/reference/action/#emulating-pageactions-with-declarativecontent).
 
 ## Provide the extension icons
 


### PR DESCRIPTION
Issue: No issue corresponding to this PR.

Changes proposed in this pull request:

- Fix link in `user_interface` docs: Full link is changing from the invalid
`https://developer.chrome.com/docs/extensions/mv3/user_interface/docs/extensions/reference/action/#emulating-pageactions-with-declarativecontent` to
`https://developer.chrome.com/docs/extensions/reference/action/#emulating-pageactions-with-declarativecontent`.