### PR TITLE
Add Project Fugu API Showcase, migrate `https://web.dev/fugu-status/`

### DIFF
--- a/site/en/blog/fugu-showcase/index.md
+++ b/site/en/blog/fugu-showcase/index.md
@@ -6,7 +6,7 @@ subhead: >
   in the context of Project Fugu.
 authors:
   - thomassteiner
-date: 2022-04-22
+date: 2022-04-25
 # updated: 2022-04-21
 hero: image/8WbTDNrhLsU0El80frMBGE4eMCD3/8FZcBmFowbDKWxpkOytx.jpg
 alt: Blowfish swarm swimming in the ocean.

--- a/site/en/blog/fugu-showcase/index.md
+++ b/site/en/blog/fugu-showcase/index.md
@@ -9,7 +9,7 @@ authors:
 date: 2022-04-22
 # updated: 2022-04-21
 hero: image/8WbTDNrhLsU0El80frMBGE4eMCD3/8FZcBmFowbDKWxpkOytx.jpg
-alt: Blowfish swarm swimming in the ocean
+alt: Blowfish swarm swimming in the ocean.
 tags:
   - capabilities
 ---

--- a/site/en/blog/fugu-showcase/index.md
+++ b/site/en/blog/fugu-showcase/index.md
@@ -34,10 +34,6 @@ Easter egg, the Project Fugu API Showcase is of course
 <a href="https://tomayac.github.io/fugu-showcase/data/#tomayac.github.io!fugu-showcase!data" target="showcase">contained
 in the Project Fugu API Showcase</a>. Happy browsing!
 
-<div class="glitch-embed-wrap" style="height: 100%; width: 100%;">
+<div style="height: 100%; width: 100%;">
   <iframe title="Fugu showcase" name="showcase" style="min-height: 800px; width: 100%; border: 0;" src="https://tomayac.github.io/fugu-showcase/data/" allow="web-share"></iframe>
 </div>
