### PR TITLE
'biddingWasmHelperUrl' can also be updated

### DIFF
--- a/site/en/blog/fledge-api/index.md
+++ b/site/en/blog/fledge-api/index.md
@@ -516,6 +516,7 @@ interest group. In the [current implementation](https://source.chromium.org/chro
 the following attributes can be changed:
 
 * `biddingLogicUrl`
+* `biddingWasmHelperUrl`
 * `trustedBiddingSignalsUrl`
 * `trustedBiddingSignalsKeys`
 * `ads`


### PR DESCRIPTION
Just a minor thing, but if I am not mistaken, then I see in https://source.chromium.org/chromium/chromium/src/+/main:content/browser/interest_group/interest_group_storage.cc;l=707 that the field `biddingWasmHelperUrl` can also be updated.
