### PR TITLE
Correct browser.tabs permission requirements

### DIFF
--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -8,15 +8,15 @@ extra_permissions_html:
 
 You can use most `chrome.tabs` methods and events without declaring any permissions in the
 extension's [manifest][manifest] file. However, if you require access to the `url`, `pendingUrl`,
-`title`, or `favIconUrl` properties of [`tabs.Tab`][tab], you must declare the `"tabs"` permission
+`title`, or `favIconUrl` properties of [`tabs.Tab`][tab], you must declare the `"host"` permission
 in the manifest, as shown below:
 
 ```json
 {
   "name": "My extension",
   ...
-  "permissions": [
-    "tabs"
+  "host_permissions": [
+    "http://www.blogger.com/"
   ],
   ...
 }


### PR DESCRIPTION
Developers MUST use the host permission. The tabs permission is optional. Source: personal experience (trust me bro); I was able to access tab.url, tab.pendingUrl, tab.title, and tab.favIconUrl without the tabs permission. Using just the tabs permission, the console complained that I didn't have host permissions. With just the host permission and no tabs permission, I can access tab.url, tab.pendingUrl, tab.title, and tab.favIconUrl.

(I did not create an issue for this pull request; the issue is described above)

Changes proposed in this pull request:

- Tell developers that they must use host permissions instead of tabs permission
- Change the example manifest to match above