-
-## Acknowledgements
-
-Hero image based on a [photo](https://unsplash.com/photos/QURU8IY-RaI) by [Sarah Lee](https://unsplash.com/@hisarahlee).

--- a/site/en/blog/fugu-showcase/index.md
+++ b/site/en/blog/fugu-showcase/index.md
@@ -1,0 +1,43 @@
+---
+layout: 'layouts/blog-post.njk'
+title: Project Fugu API showcase
+subhead: >
+  The Project Fugu API Showcase is a collection of apps that make use of APIs that were conceived
+  in the context of Project Fugu.
+authors:
+  - thomassteiner
+date: 2022-04-22
+# updated: 2022-04-21
+hero: image/8WbTDNrhLsU0El80frMBGE4eMCD3/8FZcBmFowbDKWxpkOytx.jpg
+alt: Blowfish swarm swimming in the ocean
+tags:
+  - capabilities
+---
+
+The Capabilities Project (code name [Project Fugu](/blog/fugu-status/)) is a cross-company effort with
+the objective of making it possible for web apps to do anything platform-specific apps can. We
+enable amazing web applications like [Photoshop](https://web.dev/ps-on-the-web/) by exposing the capabilities of
+the underlying operating system platforms to the web platform, while maintaining user security,
+privacy, trust, and other core tenets of the web.
+
+But what are examples of some of the apps that make use of these capabilities? The Project Fugu API
+Showcase embedded below is sourced by community submissions and contains a filterable list of apps
+that make use of one or more APIs that were developed in the context of the project. You can propose
+missing apps by submitting them via an
+[anonymous form](https://docs.google.com/forms/d/e/1FAIpQLScNd1rClbmFWh6FcMmjUNrwg9RLz8Jk4BkHz_-EOpmkVd_-9g/viewform).
+Submissions are reviewed on a regular basis and the showcase will be updated accordingly.
+
+You can launch each app by clicking the app's name, the app's preview image, or the **Launch app**
+link. For many apps, you can also see the source code by clicking **Source code**. On supporting
+browsers, you can share any of the listed apps via the **Share app** feature. As a special inception
+Easter egg, the Project Fugu API Showcase is of course
+<a href="https://tomayac.github.io/fugu-showcase/data/#tomayac.github.io!fugu-showcase!data" target="showcase">contained
+in the Project Fugu API Showcase</a>. Happy browsing!
+
+<div class="glitch-embed-wrap" style="height: 100%; width: 100%;">
+  <iframe title="Fugu showcase" name="showcase" style="min-height: 800px; width: 100%; border: 0;" src="https://tomayac.github.io/fugu-showcase/data/" allow="web-share"></iframe>
+</div>
+
+## Acknowledgements
+
+Hero image based on a [photo](https://unsplash.com/photos/QURU8IY-RaI) by [Sarah Lee](https://unsplash.com/@hisarahlee).

--- a/site/en/blog/fugu-status/index.md
+++ b/site/en/blog/fugu-status/index.md
@@ -1,11 +1,11 @@
 ---
 layout: 'layouts/blog-post.njk'
 title: New capabilities status
-subhead: Web apps should be able to do anything iOS/Android/desktop apps can. The members of the cross-company capabilities project want to make it possible for you to build and deliver apps on the open web that have never been possible before.
+subhead: Web apps should be able to do anything iOS, Android, or desktop apps can. The members of the cross-company capabilities project want to make it possible for you to build and deliver apps on the open web that have never been possible before.
 date: 2018-11-12
 updated: 2022-04-22
 hero: image/8WbTDNrhLsU0El80frMBGE4eMCD3/8FZcBmFowbDKWxpkOytx.jpg
-alt: Blowfish swarm swimming in the ocean
+alt: Blowfish swarm swimming in the ocean.
 tags:
   - capabilities
 ---
@@ -15,7 +15,7 @@ tags:
 </figure>
 
 The [capabilities project][capabilities-project] is a cross-company effort with the objective of
-making it possible for web apps to do anything iOS/Android/desktop apps can, by exposing the
+making it possible for web apps to do anything iOS, Android, or desktop apps can, by exposing the
 capabilities of these platforms to the web platform, while maintaining user
 security, privacy, trust, and other core tenets of the web.
 

--- a/site/en/blog/fugu-status/index.md
+++ b/site/en/blog/fugu-status/index.md
@@ -24,23 +24,23 @@ This work, among many other examples, allowed
 [Excalidraw to deprecate their Electron app](https://web.dev/deprecating-excalidraw-electron/), and
 [Betty Crocker to increase purchase intent indicators by 300%](https://web.dev/betty-crocker/).
 
+{% Aside %}
+Be sure to try out some of the apps the community has built with Fugu APIs
+by heading over to our [Project Fugu API Showcase](/blog/fugu-showcase/) and exploring it.
+{% endAside %}
+
 You can see the list of new and potential capabilities and the stage each proposal
 is in on the [Fugu API Tracker](https://goo.gle/fugu-api-tracker).
 It's worth noting that many ideas never make it past the explainer or origin trial stage.
 The goal of the process is to ship the right features. That means we need to learn and
 iterate quickly. Not shipping a feature because it doesn't solve the developer need is OK.
 
-{% Aside 'codelab' %}
-Be sure to try out some of the apps the community has built with Fugu APIs
-by heading over to our [Project Fugu API Showcase](/blog/fugu-showcase/) and exploring it.
-{% endAside %}
-
 ## Capabilities available in stable {: #in-stable }
 
 The following APIs have graduated from origin trial and are available in the
 latest version of Chrome, and in many cases other Chromium based browsers.
 
-<a style="text-decoration: none;" class="button" data-type="primary" href="https://fugu-tracker.web.app/#shipped">
+<a class="material-button button-filled button-round display-inline-flex color-bg bg-primary gap-top-400" href="https://fugu-tracker.web.app/#shipped">
   All already shipped APIs
 </a>
 
@@ -58,7 +58,7 @@ available behind a flag (see below) it's still possible for an API surface to
 change based on your feedback. There's more info on origin trials in the [Origin
 Trials Guide for Web Developers][ot-guide].
 
-<a style="text-decoration: none;" class="button" data-type="primary" href="https://fugu-tracker.web.app/#origin-trial">
+<a class="material-button button-filled button-round display-inline-flex color-bg bg-primary gap-top-400" href="https://fugu-tracker.web.app/#origin-trial">
   All APIs currently in origin trial
 </a>
 
@@ -69,7 +69,7 @@ under development. They are not ready for use in production. There's a good
 chance there are bugs, that these APIs will break, or the API surface will
 change.
 
-<a style="text-decoration: none;" class="button" data-type="primary" href="https://fugu-tracker.web.app/#developer-trial">
+<a class="material-button button-filled button-round display-inline-flex color-bg bg-primary gap-top-400" href="https://fugu-tracker.web.app/#developer-trial">
   All APIs currently behind a flag
 </a>
 
@@ -79,7 +79,7 @@ Work on these APIs has just started. There is not much to see yet,
 but interested developers may want to star the relevant Chromium bugs
 to stay updated on progress that is being made.
 
-<a style="text-decoration: none;" class="button" data-type="primary" href="https://fugu-tracker.web.app/#started">
+<a class="material-button button-filled button-round display-inline-flex color-bg bg-primary gap-top-400" href="https://fugu-tracker.web.app/#started">
   All APIs on which work has started
 </a>
 
@@ -89,7 +89,7 @@ This is the backlog of APIs and ideas we have not gotten to yet.
 It is worthwhile to star the relevant Chromium bugs to cast your vote
 for a feature, and to be informed once work starts.
 
-<a style="text-decoration: none;" class="button" data-type="primary" href="https://fugu-tracker.web.app/#under-consideration">
+<a class="material-button button-filled button-round display-inline-flex color-bg bg-primary gap-top-400" href="https://fugu-tracker.web.app/#under-consideration">
   All APIs under consideration
 </a>
 

--- a/site/en/blog/fugu-status/index.md
+++ b/site/en/blog/fugu-status/index.md
@@ -1,0 +1,111 @@
+---
+layout: 'layouts/blog-post.njk'
+title: New capabilities status
+subhead: Web apps should be able to do anything iOS/Android/desktop apps can. The members of the cross-company capabilities project want to make it possible for you to build and deliver apps on the open web that have never been possible before.
+date: 2018-11-12
+updated: 2022-04-22
+hero: image/8WbTDNrhLsU0El80frMBGE4eMCD3/8FZcBmFowbDKWxpkOytx.jpg
+alt: Blowfish swarm swimming in the ocean
+tags:
+  - capabilities
+---
+
+<figure data-float="right">
+{% Img src="image/8WbTDNrhLsU0El80frMBGE4eMCD3/uIIvM9xocYkjmBfHSrJE.svg", alt="A fugu fish, the logo of Project Fugu.", width="150", height="150" %}
+</figure>
+
+The [capabilities project][capabilities-project] is a cross-company effort with the objective of
+making it possible for web apps to do anything iOS/Android/desktop apps can, by exposing the
+capabilities of these platforms to the web platform, while maintaining user
+security, privacy, trust, and other core tenets of the web.
+
+This work, among many other examples, allowed
+[Adobe to bring Photoshop to the web](https://web.dev/ps-on-the-web/),
+[Excalidraw to deprecate their Electron app](https://web.dev/deprecating-excalidraw-electron/), and
+[Betty Crocker to increase purchase intent indicators by 300%](https://web.dev/betty-crocker/).
+
+You can see the list of new and potential capabilities and the stage each proposal
+is in on the [Fugu API Tracker](https://goo.gle/fugu-api-tracker).
+It's worth noting that many ideas never make it past the explainer or origin trial stage.
+The goal of the process is to ship the right features. That means we need to learn and
+iterate quickly. Not shipping a feature because it doesn't solve the developer need is OK.
+
+{% Aside 'codelab' %}
+Be sure to try out some of the apps the community has built with Fugu APIs
+by heading over to our [Project Fugu API Showcase](/blog/fugu-showcase/) and exploring it.
+{% endAside %}
+
+## Capabilities available in stable {: #in-stable }
+
+The following APIs have graduated from origin trial and are available in the
+latest version of Chrome, and in many cases other Chromium based browsers.
+
+<a style="text-decoration: none;" class="button" data-type="primary" href="https://fugu-tracker.web.app/#shipped">
+  All already shipped APIs
+</a>
+
+## Capabilities available as an origin trial {: #origin-trial }
+
+These APIs are available as an [origin trial][ot-dashboard] in Chrome. Origin
+trials provide an opportunity for Chrome to validate experimental features and
+APIs, and make it possible for you to provide feedback on their usability
+and effectiveness in broader deployment.
+
+Opting into an origin trial allows you to build demos and prototypes that your
+beta testing users can try for the duration of the trial without requiring them
+to flip any flags in their browser. Although typically more stable than features
+available behind a flag (see below) it's still possible for an API surface to
+change based on your feedback. There's more info on origin trials in the [Origin
+Trials Guide for Web Developers][ot-guide].
+
+<a style="text-decoration: none;" class="button" data-type="primary" href="https://fugu-tracker.web.app/#origin-trial">
+  All APIs currently in origin trial
+</a>
+
+## Capabilities available behind a flag {: #flag }
+
+These APIs are only available behind a flag. They're experimental and still
+under development. They are not ready for use in production. There's a good
+chance there are bugs, that these APIs will break, or the API surface will
+change.
+
+<a style="text-decoration: none;" class="button" data-type="primary" href="https://fugu-tracker.web.app/#developer-trial">
+  All APIs currently behind a flag
+</a>
+
+## Capabilities that are started {: #started }
+
+Work on these APIs has just started. There is not much to see yet,
+but interested developers may want to star the relevant Chromium bugs
+to stay updated on progress that is being made.
+
+<a style="text-decoration: none;" class="button" data-type="primary" href="https://fugu-tracker.web.app/#started">
+  All APIs on which work has started
+</a>
+
+## Capabilities that are under consideration {: #under-consideration }
+
+This is the backlog of APIs and ideas we have not gotten to yet.
+It is worthwhile to star the relevant Chromium bugs to cast your vote
+for a feature, and to be informed once work starts.
+
+<a style="text-decoration: none;" class="button" data-type="primary" href="https://fugu-tracker.web.app/#under-consideration">
+  All APIs under consideration
+</a>
+
+## Suggest a new capability {: #suggest-new }
+
+Do you have a suggestion for a capability you think Chromium should consider?
+Tell us about it by filing a [new feature request](https://goo.gl/qWhHXU).
+Be sure to include as much detail as you can, such as
+the problem you're trying to solve, suggested use cases, and anything else
+that might be helpful.
+
+{% Aside %}
+Want to try some of these new capabilities? Check out the
+[Web Capabilities Codelab](https://developers.google.com/codelabs/project-fugu#0).
+{% endAside %}
+
+[ot-dashboard]: https://developers.chrome.com/origintrials/#/trials/active
+[ot-guide]: https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md
+[capabilities-project]: https://developers.google.com/web/updates/capabilities

--- a/site/es/blog/fugu-status/index.md
+++ b/site/es/blog/fugu-status/index.md
@@ -1,0 +1,59 @@
+---
+layout: 'layouts/blog-post.njk'
+title: Estado de las nuevas capacidades
+subhead: Las aplicaciones web deberían ser capaces de hacer todo lo que las aplicaciones de escritorio/iOS/Android pueden hacer. Los miembros del proyecto de capacidades entre empresas quieren hacer posible que usted cree y entregue aplicaciones en la web abierta que nunca antes habían sido posibles.
+date: 2018-11-12
+updated: 2021-11-04
+tags:
+  - capabilities
+---
+
+<figure data-float="right"> {% Img src="image/8WbTDNrhLsU0El80frMBGE4eMCD3/uIIvM9xocYkjmBfHSrJE.svg", alt="Un pez fugu (pez globo), el logo de Project Fugu", width="150", height="150" %}</figure>
+
+El [proyecto de capacidades](https://developers.google.com/web/updates/capabilities) es un esfuerzo entre empresas con el objetivo de hacer posible que las aplicaciones web hagan todo lo que pueden hacer las aplicaciones de escritorio/iOS/Android, al exponer las capacidades de estas plataformas a la plataforma web, mientras se mantiene la seguridad, privacidad y confianza del usuario. y otros principios básicos de la web.
+
+Este trabajo, entre muchos otros ejemplos, permitió a [Adobe llevar Photoshop a la web](/ps-on-the-web/), a [Excalidraw desaprobar su aplicación Electron](/deprecating-excalidraw-electron/) y a [Betty Crocker aumentar los indicadores de intención de compra en un 300%](/betty-crocker/).
+
+{% Aside %}
+Asegúrate de probar algunas de las aplicaciones que la comunidad ha creado con las APIs de Fugu visitando nuestra [Exhibición de las APIs de Project Fugu](/blog/fugu-showcase/) y explorándola.
+{% endAside %}
+
+Puede ver la lista completa de capacidades nuevas y potenciales y la etapa en la que se encuentra cada propuesta en el [Rastreador de API de Fugu](https://goo.gle/fugu-api-tracker). Vale la pena señalar que muchas ideas nunca pasan de la etapa de explicación o prueba de origen. El objetivo del proceso es enviar las funciones adecuadas. Eso significa que debemos aprender e iterar rápidamente. Está bien no enviar una función si no resuelve la necesidad del desarrollador.
+
+## Capacidades disponibles en estable {: #in-stable }
+
+Las siguientes API superaron la versión de prueba original y están disponibles en la última versión de Chrome y, en muchos casos, en otros navegadores basados en Chromium.
+
+<a class="material-button button-filled button-round display-inline-flex color-bg bg-primary gap-top-400" href="https://fugu-tracker.web.app/#shipped"> Todas las API enviadas </a>
+
+## Capacidades disponibles como prueba de origen {: #origin-trial }
+
+Estas API están disponibles en Chrome como [pruebas de origen](https://developers.chrome.com/origintrials/#/trials/active). Las pruebas de origen brindan una oportunidad para que Chrome valide las funciones experimentales y las API, y le permite dar retroalimentación sobre su usabilidad y efectividad en una implementación más amplia.
+
+Optar por una prueba de origen le permite crear demostraciones y prototipos que los usuarios de la prueba beta pueden probar durante la duración de la prueba, sin necesidad de que cambien ninguna marca en su navegador. Aunque normalmente es más estable que las funciones disponibles detrás de una bandera (ver más abajo), es posible que la superficie de una API cambie en función de sus comentarios. Hay más información sobre las pruebas de origen en la [Guía de pruebas de origen para desarrolladores web](https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md).
+
+<a class="material-button button-filled button-round display-inline-flex color-bg bg-primary gap-top-400" href="https://fugu-tracker.web.app/#origin-trial"> Todas las API actualmente en prueba de origen </a>
+
+## Capacidades disponibles detrás de una bandera {: #flag }
+
+Estas API solo están disponibles detrás de una bandera. Son experimentales y aún están en desarrollo. No están listos para su uso en producción. Es muy probable que haya errores, que estas API se rompan o que la superficie de la API cambie.
+
+<a class="material-button button-filled button-round display-inline-flex color-bg bg-primary gap-top-400" href="https://fugu-tracker.web.app/#developer-trial"> Todas las API actualmente detrás de una bandera </a>
+
+## Capacidades que están en inicio {: #started }
+
+El trabajo en estas API acaba de comenzar. Todavía no hay mucho que ver, pero los desarrolladores interesados pueden querer destacar los errores relevantes de Chromium para mantenerse actualizados sobre el progreso que se está realizando.
+
+<a class="material-button button-filled button-round display-inline-flex color-bg bg-primary gap-top-400" href="https://fugu-tracker.web.app/#started">Todas las API en las que se ha comenzado a trabajar</a>
+
+## Capacidades que están bajo consideración {: #under-consider }
+
+Estas son las API e ideas que siguen bajo consideración. Vale la pena destacar los errores más relevantes en Chromium para votar por una función y estar informado una vez que comience el trabajo.
+
+<a class="material-button button-filled button-round display-inline-flex color-bg bg-primary gap-top-400" href="https://fugu-tracker.web.app/#under-consideration">Todas las API en consideración</a>
+
+## Sugerir una nueva capacidad {: #suggest-new }
+
+¿Tiene alguna sugerencia para una capacidad que cree que Chromium debería considerar? Cuéntenoslo presentando una [nueva solicitud de función](https://goo.gl/qWhHXU). Asegúrese de incluir tantos detalles como pueda, como el problema que está tratando de resolver, los casos de uso sugeridos y cualquier otra cosa que pueda ser útil.
+
+{% Aside %} ¿Quieres probar algunas de estas nuevas capacidades? Consulte el [laboratorio de códigos de capacidades web](https://developers.google.com/codelabs/project-fugu#0). {% endAside %}

--- a/site/es/blog/fugu-status/index.md
+++ b/site/es/blog/fugu-status/index.md
@@ -3,7 +3,7 @@ layout: 'layouts/blog-post.njk'
 title: Estado de las nuevas capacidades
 subhead: Las aplicaciones web deberían ser capaces de hacer todo lo que las aplicaciones de escritorio/iOS/Android pueden hacer. Los miembros del proyecto de capacidades entre empresas quieren hacer posible que usted cree y entregue aplicaciones en la web abierta que nunca antes habían sido posibles.
 date: 2018-11-12
-updated: 2021-11-04
+updated: 2022-04-22
 tags:
   - capabilities
 ---

--- a/site/ko/blog/fugu-status/index.md
+++ b/site/ko/blog/fugu-status/index.md
@@ -1,0 +1,59 @@
+---
+layout: 'layouts/blog-post.njk'
+title: 새로운 기능 상태
+subhead: 웹 앱은 iOS/Android/데스크톱 앱이 할 수 있는 모든 작업을 수행할 수 있어야 합니다. 회사 간 기능 프로젝트의 구성원은 이전에는 불가능했던 개방형 웹에서 앱을 빌드하고 제공할 수 있도록 하고자 합니다.
+date: 2018-11-12
+updated: 2021-11-04
+tags:
+  - capabilities
+---
+
+<figure data-float="right">{% Img src="image/8WbTDNrhLsU0El80frMBGE4eMCD3/uIIvM9xocYkjmBfHSrJE.svg", alt="복어, Fugu 프로젝트 로고.", width="150", height="150" %}</figure>
+
+[기능 프로젝트](https://developers.google.com/web/updates/capabilities)는 사용자 보안, 개인정보 보호, 신뢰 및 웹의 다른 핵심 교리를 유지하면서 이러한 플랫폼의 기능을 웹 플랫폼에 노출함으로써 웹 앱이 iOS/Android/데스크톱 앱이 할 수 있는 모든 작업을 수행할 수 있도록 하는 것을 목표로 하는 회사 간 노력입니다.
+
+다른 여러 예제 중에서 이 작업을 통해 [Adobe는 Photoshop을 웹에 제공하고](/ps-on-the-web/), [Excalidraw은 자체 Electron 앱 사용을 중단하며](/deprecating-excalidraw-electron/) [Betty Crocker는 구매력 지표를 300%까지 늘릴 수 있었습니다](/betty-crocker/).
+
+{% Aside %}
+[프로젝트 Fugu API 쇼케이스](/blog/fugu-showcase/)로 이동하여 탐색하여 커뮤니티에서 Fugu API로 구축한 일부 앱을 사용해 보십시오.
+{% endAside %}
+
+[Fugu API Tracker](https://goo.gle/fugu-api-tracker)에서 새롭고 잠재적인 기능 및 각 제안이 있는 단계에 대한 전체 목록을 볼 수 있습니다. 많은 아이디어가 설명자 또는 원본 시도 단계를 통과하지 못한다는 점은 주목할 가치가 있습니다. 프로세스의 목표는 올바른 기능을 제공하는 것입니다. 즉, 빠르게 배우고 반복해야 합니다. 개발자의 요구 사항을 해결하지 못하기 때문에 기능을 제공하지 않아도 괜찮습니다.
+
+## 안정적으로 사용 가능한 기능 {: #in-stable }
+
+다음 API의 평가 기간이 종료되었으며 최신 버전의 Chrome 및 많은 경우 다른 Chromium 기반 브라우저에서 사용할 수 있습니다.
+
+<a class="material-button button-filled button-round display-inline-flex color-bg bg-primary gap-top-400" href="https://fugu-tracker.web.app/#shipped">이미 전달된 모든 API</a>
+
+## 본래의 평가판으로 사용 가능한 기능 {: #origin-trial }
+
+이러한 API는 Chrome에서 [본래의 평가판](https://developers.chrome.com/origintrials/#/trials/active)으로 사용할 수 있습니다. 본래의 평가판은 Chrome이 실험 기능 및 API를 검증할 수 있는 기회를 제공하고 사용자가 더 광범위한 배포 과정에서 사용성과 효율성에 대한 피드백을 제공할 수 있도록 합니다.
+
+본래의 평가판을 선택하면 베타 테스트 사용자가 브라우저에서 플래그를 뒤집을 필요 없이 평가판 기간 동안 시도할 수 있는 데모 및 프로토타입을 빌드할 수 있습니다. 일반적으로 플래그 뒤에서 사용할 수 있는 기능보다 더 안정적이지만(아래 참조) 피드백에 따라 API 표면이 변경될 수 있습니다. [웹 개발자를 위한 본래의 평가판 가이드](https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md)에는 본래의 평가판에 대한 자세한 정보가 나와 있습니다.
+
+<a class="material-button button-filled button-round display-inline-flex color-bg bg-primary gap-top-400" href="https://fugu-tracker.web.app/#origin-trial">현재 본래의 평가판에 있는 모든 API</a>
+
+## 플래그 뒤에서 사용 가능한 기능 {: #flag }
+
+이러한 API는 플래그 뒤에서만 사용할 수 있습니다. 실험적이며 아직 개발 중입니다. 프로덕션에서 사용할 준비가 되지 않았습니다. 버그가 있거나 이러한 API가 중단되거나 API 표면이 변경될 수 있습니다.
+
+<a class="material-button button-filled button-round display-inline-flex color-bg bg-primary gap-top-400" href="https://fugu-tracker.web.app/#developer-trial">현재 플래그 뒤에 있는 모든 API</a>
+
+## 시작된 기능 {: #started }
+
+이 API에 대한 작업이 막 시작되었습니다. 아직 볼 것이 많지 않지만 관심 있는 개발자는 관련 Chromium 버그에 별표를 표시하여 진행 중인 진행 상황을 최신 상태로 유지할 수 있습니다.
+
+<a class="material-button button-filled button-round display-inline-flex color-bg bg-primary gap-top-400" href="https://fugu-tracker.web.app/#started">작업이 시작된 모든 API</a>
+
+## 고려 중인 기능 {: #under-consideration }
+
+이러한 기능은 아직 구현하지 못한 API와 아이디어에 대한 백로그입니다. 관련 Chromium 버그에 별표를 표시하여 기능에 투표하고 작업이 시작되면 알림을 받는 것이 좋습니다.
+
+<a class="material-button button-filled button-round display-inline-flex color-bg bg-primary gap-top-400" href="https://fugu-tracker.web.app/#under-consideration">고려 중인 모든 API</a>
+
+## 새로운 기능 제안 {: #suggest-new }
+
+Chromium이 고려해야 한다고 생각하는 기능에 대한 제안 사항이 있나요? [새로운 기능 요청](https://goo.gl/qWhHXU)을 제출하여 이에 대해 알려주세요. 해결하려는 문제, 제안된 사용 사례 및 기타 유용할 수 있는 모든 것 등 가능한 한 많은 세부 정보를 포함해야 합니다.
+
+{% Aside %} 이러한 새로운 기능을 사용해 보고 싶나요? [웹 기능 Codelab](https://developers.google.com/codelabs/project-fugu#0)을 확인해 보세요. {% endAside %}

--- a/site/ko/blog/fugu-status/index.md
+++ b/site/ko/blog/fugu-status/index.md
@@ -3,7 +3,7 @@ layout: 'layouts/blog-post.njk'
 title: 새로운 기능 상태
 subhead: 웹 앱은 iOS/Android/데스크톱 앱이 할 수 있는 모든 작업을 수행할 수 있어야 합니다. 회사 간 기능 프로젝트의 구성원은 이전에는 불가능했던 개방형 웹에서 앱을 빌드하고 제공할 수 있도록 하고자 합니다.
 date: 2018-11-12
-updated: 2021-11-04
+updated: 2022-04-22
 tags:
   - capabilities
 ---

--- a/site/pt/blog/fugu-status/index.md
+++ b/site/pt/blog/fugu-status/index.md
@@ -1,0 +1,59 @@
+---
+layout: 'layouts/blog-post.njk'
+title: Status de novos recursos
+subhead: Os aplicativos da Web devem ser capazes de fazer qualquer coisa que os aplicativos iOS, Android e desktop possam. Os membros do projeto de recursos entre empresas querem possibilitar que você crie e entregue aplicativos na web aberta que nunca foram possíveis antes.
+date: 2018-11-12
+updated: 2021-11-04
+tags:
+  - capabilities
+---
+
+<figure data-float="right"> {% Img src="image/8WbTDNrhLsU0El80frMBGE4eMCD3/uIIvM9xocYkjmBfHSrJE.svg", alt="A fugu fish, the logo of Project Fugu.", width="150", height="150" %}</figure>
+
+O [projeto de recursos](https://developers.google.com/web/updates/capabilities) é um esforço entre empresas com o objetivo de possibilitar que os aplicativos da web façam qualquer coisa que os aplicativos iOS / Android / desktop podem, expondo os recursos dessas plataformas para a plataforma web, mantendo a segurança, privacidade e confiança do usuário e outros princípios básicos da web.
+
+Este trabalho, entre muitos outros exemplos, permitiu que a [Adobe trouxesse o Photoshop para a web](/ps-on-the-web/), [Excalidraw para descontinuar seu aplicativo Electron](/deprecating-excalidraw-electron/) e [Betty Crocker para aumentar os indicadores de intenção de compra em 300%](/betty-crocker/).
+
+{% Aside %}
+Certifique-te de experimentar alguns dos aplicativos que a comunidade criou com APIs do Fugu acessando nosso [Projeto Fugu API Showcase](/blog/fugu-showcase/) e explorando-o.
+{% endAside %}
+
+Você pode ver a lista completa de recursos novos e potenciais e o estágio em que cada proposta se encontra no [Fugu API Tracker](https://goo.gle/fugu-api-tracker) . É importante notar que muitas ideias nunca passam do estágio de explicação ou de teste de origem. O objetivo do processo é enviar os recursos corretos. Isso significa que precisamos aprender e iterar rapidamente. Não enviar um recurso porque não resolve a necessidade do desenvolvedor está OK.
+
+## Recursos disponíveis na versão estável {: #in-stable}
+
+As seguintes APIs passaram do teste de origem e estão disponíveis na versão mais recente do Chrome e, em muitos casos, em outros navegadores baseados em Chromium.
+
+<a class="material-button button-filled button-round display-inline-flex color-bg bg-primary gap-top-400" href="https://fugu-tracker.web.app/#shipped">Todas as APIs já enviadas</a>
+
+## Recursos disponíveis como um teste de origem {: #origin-trial}
+
+Essas APIs estão disponíveis como um [teste de origem](https://developers.chrome.com/origintrials/#/trials/active) no Chrome. Os testes de origem fornecem uma oportunidade para o Chrome validar recursos experimentais e APIs e possibilitar que você forneça feedback sobre sua usabilidade e eficácia em uma implantação mais ampla.
+
+Optar por um teste de origem permite que você crie demonstrações e protótipos que seus usuários de teste beta podem experimentar durante o período de teste, sem exigir que eles mudem qualquer sinalizador em seus navegadores. Embora normalmente mais estável do que os recursos disponíveis por trás de uma bandeira (veja abaixo), ainda é possível que a superfície de uma API mude com base em seus comentários. Há mais informações sobre os testes de origem no [Guia de testes de origem para desenvolvedores da Web](https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md).
+
+<a class="material-button button-filled button-round display-inline-flex color-bg bg-primary gap-top-400" href="https://fugu-tracker.web.app/#origin-trial">Todas as APIs atualmente em teste de origem</a>
+
+## Recursos disponíveis por trás de um sinalizador {: #flag}
+
+Essas APIs estão disponíveis apenas atrás de um sinalizador. Eles são experimentais e ainda estão em desenvolvimento. Eles não estão prontos para uso na produção. Há uma boa chance de que haja bugs, que essas APIs apresentem problemas ou que a superfície da API mude.
+
+<a class="material-button button-filled button-round display-inline-flex color-bg bg-primary gap-top-400" href="https://fugu-tracker.web.app/#started">Todas as APIs nas quais o trabalho foi iniciado</a>
+
+## Recursos que são iniciados {: #started}
+
+O trabalho nessas APIs acabou de começar. Não há muito para ver ainda, mas os desenvolvedores interessados podem querer marcar os bugs relevantes do Chromium para se manterem atualizados sobre o progresso que está sendo feito.
+
+<a class="material-button button-filled button-round display-inline-flex color-bg bg-primary gap-top-400" href="https://fugu-tracker.web.app/#started">Todas as APIs nas quais o trabalho foi iniciado</a>
+
+## Recursos que estão sob consideração {: #under-consideration}
+
+Este é o backlog de APIs e ideias que ainda não fizemos. Vale a pena marcar com estrela os bugs relevantes do Chromium para votar em um recurso e ser informado assim que o trabalho começar.
+
+<a class="material-button button-filled button-round display-inline-flex color-bg bg-primary gap-top-400" href="https://fugu-tracker.web.app/#under-consideration">Todas as APIs em consideração</a>
+
+## Sugira um novo recurso {: #suggest-new}
+
+Você tem uma sugestão para um recurso que você acha que o Chromium deveria levar em conta? Conte-nos sobre isso preenchendo um [pedido de novo recurso](https://goo.gl/qWhHXU). Lembre-se de incluir o máximo de detalhes possível, como o problema que você está tentando resolver, casos de uso sugeridos e qualquer outra coisa que possa ser útil.
+
+{% Aside %} Quer experimentar alguns desses novos recursos? Confira o [Codelab de recursos da Web](https://developers.google.com/codelabs/project-fugu#0). {% endAside %}

--- a/site/pt/blog/fugu-status/index.md
+++ b/site/pt/blog/fugu-status/index.md
@@ -3,7 +3,7 @@ layout: 'layouts/blog-post.njk'
 title: Status de novos recursos
 subhead: Os aplicativos da Web devem ser capazes de fazer qualquer coisa que os aplicativos iOS, Android e desktop possam. Os membros do projeto de recursos entre empresas querem possibilitar que você crie e entregue aplicativos na web aberta que nunca foram possíveis antes.
 date: 2018-11-12
-updated: 2021-11-04
+updated: 2022-04-22
 tags:
   - capabilities
 ---

--- a/site/zh/blog/fugu-status/index.md
+++ b/site/zh/blog/fugu-status/index.md
@@ -3,7 +3,7 @@ layout: 'layouts/blog-post.njk'
 title: 新功能状态
 subhead: Web 应用理应能够执行任何 iOS/Android/桌面应用可以执行的操作。跨公司能力项目的成员希望让您能够在开放的 Web 上构建和交付以前从未实现过的应用。
 date: 2018-11-12
-updated: 2021-11-04
+updated: 2022-04-22
 tags:
   - capabilities
 ---

--- a/site/zh/blog/fugu-status/index.md
+++ b/site/zh/blog/fugu-status/index.md
@@ -1,0 +1,59 @@
+---
+layout: 'layouts/blog-post.njk'
+title: 新功能状态
+subhead: Web 应用理应能够执行任何 iOS/Android/桌面应用可以执行的操作。跨公司能力项目的成员希望让您能够在开放的 Web 上构建和交付以前从未实现过的应用。
+date: 2018-11-12
+updated: 2021-11-04
+tags:
+  - capabilities
+---
+
+<figure data-float="right"> {% Img src="image/8WbTDNrhLsU0El80frMBGE4eMCD3/uIIvM9xocYkjmBfHSrJE.svg", alt="一只河豚，Project Fugu 的标志", width="150", height="150" %}</figure>
+
+[功能项目](https://developers.google.com/web/updates/capabilities)是一项跨公司的工作，其目标是让 Web 应用可以执行 iOS/Android/桌面应用可以执行的任何操作，方法是将这些平台的功能赋予 Web 平台，同时维护用户的安全性、隐私和信任，以及 Web 的其他核心原则。
+
+这项工作使 [Adobe 能够将 Photoshop 引入网络](/ps-on-the-web/)、[Excalidraw 弃用他们的 Electron 应用](/deprecating-excalidraw-electron/)、[Betty Crocker 将购买意向指标提高了 300%](/betty-crocker/)，这样的例子比比皆是。
+
+{% Aside %}
+通过前往我们的 [Project Fugu API 展示](/blog/fugu-showcase/) 并探索它，一定要尝试社区使用 Fugu API 构建的一些应用程序。
+{% endAside %}
+
+您可以在[Fugu API Tracker](https://goo.gle/fugu-api-tracker) 上查看新功能和潜在功能的完整列表以及每个提案所处的阶段。值得注意的是，许多想法从未通过解释器或初始试验阶段。该过程的目标是发布正确的功能。这意味着我们需要快速学习和迭代。如果某个功能不能解决开发人员的需求，对其不进行发布是允许的。
+
+## 稳定可用的功能 {: #in-stable }
+
+以下 API 已通过初始试用，可在最新版本的 Chrome 中使用，并且在许多情况下可用于其他基于 Chromium 的浏览器。
+
+<a class="material-button button-filled button-round display-inline-flex color-bg bg-primary gap-top-400" href="https://fugu-tracker.web.app/#shipped">所有已经发布的 API</a>
+
+## 可进行初始试用的功能 {: #origin-trial }
+
+这些 API 可在 Chrome 中进行[初始试用](https://developers.chrome.com/origintrials/#/trials/active)。初始试用为 Chrome 提供验证实验性功能和 API 的机会，并使您可以提供有关它们在更广泛部署中的可用性和有效性的反馈。
+
+选择加入初始试用，可让您在试用期间为试用版测试用户构建他们试用的演示和原型，而无需他们在浏览器中翻转任何标志。尽管通常比标志后面的可用功能（见下文）更稳定，但 API 表面仍然可能根据您的反馈进行更改。有关初始试用的更多信息，请参阅[面向 Web 开发人员的初始试用指南](https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md)。
+
+<a class="material-button button-filled button-round display-inline-flex color-bg bg-primary gap-top-400" href="https://fugu-tracker.web.app/#origin-trial">当前处于初始试用阶段的所有 API</a>
+
+## 标志后面可用的功能 {: #flag }
+
+这些 API 仅在标志后面可用。它们是实验性的，仍在开发中。它们还没有准备好用于生产。很有可能存在错误，这些 API 会损坏，或者 API 表面会发生变化。
+
+<a class="material-button button-filled button-round display-inline-flex color-bg bg-primary gap-top-400" href="https://fugu-tracker.web.app/#developer-trial">当前处于标志之后的所有 API </a>
+
+## 已着手开始创建的功能 {: #started }
+
+这些 API 的工作才刚刚开始。目前还没有太多可看的，但感兴趣的开发人员可能希望为相关的 Chromium 错误加注星标，以随时了解正在取得的进展。
+
+<a class="material-button button-filled button-round display-inline-flex color-bg bg-primary gap-top-400" href="https://fugu-tracker.web.app/#started">已着手开始创建的所有 API</a>
+
+## 正在考虑的功能 {: #under-consideration }
+
+这是我们累积的尚未获得的 API 和想法。值得为相关的 Chromium 错误加注星标以投票支持某个功能，并将在工作开始后发送通知。
+
+<a class="material-button button-filled button-round display-inline-flex color-bg bg-primary gap-top-400" href="https://fugu-tracker.web.app/#under-consideration">正在考虑的所有 API</a>
+
+## 建议新功能 {: #suggest-new }
+
+您有对 Chromium 功能方面的建议吗？请提交[新功能请求](https://goo.gl/qWhHXU)来告诉我们。请提供尽可能多的详细信息，例如您尝试解决的问题、建议的用例以及任何其他可能有帮助的内容。
+
+{% Aside %} 想尝试其中的一些新功能吗？请查看[Web 功能代码实验室](https://developers.google.com/codelabs/project-fugu#0)。 {% endAside %}


### PR DESCRIPTION
Fixes https://github.com/GoogleChrome/web.dev/issues/7777.

Changes proposed in this pull request:

- Add Project Fugu API Showcase
- Migrate `https://web.dev/fugu-status/`