### PR TITLE
Add opt-out information moved from /docs/privacy-sandbox/fledge

### DIFF
--- a/site/en/blog/fledge-api/index.md
+++ b/site/en/blog/fledge-api/index.md
@@ -6,7 +6,7 @@ authors:
 description: >
   FLEDGE is a Privacy Sandbox proposal to serve remarketing and custom audience use cases, designed so it cannot be used by third parties to track user browsing behavior across sites. 
 date: 2022-01-27
-updated: 2022-05-03
+updated: 2022-05-13
 thumbnail: image/80mq7dk16vVEg8BBhsVe42n6zn82/UiyBX61nCLHExFoy0eEn.jpg
 alt: Photograph of a piping plover bird with a chick on a sandy beach in Middletown, New Jersey, United States.
 tags:
@@ -222,6 +222,55 @@ disabled the API via browser settings, or they may have other settings that prev
 being used. In order to protect user privacy, there is no way to check for this programmatically.
 
 {% endAside %}
+
+
+## How can I opt out of FLEDGE? {: #opt-out}
+
+You can block access to the FLEDGE API either as a site owner, or as an individual user.
+
+### How can sites control access? {: #opt-out-site}
+
+FLEDGE will eventually require sites to set a [Permissions Policy](/docs/privacy-sandbox/permissions-policy/)
+to allow FLEDGE functionality to be available. This will help ensure that arbitrary third parties can't use the API without a site's
+knowledge. However, to facilitate testing during [the first origin trial](/blog/privacy-sandbox-unified-origin-trial),
+this requirement is [waived by default](https://github.com/WICG/turtledove/blob/main/Proposed_First_FLEDGE_OT_Details.md#permissions-policy).
+Sites that would like to explicitly disable FLEDGE functionality during the testing period can use
+the relevant Permissions Policy to block access.
+
+There are two FLEDGE permissions policies that can be set independently:
+* `join-ad-interest-group` enables/disables functionality to add a browser to interest groups
+* `run-ad-auction` enables/disables functionality to run an on-device auction
+
+Access to FLEDGE APIs can be disabled completely in first-party contexts by specifying the following
+permissions policy in an HTTP response header:
+
+``` text
+Permissions-Policy: join-ad-interest-group=(), run-ad-auction=()
+```
+
+You can disable usage of the APIs in an iframe by adding the following `allow` attribute to an
+iframe element:
+
+``` html
+<iframe src="https://example.com" allow="join-ad-interest-group 'none'; run-ad-auction 'none'"></iframe>
+```
+
+The [Proposed First FLEDGE Origin Trial Permissions-Policy](https://github.com/WICG/turtledove/blob/main/Proposed_First_FLEDGE_OT_Details.md#permissions-policy) section provides more detail.
+
+### User opt-out {: #opt-out-user}
+
+A user can block access to the FLEDGE API and other Privacy Sandbox features by using any of the
+following mechanisms:
+
+*  **Disable the Privacy Sandbox trials** in Chrome Settings: **Settings** >
+    **Security and privacy** > **Privacy Sandbox**. This is also accessible at `chrome://settings/privacySandbox`.
+* **Disable third-party cookies** in Chrome Settings: **Settings** > **Security and privacy**.
+* Set **Cookies and other site data** to either "Block third-party cookies" or "Block all cookies"
+  from `chrome://settings/cookies`.
+* Use Incognito mode.
+
+The FLEDGE explainer provides [more detail about API design elements](https://github.com/WICG/turtledove/blob/main/FLEDGE.md#design-elements) and describes how the API seeks to meet [privacy goals](https://github.com/WICG/turtledove/blob/main/FLEDGE.md#:~:text=privacy%20goal).
+
 
 ## Debug FLEDGE worklets {: #debugging }
 

--- a/site/en/docs/privacy-sandbox/fledge/index.md
+++ b/site/en/docs/privacy-sandbox/fledge/index.md
@@ -6,7 +6,7 @@ subhead: >
 description: >
   FLEDGE is a Privacy Sandbox proposal to serve remarketing and custom audience use cases, designed so it cannot be used by third parties to track user browsing behavior across sites. The API enables on-device auctions by the browser, to choose relevant ads from websites the user has previously visited.
 date: 2022-01-27
-updated: 2022-05-03
+updated: 2022-05-13
 authors:
   - samdutton
 ---
@@ -149,50 +149,8 @@ removed when users clear their site data.
 
 ## How can I opt out of FLEDGE? {: #opt-out}
 
-You can block access to the FLEDGE API either as a site owner, or as an individual user.
-
-### How can sites control access? {: #opt-out-site}
-
-FLEDGE will eventually require sites to set a [Permissions Policy](/docs/privacy-sandbox/permissions-policy/)
-to allow FLEDGE functionality to be available. This will help ensure that arbitrary third parties can't use the API without a site's
-knowledge. However, to facilitate testing during [the first origin trial](/blog/privacy-sandbox-unified-origin-trial),
-this requirement is [waived by default](https://github.com/WICG/turtledove/blob/main/Proposed_First_FLEDGE_OT_Details.md#permissions-policy).
-Sites that would like to explicitly disable FLEDGE functionality during the testing period can use
-the relevant Permissions Policy to block access.
-
-There are two FLEDGE permissions policies that can be set independently:
-* `join-ad-interest-group` enables/disables functionality to add a browser to interest groups
-* `run-ad-auction` enables/disables functionality to run an on-device auction
-
-Access to FLEDGE APIs can be disabled completely in first-party contexts by specifying the following
-permissions policy in an HTTP response header:
-
-``` text
-Permissions-Policy: join-ad-interest-group=(), run-ad-auction=()
-```
-
-You can disable usage of the APIs in an iframe by adding the following `allow` attribute to an
-iframe element:
-
-``` html
-<iframe src="https://example.com" allow="join-ad-interest-group 'none'; run-ad-auction 'none'"></iframe>
-```
-
-The [Proposed First FLEDGE Origin Trial Permissions-Policy](https://github.com/WICG/turtledove/blob/main/Proposed_First_FLEDGE_OT_Details.md#permissions-policy) section provides more detail.
-
-### User opt-out {: #opt-out-user}
-
-A user can block access to the FLEDGE API and other Privacy Sandbox features by using any of the
-following mechanisms:
-
-*  **Disable the Privacy Sandbox trials** in Chrome Settings: **Settings** >
-    **Security and privacy** > **Privacy Sandbox**. This is also accessible at `chrome://settings/privacySandbox`.
-* **Disable third-party cookies** in Chrome Settings: **Settings** > **Security and privacy**.
-* Set **Cookies and other site data** to either "Block third-party cookies" or "Block all cookies"
-  from `chrome://settings/cookies`.
-* Use Incognito mode.
-
-The FLEDGE explainer provides [more detail about API design elements](https://github.com/WICG/turtledove/blob/main/FLEDGE.md#design-elements) and describes how the API seeks to meet [privacy goals](https://github.com/WICG/turtledove/blob/main/FLEDGE.md#:~:text=privacy%20goal).
+The FLEDGE API developer guide explains how you can [block access to the FLEDGE API](/blog/fledge-api#opt-out) 
+either as a site owner, or as an individual user.
 
 
 ## Why do we need FLEDGE? {: #why}


### PR DESCRIPTION
It makes more sense to have technical detail in this article.

**Content is moved, not new. Shouldn't need editing or checking.**