### PR TITLE
Update testing instructions for Shared Storage

### DIFF
--- a/site/en/docs/privacy-sandbox/shared-storage/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/index.md
@@ -210,15 +210,10 @@ register("send-reach-report", SendReachReportOperation);
 
 ## Try the Shared Storage API
 
-Shared Storage API is available in Chrome Canary 104 with a command line
-flag:
+Shared Storage API can be tested in Chrome Canary 104 by enabling the [Privacy Sandbox Ads APIs 
+experiment](chrome://flags/#privacy-sandbox-ads-apis) flag.
 
-```text
---args --enable-features=SharedStorageAPI,FencedFrames,PrivacySandboxAdsAPIsOverride
-```
-
-If you have previously enabled the [Privacy Sandbox Ads APIs 
-experiment](chrome://flags/#privacy-sandbox-ads-apis), you must disable it as this setting overrides flags set from the command line. 
+{% Img src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/CWfgCMJQ5cYPOfjttF3k.png", alt="Shared Storage API flag screen", width="744", height="124" %}
 
 ## Engage and share feedback
 

--- a/site/en/docs/privacy-sandbox/shared-storage/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/index.md
@@ -214,11 +214,6 @@ Shared Storage API with Fenced Frame can be tested in Chrome 104 (>= 104.0.5086.
 
 {% Img src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/CWfgCMJQ5cYPOfjttF3k.png", alt="Shared Storage API flag screen", width="744", height="124" %}
 
-To test rendering an opaque source into an iframe instead of a fenced frame, start Chrome Canary from the terminal with the following command line flags: 
-```text
---args --enable-features=PrivacySandboxAdsAPIsOverride,AllowURNsInIframes,SharedStorageAPI --disable-features=FencedFrame
-```
-
 ## Engage and share feedback
 
 The shared storage proposal is under active discussion and subject to change

--- a/site/en/docs/privacy-sandbox/shared-storage/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/index.md
@@ -210,13 +210,12 @@ register("send-reach-report", SendReachReportOperation);
 
 ## Try the Shared Storage API
 
-Shared Storage API with Fenced Frame can be tested in Chrome Canary 104 (>= 104.0.5086.0) by enabling the "Privacy Sandbox Ads APIs 
-experiment" flag by visiting `chrome://flags/#privacy-sandbox-ads-apis`.
+Shared Storage API with Fenced Frame can be tested in Chrome Canary 104 (>= 104.0.5086.0) by enabling the "Privacy Sandbox Ads APIs experiment" flag by visiting `chrome://flags/#privacy-sandbox-ads-apis`.
 
 {% Img src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/CWfgCMJQ5cYPOfjttF3k.png", alt="Shared Storage API flag screen", width="744", height="124" %}
 
 To test rendering an opaque source into an iframe instead of a fenced frame, start Chrome Canary from the terminal with the following command line flags: 
-```
+```text
 --args --enable-features=PrivacySandboxAdsAPIsOverride,AllowURNsInIframes,SharedStorageAPI --disable-features=FencedFrame
 ```
 

--- a/site/en/docs/privacy-sandbox/shared-storage/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/index.md
@@ -210,10 +210,15 @@ register("send-reach-report", SendReachReportOperation);
 
 ## Try the Shared Storage API
 
-Shared Storage API can be tested in Chrome Canary 104 by enabling the [Privacy Sandbox Ads APIs 
-experiment](chrome://flags/#privacy-sandbox-ads-apis) flag.
+Shared Storage API with Fenced Frame can be tested in Chrome Canary 104 (>= 104.0.5086.0) by enabling the "Privacy Sandbox Ads APIs 
+experiment" flag by visiting `chrome://flags/#privacy-sandbox-ads-apis`.
 
 {% Img src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/CWfgCMJQ5cYPOfjttF3k.png", alt="Shared Storage API flag screen", width="744", height="124" %}
+
+To test rendering an opaque source into an iframe instead of a fenced frame, start Chrome Canary from the terminal with the following command line flags: 
+```
+--args --enable-features=PrivacySandboxAdsAPIsOverride,AllowURNsInIframes,SharedStorageAPI --disable-features=FencedFrame
+```
 
 ## Engage and share feedback
 

--- a/site/en/docs/privacy-sandbox/shared-storage/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/index.md
@@ -210,7 +210,7 @@ register("send-reach-report", SendReachReportOperation);
 
 ## Try the Shared Storage API
 
-Shared Storage API with Fenced Frame can be tested in Chrome Canary 104 (>= 104.0.5086.0) by enabling the "Privacy Sandbox Ads APIs experiment" flag by visiting `chrome://flags/#privacy-sandbox-ads-apis`.
+Shared Storage API with Fenced Frame can be tested in Chrome 104 (>= 104.0.5086.0) by enabling the "Privacy Sandbox Ads APIs experiment" flag from the `chrome://flags/#privacy-sandbox-ads-apis` page.
 
 {% Img src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/CWfgCMJQ5cYPOfjttF3k.png", alt="Shared Storage API flag screen", width="744", height="124" %}
 

--- a/site/en/docs/privacy-sandbox/shared-storage/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/index.md
@@ -6,7 +6,7 @@ subhead: >
 description: >
   Allow access to unpartitioned cross-site data in a secure environment.
 date: 2022-04-25
-updated: 2022-05-24
+updated: 2022-06-06
 authors:
   - alexandrawhite
   - kevinkiklee
@@ -210,9 +210,11 @@ register("send-reach-report", SendReachReportOperation);
 
 ## Try the Shared Storage API
 
-Shared Storage API with Fenced Frame can be tested in Chrome 104 (>= 104.0.5086.0) by enabling the "Privacy Sandbox Ads APIs experiment" flag from the `chrome://flags/#privacy-sandbox-ads-apis` page.
+Shared Storage API with Fenced Frames can be tested in Chrome 104 (version
+104.0.5086.0 or later) by enabling the **Privacy Sandbox Ads APIs experiment**
+flag at `chrome://flags/#privacy-sandbox-ads-apis`.
 
-{% Img src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/CWfgCMJQ5cYPOfjttF3k.png", alt="Shared Storage API flag screen", width="744", height="124" %}
+{% Img src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/CWfgCMJQ5cYPOfjttF3k.png", alt="Set Privacy Sandbox Ads APIs experiment to enabled to use these APIs", width="744", height="124" %}
 
 ## Engage and share feedback
 


### PR DESCRIPTION
This PR updates the Shared Storage testing instructions to use the `chrome://flags` page instead of the command line flag. 