### PR TITLE
Match braces in "sandbox" code sample

### DIFF
--- a/site/en/docs/extensions/mv3/manifest/sandbox/index.md
+++ b/site/en/docs/extensions/mv3/manifest/sandbox/index.md
@@ -32,7 +32,7 @@ custom CSP:
       "page1.html",
       "directory/page2.html"
     ]
-  ],
+  },
   ...
 }
 ```


### PR DESCRIPTION
Fixes a bug where the "sandbox" object in manifest.json used a closing square bracket (`]`) instead of a closing brace (`}`).