### PR TITLE
[cws-doc] Add Trader/Non-Trader developer identification

### DIFF
--- a/site/_data/docs/webstore/toc.yml
+++ b/site/_data/docs/webstore/toc.yml
@@ -35,6 +35,7 @@
   sections:
     - url: /docs/webstore/terms/
     - url: /docs/webstore/program_policies/
+    - url: /docs/webstore/trader-disclosure/
     - url: /docs/webstore/spam-faq/
     - url: /docs/webstore/deceptive_installation_tactics/
     - url: /docs/webstore/user_data/

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -1,10 +1,9 @@
 ---
 layout: 'layouts/doc-post.njk'
-
 title: What's new in Chrome extensions
 description: 'Recent changes to the Chrome extensions platform, documentation, and policy'
 date: 2021-02-25
-updated: 2022-04-11
+updated: 2022-05-26
 
 # Note: disabling the linter for duplicate headings because this isn't hierarchical and it needs
 # smaller font headings.
@@ -15,6 +14,12 @@ updated: 2022-04-11
 
 Check this page often to learn about changes to the Chrome extensions platform, its documentation,
 and related policy or other changes.
+
+### Docs update: Developer trader/non-trader disclosure {: #cws-trader-disclosure-doc }
+
+May 26, 2022
+
+Added the [trader/non-trader developer identification](/docs/webstore/trader-disclosure) that informs developers to accurately self-declare their trader/non-trader status.
 
 ### Chrome 102: {: #m102-registercontentscripts-main-world }
 

--- a/site/en/docs/webstore/trader-disclosure/index.md
+++ b/site/en/docs/webstore/trader-disclosure/index.md
@@ -1,0 +1,45 @@
+---
+layout: "layouts/doc-post.njk"
+title: "Trader/Non-Trader developer identification"
+date: 2022-05-26
+description:  "Developer’s requirement to disclose their trader/non-trader status."
+subhead:  "Developer’s requirement to disclose their trader/non-trader status."
+---
+
+## (Non)-Trader Transparency Requirement
+
+On April 11, 2018, the European Commission adopted the New Deal for Consumers, stating that the
+legislation is “aimed at strengthening enforcement of EU consumer law” and “modernizing EU consumer
+protection rules in view of market developments.”
+
+One of the provisions of the New Deal, which went into effect on May 28, 2022, requires online
+marketplaces to inform consumers about the identity of the party with whom they are concluding a
+contract (i.e. whether the party is a professional trader or an individual).
+
+As a result, third party suppliers that provide services on online marketplaces may be asked to
+identify themselves as either traders or non-traders so that consumers can determine if they are
+dealing with a professional trader and would be able to benefit from consumer rights.
+
+## Defining trader vs. non-trader
+
+The European Commission defines traders and non-traders as follows:
+
+Trader : Any natural person or any legal person, who is acting for purposes relating to his trade,
+business, craft or profession in relation to contracts on this marketplace.
+
+Non-trader : Any natural person or any legal person, who is acting for purposes which are outside of
+his trade, business, craft or profession in relation to contracts on this marketplace.
+
+If you are a non-trader, the consumer will be informed that consumer rights stemming from consumer
+protection laws may not apply to any contracts between you and the consumer.  Please note that it is
+the developer’s responsibility to accurately self-declare their trader/non-trader status.
+
+## For more information on the EU New Deal 
+
+If you would like more information on the EU’s New Deal for Consumers, take a look at the European
+Commission’s [press release describing the New Deal][press-release-new-deal] or visit the European
+Commission’s [repository on resources related to this legislation][related-resources].
+
+
+[press-release-new-deal]: https://ec.europa.eu/commission/presscorner/detail/en/IP_18_3041
+[related-resources]: https://ec.europa.eu/newsroom/just/items/620435/en


### PR DESCRIPTION
Adds the new Trader/Non-trader developer identification policy

Based on [doc](https://docs.google.com/document/d/1KNvy-SYACA2q5G2rjj-ZRXrfvmfUAVf_9Os2cve-nGE/edit?mode=html&resourcekey=0-Qx-bwDd0NpcHzlDJNLfadw#heading=h.sr2830oicwbx) provided

### Staged links
[What's new](https://deploy-preview-2910--developer-chrome-com.netlify.app/docs/extensions/whatsnew/)
[Trader/Non-trader](https://deploy-preview-2910--developer-chrome-com.netlify.app/docs/webstore/trader-disclosure/)
