### PR TITLE
A tweak to link to a Japanese Privacy Sandbox feedback form

### DIFF
--- a/site/ja/docs/privacy-sandbox/feedback/index.md
+++ b/site/ja/docs/privacy-sandbox/feedback/index.md
@@ -220,7 +220,7 @@ Chrome チームの公開レポートに含められる場合があります。
 {% Aside %}
 
 [**フィードバック
-フォームを使ってフィードバックをお送りいただけます**](https://goo.gle/privacy-sandbox-feedback)。
+フォームを使ってフィードバックをお送りいただけます**](https://goo.gle/privacy-sandbox-feedback-ja)。
 
 {% endAside %}
 


### PR DESCRIPTION
The short link is still not working, but it will be available shortly.