### PR TITLE
Fix a typo

### DIFF
--- a/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
+++ b/site/en/docs/extensions/mv3/intro/mv3-migration/index.md
@@ -397,7 +397,7 @@ service workers as of Chrome 87.
 There is a new
 [declarativeNetRequest](/docs/extensions/reference/declarativeNetRequest) for
 network request modification, which provides an alternative for much of the
-[webRequest](/docs/extensions/reference/webRequest) AP's functionality.
+[webRequest](/docs/extensions/reference/webRequest) API's functionality.
 
 
 ### When can you use blocking webRequest?  {: #when-use-blocking-webrequest }


### PR DESCRIPTION
Changes proposed in this pull request:

- Fixed a typo on the Manifest V3 migration page ("AP" to "API")

![image](https://user-images.githubusercontent.com/57513430/172513029-c2a040a9-5412-4144-9059-395e1f17aad6.png)
