### PR TITLE
Revise to better reflect MV3 behaviors

### DIFF
--- a/site/en/docs/extensions/mv3/manifest/sandbox/index.md
+++ b/site/en/docs/extensions/mv3/manifest/sandbox/index.md
@@ -44,7 +44,7 @@ You can specify your CSP value to restrict the sandbox even further, but it MUST
 `sandbox` directive and MUST NOT have the `allow-same-origin` token (see [the HTML5
 specification][3] for possible sandbox tokens).
 
-Note that you only need to list pages that you expected to be loaded in windows or frames. Resources
+Note that you only need to list pages that you expect to be loaded in windows or frames. Resources
 used by sandboxed pages (e.g. stylesheets or JavaScript source files) do not need to appear in the
 `pages` list because they will use the sandbox of the frame that embeds them.
 

--- a/site/en/docs/extensions/mv3/manifest/sandbox/index.md
+++ b/site/en/docs/extensions/mv3/manifest/sandbox/index.md
@@ -18,24 +18,24 @@ Being in a sandbox has two implications:
     the extension (it has its own separate CSP value). This means that, for example, it can
     use inline script and `eval`.
 
-    For example, here's how to specify that two extension pages are to be served in a sandbox with a
-    custom CSP:
+For example, here's how to specify that two extension pages are to be served in a sandbox with a
+custom CSP:
 
-    ```json
-    {
-      ...
-      "content_security_policy": {
-        "sandbox": "sandbox allow-scripts; script-src 'self' https://example.com"
-      },
-      "sandbox": {
-        "pages": [
-          "page1.html",
-          "directory/page2.html"
-        ]
-      ],
-      ...
-    }
-    ```
+```json
+{
+  ...
+  "content_security_policy": {
+    "sandbox": "sandbox allow-scripts; script-src 'self' https://example.com"
+  },
+  "sandbox": {
+    "pages": [
+      "page1.html",
+      "directory/page2.html"
+    ]
+  ],
+  ...
+}
+```
 
 If not specified, the default `content_security_policy` value is `sandbox allow-scripts allow-forms
 allow-popups allow-modals; script-src 'self' 'unsafe-inline' 'unsafe-eval'; child-src 'self';`.

--- a/site/en/docs/extensions/mv3/manifest/sandbox/index.md
+++ b/site/en/docs/extensions/mv3/manifest/sandbox/index.md
@@ -2,15 +2,15 @@
 layout: "layouts/doc-post.njk"
 title: "Manifest - Sandbox"
 date: 2013-05-12
-updated: 2018-04-26
+updated: 2022-04-28
 description: Reference documentation for the sandbox property of manifest.json.
 ---
 
-**_Warning:_** Starting in version 57, Chrome will no longer allow external web content (including
-embedded frames and scripts) inside sandboxed pages. Please use a [webview][1] instead.
+Defines a collection of extension pages that are to be served in a sandboxed unique origin. The
+Content Security Policy used by an extension's sandboxed pages is specified in the
+`content_security_policy` key.
 
-Defines a collection of extension pages that are to be served in a sandboxed unique origin,
-and optionally a Content Security Policy to use with them. Being in a sandbox has two implications:
+Being in a sandbox has two implications:
 
 1.  A sandboxed page will not have access to extension APIs, or direct access to
     non-sandboxed pages (it may communicate with them via `postMessage()`).
@@ -24,35 +24,35 @@ and optionally a Content Security Policy to use with them. Being in a sandbox ha
     ```json
     {
       ...
+      "content_security_policy": {
+        "sandbox": "sandbox allow-scripts; script-src 'self' https://example.com"
+      },
       "sandbox": {
         "pages": [
           "page1.html",
           "directory/page2.html"
         ]
-        // content_security_policy is optional.
-        "content_security_policy":
-            "sandbox allow-scripts; script-src 'self'"
       ],
       ...
     }
     ```
 
-    If not specified, the default `content_security_policy` value is
-    `sandbox allow-scripts allow-forms allow-popups allow-modals; script-src 'self' 'unsafe-inline' 'unsafe-eval'; child-src 'self';`.
-    You can specify your CSP value to restrict the sandbox even further, but it must have the
-    `sandbox` directive and may not have the `allow-same-origin` token (see [the HTML5
-    specification][3] for possible sandbox tokens). Also, the CSP you specify may not allow loading
-    external web content inside sandboxed pages.
+If not specified, the default `content_security_policy` value is `sandbox allow-scripts allow-forms
+allow-popups allow-modals; script-src 'self' 'unsafe-inline' 'unsafe-eval'; child-src 'self';`.
+
+You can specify your CSP value to restrict the sandbox even further, but it MUST include the
+`sandbox` directive and MUST NOT have the `allow-same-origin` token (see [the HTML5
+specification][3] for possible sandbox tokens).
 
 Note that you only need to list pages that you expected to be loaded in windows or frames. Resources
 used by sandboxed pages (e.g. stylesheets or JavaScript source files) do not need to appear in the
-`sandboxed_page` list, they will use the sandbox of the page that embeds them.
+`pages` list because they will use the sandbox of the frame that embeds them.
 
 ["Using eval in Chrome Extensions. Safely."][4] goes into more detail about implementing a
 sandboxing workflow that enables use of libraries that would otherwise have issues executing under
 extension's [default Content Security Policy][5].
 
-Sandboxed page may only be specified when using [`manifest_version`][6] 2 or above.
+Sandboxed pages may only be specified when using [`manifest_version`][6] 2 or above.
 
 [1]: /docs/apps/webview_tag
 [2]: /docs/extensions/mv3/contentSecurityPolicy


### PR DESCRIPTION
While reviewing the sandboxed pages documentation before linking it to someone, I noticed several inaccuracies. This PR revises the guidance to better reflect how sandboxed pages should behave in Manifest V3. 

[Staging link](https://deploy-preview-2721--developer-chrome-com.netlify.app/docs/extensions/mv3/manifest/sandbox/)