### PR TITLE
Reduces friction for CUJ "I want to know how to migrate my Manifest V2 extension to Manifest V3"

### DIFF
--- a/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
+++ b/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
@@ -4,7 +4,7 @@ title: Migrating to Manifest V3
 subhead: 'Getting you headed in the right direction.'
 description: 'A high-level guide to how you can migrate your Manifest V2 extensions to Manifest V3.'
 date: 2020-11-09
-updated: 2021-08-13
+updated: 2022-06-02
 ---
 
 This guide provides developers with the information they need to begin migrating an extension from
@@ -465,7 +465,6 @@ workers as of Chrome 87.
 
 {% endAside %}
 
-
 ## Modifying network requests  {: #modifying-network-requests }
 
 There is a new [declarativeNetRequest][api-declarativenetrequest] for network request modification,
@@ -487,7 +486,6 @@ host permissions.
 Request redirects and header modifications **do** require the user to grant host permissions.
 
 {% endAside %}
-
 
 ### How do you use declarativeNetRequest?  {: #how-use-declarativenetrequest }
 
@@ -528,7 +526,6 @@ This approach allows privacy-conscious users to withhold those permissions and s
 extension's functionality. This means that developers can implement many common use cases, such as
 content-blocking functionality, without requiring any host permissions.
 
-
 ## Sunset for deprecated APIs  {: #sunset-deprecated-apis }
 
 There are a number of APIs that have long been deprecated. Manifest V3 finally removes support for
@@ -568,13 +565,13 @@ when you migrate to Manifest V3.
 [bootstrap-gs]: https://getbootstrap.com/docs/5.1/getting-started/introduction/
 [csp]: https://content-security-policy.com/
 [dev-google-sw]: https://developers.google.com/web/fundamentals/primers/service-workers
+[doc-background-to-worker]: /docs/extensions/mv3/migrating_to_service_workers
 [doc-manifest]: /docs/extensions/mv3/manifest
 [doc-match-pattern]: /docs/extensions/mv3/match_patterns/
 [doc-perm-warn]: /docs/extensions/mv3/permission_warnings/
+[doc-static-cs]: /docs/extensions/mv3/content_scripts/#static-declarative
 [doc-war]: /docs/extensions/mv3/manifest/web_accessible_resources/
 [doc-whats-new]: /docs/extensions/whatsnew/
-[doc-background-to-worker]: /docs/extensions/mv3/migrating_to_service_workers
-[doc-static-cs]: /docs/extensions/mv3/content_scripts/#static-declarative
 [enterprise-force-list]: https://cloud.google.com/docs/chrome-enterprise/policies/?policy=ExtensionInstallForcelist
 [enterprise-settings]: https://cloud.google.com/docs/chrome-enterprise/policies/?policy=ExtensionSettings
 [github-samples-content]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/reference/mv3/intro/mv3-migration/content-scripts

--- a/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
+++ b/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
@@ -290,16 +290,19 @@ In Manifest V3, all of your extension's logic must be included in the extension.
 load and execute a remotely hosted file. A number of alternative approaches are available, depending
 on your use case and the reason for remote hosting. Here's a few approaches are:
 
-Configuration-driven features and logic : In this approach, your extension loads a remote
+Configuration-driven features and logic
+: In this approach, your extension loads a remote
 configuration (for example a JSON file) at runtime and caches the configuration locally. The
 extension then uses this cached configuration to decide which features to enable.
 
-Externalize logic with a remote service : Consider migrating application logic from the extension to
+Externalize logic with a remote service
+: Consider migrating application logic from the extension to
 a remote web service that your extension can call. (Essentially a form of message passing.) This
 provides you the ability to keep code private and change the code on demand while avoiding the extra
 overhead of resubmitting to the Chrome Web Store.
 
-Bundle third-party libraries : If you are using a popular framework like [React][react-cdn] or
+Bundle third-party libraries
+: If you are using a popular framework like [React][react-cdn] or
 [Bootstrap][bootstrap-gs], you can download the minified files, add them to your project and import
 them locally. For example:
 

--- a/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
+++ b/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
@@ -4,7 +4,7 @@ title: Migrating to Manifest V3
 subhead: 'Getting you headed in the right direction.'
 description: 'A high-level guide to how you can migrate your Manifest V2 extensions to Manifest V3.'
 date: 2020-11-09
-updated: 2022-06-02
+updated: 2022-06-13
 ---
 
 This guide provides developers with the information they need to begin migrating an extension from
@@ -68,7 +68,7 @@ determines whether you're using the Manifest V2 or Manifest V3 feature set:
 
 ### Service worker  {: #man-sw }
 
-In Manifest V3, background pages are now [*service workers*](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API). Register the service worker under the
+In Manifest V3, background pages are now [*service workers*][mdn-service-workers]. Register the service worker under the
 `"background"` field. This field uses the `"service_worker"` key, which specifies a single
 JavaScript file.
 
@@ -364,8 +364,8 @@ manifest file. This API does not [trigger a permission warning][doc-perm-warn].
 
 #### Injecting a static file {: #cs-static-file}
 
-Static file injection with `scripting.executeScript()` is almost identical to it used to work in
-Tabs API. While the old method only took a single file, the new method now takes an array of files.
+Static file injection with `scripting.executeScript()` is almost identical to how it used to work in
+the Tabs API. While the old method only took a single file, the new method now takes an array of files.
 
 {% Columns %}
 ```js
@@ -485,7 +485,7 @@ without requiring the extension to have permissions.
 
 ### Can Manifest V3 extensions use blocking Web Request?  {: #when-use-blocking-webrequest }
 
-The blocking version of the [Web Request API][api-webrequest] exists in Manifest V3, but it can only be used by extensions that are force-installed using Chrome's Enterprise Policies: 
+The blocking version of the [Web Request API][api-webrequest] exists in Manifest V3, but it can only be used by extensions that are force-installed using Chrome's enterprise policies: 
 [ExtensionSettings][enterprise-settings], [ExtensionInstallForcelist][enterprise-force-list].
 
 Extensions meant to be used by the general public must now use [Declarative Net
@@ -513,7 +513,7 @@ do.
 
 Host permissions are still required if the extension wants to *redirect* a request or modify its
 headers. The `declarativeNetRequestWithHostAccess` permission always requires host permissions to
-the request URL and initiator to act on a request.
+the request URL and it's initiator to act on a request.
 
 {% endAside %}
 
@@ -578,6 +578,7 @@ when you migrate to Manifest V3.
 [mdn-cdn]: https://developer.mozilla.org/docs/Glossary/CDN
 [mdn-eval]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/eval
 [mdn-fetch]: https://developer.mozilla.org/docs/Web/API/Fetch_API/Using_Fetch
+[mdn-service-workers]: https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API
 [mv3-checklist]: /docs/extensions/mv3/mv3-migration-checklist
 [mv3-declarative]: /docs/extensions/reference/declarativeNetRequest
 [mv3-network]: /docs/extensions/mv3/intro/mv3-overview#network-request-modification

--- a/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
+++ b/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
@@ -620,7 +620,7 @@ when you migrate to Manifest V3.
 [mdn-cdn]: https://developer.mozilla.org/docs/Glossary/CDN
 [mdn-eval]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/eval
 [mdn-fetch]: https://developer.mozilla.org/docs/Web/API/Fetch_API/Using_Fetch
-[mdn-service-workers]: https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API
+[mdn-service-workers]: https://developer.mozilla.org/docs/Web/API/Service_Worker_API
 [mv3-checklist]: /docs/extensions/mv3/mv3-migration-checklist
 [mv3-declarative]: /docs/extensions/reference/declarativeNetRequest
 [mv3-network]: /docs/extensions/mv3/intro/mv3-overview#network-request-modification

--- a/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
+++ b/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
@@ -39,7 +39,7 @@ For a fuller description of these changes, see the [Manifest V3 Overview][mv3-ov
 
 To use the features of Manifest V3, you need to update your [manifest file][doc-manifest].
 Naturally, you'll need to change the manifest version, but there are other changes that will require
-manifest updates. Each of these is detailed further on in this document.
+manifest updates. Each of these is explained further on in this document.
 
 - [service worker][section-man-sw]
 - [host permissions][section-host]
@@ -49,7 +49,7 @@ manifest updates. Each of these is detailed further on in this document.
 
 ### Manifest version  {: #manifest-version }
 
-Changing the value of the manifest_version element is the key to upgrading your extension. This
+Changing the value of the `"manifest_version"` element is the key to upgrading your extension. This
 determines whether you're using the Manifest V2 or Manifest V3 feature set:
 
 {% Columns %}
@@ -68,7 +68,7 @@ determines whether you're using the Manifest V2 or Manifest V3 feature set:
 
 ### Service worker  {: #man-sw }
 
-In Manifest V3, background pages are now *service workers*. Register the service worker under the
+In Manifest V3, background pages are now [*service workers*](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API). Register the service worker under the
 `"background"` field. This field uses the `"service_worker"` key, which specifies a single
 JavaScript file.
 
@@ -198,14 +198,14 @@ the following values:
 
 CSP modifications for `sandbox` have no such new restrictions.
 
-In Chrome 102, Manifest V3 extensions can include `wasm-unsafe-eval` in the CSP to use WebAssembly
+Starting in Chrome 102, Manifest V3 extensions can include `wasm-unsafe-eval` in the CSP to use WebAssembly
 files bundled as part of the extension.
 
 ### Action API unification  {: #action-api-unification }
 
-In Manifest V2, there were two different APIs to implement actions: `browser_action` and
-`page_action`. These APIs filled distinct roles when they were introduced, but over time they've
-become redundant so in Manifest V3 we are unifying them into as single `action` API:
+In Manifest V2, there were two different APIs to implement actions: `"browser_action"` and
+`"page_action"`. These APIs filled distinct roles when they were introduced, but over time they've
+become redundant so in Manifest V3 we are unifying them into as single `"action"` API:
 
 {% Columns %}
 ```js
