### PR TITLE
SharedArrayBuffer deprecation OT postponed until 106

### DIFF
--- a/site/en/blog/coep-credentialless-origin-trial/index.md
+++ b/site/en/blog/coep-credentialless-origin-trial/index.md
@@ -22,7 +22,7 @@ alt: >
 
 **Update, May 2022**
 
-`Cross-Origin-Embedder-Policy: credentialless` has been shipped and available in
+`Cross-Origin-Embedder-Policy: credentialless` shipped and has been available in
 Chrome since 96. We've updated this article accordingly.
 
 {% endAside %}

--- a/site/en/blog/coep-credentialless-origin-trial/index.md
+++ b/site/en/blog/coep-credentialless-origin-trial/index.md
@@ -8,7 +8,7 @@ subhead: >
   headers. If they can be requested without credentials, now you can enable cross-origin
   isolation by marking them as such. 
 date: 2021-07-29
-updated: 2021-10-14
+updated: 2022-05-13
 authors:
   - agektmr
 tags:
@@ -18,7 +18,16 @@ alt: >
   Anonymous people are walking a corridor.
 ---
 
-We are experimenting with the new Cross-Origin Embedder Policy (COEP) value
+{% Aside %}
+
+**Update, May 2022**
+
+`Cross-Origin-Embedder-Policy: credentialless` has been shipped and available in
+Chrome since 96. We've updated this article accordingly.
+
+{% endAside %}
+
+We have shipped the new Cross-Origin Embedder Policy (COEP) value
 `credentialless` which allows the browser to load cross-origin resources which
 don't use the Cross-Origin Resource Policy (CORP), by sending a request without
 credentials, such as cookies. This helps developers to adopt cross-origin
@@ -135,39 +144,11 @@ credentials.
 
 ### Will this feature be adopted by other browsers?
 
-* Mozilla Request for position: [Worth
-  prototyping](https://github.com/mozilla/standards-positions/issues/539)
+* [Firefox tracking issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1731778)
 * Webkit Request for position: [No
   signal](https://lists.webkit.org/pipermail/webkit-dev/2021-June/031898.html)
 * [W3C TAG](https://www.w3.org/2001/tag/) Request for position:
   [Pending](https://github.com/w3ctag/design-reviews/issues/582)
-
-## Register for an origin trial
-
-To ensure that `COEP: credentialless` is helping developers to adopt cross
-origin isolation, we are making it available in Chrome 93 as an origin trial.
-You can register for it to allowlist your website to make the
-`Cross-Origin-Embedder-Policy: credentialless` header to take effect.
-
-1. [Request a
-   token](/origintrials/#/view_trial/3036552048754556929)
-   for your origin.
-2. Apply an `Origin-Trial` HTTP header to the document you want to apply
-   `Cross-Origin-Embedder-Policy: credentialless` header. The resulting response
-   header should look something like: `Origin-Trial: TOKEN_GOES_HERE`. (Adding
-   the token as a meta tag is usually an option for many origin trials, but it
-   won't work for this feature.)
-3. Start serving `COEP: credentialless`.
-
-For instance, to get a cross-origin isolated environment, the HTTP headers sent
-are:
-
-* `Origin-Trial: TOKEN_GOES_HERE`
-* `Cross-Origin-Embedder-Policy: credentialless`
-* `Cross-Origin-Opener-Policy:same-origin`
-
-If you have any feedback on this functionality, file an issue at [the
-GitHub repository](https://github.com/WICG/credentiallessness).
 
 ## What's coming next
 
@@ -184,7 +165,7 @@ SharedArrayBuffer
 change](/blog/enabling-shared-array-buffer/) due to
 the above obstacles might be wondering when it will be terminated. Originally we
 announced that it will be terminated in Chrome 96, but we have decided to
-postpone this to Chrome 103.
+postpone this to Chrome 106.
 
 ## Resources
 

--- a/site/en/blog/enabling-shared-array-buffer/index.md
+++ b/site/en/blog/enabling-shared-array-buffer/index.md
@@ -8,23 +8,23 @@ description: >
   SharedArrayBuffer will arrive in Android Chrome 88. It will only be available
   to pages that are cross-origin isolated. Starting in Desktop Chrome 92 it will
   also only be available to cross-origin isolated pages. You can register for an
-  origin trial to retain the current behavior until Desktop Chrome 103.
+  origin trial to retain the current behavior until Desktop Chrome 106.
 origin_trial:
   url: /origintrials/#/view_trial/303992974847508481
 date: 2021-01-18
-updated: 2021-12-21
+updated: 2022-05-13
 hero: image/CZmpGM8Eo1dFe0KNhEO9SGO8Ok23/tWnZEOnNmBeFcZxuR9Dx.jpg
 alt: A collection of padlocks.
 ---
 
 {% Aside %}
 
-**Update, October 2021**
+**Update, May 2022**
 
 To secure more time to introduce ways to relax the requirement to enable
 cross-origin isolation, we've decided to postpone the restriction on
-`SharedArrayBuffer` on desktop described in this article to Chrome 103
-(originally Chrome 96). You might need to update the token.
+`SharedArrayBuffer` on desktop described in this article to Chrome 106
+(originally Chrome 103). You might need to update the token.
 
 {% endAside %}
 
@@ -40,7 +40,7 @@ web, but things are settling down. Here's what you need to know:
   92 it will be limited to cross-origin isolated pages. If you don't think you
   can make this change in time, you can [register for an origin
   trial](#origin-trial) to retain the current behavior until at least Chrome
-  103.
+  106.
 - If you intend to enable cross-origin isolation to continue using
   `SharedArrayBuffer` evaluate the impact this will have on other cross-origin
   elements on your website, such as ad placements. Check if `SharedArrayBuffer`
@@ -70,7 +70,7 @@ can gather data on requests that failed as a result of
 
 If you don't think you can make these changes in time for Chrome 92, you can
 [register for an origin trial](#origin-trial) to retain current Desktop Chrome
-behavior until at least Chrome 103.
+behavior until at least Chrome 106.
 
 {% Aside %}
 **Update, December 2021**
@@ -188,7 +188,7 @@ isolation.
 This is a temporary exception in the form of an 'origin trial' that gives folks
 more time to implement cross-origin isolated pages. It enables
 `SharedArrayBuffer` without requiring the page to be cross-origin isolated. The
-exception expires in Chrome 103, and the exception only applies to Desktop
+exception expires in Chrome 106, and the exception only applies to Desktop
 Chrome.
 
 1. [Request a token]({{origin_trial.url}}) for your origin.


### PR DESCRIPTION
Update two articles reflecting the decision we'll postpone the deprecation origin trial for SharedArrayBuffer gated behind cross-origin isolation to Chrome 106.
@lutzvahl