### PR TITLE
[PNA] Update rollout timeline.

### DIFF
--- a/site/en/blog/private-network-access-preflight/index.md
+++ b/site/en/blog/private-network-access-preflight/index.md
@@ -63,10 +63,13 @@ the change and adjust accordingly.
       the same time to allow for websites affected by this phase to request a
       time extension. The trial will last for at least 6 months.
 
-An earlier attempt was made at rolling out warnings in Chrome 98, as previously
+{% Aside %}
+An earlier attempt was made to roll out warnings in Chrome 98, previously
 announced by this blog post. This was rolled back after stability and
-compatibility issues were discovered during the rollout. The identified issues
-were then fixed before the second attempt in Chrome 102.
+compatibility issues were discovered during the rollout.
+
+The identified issues were fixed for Chrome 102.
+{% endAside %}
 
 ## What is Private Network Access (PNA)
 

--- a/site/en/blog/private-network-access-preflight/index.md
+++ b/site/en/blog/private-network-access-preflight/index.md
@@ -6,24 +6,20 @@ authors:
   - agektmr
 description: Chrome is deprecating access to private network endpoints from non-secure public websites as part of the Private Network Access specification. Read on for recommended actions.
 date: 2022-01-06
-updated: 2022-03-07
+updated: 2022-04-27
 hero: image/VbsHyyQopiec0718rMq2kTE1hke2/iqanYAE91Ab6BsgwhBjq.jpg
 alt: An airplane in the sky
 tags:
   - chrome-98
+  - chrome-102
   - security
 ---
 
-{% Aside 'warning' %}
+**Updates**
 
-- **March 7, 2022**: The experiment in Chrome 98 was rolled back due to
-  stability and compatibility issues discovered in the rollout to Chrome
-  stable. These issues will be fixed before the experiment is tried again, no
-  earlier than in Chrome 101. Learn more in the [blink-dev@chromium.org Intent to Ship
-  email
-  thread](https://groups.google.com/a/chromium.org/g/blink-dev/c/72CK2mxD47c/m/d835CNGtAAAJ)
-  for more details.
-{% endAside %}
+- **April 27, 2022**: Updated timeline announcement.
+- **March 7, 2022**: Announced rollback after issues were discovered in
+  Chrome 98.
 
 ## Introduction
 
@@ -49,7 +45,7 @@ allowing attackers to redirect them to malicious servers.
 Chrome will roll this change out in two phases to give websites time to notice
 the change and adjust accordingly.
 
-1. In Chrome 98:
+1. In Chrome 102:
     * Chrome experiments by sending preflight requests ahead of private network
       subresource
       requests.
@@ -58,7 +54,7 @@ the change and adjust accordingly.
     * Chrome gathers compatibility data and reaches out to the largest
       affected websites.
     * We expect this to be broadly compatible with existing websites.
-1. In Chrome 101 at the earliest:
+1. In Chrome 105 at the earliest:
     * This will begin _only_ if and when compatibility data indicates that the
       change is safe enough and we've outreached directly when necessary.
     * Chrome enforces that preflight requests must succeed, otherwise failing
@@ -67,6 +63,10 @@ the change and adjust accordingly.
       the same time to allow for websites affected by this phase to request a
       time extension. The trial will last for at least 6 months.
 
+An earlier attempt was made at rolling out warnings in Chrome 98, as previously
+announced by this blog post. This was rolled back after stability and
+compatibility issues were discovered during the rollout. The identified issues
+were then fixed before the second attempt in Chrome 102.
 
 ## What is Private Network Access (PNA)
 
@@ -251,7 +251,7 @@ Access-Control-Allow-Origin: https://foo.example
 
 ## How to know if your website is affected
 
-Starting in Chrome 98, if a private network request is detected, a preflight
+Starting in Chrome 102, if a private network request is detected, a preflight
 request will be sent ahead of it. If this preflight request fails, the final
 request will still be sent, but a warning will be surfaced in the DevTools
 issues panel.
@@ -302,7 +302,7 @@ the same way as warnings using the DevTools panels mentioned above.
 
 ## What to do if your website is affected
 
-When this change rolls out in Chrome 98, it is not expected to break any
+When this change rolls out in Chrome 102, it is not expected to break any
 website. However, we strongly encourage you to update affected request paths to
 ensure your website keeps running as expected.
 
@@ -360,10 +360,10 @@ the component to `Blink>SecurityFeature>CORS>PrivateNetworkAccess`.
 Next up, Chrome will extend Private Network Access checks to cover
 [web workers](https://developer.mozilla.org/docs/Web/API/Web_Workers_API):
 dedicated workers, shared workers and service workers. We're tentatively aiming
-for Chrome 100 to begin showing warnings.
+for Chrome 104 to begin showing warnings.
 
 Then, Chrome will extend Private Network Access checks to cover navigations,
-including iframes and popups. We're tentatively aiming for Chrome 102 to start
+including iframes and popups. We're tentatively aiming for Chrome 105 to start
 showing warnings.
 
 In both cases, we will be proceeding cautiously with a similar phased rollout,


### PR DESCRIPTION
PNA warning preflights are rolling out in Chrome 102 once more. Enforcement will be enabled in 105 at the earliest. In general, timelines have been set back by 4 milestones.

https://deploy-preview-2714--developer-chrome-com.netlify.app/blog/private-network-access-preflight/