@@ -296,7 +296,7 @@ loadable resource. For example, the following are considered remotely hosted cod
 
 - JavaScript files pulled from the developer's server.
 - Any library hosted on a [CDN][mdn-cdn].
-- a code string passed into [`"eval()"`][mdn-eval] at runtime
+- a code string passed into [`eval()`][mdn-eval] at runtime
 
 In Manifest V3, all of your extension's logic must be included in the extension. You can no longer
 load and execute a remotely hosted file. A number of alternative approaches are available, depending
@@ -348,7 +348,7 @@ To include a library in a service worker, you have two options:
 In Manifest V2, it was possible to execute an arbitrary string of code using
 [`tabs.executeScript()`][api-tabs-executescript] and the `code` property on the options object.
 Manifest V3 does not allow arbitrary code execution. In order to adapt to this requirement,
-extension developers can use the [`scripting.executeScript()`][api-scripting-executescript] API to
+extension developers can use the [`scripting.executeScript()`][api-scripting-executescript] method to
 either inject a static file or a function.
 
 To use the [Scripting API][api-scripting], you need to include the `"scripting"` permission in your
@@ -463,14 +463,14 @@ differences:
 |-----------------------------|-------------------------------------------------|
 | Can use a persistent page.  | Terminates when not in use.                     |
 | Has access to the DOM.      | Doesn't have access to the DOM.                 |
-| Can use `XMLHttpRequest()`. | Must use [fetch()][mdn-fetch] to make requests. |
+| Can use `XMLHttpRequest()`. | Must use [`fetch()`][mdn-fetch] to make requests. |
 
 See [Migrating from Background Pages to Service Workers][doc-background-to-worker] to explore how to
 adapt to these and other challenges.
 
 {% Aside %}
 
-In order to aid with the migration process, Manifest V2 extensions can use background service
+To aid with the migration process, Manifest V2 extensions can use service
 workers as of Chrome 87.
 
 {% endAside %}
@@ -489,8 +489,8 @@ The blocking version of the [Web Request API][api-webrequest] exists in Manifest
 [ExtensionSettings][enterprise-settings], [ExtensionInstallForcelist][enterprise-force-list].
 
 Extensions meant to be used by the general public must now use [Declarative Net
-Request][api-declarativenetrequest] for network request modification. Here used by the general
-public means any extension published to the Chrome Web Store except those deployed to a given domain
+Request][api-declarativenetrequest] for network request modification. Here 'used by the general
+public' means any extension published to the Chrome Web Store except those deployed to a given domain
 or to trusted testers. 
 
 ### How do you use declarativeNetRequest?  {: #how-use-declarativenetrequest }
@@ -506,7 +506,7 @@ cases without requiring host permissions, and without needing to read the actual
 
 ### Conditional permissions and declarativeNetRequest  {: #declarativenetrequest-conditional-perms }
 
-Most use cases for declarativeNetRequest don't require any host permissions at all. However, some
+Most use cases for `declarativeNetRequest` don't require any host permissions at all. However, some
 do.
 
 {% Aside 'caution' %}

--- a/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
+++ b/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
@@ -55,15 +55,22 @@ determines whether you're using the Manifest V2 or Manifest V3 feature set:
 {% Columns %}
 ```json
 // Manifest V2
-
-"manifest_version": 2
+{
+  ...
+  "manifest_version": 2
+  ...
+}
 ```
 
 ```json
 // Manifest V3
-
-"manifest_version": 3
+{
+  ...
+  "manifest_version": 3
+  ...
+}
 ```
+
 {% endColumns %}
 
 ### Service worker  {: #man-sw }
@@ -115,34 +122,40 @@ from other permissions.
 {% Columns %}
 ```js
 // Manifest V2
-"permissions": [
-  "tabs",
-  "bookmarks",
-  "http://www.blogger.com/",
-],
-"optional_permissions": [
-  "unlimitedStorage",
-  "*://*/*",
-
-]
+{
+  ...
+  "permissions": [
+    "tabs",
+    "bookmarks",
+    "http://www.blogger.com/",
+  ],
+  "optional_permissions": [
+    "unlimitedStorage",
+    "*://*/*",
+  ]
+  ...
+}
 ```
 
 ```js/8-13
 // Manifest V3
-"permissions": [
-  "tabs",
-  "bookmarks"
-],
-"optional_permissions": [
-  "unlimitedStorage"
-],
-"host_permissions": [
-  "http://www.blogger.com/",
-],
-"optional_host_permissions": [
-  "*://*/*",
-]
-
+{
+  ...
+  "permissions": [
+    "tabs",
+    "bookmarks"
+  ],
+  "optional_permissions": [
+    "unlimitedStorage"
+  ],
+  "host_permissions": [
+    "http://www.blogger.com/",
+  ],
+  "optional_host_permissions": [
+    "*://*/*",
+  ]
+  ...
+}
 ```
 {% endColumns %}
 
@@ -161,16 +174,22 @@ Manifest V3 it is an object with members representing alternative CSP contexts:
 {% Columns %}
 ```json
 // Manifest V2
-
-"content_security_policy": "..."
+{
+  ...
+  "content_security_policy": "..."
+  ...
+}
 ```
 
 ```json
 // Manifest V3
-
-"content_security_policy": {
-  "extension_pages": "...",
-  "sandbox": "..."
+{
+  ...
+  "content_security_policy": {
+    "extension_pages": "...",
+    "sandbox": "..."
+  }
+  ...
 }
 ```
 {% endColumns %}
@@ -213,13 +232,15 @@ become redundant so in Manifest V3 we are unifying them into as single `"action"
 
 // manifest.json
 {
-  "browser_action": { … },
-  "page_action": { … }
+  ...
+  "browser_action": { ... },
+  "page_action": { ... }
+  ...
 }
 
 // background.js
-chrome.browserAction.onClicked.addListener(tab => { … });
-chrome.pageAction.onClicked.addListener(tab => { … });
+chrome.browserAction.onClicked.addListener(tab => { ... });
+chrome.pageAction.onClicked.addListener(tab => { ... });
 ```
 
 ```js
@@ -227,12 +248,14 @@ chrome.pageAction.onClicked.addListener(tab => { … });
 
 // manifest.json
 {
-  "action": { … }
+  ...
+  "action": { ... }
+  ...
 }
 
 
 // background.js
-chrome.action.onClicked.addListener(tab => { … });
+chrome.action.onClicked.addListener(tab => { ... });
 ```
 {% endColumns %}
 
@@ -246,21 +269,27 @@ set of URLs or extension IDs:
 
 ```json
 // Manifest V2
-
-"web_accessible_resources": [
-  RESOURCE_PATHS
-]
+{
+  ...
+  "web_accessible_resources": [
+    RESOURCE_PATHS
+  ]
+  ...
+}
 ```
 
 ```json
 // Manifest V3
-
-"web_accessible_resources": [{
-  "resources": [RESOURCE_PATHS],
-  "matches": [MATCH_PATTERNS],
-  "extension_ids": [EXTENSION_IDS],
-  optional "use_dynamic_url": boolean
-}]
+{
+  ...
+  "web_accessible_resources": [{
+    "resources": [RESOURCE_PATHS],
+    "matches": [MATCH_PATTERNS],
+    "extension_ids": [EXTENSION_IDS],
+    "use_dynamic_url": boolean //optional
+  }]
+  ...
+}
 ```
 
 {% endColumns %}
@@ -286,7 +315,7 @@ Manifest V3 imposes new restrictions that limit an extension's ability to execut
 JavaScript through a combination of platform changes and policy limitations.
 
 Many extensions are unaffected by this change. However, if your Manifest V2 extension executes
-remotely hosted scripts, injects code strings into pages, or evals strings at runtime, you'll need
+remotely hosted scripts, injects code strings into pages, or eval strings at runtime, you'll need
 to update your code execution strategies when migrating to Manifest V3.
 
 ### Remotely hosted code restrictions  {: #remotely-hosted-code }
@@ -324,17 +353,20 @@ them locally. For example:
 // Manifest V2
 
 // popup.html
+...
 <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
-
+...
 ```
 
 ```html
 // Manifest V3
 
 // popup.html
+...
 <script src="./react-dom.production.min.js"></script>
 <link href="./bootstrap.min.css" rel="stylesheet">
