### PR TITLE
Fix quoting error in Migrating From section

### DIFF
--- a/site/en/docs/privacy-sandbox/permissions-policy/index.md
+++ b/site/en/docs/privacy-sandbox/permissions-policy/index.md
@@ -285,7 +285,7 @@ Update it to the Structured Fields syntax that Permissions Policy header uses:
 Permissions-Policy: 
   autoplay=*,
   geolocation=(self),
-  camera=(self ‘https://trusted-site.example’),
+  camera=(self "https://trusted-site.example"),
   fullscreen=()
 ```
 

--- a/site/en/docs/privacy-sandbox/permissions-policy/index.md
+++ b/site/en/docs/privacy-sandbox/permissions-policy/index.md
@@ -8,16 +8,30 @@ authors:
   - kevinkiklee
 ---
 
-Permissions Policy allows the developer to control the browser features available to a page, its iframes, and subresources, by declaring a set of policies for the browser to enforce. The policies are applied to origins provided in a response header origin list. The origin list can contain same-origins and/or cross-origins, and it enables the developer to control first-party and third-party access to browser features. The user has the final decision to allow access to more powerful features, and needs to provide explicit permission via a prompt. 
+Permissions Policy, formerly known as Feature Policy, allows the developer to
+control the browser features available to a page, its iframes, and
+subresources, by declaring a set of policies for the browser to enforce. These
+policies are applied to origins provided in a response header origin list.
+The origin list can contain same-origins and/or cross-origins, and it allows
+the developer to control first-party and third-party access to browser features.
 
-Permissions Policy allows the top-level site to define what it and its third parties intend to use, and removes the burden from the user of determining whether the feature access request is legitimate or not. For example, by blocking the geolocation feature for all third parties via Permissions Policy, the developer can be certain that no third party will gain access to the user's geolocation. 
+The user has the final decision to allow access to more powerful features, and needs to provide explicit permission via a prompt. 
+
+Permissions Policy allows the top-level site to define what it and its third
+parties intend to use, and removes the burden from the user of determining
+whether the feature access request is legitimate or not. For example, by
+blocking the geolocation feature for all third parties via Permissions Policy,
+the developer can be certain that no third party will gain access to the user's
+geolocation. 
 
 {% Aside %}
-[Privacy Sandbox](https://web.dev/digging-into-the-privacy-sandbox/) is a series of proposals to satisfy third-party use cases without third-party cookies or other tracking mechanisms. Privacy Sandbox APIs, such as [User-Agent Client Hints](https://web.dev/user-agent-client-hints/) and the [Topics API](/docs/privacy-sandbox/topics/), are managed by Permissions Policy in the same way that features like `geolocation` and `camera` are managed. For a list of web platform APIs that rely on Permissions Policy, see the [feature list](https://github.com/w3c/webappsec-permissions-policy/blob/main/features.md) (The list may not be always up to date).
+[Privacy Sandbox](https://web.dev/digging-into-the-privacy-sandbox/) is a series of proposals to satisfy third-party use cases without third-party cookies or other tracking mechanisms.
+
+Privacy Sandbox APIs, such as [User-Agent Client Hints](https://web.dev/user-agent-client-hints/) and the [Topics API](/docs/privacy-sandbox/topics/), are managed by Permissions Policy in the same way that features like `geolocation` and `camera` are managed. For a list of web platform APIs that rely on Permissions Policy, see the [feature list](https://github.com/w3c/webappsec-permissions-policy/blob/main/features.md). Note, this list may not be current.
 {% endAside %}
 
 
-## Changes to Permissions Policy, formerly Feature Policy
+## Changes to Permissions Policy
 
 Permissions Policy was previously known as Feature Policy. The key concepts remain the same, but there are some important changes along with the name.
 
@@ -277,6 +291,9 @@ Feature-Policy:
   camera 'self' 'https://trusted-site.example';
   fullscreen 'none';	
 ```
+  {% CompareCaption %}
+    Before with Feature Policy.
+  {% endCompareCaption %}
 {% endCompare %}
 
 {% Compare 'better', 'new' %}
@@ -287,6 +304,9 @@ Permissions-Policy:
   camera=(self "https://trusted-site.example"),
   fullscreen=()
 ```
+  {% CompareCaption %}
+    Now with Permissions Policy.
+  {% endCompareCaption %}
 {% endCompare %}
 
 ### Update `document.allowsFeature(feature, origin)` usage

--- a/site/en/docs/privacy-sandbox/permissions-policy/index.md
+++ b/site/en/docs/privacy-sandbox/permissions-policy/index.md
@@ -8,11 +8,9 @@ authors:
   - kevinkiklee
 ---
 
-<!--lint disable no-smart-quotes-->
-
 Permissions Policy allows the developer to control the browser features available to a page, its iframes, and subresources, by declaring a set of policies for the browser to enforce. The policies are applied to origins provided in a response header origin list. The origin list can contain same-origins and/or cross-origins, and it enables the developer to control first-party and third-party access to browser features. The user has the final decision to allow access to more powerful features, and needs to provide explicit permission via a prompt. 
 
-Permissions Policy allows the top-level site to define what it and its third parties intend to use, and removes the burden from the user of determining whether the feature access request is legitimate or not. For example, by blocking the geolocation feature for all third parties via Permissions Policy, the developer can be certain that no third party will gain access to the user’s geolocation. 
+Permissions Policy allows the top-level site to define what it and its third parties intend to use, and removes the burden from the user of determining whether the feature access request is legitimate or not. For example, by blocking the geolocation feature for all third parties via Permissions Policy, the developer can be certain that no third party will gain access to the user's geolocation. 
 
 {% Aside %}
 [Privacy Sandbox](https://web.dev/digging-into-the-privacy-sandbox/) is a series of proposals to satisfy third-party use cases without third-party cookies or other tracking mechanisms. Privacy Sandbox APIs, such as [User-Agent Client Hints](https://web.dev/user-agent-client-hints/) and the [Topics API](/docs/privacy-sandbox/topics/), are managed by Permissions Policy in the same way that features like `geolocation` and `camera` are managed. For a list of web platform APIs that rely on Permissions Policy, see the [feature list](https://github.com/w3c/webappsec-permissions-policy/blob/main/features.md) (The list may not be always up to date).
@@ -29,7 +27,7 @@ Permissions Policy was previously known as Feature Policy. The key concepts rema
 
 {% Compare 'worse', 'old' %}
   ```text
-  geolocation ‘self’ https://example.com; camera ‘none’
+  geolocation 'self' https://example.com; camera 'none'
   ```
   {% CompareCaption %}
     Before with Feature Policy.
@@ -58,7 +56,7 @@ Feature Policy can still be used after Chrome 88, but it acts as an alias for Pe
 
 ### Quick overview
 
-Before we dive deep, let’s take a quick look at a common scenario where you are the owner of a website and you want to control how your site and third-party code use browser features. 
+Before we dive deep, let's take a quick look at a common scenario where you are the owner of a website and you want to control how your site and third-party code use browser features. 
 
 * Your site is `https://your-site.example`.
 * Your site embeds an iframe from same-origin (`https://your-site.example`). 
@@ -67,6 +65,7 @@ Before we dive deep, let’s take a quick look at a common scenario where you ar
 * You want to allow geolocation only for your site and the trusted site, not for the ad. 
 
 In this case, use the following header: 
+
 ```text
 Permissions-Policy: geolocation=(self "https://trusted-site.example")
 ```
@@ -76,20 +75,20 @@ And explicitly set the `allow` attribute to the iframe tag for the trusted site:
 ```html
 <iframe src="https://trusted-site.example" allow="geolocation">
 ```
-{% Img src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/8mRSZZQAhoAHsa6Tgvyo.png", alt="Quick overview diagram of Permissions Policy usage", width="700", height="238" %}
+{% Img src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/8mRSZZQAhoAHsa6Tgvyo.png", alt="Quick overview diagram of Permissions Policy usage.", width="700", height="238" %}
 
-In this example, the header origin list lets only your site (`self`) and `https://trusted-site.example` to use the geolocation feature. `https://ad.example` is not allowed to use geolocation. 
+In this example, the header origin list lets only your site (`self`) and `trusted-site.example` to use the geolocation feature. `ad.example` is not allowed to use geolocation. 
 
-1. Your site `https://your-site.example` is allowed to use the geolocation feature with the user’s consent.
-1. A same-origin iframe (`https://your-site.example`) is allowed to use the feature without the usage of the `allow` attribute.
-1. An iframe served from a different subdomain (`https://subdomain.your-site-example`) that was not added to the origin list, and has the allow attribute set on the iframe tag, is blocked from using the feature. Different subdomains are considered same-site but cross-origin. 
-1. A cross-origin iframe (`https://trusted-site.example`) that was added to the origin list and has the `allow` attribute set on the iframe tag is allowed to use the feature.
-1. A cross-origin iframe (`https://trusted-site.example`) added to the origin list, without the `allow` attribute, is blocked from using the feature.
-1. A cross-origin iframe (`https://ad.example`) which wasn't added to the origin list is blocked from using the feature, even if the `allow` attribute is included in the iframe tag.
+1. Your site `your-site.example` is allowed to use the geolocation feature with the user's consent.
+1. A same-origin iframe (`your-site.example`) is allowed to use the feature without the usage of the `allow` attribute.
+1. An iframe served from a different subdomain (`subdomain.your-site-example`) that was not added to the origin list, and has the allow attribute set on the iframe tag, is blocked from using the feature. Different subdomains are considered same-site but cross-origin. 
+1. A cross-origin iframe (`trusted-site.example`) that was added to the origin list and has the `allow` attribute set on the iframe tag is allowed to use the feature.
+1. A cross-origin iframe (`trusted-site.example`) added to the origin list, without the `allow` attribute, is blocked from using the feature.
+1. A cross-origin iframe (`ad.example`) which wasn't added to the origin list is blocked from using the feature, even if the `allow` attribute is included in the iframe tag.
 
 ### `Permissions-Policy` HTTP response header
 
-  {% Img src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/jfhckpPdaepkw8bRPM0G.png", alt="Architecture diagram that shows how the user makes a request, the server responds with the Permissions Policy header, and then the browser granting access based on that header", width="800", height="459" %}
+{% Img src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/jfhckpPdaepkw8bRPM0G.png", alt="The user makes a request, the server responds with the Permissions Policy header, and then the browser grants access based on that header.", width="800", height="459" %}
 
 ```text
 Permissions-Policy: &lt;feature&gt;=(&lt;token&gt;|&lt;origin(s)&gt;)
@@ -117,16 +116,16 @@ Here are some example key-value pairs:
   * Example: `geolocation=()`
 
 {% Aside 'warning' %}
-If the Permission Policy header is not present in the response, the default value `*` token is used, which allows all iframes on the page with an `allow` attribute to use the feature. Therefore, it is strongly recommended that the origin list is explicitly set in the Permissions-Policy header to control access. 
+If the Permission Policy header is not present in the response, the default value `*` token is used. This allows all iframes on the page with an `allow` attribute to use the feature. Therefore, it is strongly recommended that the origin list is explicitly set in the Permissions-Policy header to control access. 
 {% endAside %}
 
 {% Aside 'gotchas' %}
-With the change in Permissions Policy from Feature Policy, adding the origin to the header origin list is no longer enough to enable the feature for a cross-origin iframe. The iframe must include the `allow` attribute if it’s cross-origin, regardless of what is set in the header origin list. 
+With the change in Permissions Policy from Feature Policy, adding the origin to the header origin list is no longer enough to enable the feature for a cross-origin iframe. The iframe must include the `allow` attribute if it's cross-origin, regardless of what is set in the header origin list. 
 {% endAside %}
 
 #### Different subdomains and paths
 
-Different subdomains, such as `https://your-site.example` and `https://subdomain.your-site.example`, are considered [same-site but cross-origin](https://web.dev/same-site-same-origin/). Therefore, adding a subdomain in the origin list does not allow access to another subdomain of the same site. Every embedded subdomain that wants to use the feature must be added separately to the origin list.  For example, if access to the user’s browsing topics is allowed to the same-origin only with the header `Permissions-Policy: browsing-topics=(self)`, an iframe from a different subdomain of the same site, `https://subdomain.your-site.example`, will not have access to the topics. 
+Different subdomains, such as `https://your-site.example` and `https://subdomain.your-site.example`, are considered [same-site but cross-origin](https://web.dev/same-site-same-origin/). Therefore, adding a subdomain in the origin list does not allow access to another subdomain of the same site. Every embedded subdomain that wants to use the feature must be added separately to the origin list. For example, if access to the user's browsing topics is allowed to the same-origin only with the header `Permissions-Policy: browsing-topics=(self)`, an iframe from a different subdomain of the same site, `https://subdomain.your-site.example`, will not have access to the topics. 
 
 Different paths, such as `https://your-site.example` and `https://your-site.example/embed`, are considered same-origin, and different paths do not have to be listed in the origin list. 
 
@@ -136,7 +135,7 @@ Different paths, such as `https://your-site.example` and `https://your-site.exam
 
 For cross-origin usage, an iframe needs the `allow` attribute in the tag to gain access to the feature.
 
-Syntax: `<iframe src="[ORIGIN]" allow="[FEATURE] <’src’ | [ORIGIN(s)]"></iframe>`
+Syntax: `<iframe src="[ORIGIN]" allow="[FEATURE] <'src' | [ORIGIN(s)]"></iframe>`
 
 For example:
 
@@ -145,7 +144,7 @@ For example:
 ```
 
 {% Aside %}
-The syntax `allow="geolocation"` is a shorthand for allow="geolocation 'src'". src is a special token that expands into the origin of the iframe’s `src` attribute. 
+The syntax `allow="geolocation"` is a shorthand for allow="geolocation 'src'". src is a special token that expands into the origin of the iframe's `src` attribute. 
 {% endAside %} 
 
 #### Handling iframe navigation
@@ -177,7 +176,7 @@ Permissions-Policy: geolocation=*
 <iframe src="https://ad.example" allow="geolocation">
 ```
 
-When the origin list is set to the `*` token, the feature is allowed for all origins present on the page, including itself and all iframes. In this example, all code served from `https://your-site.example` and the codes served from `https://trusted-site.example` iframe and `https://ad.example` have access to the geolocation feature in the user’s browser. Remember that the allow attribute must also be set on the iframe itself along with adding the origin to the header origin list. 
+When the origin list is set to the `*` token, the feature is allowed for all origins present on the page, including itself and all iframes. In this example, all code served from `https://your-site.example` and the codes served from `https://trusted-site.example` iframe and `https://ad.example` have access to the geolocation feature in the user's browser. Remember that the allow attribute must also be set on the iframe itself along with adding the origin to the header origin list. 
 
 This setup can be seen in the [demo](https://permissions-policy-demo.glitch.me/demo/all-allowed). 
 
@@ -201,7 +200,7 @@ This setup can be seen in the [demo](https://permissions-policy-demo.glitch.me/d
 Permissions-Policy: geolocation=(self "https://trusted-site.example")
 ```
 
-This syntax allows the usage of geolocation to both self (`https://your-site.example`) and `https://trusted-site.example`. Remember to explicitly add the allow attribute to the iframe tag. If there is another iframe with `<iframe src="https://ad.example” allow="geolocation">`, then `https://ad.example` will not have access to the geolocation feature. Only the original page and `https://trusted-site.example` that is listed in the origin list along with having the allow attribute in the iframe tag will have access to the user’s feature. 
+This syntax allows the usage of geolocation to both self (`https://your-site.example`) and `https://trusted-site.example`. Remember to explicitly add the allow attribute to the iframe tag. If there is another iframe with `<iframe src="https://ad.example” allow="geolocation">`, then `https://ad.example` will not have access to the geolocation feature. Only the original page and `https://trusted-site.example` that is listed in the origin list along with having the allow attribute in the iframe tag will have access to the user's feature. 
 
 This setup can be seen in the [demo](https://permissions-policy-demo.glitch.me/demo/some-allowed). 
 
@@ -221,25 +220,24 @@ The existing JavaScript API of Feature Policy is found as an object on either th
 
 The Feature Policy API can be used for policies set by Permissions Policy, with some limitations. There are [remaining questions](https://github.com/w3c/webappsec-permissions-policy/issues/401) regarding a JavaScript API implementation, and a [proposal](https://github.com/w3c/webappsec-permissions-policy/issues/401#issuecomment-824878596) has been made to move the logic into the [Permissions API](https://developer.mozilla.org/docs/Web/API/Permissions_API). Join the discussion if you have any thoughts. 
 
-
 ### featurePolicy.allowsFeature(feature)
 
 * Returns `true` if the feature is allowed for the default-origin usage. 
 * The behavior is the same for both policies set by Permissions Policy and the previous Feature Policy
-* When `allowsFeature()` is called on an iframe element (`iframeEl.featurePolicy.allowsFeature(‘geolocation’)`), the returned value reflects if the allow attribute is set on the iframe
+* When `allowsFeature()` is called on an iframe element (`iframeEl.featurePolicy.allowsFeature('geolocation')`), the returned value reflects if the allow attribute is set on the iframe
 
 ### featurePolicy.allowsFeature(feature, origin)
 
 * Returns `true` if the feature is allowed for the specified origin. 
-* If the method is called on `document`, this method no longer tells you whether the feature is allowed for the specified origin like Feature Policy did. Now, this method tells you that it’s possible for the feature to be allowed to that origin. You must conduct an additional check of whether the iframe has the `allow` attribute set or not. The developer must conduct an additional check for the `allow` attribute on the iframe element to determine if the feature is allowed for the third-party origin. 
+* If the method is called on `document`, this method no longer tells you whether the feature is allowed for the specified origin like Feature Policy did. Now, this method tells you that it's possible for the feature to be allowed to that origin. You must conduct an additional check of whether the iframe has the `allow` attribute set or not. The developer must conduct an additional check for the `allow` attribute on the iframe element to determine if the feature is allowed for the third-party origin. 
 
 #### Check for features in an iframe with the  `element` object
 
 You can use `element.allowsFeature(feature)` that takes the allow attribute into account unlike `document.allowsFeature(feature, origin)` that does not. 
 
 ```js
-const someIframeEl = document.getElementById(‘some-iframe’)
-const isCameraFeatureAllowed = someIframeEl.featurePolicy.allowsFeature(‘camera’)
+const someIframeEl = document.getElementById('some-iframe')
+const isCameraFeatureAllowed = someIframeEl.featurePolicy.allowsFeature('camera')
 ```
 
 ### featurePolicy.allowedFeatures()
@@ -271,16 +269,17 @@ If you are currently using the `Feature-Policy` header, you can implement the fo
 
 Since the Feature Policy headers are only supported in Chromium-based browsers, and Permissions Policy headers are supported since [Chrome 88](https://chromestatus.com/feature/5745992911552512), it is safe to update the existing headers with Permissions Policy.
 
-If you have a Feature-Policy header like this:
+{% Compare 'worse', 'old' %}
 ```text
 Feature-Policy:
   autoplay *;
-  geolocation ‘self’;
-  camera ‘self’ ‘https://trusted-site.example’;
-  fullscreen ‘none’;	
+  geolocation 'self';
+  camera 'self' 'https://trusted-site.example';
+  fullscreen 'none';	
 ```
+{% endCompare %}
 
-Update it to the Structured Fields syntax that Permissions Policy header uses:
+{% Compare 'better', 'new' %}
 ```text
 Permissions-Policy: 
   autoplay=*,
@@ -288,13 +287,15 @@ Permissions-Policy:
   camera=(self "https://trusted-site.example"),
   fullscreen=()
 ```
+{% endCompare %}
 
 ### Update `document.allowsFeature(feature, origin)` usage
 
 If you are using `document.allowsFeature(feature, origin)` method to check allowed features for iframes, use `allowsFeature(feature)` method attached on the iframe element, and not the containing `document`. The method `element.allowsFeature(feature)` accounts for the allow attribute while `document.allowsFeature(feature, origin)` does not.  
 
 #### Checking feature access with `document`
-If you wish to continue using `document` as the base node, then you must conduct an additional check for the `allow` attribute on the iframe tag. 
+
+To continue using `document` as the base node, then you must conduct an additional check for the `allow` attribute on the iframe tag. 
 
 ```html
 <iframe id="some-iframe" src="https://example.com" allow="camera"></iframe>
@@ -305,16 +306,16 @@ Permissions-Policy: camera=(self "https://example.com")
 ```
 
 ```js
-const isCameraPolicySet = document.featurePolicy.allowsFeature(‘camera’, ‘https://example.com’) 
+const isCameraPolicySet = document.featurePolicy.allowsFeature('camera', 'https://example.com') 
 
-const someIframeEl = document.getElementById(‘some-iframe’)
+const someIframeEl = document.getElementById('some-iframe')
 const hasCameraAttributeValue = someIframeEl.hasAttribute('allow') 
-&& someIframeEl.getAttribute(‘allow’).includes('camera')
+&& someIframeEl.getAttribute('allow').includes('camera')
 
 const isCameraFeatureAllowed = isCameraPolicySet && hasCameraAttributeValue
 ```
 
-Instead of updating the existing code using `document`, it’s recommended to call `allowsFeature()` on the `element` object like the example in the [previous section]().
+Instead of updating the existing code using `document`, it's recommended to call `allowsFeature()` on the `element` object like the previous example.
 
 ## Reporting API
 
@@ -334,13 +335,13 @@ Document-Policy: document-write=?0; report-to=main-endpoint;
 In the current implementation, you can receive policy violation reports from any violations occurring within that frame by configuring an endpoint named 'default' like the example above. Subframes will require their own reporting configuration. 
 
 {% Aside %}
-If you would like to see Permissions Policy support in the Reporting API by default, then add your support or comments to the [discussion](https://github.com/w3c/webappsec-permissions-policy/issues/386).
+If you would like to see Permissions Policy support in the Reporting API by default, [add your support or comments to the discussion](https://github.com/w3c/webappsec-permissions-policy/issues/386).
 {% endAside %}
 
 ## Find out more
 
-For a deeper understanding of Permissions Policy, utilize the following resources: 
+For a deeper understanding of Permissions Policy, refer to the following resources: 
 
 * [Permissions Policy specs](https://www.w3.org/TR/permissions-policy-1/)
 * [Permissions Policy explainer](https://github.com/w3c/webappsec-permissions-policy/blob/main/permissions-policy-explainer.md)
-* [A list of policy controlled features](https://github.com/w3c/webappsec-permissions-policy/blob/main/features.md).
+* A list of [policy-controlled features](https://github.com/w3c/webappsec-permissions-policy/blob/main/features.md).


### PR DESCRIPTION
The Migration section has an incorrect example that uses single quotes instead of double quotes.

Changes proposed in this pull request:
- change single quote to double quote so the example is value
