### PR TITLE
Check all translations in presubmit

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,6 +10,9 @@ jobs:
     env:
       # Increase RAM limit, and make uncaught exceptions crash (default in 16+).
       NODE_OPTIONS: --max_old_space_size=4096 --unhandled-rejections=strict
+      # Make sure we check all translations in our GH Action presubmit.
+      # See https://github.com/GoogleChrome/developer.chrome.com/issues/3029
+      ELEVENTY_INCLUDE_TRANSLATED: true
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Fixes #3029

This will increase the amount of time it takes for our presubmit checks to run, but at the same time, we really should have full coverage given the issue that we fixed in #3028.