### PR TITLE
[New in Chrome 102] Prepare for migration

### DIFF
--- a/site/en/blog/new-in-chrome-102/index.md
+++ b/site/en/blog/new-in-chrome-102/index.md
@@ -114,7 +114,7 @@ Check out [Introducing inert](/articles/inert/) for more details.
 ## Navigation API {: #navigation-api }
 
 Many web apps depend on the ability to update the URL without a page
-navigation. Today, we use the [history API][mdn-history], but it's clunky and
+navigation. Today, we use the [History API][mdn-history], but it's clunky and
 doesn't always work as expected. Rather than trying to patch the History API's
 rough edges, the Navigation API completely overhauls this space.
 

--- a/site/en/blog/new-in-chrome-102/index.md
+++ b/site/en/blog/new-in-chrome-102/index.md
@@ -4,6 +4,7 @@ description: >
   Chrome 102 is rolling out now! Installed PWAs can register as file handlers, making it easy for users to open files directly from disk. The inert attribute allows you to mark parts of the DOM as inert. The Navigation API makes it easier for single page apps to handle navigation and updates to the URL. And there's plenty more!
 layout: 'layouts/blog-post.njk'
 date: 2022-06-09
+updated: 2022-06-09
 authors:
   - petelepage
 hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/6zvxf9vrqKPSpM23mIwd.png'
@@ -78,7 +79,7 @@ launchQueue.setConsumer((launchParams) => {
 ```
 
 Check out [Let installed web applications be file handlers](https://web.dev/file-handling/)
-on web.dev for all the details.
+for all the details.
 
 ## The `inert` property {: #inert }
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Remove "on web.dev", since it may change soon.