### PR TITLE
Secure Payment Confirmation collection

### DIFF
--- a/site/_data/i18n/tags.yml
+++ b/site/_data/i18n/tags.yml
@@ -239,3 +239,6 @@ payments:
 
 spc:
   en: Secure Payment Confirmation
+  
+webauthn:
+  en: WebAuthn

--- a/site/_data/i18n/tags.yml
+++ b/site/_data/i18n/tags.yml
@@ -215,3 +215,27 @@ insider:
 web-vitals:
   en: Web Vitals
   zh: 网页指标
+
+#####
+# These are for Privacy Sandbox
+
+proposal:
+  en: Proposal
+
+experiment:
+  en: Experimental
+
+chrome-stable:
+  en: Supported in Chrome stable
+
+cross-browser:
+  en: Supported cross-browser
+
+####
+# These are for collections
+
+payments:
+  en: Payments
+
+spc:
+  en: Secure Payment Confirmation

--- a/site/en/articles/authenticate-secure-payment-confirmation/index.md
+++ b/site/en/articles/authenticate-secure-payment-confirmation/index.md
@@ -1,0 +1,329 @@
+---
+layout: 'layouts/article-post.njk'
+title: Authenticate with Secure Payment Confirmation
+description: >
+   Implement authentication protocols for SPC, to validate customer transactions.
+authors:
+  - agektmr
+date: 2022-05-27
+tags:
+  - payments
+  - experiment
+---
+
+Merchants can use Secure Payment Confirmation (SPC) as part of a strong customer authentication (SCA) process for a given credit card or bank account. WebAuthn performs the authentication (frequently through biometrics). WebAuthn must be registered in advance, which you can learn about in [Register a Secure Payment Confirmation](/articles/register-secure-payment-confirmation).
+
+{% Video src="video/YLflGBAPWecgtKJLqCJHSzHqe2J2/Ifnl5iGvDFs20BdoUTRo.mov", autoplay=true, loop=true %}
+
+## How a typical implementation works
+
+The most common SPC use case is when a customer makes a purchase on a merchant's site, and the credit card issuer or bank requires payer authentication.
+
+<figure class="screenshot">
+{% Img src="image/VbsHyyQopiec0718rMq2kTE1hke2/dArhbZxZhQokGLfwL0Dg.svg", alt="Authentication workflow.", width="788", height="517" %}
+</figure>
+
+
+
+Here's how the authentication flow works:
+
+1. A customer provides their payment credentials (such as credit card information) to the merchant.
+2. The merchant asks the payment credential's corresponding issuer or bank
+   (relying party or RP) if the payer needs a separate authentication. This
+   exchange might happen, for example, with
+   [EMV® 3-D Secure](https://www.emvco.com/emv-technologies/3d-secure/).
+   *  If the RP wishes the merchant to use SPC, and if the user has previously
+      registered, the RP responds with a list of credential IDs registered by
+      the payer and a challenge.
+   *  If an authentication is not needed, the merchant can continue to
+      complete the transaction.
+3. If an authentication is needed, the merchant [determines whether the browser supports SPC](#feature-detection).
+   *  If the browser does not support SPC, proceed with the existing
+      authentication flow.
+4. The merchant invokes SPC. The browser displays a confirmation dialog.
+   *  If there are no credential IDs passed from the RP, fall back to the
+      existing authentication flow.  
+      After a successful authentication, **consider [SPC registration](/articles/register-secure-payment-confirmation) to streamline future authentications**.
+5. The user confirms the amount and the destination of the payment. Then, they authenticate by unlocking the device.
+6. The merchant receives a credential from the authentication.
+7. The RP receives the credential from the merchant and verifies its authenticity.
+8. The RP notifies the verification results to the merchant.
+9. The merchant shows an interface to the user to indicate if the payment was successful or unsuccessful.
+
+{% Aside 'gotchas' %}
+To quickly support an initial SPC experiment, this API was designed atop
+existing implementations of the Payment Request and Payment Handler APIs.
+There is now general agreement to explore a design of SPC independent of
+Payment Request. We expect (without a concrete timeline) that SPC will move
+away from its payment request origins.
+
+For developers, this should improve feature detection, invocation, and other
+aspects of the API.
+{% endAside %}
+
+## Feature detection
+
+To detect whether SPC is supported on the browser, you can send a fake call to
+[`canMakePayment()`](https://web.dev/how-payment-request-api-works/#check-whether-the-payment-method-is-available).
+
+Copy and paste the following code to feature detect SPC on a merchant's website.
+
+```javascript
+const isSecurePaymentConfirmationSupported = async () => {
+  if (!'PaymentRequest' in window) {
+    return [false, 'Payment Request API is not supported'];
+  }
+
+  try {
+    // The data below is the minimum required to create the request and
+    // check if a payment can be made.
+    const supportedInstruments = [
+      {
+        supportedMethods: "secure-payment-confirmation",
+        data: {
+          // RP's hostname as its ID
+          rpId: 'rp.example',
+          // A dummy credential ID
+          credentialIds: [new Uint8Array(1)],
+          // A dummy challenge
+          challenge: new Uint8Array(1),
+          instrument: {
+            // Non-empty display name string
+            displayName: ' ',
+            // Transparent-black pixel.
+            icon: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+P+/HgAFhAJ/wlseKgAAAABJRU5ErkJggg==',
+          },
+          // A dummy merchant origin
+          payeeOrigin: 'https://non-existent.example',
+        }
+      }
+    ];
+
+    const details = {
+      // Dummy shopping details
+      total: {label: 'Total', amount: {currency: 'USD', value: '0'}},
+    };
+
+    const request = new PaymentRequest(supportedInstruments, details);
+    const canMakePayment = await request.canMakePayment();
+    return [canMakePayment, canMakePayment ? '' : 'SPC is not available'];
+  } catch (error) {
+    console.error(error);
+    return [false, error.message];
+  }
+};
+
+isSecurePaymentConfirmationSupported().then(result => {
+  const [isSecurePaymentConfirmationSupported, reason] = result;
+  if (isSecurePaymentConfirmationSupported) {
+    // Display the payment button that invokes SPC.
+  } else {
+    // Fallback to the legacy authentication method.
+  }
+});
+```
+
+## Authenticate the user
+
+To authenticate the user, invoke the `PaymentRequest.show()` method with
+`secure-payment-confirmation` and WebAuthn parameters: 
+*  [`PublicKeyCredentialRequestOptions`](https://w3c.github.io/webauthn/#dictdef-publickeycredentialrequestoptions)
+*  Other [payment specific parameters](https://w3c.github.io/secure-payment-confirmation/#sctn-securepaymentconfirmationrequest-dictionary) on the merchant's platform.
+
+Here's the parameters you should provide to the payment method's `data` property,  [`SecurePaymentConfirmationRequest`](https://w3c.github.io/secure-payment-confirmation/#sctn-securepaymentconfirmationrequest-dictionary).
+
+<div class="table-wrapper scrollbar">
+  <table>
+    <thead>
+      <tr>
+        <th>Parameter</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>rpId</code></td>
+        <td>The hostname of the RP origin as RP ID.</td>
+      </tr>
+      <tr>
+        <td><code>challenge</code></td>
+        <td>A random challenge that prevents replay attacks.</td>
+      </tr>
+      <tr>
+        <td><code>credentialIds</code></td>
+        <td>An array of credential IDs. In WebAuthn's authentication, <code>allowCredentials</code> property accepts an array of <a href="https://w3c.github.io/webauthn/#dictionary-credential-descriptor"><code>PublicKeyCredentialDescriptor</code></a> objects, but in SPC, you only pass a list of credential IDs.</td>
+      </tr>
+      <tr>
+        <td><code>payeeName</code> (optional)</td>
+        <td>Name of the payee.</td>
+      </tr>
+      <tr>
+        <td><code>payeeOrigin</code></td>
+        <td>The origin of the payee. In the above mentioned scenario, it's the merchant's origin.</td>
+      </tr>
+      <tr>
+        <td><code>instrument</code></td>
+        <td>A string for <code>displayName</code> and a URL for <code>icon</code> that points to an image resource. An optional boolean (defaults to <code>true</code>) for <code>iconMustBeShown</code> that specifies an icon must be successfully fetched and shown for the request to succeed.</td>
+      </tr>
+      <tr>
+        <td><code>timeout</code></td>
+        <td>Timeout to sign the transaction in milliseconds</td>
+      </tr>
+      <tr>
+        <td><code>extensions</code></td>
+        <td>Extensions added to WebAuthn call. You don't have to specify the "payment" extension yourself.</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+Check out this example code:
+
+```javascript
+// After confirming SPC is available on this browser via a feature detection,
+// fetch the request options cross-origin from the RP server.
+const options = fetchFromServer('https://rp.example/spc-auth-request');
+const { credentialIds, challenge } = options;
+
+const request = new PaymentRequest([{
+  // Specify `secure-payment-confirmation` as payment method.
+  supportedMethods: "secure-payment-confirmation",
+  data: {
+    // The RP ID
+    rpId: 'rp.example',
+
+    // List of credential IDs obtained from the RP server.
+    credentialIds,
+
+    // The challenge is also obtained from the RP server.
+    challenge,
+
+    // A display name and an icon that represent the payment instrument.
+    instrument: {
+      displayName: "Fancy Card ****1234",
+      icon: "https://rp.example/card-art.png",
+      iconMustBeShown: false
+    },
+
+    // The origin of the payee (merchant)
+    payeeOrigin: "https://merchant.example",
+
+    // The number of milliseconds to timeout.
+    timeout: 360000,  // 6 minutes
+  }
+}], {
+  // Payment details.
+  total: {
+    label: "Total",
+    amount: {
+      currency: "USD",
+      value: "5.00",
+    },
+  },
+});
+
+try {
+  const response = await request.show();
+
+  // response.details is a PublicKeyCredential, with a clientDataJSON that
+  // contains the transaction data for verification by the issuing bank.
+  // Make sure to serialize the binary part of the credential before
+  // transferring to the server.
+  const result = fetchFromServer('https://rp.example/spc-auth-response', response.details);
+  if (result.success) {
+    await response.complete('success');
+  } else {
+    await response.complete('fail');
+  }
+} catch (err) {
+  // SPC cannot be used; merchant should fallback to traditional flows
+  console.error(err);
+}
+```
+
+The `.show()` function results in a
+[`PaymentResponse`](https://w3c.github.io/payment-request/#dom-paymentresponse)
+object except the `details` contains a public key credential with a
+`clientDataJSON` that contains the transaction data
+([`payment`](https://w3c.github.io/secure-payment-confirmation/#sctn-collectedclientpaymentdata-dictionary))
+for verification by the RP.
+
+The resulting credential must be transferred cross-origin to the RP and
+verified.
+
+## How the RP verifies the transaction
+
+Verifying the transaction data at the RP server is the most important step in
+the payment process.
+
+To verify the transaction data, the RP can follow WebAuthn's [authentication
+assertion verification process](https://www.w3.org/TR/webauthn-3/#sctn-verifying-assertion).
+In addition, they need to
+[verify the `payment`](https://w3c.github.io/secure-payment-confirmation/#sctn-verifying-assertion).
+
+An example payload of the `clientDataJSON`:
+
+```json
+{
+  "type":"payment.get",
+  "challenge":"SAxYy64IvwWpoqpr8JV1CVLHDNLKXlxbtPv4Xg3cnoc",
+  "origin":"https://spc-merchant.glitch.me",
+  "crossOrigin":false,
+  "payment":{
+    "rp":"spc-rp.glitch.me",
+    "topOrigin":"https://spc-merchant.glitch.me",
+    "payeeOrigin":"https://spc-merchant.glitch.me",
+    "total":{
+      "value":"15.00",
+      "currency":"USD"
+    },
+    "instrument":{
+      "icon":"https://cdn.glitch.me/94838ffe-241b-4a67-a9e0-290bfe34c351%2Fbank.png?v=1639111444422",
+      "displayName":"Fancy Card 825809751248"
+    }
+  }
+}
+```
+
+{% Aside 'caution' %}
+The `type` property uses `payment.get` instead of `public-key`. This
+may require some tweaking to [the existing WebAuthn
+libraries](https://github.com/herrjemand/awesome-webauthn/blob/main/README.md#server-libs),
+if you choose to use one of them.
+{% endAside %}
+
+*  The `rp` matches the RP's origin.
+*  The `topOrigin` matches the top-level origin that the RP expects (the
+   merchant's origin in the example above).
+*  The `payeeOrigin` matches the origin of the payee that should have been
+   displayed to the user.
+*  The `total` matches the transaction amount that should have been displayed
+   to the user.
+*  The `instrument` matches the payment instrument details that should have
+   been displayed to the user.
+
+```javascript
+const clientData = base64url.decode(response.clientDataJSON);
+const clientDataJSON = JSON.parse(clientData);
+
+if (!clientDataJSON.payment) {
+  throw 'The credential does not contain payment payload.';
+}
+
+const payment = clientDataJSON.payment;
+if (payment.rp !== expectedRPID ||
+    payment.topOrigin !== expectedOrigin ||
+    payment.payeeOrigin !== expectedOrigin ||
+    payment.total.value !== '15.00' ||
+    payment.total.currency !== 'USD') {
+  throw 'Malformed payment information.';
+}
+```
+
+After all the verification criteria have been passed, the RP can tell the
+merchant that the transaction is successful.
+
+## Next steps
+
+* Read the overview of [Secure Payment Confirmation](/articles/secure-payment-confirmation)
+* Learn about [registration with Secure Payment Confirmation](/articles/register-secure-payment-confirmation)

--- a/site/en/articles/authenticate-secure-payment-confirmation/index.md
+++ b/site/en/articles/authenticate-secure-payment-confirmation/index.md
@@ -1,5 +1,5 @@
 ---
-layout: 'layouts/article-post.njk'
+layout: 'layouts/blog-post.njk'
 title: Authenticate with Secure Payment Confirmation
 description: >
    Implement authentication protocols for SPC, to validate customer transactions.

--- a/site/en/articles/authenticate-secure-payment-confirmation/index.md
+++ b/site/en/articles/authenticate-secure-payment-confirmation/index.md
@@ -8,7 +8,8 @@ authors:
 date: 2022-05-27
 tags:
   - payments
-  - experiment
+  - webauthn
+  - chrome-stable
   - spc
 ---
 

--- a/site/en/articles/authenticate-secure-payment-confirmation/index.md
+++ b/site/en/articles/authenticate-secure-payment-confirmation/index.md
@@ -9,6 +9,7 @@ date: 2022-05-27
 tags:
   - payments
   - experiment
+  - spc
 ---
 
 Merchants can use Secure Payment Confirmation (SPC) as part of a strong customer authentication (SCA) process for a given credit card or bank account. WebAuthn performs the authentication (frequently through biometrics). WebAuthn must be registered in advance, which you can learn about in [Register a Secure Payment Confirmation](/articles/register-secure-payment-confirmation).

--- a/site/en/articles/authenticate-secure-payment-confirmation/index.md
+++ b/site/en/articles/authenticate-secure-payment-confirmation/index.md
@@ -19,17 +19,17 @@ Merchants can use Secure Payment Confirmation (SPC) as part of a strong customer
 
 ## How a typical implementation works
 
-The most common SPC use case is when a customer makes a purchase on a merchant's site, and the credit card issuer or bank requires payer authentication.
+The most common use for SPC is when a customer makes a purchase on a merchant's
+site, and the credit card issuer or bank requires payer authentication.
 
 <figure class="screenshot">
 {% Img src="image/VbsHyyQopiec0718rMq2kTE1hke2/dArhbZxZhQokGLfwL0Dg.svg", alt="Authentication workflow.", width="788", height="517" %}
 </figure>
 
+Let's walk through the authentication flow:
 
-
-Here's how the authentication flow works:
-
-1. A customer provides their payment credentials (such as credit card information) to the merchant.
+1. A customer provides their payment credentials (such as credit card
+   information) to the merchant.
 2. The merchant asks the payment credential's corresponding issuer or bank
    (relying party or RP) if the payer needs a separate authentication. This
    exchange might happen, for example, with
@@ -45,12 +45,16 @@ Here's how the authentication flow works:
 4. The merchant invokes SPC. The browser displays a confirmation dialog.
    *  If there are no credential IDs passed from the RP, fall back to the
       existing authentication flow.  
-      After a successful authentication, **consider [SPC registration](/articles/register-secure-payment-confirmation) to streamline future authentications**.
-5. The user confirms the amount and the destination of the payment. Then, they authenticate by unlocking the device.
+      After a successful authentication, **consider using [SPC registration](/articles/register-secure-payment-confirmation)
+	to streamline future authentications**.
+5. The user confirms and authenticates the amount and the destination of the
+   payment by unlocking the device.
 6. The merchant receives a credential from the authentication.
-7. The RP receives the credential from the merchant and verifies its authenticity.
-8. The RP notifies the verification results to the merchant.
-9. The merchant shows an interface to the user to indicate if the payment was successful or unsuccessful.
+7. The RP receives the credential from the merchant and verifies its
+   authenticity.
+8. The RP sends the verification results to the merchant.
+9. The merchant shows the user a message to indicate if the payment was
+   successful or unsuccessful.
 
 {% Aside 'gotchas' %}
 To quickly support an initial SPC experiment, this API was designed atop
@@ -129,6 +133,7 @@ isSecurePaymentConfirmationSupported().then(result => {
 
 To authenticate the user, invoke the `PaymentRequest.show()` method with
 `secure-payment-confirmation` and WebAuthn parameters: 
+
 *  [`PublicKeyCredentialRequestOptions`](https://w3c.github.io/webauthn/#dictdef-publickeycredentialrequestoptions)
 *  Other [payment specific parameters](https://w3c.github.io/secure-payment-confirmation/#sctn-securepaymentconfirmationrequest-dictionary) on the merchant's platform.
 

--- a/site/en/articles/register-secure-payment-confirmation/index.md
+++ b/site/en/articles/register-secure-payment-confirmation/index.md
@@ -9,6 +9,7 @@ date: 2022-05-27
 tags:
   - payments
   - experiment
+  - spc
 ---
 
 To use Secure Payment Confirmation (SPC) in a transaction, the customer must

--- a/site/en/articles/register-secure-payment-confirmation/index.md
+++ b/site/en/articles/register-secure-payment-confirmation/index.md
@@ -219,10 +219,10 @@ additional is required to comply with SPC.
 
 ## Registration from within an iframe
 
-If the payer hasn't registered their device with the RP (payment issuer), they
-can still do so at the merchant website. After a successful authentication
-during a purchase, the issuer can request the payer to register their device
-indirectly from within an iframe.
+If the payer hasn't registered their device with the RP (payment issuer), the
+payer can register on the merchant website. After a successful authentication
+during a purchase, the RP can request the payer register their device
+indirectly, from within an iframe.
 
 <figure class="screenshot">
 {% Img
@@ -232,10 +232,12 @@ indirectly from within an iframe.
 %}
 </figure>
 
-To do so, the issuer can follow the same steps as previously described within
-an iframe, except the merchant or the parent frame must explicitly allow it
-using [the Permissions Policy](/docs/privacy-sandbox/permissions-policy/).
-There are two approaches to allow it:
+To do so, the merchant or parent must explicitly allow this action within an
+iframe using [the Permissions Policy](/docs/privacy-sandbox/permissions-policy/).
+The issuer follows the [same steps to register an
+authenticator](#register-an-authenticator) within an iframe.
+
+There are two approaches for the merchant to allow registration:
 
 1. The iframe tag in the HTML served from the merchant domain adds an `allow` attribute:
 

--- a/site/en/articles/register-secure-payment-confirmation/index.md
+++ b/site/en/articles/register-secure-payment-confirmation/index.md
@@ -8,7 +8,8 @@ authors:
 date: 2022-05-27
 tags:
   - payments
-  - experiment
+  - webauthn
+  - chrome-stable
   - spc
 ---
 

--- a/site/en/articles/register-secure-payment-confirmation/index.md
+++ b/site/en/articles/register-secure-payment-confirmation/index.md
@@ -1,0 +1,257 @@
+---
+layout: 'layouts/article-post.njk'
+title: Register a Secure Payment Confirmation
+description: >
+   Implement the registration protocols and flow for SPC, so customers can strongly authenticate against card issuers or banks directly from a merchant.
+authors:
+  - agektmr
+date: 2022-05-27
+tags:
+  - payments
+  - experiment
+---
+
+To use Secure Payment Confirmation (SPC) in a transaction, the customer must
+first register an authenticator. This process is very similar to the WebAuthn
+registration process, with the addition of a payment extension.
+
+In this article, issuing banks acting as relying parties (RPs) can learn how
+to implement SPC registration. The user experience is further explained in the
+[overview of Secure Payment Confirmation](/articles/secure-payment-confirmation).
+
+## How does Secure Payment Confirmation registration work?
+
+SPC is built as an extension to the WebAuthn standard. 
+
+As of April 2022, SPC only supports User Verifying Platform Authenticators
+(UVPA) on desktop. This means the customer needs to be on a desktop or laptop
+with an embedded authenticator such as:
+
+*  Unlock feature including Touch ID on a macOS device
+*  Windows Hello on a Windows device
+
+## Register the device
+
+The relying party's (RP's) registration of a device should follow a
+sufficiently strong user verification process. The RP must make sure that the
+customer has signed in to the website using strong authentication so that the
+account is not easily hijacked. Be careful: a lack of security in this process
+puts SPC at risk as well.
+
+Once the RP has successfully authenticated the customer, the customer can now
+register a device.
+
+<figure class="screenshot">
+{% Img
+   src="image/VbsHyyQopiec0718rMq2kTE1hke2/QCN0uPTrGX1s3AFov5sv.svg", alt="Typical registration workflow on the relying party's website",
+   width="800", height="471"
+%}
+</figure>
+
+### Feature detection
+
+Before asking the customer to register the device, the RP must check that the
+browser supports SPC.
+
+```javascript
+const isSecurePaymentConfirmationSupported = async () => {
+  if (!'PaymentRequest' in window) {
+    return [false, 'Payment Request API is not supported'];
+  }
+
+  try {
+    // The data below is the minimum required to create the request and
+    // check if a payment can be made.
+    const supportedInstruments = [
+      {
+        supportedMethods: "secure-payment-confirmation",
+        data: {
+          // RP's hostname as its ID
+          rpId: 'rp.example',
+          // A dummy credential ID
+          credentialIds: [new Uint8Array(1)],
+          // A dummy challenge
+          challenge: new Uint8Array(1),
+          instrument: {
+            // Non-empty display name string
+            displayName: ' ',
+            // Transparent-black pixel.
+            icon: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+P+/HgAFhAJ/wlseKgAAAABJRU5ErkJggg==',
+          },
+          // A dummy merchant origin
+          payeeOrigin: 'https://non-existent.example',
+        }
+      }
+    ];
+
+    const details = {
+      // Dummy shopping details
+      total: {label: 'Total', amount: {currency: 'USD', value: '0'}},
+    };
+
+    const request = new PaymentRequest(supportedInstruments, details);
+    const canMakePayment = await request.canMakePayment();
+    return [canMakePayment, canMakePayment ? '' : 'SPC is not available'];
+  } catch (error) {
+    console.error(error);
+    return [false, error.message];
+  }
+};
+
+isSecurePaymentConfirmationSupported().then(result => {
+  const [isSecurePaymentConfirmationSupported, reason] = result;
+  if (isSecurePaymentConfirmationSupported) {
+    // Display the payment button that invokes SPC.
+  } else {
+    // Fallback to the legacy authentication method.
+  }
+});
+```
+
+### Register an authenticator
+
+To register a device for SPC, follow the [WebAuthn registration
+process](https://w3c.github.io/webauthn/#sctn-op-make-cred) with the following
+requirements:
+
+*  The platform authenticator is required:
+   `authenticatorSelection.authenticatorAttachment` is `platform`.
+*  The user verification is required:
+   `authenticatorSelection.userVerification` is `required`.
+*  Discoverable credentials (resident keys) are required:
+   `authenticatorSelection.residentKey` is `required`.
+
+{% Aside %}
+Discoverable credentials are the mechanism in FIDO where authenticators can
+store information about the user so that the user-agent can provide a UI of
+accounts for the user to sign in with upon authentication. This UX is not
+currently actively used, but is required for future compatibility.
+{% endAside %}
+
+In addition, specify a "payment" extension with `isPayment: true`. Specifying
+this extension without meeting the above requirements will throw an exception
+
+{% Aside %}
+WebAuthn supports the `attestation` option which helps the RP to check the manufacturer and the model of the registering authenticator. However, since the Secure Payment Confirmation is currently only available on Chrome, and is restricted to the platform authenticator on certain platforms, this may not be useful and is optional.
+{% endAside %}
+
+Some other caveats:
+
+*  `rp.id`: the hostname of the RP.
+   [The eTLD+1](https://web.dev/same-site-same-origin/#site) part of the
+   domain must match where it's being registered. It can be used for
+   authentication on domains that match eTLD+1.
+*  `user.id`: a binary expression of the user identifier. The same identifier
+   will be returned on successful authentication so the RP should provide a
+   consistent user identifier of the card holder.
+*  `excludeCredentials`: an array of credentials so that the RP can avoid
+   registering the same authenticator.
+
+For more on the WebAuthn registration process, refer to
+[webauthn.guide](https://webauthn.guide#registration).
+
+Example registration code:
+
+```javascript
+const options = {
+  challenge: new Uint8Array([21...]),
+  rp: {
+    id: "rp.example", 
+    name: "Fancy Bank",
+  },
+  user: {
+    id: new Uint8Array([21...]),
+    name: "jane.doe@example.com",
+    displayName: "Jane Doe",
+  },
+  excludeCredentials: [{
+    id: new Uint8Array([21...]),
+    type: 'public-key',
+    transports: ['internal'],
+  }, ...],
+  pubKeyCredParams: [{
+    type: "public-key",
+    alg: -7 // "ES256"
+  }, {
+    type: "public-key",
+    alg: -257 // "RS256"
+  }],
+  authenticatorSelection: {
+    userVerification: "required",
+    residentKey: "required",
+    authenticatorAttachment: "platform",
+  },
+  timeout: 360000,  // 6 minutes
+
+  // Indicate that this is an SPC credential. This is currently required to
+  // allow credential creation in an iframe, and so that the browser knows this
+  // credential relates to SPC.
+  extensions: {
+    "payment": {
+      isPayment: true,
+    }
+  }
+};
+
+try {
+  const credential = await navigator.credentials.create({ publicKey: options });
+  // Send new credential info to server for verification and registration.
+} catch (e) {
+  // No acceptable authenticator or user refused consent. Handle appropriately.
+}
+```
+
+{% Aside %}
+If the browser does not support the payment extension, it will ignore it and
+just register the authenticator as a regular public key credential.
+{% endAside %}
+
+After a successful registration, the RP receives a credential to send to the server for verification.
+
+## Verify registration
+
+On the server, the RP must verify the credential and keep the public key for
+later use. The server-side registration process is the same as [an ordinary
+WebAuthn registration](https://webauthn.guide/#registration). Nothing
+additional is required to comply with SPC.
+
+## Registration from within an iframe
+
+If the payer hasn't registered their device with the RP (payment issuer), they
+can still do so at the merchant website. After a successful authentication
+during a purchase, the issuer can request the payer to register their device
+indirectly from within an iframe.
+
+<figure class="screenshot">
+{% Img
+   src="image/VbsHyyQopiec0718rMq2kTE1hke2/J0oIPcNBfDwVSxMh2dA5.svg", 
+   alt="Workflow of registration on a merchant website during payment.", 
+   width="800", height="462"
+%}
+</figure>
+
+To do so, the issuer can follow the same steps as previously described within
+an iframe, except the merchant or the parent frame must explicitly allow it
+using [the Permissions Policy](/docs/privacy-sandbox/permissions-policy/).
+There are two approaches to allow it:
+
+1. The iframe tag in the HTML served from the merchant domain adds an `allow` attribute:
+
+   ```html
+   <iframe name="iframe" allow="payment https://spc-rp.glitch.me"></iframe>
+   ```
+   
+   Make sure the `allow` attribute contains `payment` and the RP origin that invokes WebAuthn registration.
+
+2. The parent frame document (served from the merchant domain) is sent with a `Permissions-Policy` HTTP header:
+
+   ```http
+   Permissions-Policy: payment=(self "https://spc-rp.glitch.me")
+   ```
+
+## Next steps
+
+Once a device is registered to the relying party, the customer can confirm payments on the merchant's website using Secure Payment Confirmation.
+
+* Learn to [authenticate with a Secure Payment Confirmation](/articles/authenticate-secure-payment-confirmation)
+* Read the overview of [Secure Payment Confirmation](/articles/secure-payment-confirmation)

--- a/site/en/articles/register-secure-payment-confirmation/index.md
+++ b/site/en/articles/register-secure-payment-confirmation/index.md
@@ -1,5 +1,5 @@
 ---
-layout: 'layouts/article-post.njk'
+layout: 'layouts/blog-post.njk'
 title: Register a Secure Payment Confirmation
 description: >
    Implement the registration protocols and flow for SPC, so customers can strongly authenticate against card issuers or banks directly from a merchant.

--- a/site/en/articles/secure-payment-confirmation/index.md
+++ b/site/en/articles/secure-payment-confirmation/index.md
@@ -9,6 +9,7 @@ date: 2022-05-27
 tags:
   - payments
   - experiment
+  - spc
 ---
 
 Secure Payment Confirmation (SPC) is a

--- a/site/en/articles/secure-payment-confirmation/index.md
+++ b/site/en/articles/secure-payment-confirmation/index.md
@@ -8,7 +8,8 @@ authors:
 date: 2022-05-27
 tags:
   - payments
-  - experiment
+  - webauthn
+  - chrome-stable
   - spc
 ---
 

--- a/site/en/articles/secure-payment-confirmation/index.md
+++ b/site/en/articles/secure-payment-confirmation/index.md
@@ -1,5 +1,5 @@
 ---
-layout: 'layouts/article-post.njk'
+layout: 'layouts/blog-post.njk'
 title: Secure Payment Confirmation
 description: >
    High-level overview of a proposed web standard to allow for secure authentication with payment service providers.

--- a/site/en/articles/secure-payment-confirmation/index.md
+++ b/site/en/articles/secure-payment-confirmation/index.md
@@ -1,0 +1,199 @@
+---
+layout: 'layouts/article-post.njk'
+title: Secure Payment Confirmation
+description: >
+   High-level overview of a proposed web standard to allow for secure authentication with payment service providers.
+authors:
+  - agektmr
+date: 2022-05-27
+tags:
+  - payments
+  - experiment
+---
+
+Secure Payment Confirmation (SPC) is a
+[proposed web standard](https://www.w3.org/TR/secure-payment-confirmation/)
+that allows customers to authenticate with a credit card issuer, bank, or
+other payment service provider using a platform authenticator:
+
+*  Unlock feature including Touch ID on a macOS device
+*  Windows Hello on a Windows device
+
+With SPC, merchants can allow customers to quickly and seamlessly authenticate
+their purchases, while issuing banks protect their customers from fraud.
+
+<figure class="float-right screenshot">
+{% Img
+  src="image/VbsHyyQopiec0718rMq2kTE1hke2/idZVP2qnYqcYVhmfElma.png",
+  alt="", width="458", height="434"
+%}
+</figure>
+
+SPC has two stages: registration and authentication.
+
+*  **Registration**: the payer links their device to a relying party (RP). The
+   relying party may be a credit card issuer, bank, or other payment service
+   provider.
+*  **Authentication**: the payer uses the registered device to confirm their
+   identity with the RP directly from the merchant's platform before
+   confirming payments.
+
+## Authentication for fraud prevention
+
+Authentication plays an important role in payment fraud prevention. However,
+this verification process often relies on weak mechanisms, such as a
+combination of the credit card number and the card owner's name, or an
+additional CVC code that is written on the back of the card. These mechanisms
+are easily compromised and impersonated if the card information is leaked due
+to data security breaches such as account hijacks or phishing attacks.
+
+Additional fraud-prevention mechanisms have been introduced, such as
+[EMV® 3-D Secure](https://www.emvco.com/emv-technologies/3d-secure/), where
+the payer may be asked to authenticate against the card issuer or the bank. To
+authenticate, the user signs in with a username and password, or a
+one-time-password (OTP) delivered to the payer's phone via SMS. This works to
+protect customers from fraud, but can become a barrier for some valid
+customers to complete payment. SPC aims to reduce authentication friction,
+therefore reducing cart abandonment.
+
+Meanwhile, there is a new authentication standard on the rise called WebAuthn.
+
+### What is WebAuthn? {: #what-is-webauthn }
+
+[Web Authentication](https://webauthn.guide/) (WebAuthn in short) is a
+[web standard](https://www.w3.org/TR/webauthn-2/) that allows relying party
+(RP) servers to register and authenticate users in the browser using public key
+cryptography, instead of a password. 
+
+RPs rely on physical authenticators, such as a security key. RPs request the
+security key to generate a private-public key pair and then store the public
+key on the server (_registration_). These generated keys are unique to the
+device, which prevents attackers from impersonating the user. This standard is
+phishing-resistant because the key pair is bound to the origin.
+
+[The FIDO Alliance](https://fidoalliance.org/specifications/download/)
+standardizes authenticator behavior. Some authenticators support local user
+verification with a biometric factor (such as a fingerprint or facial
+recognition) or a knowledge factor (such as a PIN code). Many are integrated
+into computing devices, such as laptops or smartphones, known as
+_platform authenticators_. WebAuthn is supported on
+[all major browsers (desktop and mobile)](https://caniuse.com/webauthn), and
+authenticators are available on [billions of devices](https://lists.w3.org/Archives/Public/public-webauthn-adoption/2021Feb/0001.html).
+Users can register and authenticate themselves by verifying their identity
+locally on the platform.
+
+{% Aside %}
+The FIDO standard mandates the device not to transmit the biometric data outside of itself, so that the user verification only happens locally.
+{% endAside %}
+
+SPC is designed to work with User Verifying Platform Authenticators (UVPA).
+
+<figure class="screenshot">
+   {% Img
+      src="image/VbsHyyQopiec0718rMq2kTE1hke2/byYdb1HUukKGr0X07MUg.png", alt="Example UVPAs include Apple Touch ID and a mobile phone camera", 
+      width="587", height="261"
+   %}
+   <figcaption>
+      Many devices integrate a biometric sensor. Those authenticators are
+      called user verifying platform authenticator (UVPA).
+   </figcaption>
+</figure>
+
+
+### How does Secure Payment Confirmation work? {: #how-spc-work }
+
+Secure Payment Confirmation (SPC) is built upon WebAuthn and designed
+specifically for payment purposes. As WebAuthn credentials are registered for
+specific domains, these credentials can't be used to authenticate on
+unregistered sites that may be impersonating a merchant. This feature makes
+WebAuthn effective against phishing attacks.
+
+SPC adds a payment information layer on top of WebAuthn so that the card
+issuer or the bank can provide a consistent payment experience. Once a payer
+registers an authenticator with the relying party, it can be used to
+authenticate on different merchant sites. The relying party can also choose to
+use the payment credential as a regular WebAuthn credential.
+
+[Stripe](https://stripe.com/) ran an experiment with SPC on their production
+environment, as part of [Chrome's origin trials](/blog/origin-trials/). In
+this experiment, Stripe achieved an 8% better conversion rate and the checkout
+rate was three times faster. Read about their results in the
+[SPC report in the W3C Web Payments Working Group](https://www.w3.org/2021/Talks/spc-pilot-202103.pdf).
+
+## How do users experience SPC? {: #user-experience }
+
+The SPC front-end consists of two stages: registration and authentication.
+
+The customer must first register their device using the user-verifying
+platform authenticator (UVPA). Once the device is registered, it can be used
+to authenticate the user and confirm payments whenever SPC is performed on a
+merchant's site.
+
+{% Aside 'gotchas' %}
+The customer will need to register for each device they use.
+{% endAside %}
+
+### Registration {: #registration }
+
+Users can register for SPC in two ways:
+
+* Register directly on the RP website.
+* Register indirectly at a merchant website.
+
+#### Registration on the RP website {: #registration-on-rp }
+
+On the RP's website,  SPC registration is no different than WebAuthn registration. Our recommendation is that the RP asks the customer to register their UVPA as part of a sign-in flow.
+
+A typical scenario may look like this:
+
+1. A customer signs in to your bank website using a username, password, and an additional verification step (typically a one-time password or OTP).
+2. After a successful authentication, display a request for permission which asks the customer to register their device (UVPA).
+3. Once permission is granted, the browser shows a WebAuthn registration dialog.
+4. The customer consents to register the device by doing a biometric authentication.
+5. The customer can now login and pay securely using their device.
+
+With _reauthentication_, a user is already logged in but is asked to
+authenticate again to ensure the same user is still present. This design is
+typically seen in a security-critical operation, such as a request to change a
+password or when making a payment. With a WebAuthn UVPA, reauthentication is
+much quicker and stronger than using passwords.
+
+{% Video src="video/YLflGBAPWecgtKJLqCJHSzHqe2J2/8oKo5F2Gl0GN7HBPDQAp.mov", autoplay=true, loop=true %}
+
+Learn how to build a WebAuthn registration and authentication flow for
+reauthentication at [Build your first WebAuthn app](https://developers.google.com/codelabs/webauthn-reauth).
+
+#### Registration on a merchant website during payment {: #registration-on-merchant }
+
+If your customer doesn't register their device on the payment issuer's
+website, they could do so directly on a merchant website. The interface looks
+the same, but the user's registration is initiated by the RP's code.
+
+This is ideal when customers don't visit the RP website frequently but the RP would still like to offer the authentication option.
+
+{% Video src="video/YLflGBAPWecgtKJLqCJHSzHqe2J2/CFq2q2ib59ZEjuBey6Mu.mov", autoplay=true, loop=true %}
+
+### Authentication (Payment Confirmation) {: #authentication }
+
+Authentication is required when a payer provides a payment credential during a payment transaction.
+
+1. The payer provides a payment credential (such as credit card information).
+2. The merchant checks whether the browser supports Secure Payment
+   Confirmation.
+3. If the browser supports SPC, call the Payment Request API with SPC as a
+   payment method. Otherwise fall back to the existing authentication method.
+4. The payer confirms the transaction details and completes authentication
+   (such as by touching their biometric platform authenticator).
+
+{% Video src="video/YLflGBAPWecgtKJLqCJHSzHqe2J2/Ifnl5iGvDFs20BdoUTRo.mov", autoplay=true, loop=true %}
+
+## Supported platforms
+
+Secure Payment Confirmation is currently supported by Google Chrome on macOS
+and Windows. Other platforms, including Android, iOS, and ChromeOS, are not
+supported as of May 2022.
+
+## Next steps
+
+* [Registering a Secure Payment Confirmation](/articles/register-secure-payment-confirmation)
+* [Authenticating with a Secure Payment Confirmation](/articles/authenticate-secure-payment-confirmation)

--- a/site/en/payments/index.md
+++ b/site/en/payments/index.md
@@ -1,0 +1,6 @@
+---
+title: 'Secure Payment Confirmation'
+description: 'Allow customers to securely authenticate with payment service providers using platform authenticators.'
+layout: 'layouts/collection-landing.njk'
+collection_tag: 'spc'
+---


### PR DESCRIPTION
Fixes #2084

Changes proposed in this pull request:

- Adds 3 articles for SPC
   - https://deploy-preview-2906--developer-chrome-com.netlify.app/articles/secure-payment-confirmation/
   - https://deploy-preview-2906--developer-chrome-com.netlify.app/articles/register-secure-payment-confirmation/
   - https://deploy-preview-2906--developer-chrome-com.netlify.app/articles/authenticate-secure-payment-confirmation/
- Creates SPC collection ([preview](https://deploy-preview-2906--developer-chrome-com.netlify.app/payments))
- Adds tags for Privacy Sandbox

Related web.dev updates: https://github.com/GoogleChrome/web.dev/pull/7998