### PR TITLE
Fix "get current window" example

### DIFF
--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -65,7 +65,7 @@ scripts cannot use `tabs.query`.
 
 async function getCurrentTab() {
   let queryOptions = { active: true, lastFocusedWindow: true };
-  // tab will either be a Tab instance or undefined
+  // `tab` will either be a `tabs.Tab` instance or `undefined`.
   let [tab] = await chrome.tabs.query(queryOptions);
   return tab;
 }

--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -51,7 +51,9 @@ chrome.runtime.onInstalled.addListener((reason) => {
 
 ### Get the current tab
 
-This example demonstrates how the background script can retrieve the currently focused tab.
+This example demonstrates how the background script can retrieve the active tab from the
+currently-focused window (or most recently-focused window, if no Chrome windows are focused). This
+can usually be thought of as the user's current tab.
 
 {% Aside %}
 

--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -64,7 +64,8 @@ scripts cannot use `tabs.query`.
 //// background.js
 
 async function getCurrentTab() {
-  let queryOptions = { active: true, currentWindow: true };
+  let queryOptions = { active: true, lastFocusedWindow: true };
+  // tab will either be a Tab instance or undefined
   let [tab] = await chrome.tabs.query(queryOptions);
   return tab;
 }


### PR DESCRIPTION
There's currently an issue with the "get current window" example in the Tabs API documentation. The current implementation of this example uses `currentWindow` rather than `lastFocusedWindow`, which  may not match typical developer expectations.

The `currentWindow` property in the queryOptions object matches the context from which the call was executed. As such, if this function is called from an extension tab or iframe, it would return information about the window where this code was called, not the user's currently focused tab (which may be in a different window).