### PR TITLE
docs: rm duplicate is

### DIFF
--- a/site/en/docs/devtools/performance-insights/index.md
+++ b/site/en/docs/devtools/performance-insights/index.md
@@ -113,7 +113,7 @@ Click on an insight (e.g. Rendering block request) to understand it further in t
 
 ## View Web Vitals performance metrics {: #vitals }
 
-[Web Vitals](https://web.dev/vitals/) is is an initiative by Google to provide unified guidance for quality signals that are essential to delivering a great user experience on the web.
+[Web Vitals](https://web.dev/vitals/) is an initiative by Google to provide unified guidance for quality signals that are essential to delivering a great user experience on the web.
 
 You can view these metrics on the **Timeline** and **Insights** pane.
 


### PR DESCRIPTION
@jecfish， In [View Web Vitals performance metrics](https://developer.chrome.com/docs/devtools/performance-insights/#vitals)

has duplicate `is`
![image](https://user-images.githubusercontent.com/18661091/172983643-e0a0b9d2-8f9b-45f7-b4e9-33be5936d6f8.png)

Changes proposed in this pull request:

- rm duplicate is