### PR TITLE
Update retrying-requests-when-back-online

### DIFF
--- a/site/en/docs/workbox/retrying-requests-when-back-online/index.md
+++ b/site/en/docs/workbox/retrying-requests-when-back-online/index.md
@@ -16,7 +16,7 @@ Workbox abstracts this API with the [`workbox-background-sync` module](/docs/wor
 
 ## Basic usage
 
-The `BackgroundSync` plugin is exported from the `workbox-background-sync` module, and can be used to queue up failed requests and retry them when future `sync` events fire:
+The `BackgroundSyncPlugin` is exported from the `workbox-background-sync` module, and can be used to queue up failed requests and retry them when future `sync` events fire:
 
 ```js
 import {BackgroundSyncPlugin} from 'workbox-background-sync';


### PR DESCRIPTION
The original version looks weird.
Either we talk about the plugin as a whole entity, and wrap it in "code", or as a plugin responsible for something, and write it in plain text (plugin for background sync maybe?).
