### PR TITLE
Topics: add details on where to find the classifier model

### DIFF
--- a/site/en/docs/privacy-sandbox/topics/index.md
+++ b/site/en/docs/privacy-sandbox/topics/index.md
@@ -432,13 +432,14 @@ is still under consideration.
 
 You can find the path to the model file in the "Classifier" tab of `chrome://topics-internals/` page. The top 10k domains currently used are in the `override_list.pb.gz` file found in the same directory as the model above. The domain to topics associations in the list are utilized by the API in lieu of the output of the model itself.
 
-To run the model directly, refer to the documentation here: https://www.tensorflow.org/lite/guide/inference#running_a_model (Also see: https://www.tensorflow.org/learn)
+To run the model directly, refer to [TensorFlow's guide to running a model](https://www.tensorflow.org/lite/guide/inference#running_a_model).
 
-To inspect the override_list.pb.gz file:
+To inspect the `override_list.pb.gz` file:
 
 * Unpack it: `gunzip -c override_list.pb.gz > override_list.pb`
 * Use protoc to inspect: `protoc --decode_raw < override_list.pb > output.txt`
-* Also see: Taxonomy of topics with IDs: https://github.com/patcg-individual-drafts/topics/blob/main/taxonomy_v1.md
+
+ A full [taxonomy of topics with IDs is available on GitHub](https://github.com/patcg-individual-drafts/topics/blob/main/taxonomy_v1.md).
 
 #### How can I provide feedback or input on the classifier model?
 

--- a/site/en/docs/privacy-sandbox/topics/index.md
+++ b/site/en/docs/privacy-sandbox/topics/index.md
@@ -6,7 +6,7 @@ subhead: >
 description: >
  A proposal for a mechanism to enable interest-based advertising without having to resort to tracking the sites a user visits.
 date: 2022-01-25
-updated: 2022-05-25
+updated: 2022-06-15
 authors:
   - samdutton
 ---

--- a/site/en/docs/privacy-sandbox/topics/index.md
+++ b/site/en/docs/privacy-sandbox/topics/index.md
@@ -430,7 +430,7 @@ is still under consideration.
 
 #### Where can I find the current classifier model?
 
-You can find the path to the model file in the "Classifier" tab of `chrome://topics-internals/` page. The top 10k domains currently used are in the `override_list.pb.gz` file found in the same directory as the model above. The domain to topics associations in the list are utilized by the API in lieu of the output of the model itself.
+Topics are manually curated for 10,000 top domains, and this curation is used to train the classifier. This list can be found in `override_list.pb.gz`, which is available at`chrome://topics-internals/` under the current model in the "Classifier" tab. The domain-to-topics associations in the list are used by the API in lieu of the output of the model itself.
 
 To run the model directly, refer to [TensorFlow's guide to running a model](https://www.tensorflow.org/lite/guide/inference#running_a_model).
 

--- a/site/en/docs/privacy-sandbox/topics/index.md
+++ b/site/en/docs/privacy-sandbox/topics/index.md
@@ -428,6 +428,18 @@ proposes that it should be possible to view the topics for a site via browser de
 model is expected to evolve and improve over time and be updated periodically; the frequency of this
 is still under consideration.
 
+#### Where can I find the current classifier model?
+
+You can find the path to the model file in the "Classifier" tab of `chrome://topics-internals/` page. The top 10k domains currently used are in the `override_list.pb.gz` file found in the same directory as the model above. The domain to topics associations in the list are utilized by the API in lieu of the output of the model itself.
+
+To run the model directly, refer to the documentation here: https://www.tensorflow.org/lite/guide/inference#running_a_model (Also see: https://www.tensorflow.org/learn)
+
+To inspect the override_list.pb.gz file:
+
+* Unpack it: `gunzip -c override_list.pb.gz > override_list.pb`
+* Use protoc to inspect: `protoc --decode_raw < override_list.pb > output.txt`
+* Also see: Taxonomy of topics with IDs: https://github.com/patcg-individual-drafts/topics/blob/main/taxonomy_v1.md
+
 #### How can I provide feedback or input on the classifier model?
 
 There are [several channels](/docs/privacy-sandbox/feedback/) for


### PR DESCRIPTION
Adding details on where to find the classifier model and how to run it.

Fixes b/222748127

Preview: https://deploy-preview-3027--developer-chrome-com.netlify.app/docs/privacy-sandbox/topics/#where-can-i-find-the-current-classifier-model