### PR TITLE
Update Permissions Policy article references

### DIFF
--- a/site/en/blog/autoplay/index.md
+++ b/site/en/blog/autoplay/index.md
@@ -292,7 +292,7 @@ on the Chromium site.
 [do this with flags]: https://www.chromium.org/developers/how-tos/run-chromium-with-flags
 [https://airhorner.com]: https://airhorner.com/progressive-web-apps/
 [noticed]: https://webkit.org/blog/7734/auto-play-policy-changes-for-macos/
-[permissions policy]: https://w3c.github.io/webappsec-permissions-policy/
+[permissions policy]: /docs/privacy-sandbox/permissions-policy/
 [permissions policy for autoplay]: https://github.com/WICG/feature-policy/blob/main/features.md
 [policy list]: https://chromeenterprise.google/policies/
 [progressive-web-apps]: https://web.dev/progressive-web-apps/

--- a/site/en/blog/chrome-87-deps-rems/index.md
+++ b/site/en/blog/chrome-87-deps-rems/index.md
@@ -45,7 +45,7 @@ November 17, 2020.
 
 ## Comma separator in iframe allow attribute
 
-Permissions policy declarations in an `<iframe>` tag [can no longer use
+[Permissions policy](/docs/privacy-sandbox/permissions-policy/) declarations in an `<iframe>` tag [can no longer use
 commas](https://www.chromestatus.com/feature/5740835259809792) as a separator
 between items. Developers should use semicolons instead.
 

--- a/site/en/blog/embed-content/index.md
+++ b/site/en/blog/embed-content/index.md
@@ -95,8 +95,8 @@ more.
 
 ### Permissions Policy
 
-As increasingly powerful features have been developed for the web, permissions
-policies were created to manage permissions for all of them. A permissions policy
+As increasingly powerful features have been developed for the web, [permissions
+policies](/docs/privacy-sandbox/permissions-policy/) were created to manage permissions for all of them. A permissions policy
 can be applied to a parent site and to iframe content. The permissions granted
 to a parent site can also be granted to the iframe, using the `allow` attribute.
 

--- a/site/en/blog/fledge-api/index.md
+++ b/site/en/blog/fledge-api/index.md
@@ -192,7 +192,7 @@ about feature support and constraints.
 
 The default in the current implementation of FLEDGE is to allow calling `joinAdInterestGroup()` from
 anywhere in a page, even from cross-domain iframes. In the future, once site owners have had time
-to adjust their cross-domain iframe permissions policies, the plan is to disallow calls from
+to adjust their cross-domain iframe [permissions policies](/docs/privacy-sandbox/permissions-policy/), the plan is to disallow calls from
 cross-domain iframes, as the explainer describes.
 
 #### Trusted servers
@@ -358,7 +358,7 @@ For example: it must not be possible for `malicious.example` to call
 
 **Same origin**: By default, permission is implicitly granted for `joinAdInterestGroup()` calls from
 the same origin as the site being visited, i.e. from the same origin as the top-level frame of the
-current page. Sites can use a FLEDGE [permissions policy header](https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy)
+current page. Sites can use a FLEDGE [permissions policy header](/docs/privacy-sandbox/permissions-policy/)
  `join-ad-interest-group` directive to disable `joinAdInterestGroup()` calls.
 
 **Cross origin**: Calling `joinAdInterestGroup()` from origins that are different from the current

--- a/site/en/blog/floc/index.md
+++ b/site/en/blog/floc/index.md
@@ -185,7 +185,7 @@ As an example, for a publisher finding ways to select relevant content, the proc
 
 ## How can websites opt out of the FLoC computation?
 
-A site should be able to declare that it does not want to be included in the user's list of sites for cohort calculation. A new `interest-cohort` [permissions policy](https://www.w3.org/TR/permissions-policy-1/) enables this. The policy will be `allow` by default.  
+A site should be able to declare that it does not want to be included in the user's list of sites for cohort calculation. A new `interest-cohort` [permissions policy](/docs/privacy-sandbox/permissions-policy/) enables this. The policy will be `allow` by default.  
 
 For any frame that is _not_ allowed `interest-cohort` permission, the promise returned when it calls `document.interestCohort()` will reject. If the main frame does not have `interest-cohort` permission then the page visit will not be included in interest cohort calculation.  
 

--- a/site/en/blog/new-in-chrome-90/index.md
+++ b/site/en/blog/new-in-chrome-90/index.md
@@ -125,7 +125,7 @@ preselected rules, the browser overrides the behavior with better UX or
 just says, "talk to the hand," blocking the API altogether.
 
 Starting in Chrome 90, the Feature Policy API will be renamed
-Permissions Policy, and the HTTP header has been renamed along with it. At
+[Permissions Policy](/docs/privacy-sandbox/permissions-policy/), and the HTTP header has been renamed along with it. At
 the same time, the community has settled on a new syntax, based on Structured
 Field Values for HTTP.
 

--- a/site/en/blog/new-in-devtools-90/index.md
+++ b/site/en/blog/new-in-devtools-90/index.md
@@ -301,7 +301,7 @@ Chromium issue: [887173][41]
 [26]: https://crbug.com/1128885
 [27]: https://crbug.com/1069425
 [28]: https://crbug.com/1077657
-[29]: https://github.com/w3c/webappsec-permissions-policy/blob/main/permissions-policy-explainer.md
+[29]: /docs/privacy-sandbox/permissions-policy/
 [30]: https://crbug.com/1158827
 [31]: https://github.com/privacycg/first-party-sets
 [32]: https://crbug.com/1161427

--- a/site/en/blog/new-in-devtools-91/index.md
+++ b/site/en/blog/new-in-devtools-91/index.md
@@ -158,7 +158,7 @@ You can now view details on blocked features under the **Permissions policy** se
 
 Open this [demo](http://permission-policy-demo.glitch.me/) page. Go to the **Application** panel and select a frame. In the **Permissions Policy** section, scroll to the **Disabled Features** property. Click on **Show details** to view the details on why the feature is blocked. Click on the icon next to each policy to navigate to the iframe or network request that blocked the feature.
 
-[Permissions policy](https://github.com/w3c/webappsec-permissions-policy/blob/main/permissions-policy-explainer.md) is a web platform API which gives a website the ability to allow or block the use of browser features in its own frame or in iframes that it embeds.
+[Permissions policy](/docs/privacy-sandbox/permissions-policy/) is a web platform API which gives a website the ability to allow or block the use of browser features in its own frame or in iframes that it embeds.
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/8GxecpqtEUv3xoocvcLi.png", alt="Blocked features in the Frame details view", width="800", height="461" %}
 

--- a/site/en/blog/new-in-devtools-92/index.md
+++ b/site/en/blog/new-in-devtools-92/index.md
@@ -65,7 +65,7 @@ View iframe details by right clicking on the iframe element in the Elements pane
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/YdENg6wjsgPNyMODdOHC.png", alt="Show frame details", width="800", height="486" %}
 
-This takes you to a view of the iframe's details in the Application panel where you can examine document details, security & isolation status, permissions policy, and more to debug potential issues.
+This takes you to a view of the iframe's details in the Application panel where you can examine document details, security & isolation status, [permissions policy](/docs/privacy-sandbox/permissions-policy/), and more to debug potential issues.
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/hEsg9Mc95n7w2tPrv6KH.png", alt="Frame details view", width="800", height="516" %}
 

--- a/site/en/blog/origin-trial-troubleshooting/index.md
+++ b/site/en/blog/origin-trial-troubleshooting/index.md
@@ -477,7 +477,7 @@ A demo showing access to an origin trial feature in an iframe is available at
 
 ### Permissions policies are correctly configured {: #permissions-policies}
 
-Some origin trial features may be affected by a [`Permissions-Policy`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy) 
+Some origin trial features may be affected by a [`Permissions-Policy`](/docs/privacy-sandbox/permissions-policy/) 
 header (previously known as a `Feature-Policy` header). You can check for this in the 
 [Intent to Experiment](https://groups.google.com/a/chromium.org/g/blink-dev/search?q=subject%3Aintent%20subject%3Ato%20subject%3Aexperiment) 
 for the trial feature, or in developer documentation for the feature on [web.dev](https://web.dev) 

--- a/site/en/blog/show-picker/index.md
+++ b/site/en/blog/show-picker/index.md
@@ -200,7 +200,7 @@ Calendar image photo by [Eric Rothermel] on [Unsplash].
 [error]: https://developer.mozilla.org/en-US/docs/Web/API/DOMException
 [demo]: https://show-picker.glitch.me/demo.html
 [issues]: https://github.com/whatwg/html/issues
-[permissions policy]: https://w3c.github.io/webappsec-permissions-policy/
+[permissions policy]: /docs/privacy-sandbox/permissions-policy/
 [@chromiumdev]: https://twitter.com/ChromiumDev
 [mdn]: https://developer.mozilla.org/docs/Web/API/HTMLInputElement/showPicker
 [explainer]: https://github.com/whatwg/html/pull/7319

--- a/site/en/blog/user-agent-reduction-origin-trial/index.md
+++ b/site/en/blog/user-agent-reduction-origin-trial/index.md
@@ -107,7 +107,7 @@ Subresource requests to the same origin will automatically send the same
 User-Agent string as the top-level request sent. Subresource requests to
 third-party origins will also send the same User-Agent string as the top-level
 request, including the reduced UA string if the origin trial token is valid,
-provided that the permissions policy allows it.
+provided that the [permissions policy](/docs/privacy-sandbox/permissions-policy/) allows it.
 
 ## How do I participate in the User-Agent Reduction origin trial? {: #enroll-top-level }
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Updates the references to the old Permissions Policy article with the [new article](https://developer.chrome.com/docs/privacy-sandbox/permissions-policy/)