### PR TITLE
Fix broken links in webRequest API

### DIFF
--- a/site/en/docs/extensions/reference/webNavigation/index.md
+++ b/site/en/docs/extensions/reference/webNavigation/index.md
@@ -106,12 +106,12 @@ The following transition qualifiers exist:
 
 <table><tbody><tr><th>Transition qualifier</th><th>Description</th></tr><tr><td>"client_redirect"</td><td>One or more redirects caused by JavaScript or meta refresh tags on the page happened during the navigation.</td></tr><tr><td>"server_redirect"</td><td>One or more redirects caused by HTTP headers sent from the server happened during the navigation.</td></tr><tr><td>"forward_back"</td><td>The user used the Forward or Back button to initiate the navigation.</td></tr><tr><td>"from_address_bar"</td><td>The user initiated the navigation from the address bar (aka Omnibox).</td></tr></tbody></table>
 
-[1]: /docs/extensions/mv2/tabs
+[1]: /docs/extensions/mv3/manifest/
 [2]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/webNavigation/
 [3]: /docs/extensions/mv2/samples
 [4]: https://support.google.com/chrome/answer/177873
 [5]: https://support.google.com/chrome/answer/1385029
-[6]: /docs/extensions/webRequest
-[7]: /docs/extensions/tabs
-[8]: /docs/extensions/history#transition_types
+[6]: /docs/extensions/reference/webRequest
+[7]: /docs/extensions/reference/tabs
+[8]: /docs/extensions/reference/history#transition_types
 [9]: https://web.dev/bfcache/

--- a/site/en/docs/extensions/reference/webNavigation/index.md
+++ b/site/en/docs/extensions/reference/webNavigation/index.md
@@ -107,7 +107,7 @@ The following transition qualifiers exist:
 <table><tbody><tr><th>Transition qualifier</th><th>Description</th></tr><tr><td>"client_redirect"</td><td>One or more redirects caused by JavaScript or meta refresh tags on the page happened during the navigation.</td></tr><tr><td>"server_redirect"</td><td>One or more redirects caused by HTTP headers sent from the server happened during the navigation.</td></tr><tr><td>"forward_back"</td><td>The user used the Forward or Back button to initiate the navigation.</td></tr><tr><td>"from_address_bar"</td><td>The user initiated the navigation from the address bar (aka Omnibox).</td></tr></tbody></table>
 
 [1]: /docs/extensions/mv3/manifest/
-[2]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/webNavigation/
+[2]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/mv2-archive/api/webNavigation/
 [3]: /docs/extensions/mv2/samples
 [4]: https://support.google.com/chrome/answer/177873
 [5]: https://support.google.com/chrome/answer/1385029


### PR DESCRIPTION
Fixes #2835.

Changes proposed in this pull request:

- I fixed the broken links in the [WebRequest API](https://developer.chrome.com/docs/extensions/reference/webRequest/).
- PS: I don't know if the first link should be redirected to `/mv3/manifest/`, please check :)