+...
 ```
 
 {% endColumns %}
@@ -372,18 +404,23 @@ the Tabs API. While the old method only took a single file, the new method now t
 // Manifest V2
 
 // background.js
+...
 chrome.tabs.executeScript({
   file: 'content-script.js'
 });
+...
 
 // content-script.js
+...
 alert('File test alert');
+...
 ```
 
 ```js
 // Manifest V3
 
 // background.js
+...
 async function getCurrentTab() {/* ... */}
 let tab = await getCurrentTab();
 
@@ -391,10 +428,12 @@ chrome.scripting.executeScript({
   target: {tabId: tab.id},
   files: ['content-script.js']
 });
+...
 
 // content-script.js
+...
 alert('File test alert');
-
+...
 ```
 {% endColumns %}
 
@@ -422,16 +461,19 @@ there.
 // Manifest V2
 
 // background.js
+...
 let name = 'World!';
 chrome.tabs.executeScript({
   code: `alert('Hello, ${name}!')`
 });
+...
 ```
 
 ```js
 // Manifest V3
 
 // background.js
+...
 async function getCurrentTab() {/* ... */}
 let tab = await getCurrentTab();
 
@@ -445,7 +487,7 @@ chrome.scripting.executeScript({
   func: showAlert,
   args: [name],
 });
-
+...
 ```
 {% endColumns %}
 

--- a/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
+++ b/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
@@ -177,7 +177,7 @@ extension is `chrome-extension://EXTENSION_ID/foo.html`.
 {% endAside %}
 
 **`sandbox`**: This policy covers any [sandboxed extension
-pages](/docs/extensions/mv3/manifest/sandbox) that your extension uses.
+pages][manifest-sandbox] that your extension uses.
 
 In addition, Manifest V3 disallows certain CSP modifications for `extension_pages` that
 were permitted in Manifest V2. The `script-src,` `object-src`, and `worker-src`
@@ -456,14 +456,14 @@ in your manifest file. This API does not [trigger a permission warning][doc-perm
 </web-tabs>
 
 A functional version of the Manifest V3 snippets in this section can be found in the
-[chrome-extensions-samples](github-samples-content)
+[chrome-extensions-samples][github-samples-content]
 repository. See the [Tabs API examples][api-tabs-example] for an
 implementation of `getCurrentTab()`.
 
 ## Background service workers  {: #background-service-workers }
 
 Background pages in Manifest V2 are replaced by [service
-workers](dev-google-sw) in Manifest V3: this is a foundational change that affects most extensions. The following are
+workers][dev-google-sw] in Manifest V3: this is a foundational change that affects most extensions. The following are
 some notable differences:
 
 | MV2 - Background page      | MV3 - Service worker                                  |
@@ -487,13 +487,13 @@ service workers as of Chrome 87.
 ## Modifying network requests  {: #modifying-network-requests }
 
 There is a new
-[declarativeNetRequest](/docs/extensions/reference/declarativeNetRequest) for
+[declarativeNetRequest][api-declarativenetrequest] for
 network request modification, which provides an alternative for much of the
-[webRequest](/docs/extensions/reference/webRequest) API's functionality.
+[webRequest][api-webrequest] API's functionality.
 
 ### When can you use blocking webRequest?  {: #when-use-blocking-webrequest }
 
-The blocking version of the [webRequest](api-webrequest)
+The blocking version of the [webRequest][api-webrequest]
 API still exists in Manifest V3 but its use is restricted to force-installed extensions
 only. See Chrome Enterprise policies:
 [ExtensionSettings][enterprise-settings],
@@ -600,11 +600,12 @@ appropriate changes when you migrate to Manifest V3.
 [doc-perm-warn]: /docs/extensions/mv3/permission_warnings/
 [doc-war]: /docs/extensions/mv3/manifest/web_accessible_resources/
 [doc-whats-new]: /docs/extensions/whatsnew/
-[docs-background-to-worker]: /docs/extensions/mv3/migrating_to_service_workers
-[docs-static-cs]: /docs/extensions/mv3/content_scripts/#static-declarative
+[doc-background-to-worker]: /docs/extensions/mv3/migrating_to_service_workers
+[doc-static-cs]: /docs/extensions/mv3/content_scripts/#static-declarative
 [enterprise-force-list]: https://cloud.google.com/docs/chrome-enterprise/policies/?policy=ExtensionInstallForcelist
 [enterprise-settings]: https://cloud.google.com/docs/chrome-enterprise/policies/?policy=ExtensionSettings
 [github-samples-content]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/reference/mv3/intro/mv3-migration/content-scripts
+[manifest-sandbox]: /docs/extensions/mv3/manifest/sandbox
 [mdn-cdn]: https://developer.mozilla.org/docs/Glossary/CDN
 [mdn-eval]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/eval
 [mdn-fetch]: https://developer.mozilla.org/docs/Web/API/Fetch_API/Using_Fetch

--- a/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
+++ b/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
@@ -11,11 +11,11 @@ This guide provides developers with the information they need to begin
 migrating an extension from Manifest V2 to Manifest V3. Some extensions
 will require very little change to make them Manifest V3 compliant, while others will
 need to be redesigned to some degree. For a quick reference guide see the [migration
-checklist](/docs/extensions/mv3/mv3-migration-checklist).
+checklist][mv3-checklist].
 
 {% Aside %}
 
