### PR TITLE
Update jump link in extensions doc

### DIFF
--- a/site/en/docs/extensions/mv3/intro/platform-vision/index.md
+++ b/site/en/docs/extensions/mv3/intro/platform-vision/index.md
@@ -192,7 +192,7 @@ The initial steps in this area have already launched:
 * The ability to modify an extension's host access (see [Trustworthy Chrome Extensions,
   by Default](https://blog.chromium.org/2018/10/trustworthy-chrome-extensions-by-default.html)).
 * Moving extensions out of the right-click menu and into a button on the extensions menu
-  (see [A new home for your extensions](https://blog.google/products/chrome/more-intuitive-privacy-and-security-controls-chrome/)).
+  (see [A new home for your extensions](https://blog.google/products/chrome/more-intuitive-privacy-and-security-controls-chrome/#:~:text=A%20new%20home%20for%20your%20extensions)).
 
 ### Future related changes
 


### PR DESCRIPTION
Previously clicking the link took the user  to the top of the target page. The user had to scroll down and find the section "A new home for your extension". I made the specific section the target of the link to improve user experience.
 

-
-
-