### PR TITLE
Update description for storage partitioning

### DIFF
--- a/site/en/docs/privacy-sandbox/fenced-frame/index.md
+++ b/site/en/docs/privacy-sandbox/fenced-frame/index.md
@@ -58,15 +58,15 @@ and replace with more privacy-preserving variants.
 
 Chrome is working on [storage
 partitioning](https://github.com/privacycg/storage-partitioning), which
-separates browser storage per-site. Currently, if an iframe from `news.example`
-is embedded on `blog.example`, and that iframe stores a value into storage,
-then that value can be read from the `blog.example` site. When storage has been
+separates browser storage per-site. Currently, if an iframe from `shoes.example`
+is embedded on `news.example`, and that iframe stores a value into storage,
+then that value can be read from the `shoes.example` site. When storage has been
 partitioned, cross-site iframes will no longer share storage, therefore
-`blog.example` will not be able to access information stored by the iframe. If
-the iframe is served from `frame.news.example` and embedded on
-`news.example`, browser storage will be shared as these are considered [same-site](https://web.dev/same-site-same-origin/). 
+`shoes.example` will not be able to access information stored by the iframe. If
+the iframe is served from `*.shoes.example` and embedded on
+`*.shoes.example`, browser storage will be shared as these are considered [same-site](https://web.dev/same-site-same-origin/). 
 
-{% Img src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/Yy8nyLhZp1crxNLGEvtz.png", alt="A comparison of before and after state of storage partitinoing.", width="758", height="583" %}
+{% Img src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/ss7wjBshEJcwdQXcXGov.png", alt="A comparison of before and after state of storage partitinoing.", width="800", height="613" %}
 
 Storage partitioning will be applied to standard storage APIs including
 LocalStorage, IndexedDB, and cookies. In a partitioned world, information

--- a/site/en/docs/privacy-sandbox/fenced-frame/index.md
+++ b/site/en/docs/privacy-sandbox/fenced-frame/index.md
@@ -56,12 +56,9 @@ is technology which [Chrome has committed to phase
 out](https://blog.google/products/chrome/updated-timeline-privacy-sandbox-milestones/)
 and replace with more privacy-preserving variants.
 
-Chrome teams are working on [storage 
-partitioning](https://github.com/privacycg/storage-partitioning), which separates 
-browser storage per-site.  This means iframes embedded on sites with the same 
-eTLD+1, such as `frame.example` and `site.example`, could share browser storage. 
-Iframes embedded on sites that have different hostnames, such as `frame.example` 
-and `site.other`, won't share browser storage.
+Chrome teams are working on [storage partitioning](https://github.com/privacycg/storage-partitioning), which separates browser storage per-site. Currently, if an iframe from `shoes.example` is embedded in `news.example`, and that iframe stores a value into storage, then that value can be read from the actual `shoes.example` site. Once the storage has been partitioned, cross-site iframes will no longer share storage, and `shoes.example` will not be able to access information stored by the iframe. If the iframe is served from `frame.shoes.example` and embedded into `news.example`, browser storage will be shared due to being same-site. 
+
+{% Img src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/Yy8nyLhZp1crxNLGEvtz.png", alt="comparison of before and after state of storage partitinoing", width="758", height="583" %}
 
 Storage partitioning will be applied to standard storage APIs including
 LocalStorage, IndexedDB, and cookies. In a partitioned world, information leakage

--- a/site/en/docs/privacy-sandbox/fenced-frame/index.md
+++ b/site/en/docs/privacy-sandbox/fenced-frame/index.md
@@ -56,13 +56,21 @@ is technology which [Chrome has committed to phase
 out](https://blog.google/products/chrome/updated-timeline-privacy-sandbox-milestones/)
 and replace with more privacy-preserving variants.
 
-Chrome teams are working on [storage partitioning](https://github.com/privacycg/storage-partitioning), which separates browser storage per-site. Currently, if an iframe from `shoes.example` is embedded in `news.example`, and that iframe stores a value into storage, then that value can be read from the actual `shoes.example` site. Once the storage has been partitioned, cross-site iframes will no longer share storage, and `shoes.example` will not be able to access information stored by the iframe. If the iframe is served from `frame.shoes.example` and embedded into `news.example`, browser storage will be shared due to being same-site. 
+Chrome is working on [storage
+partitioning](https://github.com/privacycg/storage-partitioning), which
+separates browser storage per-site. Currently, if an iframe from `news.example`
+is embedded on `blog.example`, and that iframe stores a value into storage,
+then that value can be read from the `blog.example` site. When storage has been
+partitioned, cross-site iframes will no longer share storage, therefore
+`blog.example` will not be able to access information stored by the iframe. If
+the iframe is served from `frame.news.example` and embedded on
+`news.example`, browser storage will be shared as these are considered [same-site](https://web.dev/same-site-same-origin/). 
 
-{% Img src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/Yy8nyLhZp1crxNLGEvtz.png", alt="comparison of before and after state of storage partitinoing", width="758", height="583" %}
+{% Img src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/Yy8nyLhZp1crxNLGEvtz.png", alt="A comparison of before and after state of storage partitinoing.", width="758", height="583" %}
 
 Storage partitioning will be applied to standard storage APIs including
-LocalStorage, IndexedDB, and cookies. In a partitioned world, information leakage
-across first-party storage will be significantly reduced.
+LocalStorage, IndexedDB, and cookies. In a partitioned world, information
+leakage across first-party storage will be significantly reduced.
 
 ### Work with cross-site data {: #cross-site-data }
 


### PR DESCRIPTION
This PR updates the description for storage partitioning as s response for https://github.com/GoogleChrome/developer.chrome.com/issues/2951

```
It reads like frame.example and site.example are same-sites, but I guess it tries to say if two domains such as frame.example and frame.example, or site.example and site.example can share the storage?
Anyways, frame.example and site.example are not same-sites.
```

Updated the description to better describe how storage will be partitioned cross-site.  