### PR TITLE
blog listing images aspect-ratio

### DIFF
--- a/site/_scss/blocks/_blog-card.scss
+++ b/site/_scss/blocks/_blog-card.scss
@@ -8,8 +8,13 @@
   border: 1px solid var(--color-hairline);
 }
 
+.blog-card__thumbnail a {
+  aspect-ratio: 1.57/1;
+}
+
 .blog-card__thumbnail {
   img {
     max-height: px-to-rem(184px);
+    height: 100%;
   }
 }


### PR DESCRIPTION
I'm not familiar with the CSS for the sites, but the images for the blog listing were set to `object-fit: cover` however there was no width and height info to give them something to cover. I've therefore used the aspect ratio of our ideal sized thumbnail image (376x240 so 1.57:1).

I think this tidies up the listing a bit, and if folks don't like the thumbnail they can provide one of the right dimensions. 