### PR TITLE
Don't localize /authors/ URLs

### DIFF
--- a/site/_includes/macros/card-authors.njk
+++ b/site/_includes/macros/card-authors.njk
@@ -10,7 +10,7 @@
     {% for authorId in authors %}
       {% set author = postsData.authors[authorId] %}
       {% if author.image %}
-      <a href="{{ author.url }}" class="card-authors__image">
+      <a href="{{ author.url }}" translate="no" class="card-authors__image">
         {% Img
           class="flex-shrink-none width-600 height-600",
           src=author.image,
@@ -32,7 +32,7 @@
         {%- set author = postsData.authors[authorId] -%}
         {{- sep() -}}
         {%- if author -%}
-          <a href="{{ author.url }}" class="surface display-inline-flex color-text">{{ author.title | i18n(locale) }}</a>
+          <a href="{{ author.url }}" translate="no" class="surface display-inline-flex color-text">{{ author.title | i18n(locale) }}</a>
         {%- else -%}
           {{ authorId }}
         {%- endif -%}

--- a/site/_includes/macros/cards/author-card.njk
+++ b/site/_includes/macros/cards/author-card.njk
@@ -4,7 +4,7 @@
 <div class="blog-card rounded-lg pad-300 md:pad-400 width-full text-align-center">
   {% if author.image %}
     <div class="gap-bottom-300">
-      <a class="display-block" href="{{ author.url }}">
+      <a translate="no" class="display-block" href="{{ author.url }}">
         {% Img
           src=author.image,
           alt=author.title | i18n(locale),
@@ -19,7 +19,7 @@
   {% endif %}
 
   <h2 class="type--h5">
-    <a class="surface display-inline-flex color-text" href="{{ author.url }}">
+    <a translate="no" class="surface display-inline-flex color-text" href="{{ author.url }}">
       {{ author.title | i18n(locale) }}
     </a>
   </h2>

--- a/site/_includes/macros/post-author.njk
+++ b/site/_includes/macros/post-author.njk
@@ -9,7 +9,7 @@
 
 <div class="display-flex align-start">
   {% if author.image %}
-    <a href="{{ author.url }}" class="card-authors__image">
+    <a href="{{ author.url }}" translate="no" class="card-authors__image">
       {% Img
         class="flex-shrink-none width-600 height-600",
         src=author.image,
@@ -22,7 +22,7 @@
   {% endif %}
   <div class="display-flex direction-column align-start gap-left-300 type--small">
     {% if author %}
-      <a href="{{ author.url }}" class="surface display-inline-flex color-text">{{ author.title | i18n(locale) }}</a>
+      <a href="{{ author.url }}" translate="no" class="surface display-inline-flex color-text">{{ author.title | i18n(locale) }}</a>
       <p class="color-secondary-text">{{ author.description | i18n(locale) }}</p>
     {% else %}
       <p>{{ authorId }}</p>


### PR DESCRIPTION
Fixes #2944

Those `<a>` tags should not have their `href` attributes localized. That `translate="no"` attribute will apparently exempt them:

https://github.com/GoogleChrome/developer.chrome.com/blob/024a416352b944113648c761255fae1e3d439bac/site/_transforms/pretty-urls.js#L72-L75

