### PR TITLE
Updated `exclude`'s href to `exclude`

### DIFF
--- a/site/en/docs/extensions/mv3/content_scripts/index.md
+++ b/site/en/docs/extensions/mv3/content_scripts/index.md
@@ -321,7 +321,7 @@ registration.
       <td>array of string</td>
       <td><em>Optional.</em> Applied after <code>matches</code> to exclude URLs that match this
         glob. Intended to emulate the <a
-          href="https://wiki.greasespot.net/Metadata_Block#.40include"><code>@exclude</code></a>
+          href="https://wiki.greasespot.net/Metadata_Block#.40exclude"><code>@exclude</code></a>
         Greasemonkey keyword.</td>
     </tr>
   </tbody>

--- a/site/en/docs/extensions/mv3/content_scripts/index.md
+++ b/site/en/docs/extensions/mv3/content_scripts/index.md
@@ -172,6 +172,7 @@ They can include JavaScript files, CSS files, or both. All auto-run content scri
 </table>
 
 {% if false %}
+
 ### Inject with dynamic declarations {: #dynamic-declarative }
 
 {% Aside 'caution' %}


### PR DESCRIPTION
Fixes the link to `@exclude`
![image](https://user-images.githubusercontent.com/6422804/169477282-f6344c51-bad6-4220-af41-2b4e1520edc5.png)