-Follow [What's new in Chrome Extensions](docs/extensions/whatsnew/) to read about new Manifest V3 features as they become available.
+Follow [What's new in Chrome Extensions][doc-whats-new] to read about new Manifest V3 features as they become available.
 
 {% endAside %}
 
@@ -23,29 +23,29 @@ Follow [What's new in Chrome Extensions](docs/extensions/whatsnew/) to read abou
 
 There are a number of new features and functional changes for extensions using Manifest V3:
 
-* [Service workers](/docs/extensions/mv3/intro/mv3-overview#service-workers)
+* [Service workers][mv3-sw]
   replace background pages.
-* [Network request modification](/docs/extensions/mv3/intro/mv3-overview#network-request-modification)
+* [Network request modification][mv3-network]
   is now handled with the new
-  [declarativeNetRequest](/docs/extensions/reference/declarativeNetRequest) API.
-* [Remotely hosted code](/docs/extensions/mv3/intro/mv3-overview#remotely-hosted-code)
+  [declarativeNetRequest][mv3-declarative] API.
+* [Remotely hosted code][mv3-remote]
   is no longer allowed; an extension can only execute JavaScript that is
   included within its package.
-* [Promise](/docs/extensions/mv3/intro/mv3-overview#promises)
+* [Promise][mv3-promise]
   support has been added to many methods, though callbacks are still supported
   as an alternative.  (We will eventually support promises on all appropriate
   methods.)
 * A number of other, relatively
-  [minor feature changes](/docs/extensions/mv3/intro/mv3-overview#other-features)
+  [minor feature changes][mv3-other]
   are also introduced in Manifest V3.
 
 For a fuller description of these changes, see the
-[Manifest V3 Overview](/docs/extensions/mv3/intro/mv3-overview).
+[Manifest V3 Overview][mv3-overview].
 
 ## Updating the manifest.json file  {: #updating-manifest-dot-json }
 
 To use the features of Manifest V3, you need to update your [manifest
-file](/docs/extensions/mv3/manifest). Naturally, you'll change the manifest
+file][doc-manifest]. Naturally, you'll change the manifest
 version to "3", but there are other things you need to change in
 the manifest file: the [service worker][section-man-sw], [host permissions][section-host], [content security policy][section-csp], [action
 declarations][section-action], and [web-accessible resources][section-war].
@@ -99,7 +99,7 @@ In Manifest V3, background pages are now *service workers*. Register the service
 {% endColumns %}
 
 Even though Manifest V3, does not support multiple background scripts, you can optionally declare
-the service worker as an [ES Module](https://web.dev/es-modules-in-sw/#static-imports-only) by
+the service worker as an [ES Module][webdev-esm] by
 specifying `"type": "module"`, which allows you to import further code.
 
 ### Host permissions  {: #host-permissions }
@@ -140,13 +140,13 @@ In Manifest V3, you'll need to specify host permissions and optional host permis
 
 {% Aside 'caution' %}
 
-Moving the match patterns to `"host_permissions"` does not affect [content scripts](https://developer.chrome.com/docs/extensions/mv3/content_scripts/#static-declarative). Content script match patterns remain under `"content_scripts.matches"`.
+Moving the match patterns to `"host_permissions"` does not affect [content scripts][doc-static-cs]. Content script match patterns remain under `"content_scripts.matches"`.
 
 {% endAside %}
 
 ### Content security policy  {: #content-security-policy }
 
-An extension's [content security policy](https://content-security-policy.com/)
+An extension's [content security policy][csp]
 (CSP) was specified in Manifest V2 as a string; in Manifest V3 it is an object with members
 representing alternative CSP contexts:
 
@@ -188,6 +188,9 @@ directives may only have the following values:
 *   Any localhost source, (`http://localhost`,  `http://127.0.0.1`, or any port on those domains)
 
 CSP modifications for `sandbox` have no such new restrictions.
+
+In Chrome 102, Manifest V3 extensions can include `wasm-unsafe-eval` in the CSP to use WebAssembly
+files bundled as part of the extension.
 
 ### Action API unification  {: #action-api-unification }
 
@@ -269,7 +272,7 @@ resource access. The updated API lets extensions more tightly control what
 other sites or extensions can access extension resources. 
 
 See the [web
-accessible resources](/docs/extensions/mv3/manifest/web_accessible_resources/)
+accessible resources][doc-war]
 documentation for usage information.
 
 ## Code execution  {: #code-execution }
@@ -290,8 +293,8 @@ extension's package as a loadable resource. For example, the following
 are considered remotely hosted code:
 
 - JavaScript files pulled from a remote server
-- Any library hosted on a [CDN](https://developer.mozilla.org/en-US/docs/Glossary/CDN).
-- a code string passed into [`"eval()"`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval) at runtime
+- Any library hosted on a [CDN][mdn-cdn].
+- a code string passed into [`"eval()"`][mdn-eval] at runtime
 
 In Manifest V3, all of your extension's logic must be included in the extension. You
 can no longer load and execute a remotely hosted file. A number of alternative
@@ -312,7 +315,7 @@ code private and change the code on demand while avoiding the extra overhead of
 resubmitting to the Chrome Web Store.
 
 Bundle third-party libraries
-: If you are using a popular framework like React or Bootstrap, you can download the minified files, add them to your project and import them locally. For example:
+: If you are using a popular framework like [React][react-cdn] or [Bootstrap][bootstrap-gs], you can download the minified files, add them to your project and import them locally. For example:
 
 {% Columns %}
 
@@ -343,11 +346,11 @@ To include a library in a service worker, you have two options:
 ### Executing arbitrary strings  {: #executing-arbitrary-strings }
 
 In Manifest V2, it was possible to execute an arbitrary string of code using
-[`tabs.executeScript`](/docs/extensions/reference/tabs/#method-executeScript) and the `code`
+[`tabs.executeScript()`][api-tabs-executescript] and the `code`
 property on the options object. Manifest V3 does not allow arbitrary code execution. In order to
 adapt to this requirement, extension developers can use the
-[`scripting.executeScript`](/docs/extensions/reference/scripting/#method-executeScript) API to either
-inject a [static file][section-file] or a [function][section-func].
+[`scripting.executeScript()`][api-scripting-executescript] API to either
+inject a static file or a function.
 
 To use the [Scripting API][api-scripting], you need to include the `"scripting"` permission
 in your manifest file. This API does not [trigger a permission warning][doc-perm-warn].
@@ -453,25 +456,24 @@ in your manifest file. This API does not [trigger a permission warning][doc-perm
 </web-tabs>
 
 A functional version of the Manifest V3 snippets in this section can be found in the
-[chrome-extensions-samples](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/reference/mv3/intro/mv3-migration/content-scripts)
-repository. See the [Tabs API examples](/docs/extensions/reference/tabs/#get-the-current-tab) for an
+[chrome-extensions-samples](github-samples-content)
+repository. See the [Tabs API examples][api-tabs-example] for an
 implementation of `getCurrentTab()`.
 
 ## Background service workers  {: #background-service-workers }
 
 Background pages in Manifest V2 are replaced by [service
-workers](https://developers.google.com/web/fundamentals/primers/service-workers), that are event
-based in Manifest V3: this is a foundational change that affects most extensions. The following are
-the main differences:
+workers](dev-google-sw) in Manifest V3: this is a foundational change that affects most extensions. The following are
+some notable differences:
 
 | MV2 - Background page      | MV3 - Service worker                                  |
 |----------------------------|-------------------------------------------------------|
 | Can use a persistent page. | Terminates when not in use and restarted when needed. |
 | Has access to the DOM.     | Doesn't have access to the DOM.                       |
-| Uses XMLHttpRequest.       | Must use [fetch()][mdn-fetch] to make requests.       |
+| Can use `XMLHttpRequest()`.       | Must use [fetch()][mdn-fetch] to make requests.       |
 
 See [Migrating from Background Pages to Service
-Workers](/docs/extensions/mv3/migrating_to_service_workers) to explore how to adapt to these and
+Workers][doc-background-to-worker] to explore how to adapt to these and
 other challenges.
 
 {% Aside %}
@@ -489,32 +491,33 @@ There is a new
 network request modification, which provides an alternative for much of the
 [webRequest](/docs/extensions/reference/webRequest) API's functionality.
 
-
 ### When can you use blocking webRequest?  {: #when-use-blocking-webrequest }
 
-The blocking version of the [webRequest](/docs/extensions/reference/webRequest)
+The blocking version of the [webRequest](api-webrequest)
 API still exists in Manifest V3 but its use is restricted to force-installed extensions
 only. See Chrome Enterprise policies:
-[ExtensionSettings](https://cloud.google.com/docs/chrome-enterprise/policies/?policy=ExtensionSettings),
-[ExtensionInstallForcelist](https://cloud.google.com/docs/chrome-enterprise/policies/?policy=ExtensionInstallForcelist).
+[ExtensionSettings][enterprise-settings],
+[ExtensionInstallForcelist][enterprise-force-list].
 
 All other extensions must now use
-[declarativeNetRequest](/docs/extensions/reference/declarativeNetRequest) for
+[declarativeNetRequest][api-declarativenetrequest] for
 network request modification. This moves the actual modification of the network
 request into the Chrome browser: the extension no longer can read the actual
 network request, and in most cases needs no host permissions.
 
-{% Aside %}
+{% Aside 'caution' %}
+
 Request redirects and header modifications **do** require the user to grant host permissions.
+
 {% endAside %}
 
 
 ### How do you use declarativeNetRequest?  {: #how-use-declarativenetrequest }
 
 Instead of reading the request and programmatically altering it, your extension
-specifies a number of rules, which map a set of conditions to corresponding
+specifies a number of [rules][api-declarative-rules], which map a set of conditions to corresponding
 actions. See the
-[declarativeNetRequest](/docs/extensions/reference/declarativeNetRequest)
+[declarativeNetRequest][api-declarativenetrequest]
 reference documentation for a more detailed description of rules.
 
 This feature allows content blockers and other request-modifying extensions to
@@ -522,8 +525,10 @@ implement their use cases without requiring host permissions, and without
 needing to read the actual requests.
 
 {% Aside %}
+
 In order to aid with the migration process, the declarativeNetRequest API is
 available for use in Manifest V2 extensions as of Chrome 84.
+
 {% endAside %}
 
 
@@ -534,14 +539,16 @@ all. However, some do.
 
 {% Aside 'caution' %}
 
-Request redirects and header modifications **do** require the user to grant host permissions.
+Host permissions are still required if the extension wants to *redirect* a
+request or modify headers on it. The `declarativeNetRequestWithHostAccess` permission always
+requires host permissions to the request URL and initiator to act on a request.
 
 {% endAside %}
 
 When extensions require host permissions for these use cases, we recommend a
 "tiered" permissions strategy. This means implementing the extension's core
 functionality without using these permissions; putting the more advanced use
-cases behind an optional permission.
+cases behind an `"optional_host_permission"`.
 
 This approach allows privacy-conscious users to withhold those permissions and
 still use much of the extension's functionality. This means that developers
@@ -552,40 +559,69 @@ without requiring any host permissions.
 ## Sunset for deprecated APIs  {: #sunset-deprecated-apis }
 
 There are a number of APIs that have long been deprecated. Manifest V3 finally
-removes support for these deprecated APIs. These include:
+removes support for the following deprecated APIs:
 
-*   chrome.extension.sendRequest()
+*   chrome.extension.getExtensionTabs()
+*   chrome.extension.getURL()
+*   chrome.extension.lastError
 *   chrome.extension.onRequest
 *   chrome.extension.onRequestExternal
-*   chrome.extension.lastError
-*   chrome.extension.getURL()
-*   chrome.extension.getExtensionTabs()
-*   chrome.tabs.Tab.selected
-*   chrome.tabs.sendRequest()
-*   chrome.tabs.getSelected()
+*   chrome.extension.sendRequest()
 *   chrome.tabs.getAllInWindow()
-*   chrome.tabs.onSelectionChanged
+*   chrome.tabs.getSelected()
 *   chrome.tabs.onActiveChanged
 *   chrome.tabs.onHighlightChanged
+*   chrome.tabs.onSelectionChanged
+*   chrome.tabs.sendRequest()
+*   chrome.tabs.Tab.selected
 
 As well as the undocumented:
 
-*   chrome.extension.sendMessage()
 *   chrome.extension.connect()
 *   chrome.extension.onConnect
 *   chrome.extension.onMessage
+*   chrome.extension.sendMessage()
 
 If your extensions use any of these deprecated APIs, you'll need to make the
 appropriate changes when you migrate to Manifest V3.
 
-[section-man-sw]: #man-sw
-[section-host]: #host-permissions
-[section-csp]: #content-security-policy
-[section-action]: #action-api-unification
-[section-war]: #web-accessible-resources
-[section-file]: #inject-file
-[section-func]: #inject-func
+[api-declarative-rules]: /docs/extensions/reference/declarativeNetRequest/#example
+[api-declarativenetrequest]: /docs/extensions/reference/declarativeNetRequest
+[api-scripting-executescript]: /docs/extensions/reference/scripting/#method-executeScript
+[api-scripting]: /docs/extensions/reference/scripting/
+[api-tabs-example]: /docs/extensions/reference/tabs/#get-the-current-tab
+[api-tabs-executescript]: /docs/extensions/reference/tabs/#method-executeScript 
+[api-webrequest]: /docs/extensions/reference/webRequest
+[bootstrap-gs]: https://getbootstrap.com/docs/5.1/getting-started/introduction/
+[csp]: https://content-security-policy.com/
+[dev-google-sw]: https://developers.google.com/web/fundamentals/primers/service-workers
+[doc-manifest]: /docs/extensions/mv3/manifest
 [doc-match-pattern]: /docs/extensions/mv3/match_patterns/
 [doc-perm-warn]: /docs/extensions/mv3/permission_warnings/
-[api-scripting]: /docs/extensions/reference/scripting/
-[mdn-fetch]: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch
+[doc-war]: /docs/extensions/mv3/manifest/web_accessible_resources/
+[doc-whats-new]: /docs/extensions/whatsnew/
+[docs-background-to-worker]: /docs/extensions/mv3/migrating_to_service_workers
+[docs-static-cs]: /docs/extensions/mv3/content_scripts/#static-declarative
+[enterprise-force-list]: https://cloud.google.com/docs/chrome-enterprise/policies/?policy=ExtensionInstallForcelist
+[enterprise-settings]: https://cloud.google.com/docs/chrome-enterprise/policies/?policy=ExtensionSettings
+[github-samples-content]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/reference/mv3/intro/mv3-migration/content-scripts
+[mdn-cdn]: https://developer.mozilla.org/docs/Glossary/CDN
+[mdn-eval]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/eval
+[mdn-fetch]: https://developer.mozilla.org/docs/Web/API/Fetch_API/Using_Fetch
+[mv3-checklist]: /docs/extensions/mv3/mv3-migration-checklist
+[mv3-declarative]: /docs/extensions/reference/declarativeNetRequest
+[mv3-network]: /docs/extensions/mv3/intro/mv3-overview#network-request-modification
+[mv3-other]: /docs/extensions/mv3/intro/mv3-overview#other-features
+[mv3-overview]: /docs/extensions/mv3/intro/mv3-overview
+[mv3-promise]: /docs/extensions/mv3/intro/mv3-overview#promises
+[mv3-remote]: /docs/extensions/mv3/intro/mv3-overview#remotely-hosted-code
+[mv3-sw]: /docs/extensions/mv3/intro/mv3-overview#service-workers
+[react-cdn]: https://reactjs.org/docs/cdn-links.html
+[section-action]: #action-api-unification
+[section-csp]: #content-security-policy
+[section-file]: #inject-file
+[section-func]: #inject-func
+[section-host]: #host-permissions
+[section-man-sw]: #man-sw
+[section-war]: #web-accessible-resources
+[webdev-esm]: https://web.dev/es-modules-in-sw/#static-imports-only

--- a/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
+++ b/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
@@ -137,7 +137,7 @@ from other permissions.
 }
 ```
 
-```js/8-13
+```js/10-15
 // Manifest V3
 {
   ...
@@ -349,7 +349,7 @@ them locally. For example:
 
 {% Columns %}
 
-```html
+```js
 // Manifest V2
 
 // popup.html
@@ -359,7 +359,7 @@ them locally. For example:
 ...
 ```
 
-```html
+```js
 // Manifest V3
 
 // popup.html

--- a/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
+++ b/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
@@ -15,7 +15,7 @@ checklist](/docs/extensions/mv3/mv3-migration-checklist).
 
 {% Aside %}
 
-Follow [What's new in Chrome Extensions](https://developer.chrome.com/docs/extensions/whatsnew/) to read about new Manifest V3 features as they become available.
+Follow [What's new in Chrome Extensions](docs/extensions/whatsnew/) to read about new Manifest V3 features as they become available.
 
 {% endAside %}
 
@@ -44,12 +44,11 @@ For a fuller description of these changes, see the
 
 ## Updating the manifest.json file  {: #updating-manifest-dot-json }
 
-To use the features of Manifest V3, you need to first update your [manifest
+To use the features of Manifest V3, you need to update your [manifest
 file](/docs/extensions/mv3/manifest). Naturally, you'll change the manifest
-version to "3", but there are a number of other things you need to change in
-the manifest file: host permissions, content security policy, action
-declarations, and web-accessible resources.
-
+version to "3", but there are other things you need to change in
+the manifest file: the [service worker][section-man-sw], [host permissions][section-host], [content security policy][section-csp], [action
+declarations][section-action], and [web-accessible resources][section-war].
 
 ### Manifest version  {: #manifest-version }
 
@@ -69,6 +68,37 @@ extension. This determines whether you're using the Manifest V2 or Manifest V3 f
 "manifest_version": 3
 ```
 {% endColumns %}
+
+### Service worker  {: #man-sw }
+
+In Manifest V3, background pages are now *service workers*. Register the service worker under the `"background"` field. This field uses the `"service_worker"` key, which specifies a single JavaScript file.
+
+{% Columns %}
+
+```json
+// Manifest V2
+
+"background": {
+  "scripts": [
+    "backgroundContextMenus.js",
+    "backgroundOauth.js"
+],
+  "persistent": false
+}
+```
+
+```json
+// Manifest V3
+
+"background": {
+  "service_worker": "background.js",
+  "type": "module" //optional
+}
+```
+
+{% endColumns %}
+
+Even though Manifest V3, does not support multiple background scripts, you can optionally declare the service worker as an [ES Module](https://web.dev/es-modules-in-sw/#static-imports-only) by specifying `"type": "module"`, which allows you to import further code.
 
 ### Host permissions  {: #host-permissions }
 
@@ -486,3 +516,9 @@ As well as the undocumented:
 
 If your extensions use any of these deprecated APIs, you'll need to make the
 appropriate changes when you migrate to Manifest V3.
+
+[section-man-sw]: #man-sw
+[section-host]: #host-permissions
+[section-csp]: #content-security-policy
+[section-action]: #action-api-unification
+[section-war]: #web-accessible-resources

--- a/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
+++ b/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
@@ -102,7 +102,7 @@ Even though Manifest V3, does not support multiple background scripts, you can o
 
 ### Host permissions  {: #host-permissions }
 
-In Manifest V3, you'll need to specify host permissions separately from other permissions:
+In Manifest V3, you'll need to specify host permissions and optional host permissions separately from other permissions.
 
 {% Columns %}
 ```js
@@ -113,12 +113,11 @@ In Manifest V3, you'll need to specify host permissions separately from other pe
   "http://www.blogger.com/",
 ],
 "optional_permissions": [
-  "*://*/*",
   "unlimitedStorage"
 ]
 ```
 
-```js/8-10
+```js/8-13
 // Manifest V3
 "permissions": [
   "tabs",
@@ -129,20 +128,19 @@ In Manifest V3, you'll need to specify host permissions separately from other pe
 ],
 "host_permissions": [
   "http://www.blogger.com/",
-  "*://*/*"
 ],
+"optional_host_permissions": [
+    "https://*/*",
+]
+
 ```
 {% endColumns %}
 
+{% Aside 'caution' %}
 
-{% Aside 'warning' %}
-
-You do not have to declare content script match patterns in `host_permissions`
-in order to inject content scripts.  However, they **are** treated as host
-permissions requests by the Chrome Web Store review process.
+Moving the match patterns to `"host_permissions"` does not affect [content scripts](https://developer.chrome.com/docs/extensions/mv3/content_scripts/#static-declarative). Content script match patterns remain under `"content_scripts.matches"`.
 
 {% endAside %}
-
 
 ### Content security policy  {: #content-security-policy }
 

--- a/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
+++ b/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
@@ -265,7 +265,9 @@ Replace the following:
 Previously, the list of web accessible resources applied to all websites and
 extensions, which created opportunities for fingerprinting or unintentional
 resource access. The updated API lets extensions more tightly control what
-other sites or extensions can access extension resources. See the [web
+other sites or extensions can access extension resources. 
+
+See the [web
 accessible resources](/docs/extensions/mv3/manifest/web_accessible_resources/)
 documentation for usage information.
 
@@ -520,3 +522,4 @@ appropriate changes when you migrate to Manifest V3.
 [section-csp]: #content-security-policy
 [section-action]: #action-api-unification
 [section-war]: #web-accessible-resources
+[doc-match-pattern]: /docs/extensions/mv3/match_patterns/

--- a/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
+++ b/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
@@ -342,12 +342,23 @@ To include a library in a service worker, you have two options:
 
 ### Executing arbitrary strings  {: #executing-arbitrary-strings }
 
-In Manifest V2 it was possible to execute an arbitrary string of code using
+In Manifest V2, it was possible to execute an arbitrary string of code using
 [`tabs.executeScript`](/docs/extensions/reference/tabs/#method-executeScript) and the `code`
 property on the options object. Manifest V3 does not allow arbitrary code execution. In order to
 adapt to this requirement, extension developers can use the
 [`scripting.executeScript`](/docs/extensions/reference/scripting/#method-executeScript) API to either
-inject a [static file][section-file] or a [function][section-func]. 
+inject a [static file][section-file] or a [function][section-func].
+
+To use the [Scripting API][api-scripting], you need to include the `"scripting"` permission
+in your manifest file. This API does not [trigger a permission warning][doc-perm-warn].
+
+```json
+{
+  "manifest_version": 3,
+  "permissions": ["scripting"],
+  ...
+}
+```
 
 <web-tabs>
   <web-tab title="Injecting a static file">
@@ -448,19 +459,26 @@ implementation of `getCurrentTab()`.
 
 ## Background service workers  {: #background-service-workers }
 
-Background pages in Manifest V2 are replaced by service workers in Manifest V3: this is a
-foundational change that affects most extensions.
+Background pages in Manifest V2 are replaced by [service
+workers](https://developers.google.com/web/fundamentals/primers/service-workers), that are event
+based in Manifest V3: this is a foundational change that affects most extensions. The following are
+the main differences:
 
-[Service workers](https://developers.google.com/web/fundamentals/primers/service-workers)
-are event based, and like event pages they do not persist between invocations.
-This change generally requires some redesign, with a number of factors to
-consider: see [Migrating from Background Pages to Service
-Workers](/docs/extensions/mv3/migrating_to_service_workers) for additional
-details.
+| MV2 - Background page      | MV3 - Service worker                                  |
+|----------------------------|-------------------------------------------------------|
+| Can use a persistent page. | Terminates when not in use and restarted when needed. |
+| Has access to the DOM.     | Doesn't have access to the DOM.                       |
+| Uses XMLHttpRequest.       | Must use [fetch()][mdn-fetch] to make requests.       |
+
+See [Migrating from Background Pages to Service
+Workers](/docs/extensions/mv3/migrating_to_service_workers) to explore how to adapt to these and
+other challenges.
 
 {% Aside %}
+
 In order to aid with the migration process, Manifest V2 extensions can use background
 service workers as of Chrome 87.
+
 {% endAside %}
 
 
@@ -469,7 +487,7 @@ service workers as of Chrome 87.
 There is a new
 [declarativeNetRequest](/docs/extensions/reference/declarativeNetRequest) for
 network request modification, which provides an alternative for much of the
-[webRequest](/docs/extensions/reference/webRequest) AP's functionality.
+[webRequest](/docs/extensions/reference/webRequest) API's functionality.
 
 
 ### When can you use blocking webRequest?  {: #when-use-blocking-webrequest }
@@ -514,8 +532,10 @@ available for use in Manifest V2 extensions as of Chrome 84.
 Most use cases for declarativeNetRequest don't require any host permissions at
 all. However, some do.
 
-{% Aside %}
+{% Aside 'caution' %}
+
 Request redirects and header modifications **do** require the user to grant host permissions.
+
 {% endAside %}
 
 When extensions require host permissions for these use cases, we recommend a
@@ -566,3 +586,6 @@ appropriate changes when you migrate to Manifest V3.
 [section-file]: #inject-file
 [section-func]: #inject-func
 [doc-match-pattern]: /docs/extensions/mv3/match_patterns/
+[doc-perm-warn]: /docs/extensions/mv3/permission_warnings/
+[api-scripting]: /docs/extensions/reference/scripting/
+[mdn-fetch]: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch

--- a/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
+++ b/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
@@ -8,16 +8,16 @@ updated: 2021-08-13
 ---
 
 This guide provides developers with the information they need to begin
-migrating an extension from Manifest V2 to Manifest V3 (Manifest V3). Some extensions
+migrating an extension from Manifest V2 to Manifest V3. Some extensions
 will require very little change to make them Manifest V3 compliant, while others will
-need to be redesigned to some degree. Developers experienced with Manifest V2, and who
-are creating new Manifest V3 extensions, may also find this helpful. For a quick
-reference guide see the [migration
+need to be redesigned to some degree. For a quick reference guide see the [migration
 checklist](/docs/extensions/mv3/mv3-migration-checklist).
 
-Manifest V3 offers a number of improvements reflecting the aims of our
-[platform vision](/docs/extensions/mv3/intro/platform-vision).
+{% Aside %}
 
+Follow [What's new in Chrome Extensions](https://developer.chrome.com/docs/extensions/whatsnew/) to read about new Manifest V3 features as they become available.
+
+{% endAside %}
 
 ## Feature summary  {: #feature-summary }
 
@@ -41,7 +41,6 @@ There are a number of new features and functional changes for extensions using M
 
 For a fuller description of these changes, see the
 [Manifest V3 Overview](/docs/extensions/mv3/intro/mv3-overview).
-
 
 ## Updating the manifest.json file  {: #updating-manifest-dot-json }
 
@@ -107,9 +106,11 @@ In Manifest V3, you'll need to specify host permissions separately from other pe
 
 
 {% Aside 'warning' %}
+
 You do not have to declare content script match patterns in `host_permissions`
 in order to inject content scripts.  However, they **are** treated as host
 permissions requests by the Chrome Web Store review process.
+
 {% endAside %}
 
 

--- a/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
+++ b/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
@@ -7,15 +7,15 @@ date: 2020-11-09
 updated: 2021-08-13
 ---
 
-This guide provides developers with the information they need to begin
-migrating an extension from Manifest V2 to Manifest V3. Some extensions
-will require very little change to make them Manifest V3 compliant, while others will
-need to be redesigned to some degree. For a quick reference guide see the [migration
-checklist][mv3-checklist].
+This guide provides developers with the information they need to begin migrating an extension from
+Manifest V2 to Manifest V3. Some extensions will require very little change to make them Manifest V3
+compliant, while others will need to be redesigned to some degree. For a quick reference guide see
+the [migration checklist][mv3-checklist].
 
 {% Aside %}
 
-Follow [What's new in Chrome Extensions][doc-whats-new] to read about new Manifest V3 features as they become available.
+Follow [What's new in Chrome Extensions][doc-whats-new] to read about new Manifest V3 features as
+they become available.
 
 {% endAside %}
 
@@ -23,37 +23,30 @@ Follow [What's new in Chrome Extensions][doc-whats-new] to read about new Manife
 
 There are a number of new features and functional changes for extensions using Manifest V3:
 
-* [Service workers][mv3-sw]
-  replace background pages.
-* [Network request modification][mv3-network]
-  is now handled with the new
+* [Service workers][mv3-sw] replace background pages.
+* [Network request modification][mv3-network] is now handled with the new
   [declarativeNetRequest][mv3-declarative] API.
-* [Remotely hosted code][mv3-remote]
-  is no longer allowed; an extension can only execute JavaScript that is
-  included within its package.
-* [Promise][mv3-promise]
-  support has been added to many methods, though callbacks are still supported
-  as an alternative.  (We will eventually support promises on all appropriate
-  methods.)
-* A number of other, relatively
-  [minor feature changes][mv3-other]
-  are also introduced in Manifest V3.
+* [Remotely hosted code][mv3-remote] is no longer allowed; an extension can only execute JavaScript
+  that is included within its package.
+* [Promise][mv3-promise] support has been added to many methods, though callbacks are still
+  supported as an alternative.  (We will eventually support promises on all appropriate methods.)
+* A number of other, relatively [minor feature changes][mv3-other] are also introduced in Manifest
+  V3.
 
-For a fuller description of these changes, see the
-[Manifest V3 Overview][mv3-overview].
+For a fuller description of these changes, see the [Manifest V3 Overview][mv3-overview].
 
 ## Updating the manifest.json file  {: #updating-manifest-dot-json }
 
-To use the features of Manifest V3, you need to update your [manifest
-file][doc-manifest]. Naturally, you'll change the manifest
-version to "3", but there are other things you need to change in
-the manifest file: the [service worker][section-man-sw], [host permissions][section-host], [content security policy][section-csp], [action
-declarations][section-action], and [web-accessible resources][section-war].
+To use the features of Manifest V3, you need to update your [manifest file][doc-manifest].
+Naturally, you'll change the manifest version to "3", but there are other things you need to change
+in the manifest file: the [service worker][section-man-sw], [host permissions][section-host],
+[content security policy][section-csp], [action declarations][section-action], and [web-accessible
+resources][section-war].
 
 ### Manifest version  {: #manifest-version }
 
-Changing the value of the manifest_version element is the key to upgrading your
-extension. This determines whether you're using the Manifest V2 or Manifest V3 feature set:
+Changing the value of the manifest_version element is the key to upgrading your extension. This
+determines whether you're using the Manifest V2 or Manifest V3 feature set:
 
 {% Columns %}
 ```json
@@ -71,7 +64,9 @@ extension. This determines whether you're using the Manifest V2 or Manifest V3 f
 
 ### Service worker  {: #man-sw }
 
-In Manifest V3, background pages are now *service workers*. Register the service worker under the `"background"` field. This field uses the `"service_worker"` key, which specifies a single JavaScript file.
+In Manifest V3, background pages are now *service workers*. Register the service worker under the
+`"background"` field. This field uses the `"service_worker"` key, which specifies a single
+JavaScript file.
 
 {% Columns %}
 
@@ -99,12 +94,13 @@ In Manifest V3, background pages are now *service workers*. Register the service
 {% endColumns %}
 
 Even though Manifest V3, does not support multiple background scripts, you can optionally declare
-the service worker as an [ES Module][webdev-esm] by
-specifying `"type": "module"`, which allows you to import further code.
+the service worker as an [ES Module][webdev-esm] by specifying `"type": "module"`, which allows you
+to import further code.
 
 ### Host permissions  {: #host-permissions }
 
-In Manifest V3, you'll need to specify host permissions and optional host permissions separately from other permissions.
+In Manifest V3, you'll need to specify host permissions and optional host permissions separately
+from other permissions.
 
 {% Columns %}
 ```js
@@ -140,15 +136,15 @@ In Manifest V3, you'll need to specify host permissions and optional host permis
 
 {% Aside 'caution' %}
 
-Moving the match patterns to `"host_permissions"` does not affect [content scripts][doc-static-cs]. Content script match patterns remain under `"content_scripts.matches"`.
+Moving the match patterns to `"host_permissions"` does not affect [content scripts][doc-static-cs].
+Content script match patterns remain under `"content_scripts.matches"`.
 
 {% endAside %}
 
 ### Content security policy  {: #content-security-policy }
 
-An extension's [content security policy][csp]
-(CSP) was specified in Manifest V2 as a string; in Manifest V3 it is an object with members
-representing alternative CSP contexts:
+An extension's [content security policy][csp] (CSP) was specified in Manifest V2 as a string; in
+Manifest V3 it is an object with members representing alternative CSP contexts:
 
 {% Columns %}
 ```json
@@ -167,7 +163,8 @@ representing alternative CSP contexts:
 ```
 {% endColumns %}
 
-**`extension_pages`**:  This policy covers pages in your extension, including html files and service workers.
+**`extension_pages`**:  This policy covers pages in your extension, including html files and service
+workers.
 
 {% Aside %}
 
@@ -176,12 +173,12 @@ extension is `chrome-extension://EXTENSION_ID/foo.html`.
 
 {% endAside %}
 
-**`sandbox`**: This policy covers any [sandboxed extension
-pages][manifest-sandbox] that your extension uses.
+**`sandbox`**: This policy covers any [sandboxed extension pages][manifest-sandbox] that your
+extension uses.
 
-In addition, Manifest V3 disallows certain CSP modifications for `extension_pages` that
-were permitted in Manifest V2. The `script-src,` `object-src`, and `worker-src`
-directives may only have the following values:
+In addition, Manifest V3 disallows certain CSP modifications for `extension_pages` that were
+permitted in Manifest V2. The `script-src,` `object-src`, and `worker-src` directives may only have
+the following values:
 
 *   `self`
 *   `none`
@@ -194,10 +191,9 @@ files bundled as part of the extension.
 
 ### Action API unification  {: #action-api-unification }
 
-In Manifest V2, there were two different APIs to implement actions: `browser_action`
-and `page_action`. These APIs filled distinct roles when they were introduced,
-but over time they've become redundant so in Manifest V3 we are unifying them into as
-single `action` API:
+In Manifest V2, there were two different APIs to implement actions: `browser_action` and
+`page_action`. These APIs filled distinct roles when they were introduced, but over time they've
+become redundant so in Manifest V3 we are unifying them into as single `action` API:
 
 {% Columns %}
 ```js
@@ -230,9 +226,9 @@ chrome.action.onClicked.addListener(tab => { … });
 
 ### Web-accessible resources  {: #web-accessible-resources }
 
-This change limits access to extension resources to specific sites/extensions.
-Instead of providing a list of files, you now provide a list of objects, each
-of which can map to a set of resources to a set of URLs or extension IDs:
+This change limits access to extension resources to specific sites/extensions. Instead of providing
+a list of files, you now provide a list of objects, each of which can map to a set of resources to a
+set of URLs or extension IDs:
 
 {% Columns %}
 
@@ -240,7 +236,7 @@ of which can map to a set of resources to a set of URLs or extension IDs:
 // Manifest V2
 
 "web_accessible_resources": [
-  RESOURCE_PATHS
+  RESOURCE_PATHSA
 ]
 ```
 
@@ -266,56 +262,46 @@ Replace the following:
 - <code><var>EXTENSION_IDS</var></code>: A list of strings, each containing the ID of a given
   extension.
 
-Previously, the list of web accessible resources applied to all websites and
-extensions, which created opportunities for fingerprinting or unintentional
-resource access. The updated API lets extensions more tightly control what
-other sites or extensions can access extension resources. 
+Previously, the list of web accessible resources applied to all websites and extensions, which
+created opportunities for fingerprinting or unintentional resource access. The updated API lets
+extensions more tightly control what other sites or extensions can access extension resources. 
 
-See the [web
-accessible resources][doc-war]
-documentation for usage information.
+See the [web accessible resources][doc-war] documentation for usage information.
 
 ## Code execution  {: #code-execution }
 
-Manifest V3 imposes new restrictions that limit an extension's ability to execute
-unreviewed JavaScript through a combination of platform changes and policy
-limitations.
+Manifest V3 imposes new restrictions that limit an extension's ability to execute unreviewed
+JavaScript through a combination of platform changes and policy limitations.
 
-Many extensions are unaffected by this change. However, if your Manifest V2 extension
-executes remotely hosted scripts, injects code strings into pages, or evals
-strings at runtime, you'll need to update your code execution strategies when
-migrating to Manifest V3.
+Many extensions are unaffected by this change. However, if your Manifest V2 extension executes
+remotely hosted scripts, injects code strings into pages, or evals strings at runtime, you'll need
+to update your code execution strategies when migrating to Manifest V3.
 
 ### Remotely hosted code  {: #remotely-hosted-code }
 
-_Remotely hosted code_ refers to any code that is not included in an
-extension's package as a loadable resource. For example, the following
-are considered remotely hosted code:
+_Remotely hosted code_ refers to any code that is not included in an extension's package as a
+loadable resource. For example, the following are considered remotely hosted code:
 
 - JavaScript files pulled from a remote server
 - Any library hosted on a [CDN][mdn-cdn].
 - a code string passed into [`"eval()"`][mdn-eval] at runtime
 
-In Manifest V3, all of your extension's logic must be included in the extension. You
-can no longer load and execute a remotely hosted file. A number of alternative
-approaches are available, depending on your use case and the reason for remote
-hosting. Here's a few approaches are:
+In Manifest V3, all of your extension's logic must be included in the extension. You can no longer
+load and execute a remotely hosted file. A number of alternative approaches are available, depending
+on your use case and the reason for remote hosting. Here's a few approaches are:
 
-Configuration-driven features and logic
-: In this approach, your extension
-loads a remote configuration (for example a JSON file) at runtime and caches
-the configuration locally. The extension then uses this cached configuration to
-decide which features to enable.
+Configuration-driven features and logic : In this approach, your extension loads a remote
+configuration (for example a JSON file) at runtime and caches the configuration locally. The
+extension then uses this cached configuration to decide which features to enable.
 
-Externalize logic with a remote service
-: Consider migrating application
-logic from the extension to a remote web service that your extension can call.
-(Essentially a form of message passing.) This provides you the ability to keep
-code private and change the code on demand while avoiding the extra overhead of
-resubmitting to the Chrome Web Store.
+Externalize logic with a remote service : Consider migrating application logic from the extension to
+a remote web service that your extension can call. (Essentially a form of message passing.) This
+provides you the ability to keep code private and change the code on demand while avoiding the extra
+overhead of resubmitting to the Chrome Web Store.
 
-Bundle third-party libraries
-: If you are using a popular framework like [React][react-cdn] or [Bootstrap][bootstrap-gs], you can download the minified files, add them to your project and import them locally. For example:
+Bundle third-party libraries : If you are using a popular framework like [React][react-cdn] or
+[Bootstrap][bootstrap-gs], you can download the minified files, add them to your project and import
+them locally. For example:
 
 {% Columns %}
 
@@ -340,20 +326,18 @@ Bundle third-party libraries
 
 To include a library in a service worker, you have two options:
 - For standard service workers, use `importScripts()`.
-- To use static import statements, set the
-  `"background.type"` to `"module"` in the manifest.
+- To use static import statements, set the `"background.type"` to `"module"` in the manifest.
 
 ### Executing arbitrary strings  {: #executing-arbitrary-strings }
 
 In Manifest V2, it was possible to execute an arbitrary string of code using
-[`tabs.executeScript()`][api-tabs-executescript] and the `code`
-property on the options object. Manifest V3 does not allow arbitrary code execution. In order to
-adapt to this requirement, extension developers can use the
-[`scripting.executeScript()`][api-scripting-executescript] API to either
-inject a static file or a function.
+[`tabs.executeScript()`][api-tabs-executescript] and the `code` property on the options object.
+Manifest V3 does not allow arbitrary code execution. In order to adapt to this requirement,
+extension developers can use the [`scripting.executeScript()`][api-scripting-executescript] API to
+either inject a static file or a function.
 
-To use the [Scripting API][api-scripting], you need to include the `"scripting"` permission
-in your manifest file. This API does not [trigger a permission warning][doc-perm-warn].
+To use the [Scripting API][api-scripting], you need to include the `"scripting"` permission in your
+manifest file. This API does not [trigger a permission warning][doc-perm-warn].
 
 ```json
 {
@@ -366,8 +350,9 @@ in your manifest file. This API does not [trigger a permission warning][doc-perm
 <web-tabs>
   <web-tab title="Injecting a static file">
 
-  Static file injection with `scripting.executeScript()` is almost identical to it used to work in Tabs
-  API. While the old method only took a single file, the new method now takes an array of files.
+  Static file injection with `scripting.executeScript()` is almost identical to it used to work in
+  Tabs API. While the old method only took a single file, the new method now takes an array of
+  files.
 
   {% Columns %}
   ```js
@@ -400,8 +385,7 @@ in your manifest file. This API does not [trigger a permission warning][doc-perm
   ```
   {% endColumns %}
 
-  To include an external library, save the file locally and add it to the files
-  array:
+  To include an external library, save the file locally and add it to the files array:
 
   ```js
   ...
@@ -456,54 +440,47 @@ in your manifest file. This API does not [trigger a permission warning][doc-perm
 </web-tabs>
 
 A functional version of the Manifest V3 snippets in this section can be found in the
-[chrome-extensions-samples][github-samples-content]
-repository. See the [Tabs API examples][api-tabs-example] for an
-implementation of `getCurrentTab()`.
+[chrome-extensions-samples][github-samples-content] repository. See the [Tabs API
+examples][api-tabs-example] for an implementation of `getCurrentTab()`.
 
 ## Background service workers  {: #background-service-workers }
 
-Background pages in Manifest V2 are replaced by [service
-workers][dev-google-sw] in Manifest V3: this is a foundational change that affects most extensions. The following are
-some notable differences:
+Background pages in Manifest V2 are replaced by [service workers][dev-google-sw] in Manifest V3:
+this is a foundational change that affects most extensions. The following are some notable
+differences:
 
-| MV2 - Background page      | MV3 - Service worker                                  |
-|----------------------------|-------------------------------------------------------|
-| Can use a persistent page. | Terminates when not in use and restarted when needed. |
-| Has access to the DOM.     | Doesn't have access to the DOM.                       |
-| Can use `XMLHttpRequest()`.       | Must use [fetch()][mdn-fetch] to make requests.       |
+| MV2 - Background page       | MV3 - Service worker                                  |
+|-----------------------------|-------------------------------------------------------|
+| Can use a persistent page.  | Terminates when not in use and restarted when needed. |
+| Has access to the DOM.      | Doesn't have access to the DOM.                       |
+| Can use `XMLHttpRequest()`. | Must use [fetch()][mdn-fetch] to make requests.       |
 
-See [Migrating from Background Pages to Service
-Workers][doc-background-to-worker] to explore how to adapt to these and
-other challenges.
+See [Migrating from Background Pages to Service Workers][doc-background-to-worker] to explore how to
+adapt to these and other challenges.
 
 {% Aside %}
 
-In order to aid with the migration process, Manifest V2 extensions can use background
-service workers as of Chrome 87.
+In order to aid with the migration process, Manifest V2 extensions can use background service
+workers as of Chrome 87.
 
 {% endAside %}
 
 
 ## Modifying network requests  {: #modifying-network-requests }
 
-There is a new
-[declarativeNetRequest][api-declarativenetrequest] for
-network request modification, which provides an alternative for much of the
-[webRequest][api-webrequest] API's functionality.
+There is a new [declarativeNetRequest][api-declarativenetrequest] for network request modification,
+which provides an alternative for much of the [webRequest][api-webrequest] API's functionality.
 
 ### When can you use blocking webRequest?  {: #when-use-blocking-webrequest }
 
-The blocking version of the [webRequest][api-webrequest]
-API still exists in Manifest V3 but its use is restricted to force-installed extensions
-only. See Chrome Enterprise policies:
-[ExtensionSettings][enterprise-settings],
-[ExtensionInstallForcelist][enterprise-force-list].
+The blocking version of the [webRequest][api-webrequest] API still exists in Manifest V3 but its use
+is restricted to force-installed extensions only. See Chrome Enterprise policies:
+[ExtensionSettings][enterprise-settings], [ExtensionInstallForcelist][enterprise-force-list].
 
-All other extensions must now use
-[declarativeNetRequest][api-declarativenetrequest] for
-network request modification. This moves the actual modification of the network
-request into the Chrome browser: the extension no longer can read the actual
-network request, and in most cases needs no host permissions.
+All other extensions must now use [declarativeNetRequest][api-declarativenetrequest] for network
+request modification. This moves the actual modification of the network request into the Chrome
+browser: the extension no longer can read the actual network request, and in most cases needs no
+host permissions.
 
 {% Aside 'caution' %}
 
@@ -514,52 +491,48 @@ Request redirects and header modifications **do** require the user to grant host
 
 ### How do you use declarativeNetRequest?  {: #how-use-declarativenetrequest }
 
-Instead of reading the request and programmatically altering it, your extension
-specifies a number of [rules][api-declarative-rules], which map a set of conditions to corresponding
-actions. See the
-[declarativeNetRequest][api-declarativenetrequest]
-reference documentation for a more detailed description of rules.
+Instead of reading the request and programmatically altering it, your extension specifies a number
+of [rules][api-declarative-rules], which map a set of conditions to corresponding actions. See the
+[declarativeNetRequest][api-declarativenetrequest] reference documentation for a more detailed
+description of rules.
 
-This feature allows content blockers and other request-modifying extensions to
-implement their use cases without requiring host permissions, and without
-needing to read the actual requests.
+This feature allows content blockers and other request-modifying extensions to implement their use
+cases without requiring host permissions, and without needing to read the actual requests.
 
 {% Aside %}
 
-In order to aid with the migration process, the declarativeNetRequest API is
-available for use in Manifest V2 extensions as of Chrome 84.
+In order to aid with the migration process, the declarativeNetRequest API is available for use in
+Manifest V2 extensions as of Chrome 84.
 
 {% endAside %}
 
 
 ### Conditional permissions and declarativeNetRequest  {: #declarativenetrequest-conditional-perms }
 
-Most use cases for declarativeNetRequest don't require any host permissions at
-all. However, some do.
+Most use cases for declarativeNetRequest don't require any host permissions at all. However, some
+do.
 
 {% Aside 'caution' %}
 
-Host permissions are still required if the extension wants to *redirect* a
-request or modify headers on it. The `declarativeNetRequestWithHostAccess` permission always
-requires host permissions to the request URL and initiator to act on a request.
+Host permissions are still required if the extension wants to *redirect* a request or modify headers
+on it. The `declarativeNetRequestWithHostAccess` permission always requires host permissions to the
+request URL and initiator to act on a request.
 
 {% endAside %}
 
-When extensions require host permissions for these use cases, we recommend a
-"tiered" permissions strategy. This means implementing the extension's core
-functionality without using these permissions; putting the more advanced use
-cases behind an `"optional_host_permission"`.
+When extensions require host permissions for these use cases, we recommend a "tiered" permissions
+strategy. This means implementing the extension's core functionality without using these
+permissions; putting the more advanced use cases behind an `"optional_host_permission"`.
 
-This approach allows privacy-conscious users to withhold those permissions and
-still use much of the extension's functionality. This means that developers
-can implement many common use cases, such as content-blocking functionality,
-without requiring any host permissions.
+This approach allows privacy-conscious users to withhold those permissions and still use much of the
+extension's functionality. This means that developers can implement many common use cases, such as
+content-blocking functionality, without requiring any host permissions.
 
 
 ## Sunset for deprecated APIs  {: #sunset-deprecated-apis }
 
-There are a number of APIs that have long been deprecated. Manifest V3 finally
-removes support for the following deprecated APIs:
+There are a number of APIs that have long been deprecated. Manifest V3 finally removes support for
+the following deprecated APIs:
 
 *   chrome.extension.getExtensionTabs()
 *   chrome.extension.getURL()
@@ -582,8 +555,8 @@ As well as the undocumented:
 *   chrome.extension.onMessage
 *   chrome.extension.sendMessage()
 
-If your extensions use any of these deprecated APIs, you'll need to make the
-appropriate changes when you migrate to Manifest V3.
+If your extensions use any of these deprecated APIs, you'll need to make the appropriate changes
+when you migrate to Manifest V3.
 
 [api-declarative-rules]: /docs/extensions/reference/declarativeNetRequest/#example
 [api-declarativenetrequest]: /docs/extensions/reference/declarativeNetRequest


### PR DESCRIPTION
Fixes #2823 

Changes proposed in this pull request:

- Convert inline links to footer links.
- Update info to reflect [new MV3 features](https://developer.chrome.com/docs/extensions/whatsnew/).
- Add table with critical differences between background pages and service workers.
- Add instructions on how to bundle external libraries. 
- Misc formatting/clarification improvements. See [friction log](https://docs.google.com/document/d/1ozCf_1g18yuO1hxeEJ5jbbCRoTF1vHhgPWOqTWuM4IE/edit?mode=html#bookmark=id.bqtcgfa6ojp7).

## Staging links
[Migrating to Manifest V3](https://deploy-preview-2855--developer-chrome-com.netlify.app/docs/extensions/mv3/intro/mv3-migration/)