### PR TITLE
Add missing title for 'main world' dynamic content scripts update

### DIFF
--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -21,7 +21,7 @@ May 26, 2022
 
 Added the [trader/non-trader developer identification](/docs/webstore/trader-disclosure) that informs developers to accurately self-declare their trader/non-trader status.
 
-### Chrome 102: {: #m102-registercontentscripts-main-world }
+### Chrome 102: Dynamic content scripts in main world {: #m102-registercontentscripts-main-world }
 
 April 14, 2022
 


### PR DESCRIPTION
I accidentally forgot to give one of the recent extensions what's new updates a descriptive title. This PR fixes that omission. 