### PR TITLE
DevTools 103 > Recorder reference

### DIFF
--- a/site/_data/docs/devtools/toc.yml
+++ b/site/_data/docs/devtools/toc.yml
@@ -78,7 +78,10 @@
 - url: /docs/devtools/media-panel/
 - url: /docs/devtools/memory-inspector/
 - url: /docs/devtools/device-mode/override-user-agent/
-- url: /docs/devtools/recorder/
+- title: i18n.docs.devtools.recorder
+  sections:
+    - url: /docs/devtools/recorder/
+    - url: /docs/devtools/recorder/reference
 - title: i18n.docs.devtools.rendering
   sections:
     - url: /docs/devtools/rendering/

--- a/site/_data/i18n/docs/devtools.yml
+++ b/site/_data/i18n/docs/devtools.yml
@@ -45,3 +45,5 @@ rendering:
   en: 'Rendering'
 changes:
   en: 'Changes'
+recorder:
+  en: 'Recorder'

--- a/site/en/docs/devtools/recorder/index.md
+++ b/site/en/docs/devtools/recorder/index.md
@@ -1,28 +1,29 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Recorder: Record, replay and measure user flows"
+title: "Record, replay, and measure user flows"
 authors:
   - jecelynyeen
   - sofiayem
 date: 2021-11-02
 updated: 2022-03-25
-description: "Record, replay and measure user flows with the Recorder panel."
+description: "Record, replay, measure user flows, and edit their steps with the Recorder panel."
 tags:
   - test
   - performance
 ---
 
-Take a glance at the new **Recorder** panel (preview feature) with the video below. 
+Take a glance at the new **Recorder** panel with the video below. 
 
 {% YouTube id='rMUayh1QPYs' %}
 <!-- {% Video src="video/dPDCek3EhZgLQPGtEG3y0fTn4v82/jDJpU85zWj1dipsUPrMr.mp4", autoplay="true", muted="false", loop="true",  class="screenshot" %} -->
 
-Use the **Recorder** panel to record, replay and measure user flows.
+Complete this tutorial to learn how to use the **Recorder** panel to record, replay, measure user flows, and edit their steps.
 
 {% Aside %}
 This is a preview feature in Chrome 97. Our team is actively working on this feature and we are looking for your [feedback](https://goo.gle/recorder-feedback) for further enhancements. 
 {% endAside %}
 
+For more information on **Recorder** capabilities and options, see the [Recorder features reference](/docs/devtools/recorder/reference/).
 
 ## Open the Recorder panel {: #open }
 
@@ -106,30 +107,6 @@ Learn how to [analyze your page's runtime performance](/devtools/evaluate-perfor
 
 {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/L8tS8YwGRgmqCrSwx5ro.png", alt="Performance panel", width="800", height="531" %}
 
-## Edit user flows {: #edit-flows }
-
-Let's walk through the options to edit the user flows.
-
-{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/gRr2bASlwPtTFFbXnqeM.png", alt="DevTools Recorder panel has a drop-down menu in the header which allows you to select a user flow to edit", width="800", height="500" %}
-
-On the top of the **Recorder** panel, there are options for you to:
-
-1. **Add a new recording**{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/eY8MaTQqlXF3oiT6STmy.svg", alt="Add", width="20", height="20" %}. Click on the **+** icon to [add a new recording](#record).
-1. **View all recordings**{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/4PiXdJcg2fKUF1rZ8Vmg.svg", alt="Expand more", width="20", height="20" %}. The drop-down shows the list of saved recordings. Select the **[number] recording(s)** option to expand and manage the list of saved recordings.
-     {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/0g3cyg48vjubSa6HoSLi.png", alt="View all recordings", width="800", height="490" %}
-1. **Export a recording**{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/4dU9UXvsinS4zbgjd8rK.svg", alt="File download", width="20", height="20" %}. To further customize the script or share it for bug reporting purposes, you can export the user flow in one of the following formats:
-
-   - JSON file.
-   - [Puppeteer](https://pptr.dev) script.
-   - [@puppeteer/replay](https://github.com/puppeteer/replay) script.
-
-   For more information on the formats, see [Export a user flow](#export-flows).
-
-1. **Import a recording**{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/fqErVoYNQMbrdB03sPZp.svg", alt="File upload", width="20", height="20" %}. Only in JSON format.
-1. **Delete a recording**{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/9bkJ0VAuCp9iixG2LUtd.svg", alt="Delete", width="20", height="20" %}. Delete the selected recording.
-
-You can also edit the recording's name by clicking the edit button {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/fFpbDTHPicjesIbiG4Hm.svg", alt="Edit", width="20", height="20" %} next to it.
-
 ## Edit steps {: #edit-steps }
 
 Let's walk through the options to edit the steps within a workflow.
@@ -140,7 +117,7 @@ Expand each step to see the details of the action. For example, expand the *Clic
 
 {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/WUIZb8eMWfcPZHPyQ5C5.png", alt="In the recorder panel, the Cappuccino element has been expanded to reveal type, target, selectors, offset X, and offset Y.", width="800", height="773" %}
 
-The step above shows two **selectors**. For more information, see [Understanding the recording's selector](#selector).
+The step above shows two **selectors**. For more information, see [Understand the recording's selector](/docs/devtools/recorder/reference/#selector).
 
 When replaying the user flow, the **Recorder** tries to query the element with one of the selectors by sequence.
 For example, if the **Recorder** successfully queries the element with the first selector, it will skip the second selector and proceed to the next step.
@@ -167,35 +144,6 @@ The **selector** is editable too.  For example, if you want to select *Mocha* in
 
 1. Try to edit other step properties such as **type**, **target**, **value** and more.
 
-### Adjust timeouts for steps {: #adjust-timeout}
-
-In case your page has slow network requests or lengthy animations, the replay can fail on steps that exceed the default timeout of `5000` milliseconds.
-
-To avoid this problem, you can adjust the default timeout for each step at once or set separate timeouts for specific steps. Timeouts on specific steps overwrite the default.
-
-To adjust the default timeout for each step at once:
-
-1. Click on **Replay settings** to make the **Timeout** box editable.
-
-   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Ys9x9oHiQNATMSJkeYSn.png", alt="Replay settings", width="800", height="506" %}
-
-1. In the **Timeout** box, set the timeout value in milliseconds.
-1. Click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/gjfZMeLnwzpRfOMfXEMY.svg", alt="Replay", width="20", height="20" %}[**Replay**](#replay) to see the adjusted default timeout in action.
-
-To overwrite the default timeout on a specific step:
-
-1. [Expand the step](#expand-step) and click **Add timeout**.
-
-   <div class="elevation--2", style="margin-top: 20px; margin-bottom: 20px;">{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/MEDm7NXPbGe3aObUhVj6.png", alt="Add timeout", width="800", height="542" %}</div>
-
-1. Click on the `timeout: <value>` and set the value in milliseconds.
-
-   <div class="elevation--2", style="margin-top: 20px; margin-bottom: 20px;">{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/8jkQCHfBatGJf8PxrlFi.png", alt="Set the timeout value", width="800", height="580" %}</div>
-
-1. Click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/gjfZMeLnwzpRfOMfXEMY.svg", alt="Replay", width="20", height="20" %}[**Replay**](#replay) to see the step with the timeout in action.
-
-To remove a timeout overwrite on a step, click the **Delete**{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/9bkJ0VAuCp9iixG2LUtd.svg", alt="Delete", width="20", height="20" %} button next to it.
-
 ### Add and remove steps {: #add-and-remove-steps }
 
 There are options to add and remove steps too. This is useful if you want to add an extra step or remove an accidentally added step. Instead of re-recording the user flow, you can just edit it. Click on the **3-dot** kebab menu next to the step to open the menu. 
@@ -213,115 +161,3 @@ There are options to add and remove steps too. This is useful if you want to add
     - count: **9** (click **add count** button)
    {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/zeK91O21jvc5OD9HuovR.png", alt="The new step for coffee checkout has been updated with the aforementioned details.", width="800", height="663" %}
 6. {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/gjfZMeLnwzpRfOMfXEMY.svg", alt="Replay", width="20", height="20" %}[Replay](#replay) the flow now to see the changes.
-
-## Share user flows {: #share-flows }
-
-You can export and import user flows. This is useful for bug reporting because you can share an exact record of the steps that reproduce a bug.
-
-### Export a user flow {: #export-flows }
-
-To export a user flow:
-
-1. Open the user flow you want to export.
-2. Click on the **Export**{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/4dU9UXvsinS4zbgjd8rK.svg", alt="File download", width="20", height="20" %}. button at the top of the **Recorder** panel.
-    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/LJJqpZ0vOEdp6rdDLXmP.png", alt="Download format options", width="800", height="490" %}
- 1. Select one of the following formats from the drop-down list:
-    - **Export as a JSON file**. Download the recording as a JSON file.
-    - **Export as a @puppeteer/replay script**. Download the recording as a [Puppeteer Replay](https://github.com/puppeteer/replay) script.
-    - **Export as a Puppeteer script**. Download the recording as a [Puppeteer](https://pptr.dev/) script.
-1. Save the file.
-
-{% Aside 'gotchas' %}
-The [@puppeteer/replay](https://github.com/puppeteer/replay) is a library built on top of [Puppeteer](https://pptr.dev/). It is also a command line tool, so you can replay JSON files with it too.
-
-**Advance use case: Integrate with the Puppeteer Replay library**
-
-You can build your own library on top of the Puppeteer Replay library to replay or "stringify" the user flow JSON files, that is, convert them to something else.
-
-For example, [@cypress/chrome-recorder](https://github.com/cypress-io/cypress-chrome-recorder) is a library built on top of Puppeteer Replay. You can use it to convert user flow JSON files to Cypress test scripts. Watch this [demo](https://youtu.be/4qYs2bMz4GI) to see it in action.
-
-Learn more about the [stringify feature in Puppeteer Replay](https://github.com/puppeteer/replay#stringify-a-recording-as-a-puppeteer-script).
-
-{% endAside %}
-
-You can do the following with each export option:
-
-- **JSON**. Edit the human-readable JSON object and [import](#import-flows) the JSON file back to the **Recorder**.
-- **@puppeteer/replay**. Replay the script with the [Puppeteer Replay](https://github.com/puppeteer/replay) library. When exporting as a @puppeteer/replay script, the steps remain a JSON object. This option is perfect if you want to integrate with your CI/CD pipeline but still have the flexibility to edit the steps as JSON, later convert and import them back into the **Recorder**.
-- **Puppeteer** script. Replay the script with [Puppeteer](https://pptr.dev/). Since the steps are converted into JavaScript, you can have more fine-grained customization, for example, looping the steps. One caveat, you can't import this script back into the **Recorder**.
-
-### Import a user flow {: #import-flows }
-
-To import a user flow:
-
-1. Click the **Import**{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/fqErVoYNQMbrdB03sPZp.svg", alt="File upload", width="20", height="20" %} button at the top of the **Recorder** panel.
-    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/LdIrYNYuKa2OA7PnYVjf.png", alt="Import recording", width="800", height="490" %}
-1. Select the JSON file with the recorded user flow.
-1. Click the {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/gjfZMeLnwzpRfOMfXEMY.svg", alt="Replay", width="20", height="20" %}**Replay** button to run the imported user flow.
-
-## Understanding the recording's selector {: #selector }
-
-During recording, the **Recorder** automatically detects two types of selectors for most of the steps: ARIA and CSS.
-
-{% Aside %}
-For more information on ARIA selectors, see [Syntactic vs. semantic selectors](/blog/puppetaria/#syntactic-vs-semantic-selectors).
-{% endAside %}
-
-For simple webpages, `id` attributes and CSS `class` attributes are sufficient for the **Recorder** to detect the selectors. However, that might not always be the case, because:
-
-- Your webpages may use dynamic classes or ID's that change
-- Your selectors may break from development changes to CSS styles or JS behavior
-
-### Common test selectors {: common-test-selector}
-
-For example, the CSS `class` values might be auto-generated for applications developed with modern JavaScript frameworks (for example, [React](https://reactjs.org/), [Angular](https://angular.io/), [Vue](https://vuejs.org/)) and CSS frameworks.
-
-{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/ZtK52PaMMzKWiiAcsQfH.png", alt="Auto-generated CSS classes with randomized names", width="800", height="654" %}
-
-In these cases, you can use `data-*` attributes to create more resilient tests. There are already some common `data-*` selectors that people use for automation. The **Recorder** supports them as well. 
-
-If you have the following common test selectors defined, the **Recorder** automatically detects and uses them first:
-
-- `data-testid`
-- `data-test`
-- `data-qa`
-- `data-cy`
-- `data-test-id`
-- `data-qa-id`
-- `data-testing`
-
-For example, inspect the "Cappuccino" element on this [demo page](https://coffee-cart.netlify.app/) and see the test attributes:
-
-{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/KsR7XKgLgEM0odQZHcKV.png", alt="Defined test selectors", width="800", height="696" %}
-
-Record a click on "Cappuccino", expand the corresponding step in the recording, and check the detected selectors:
-
-{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/sEl538qiomTJGSArag00.png", alt="Detected common test selector", width="800", height="808" %}
-
-### Customize the recording's selector {: #customize-selector }
-
-You can customize the selector of a recording if the above doesn't work for you.
-
-For example, this [demo page](https://jec.fyi/demo/recorder) uses the `data-automate` attribute as the selector. [Start a new recording](/docs/devtools/recorder/#record) and enter the `data-automate` as the selector attribute.
-
-{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/2PPPt9tOC2ZEz1l9F9AK.png", alt="Customize the recording's selector", width="800", height="524" %}
-
-Fill in an email address and observe the selector value (`[data-automate=email-address]`).
-
-{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/X8r52vWEu6aC8QHFuknp.png", alt="The result of custom selector selection", width="800", height="579" %}
-
-### Selector priority {: #selector-priority }
-
-In addition to the ARIA selector, the **Recorder** looks for the best CSS selector it can find by the following attributes and in the following order:
-1. Your custom selector attribute if you specified it at the start of the recording.
-1. ARIA selector if found.
-1. The most common attributes used for testing: {: #selectors }
-   - `data-testid`
-   - `data-test`
-   - `data-qa`
-   - `data-cy`
-   - `data-test-id`
-   - `data-qa-id`
-   - `data-testing`
-1. ID attributes, for example, `<div id="some_ID">`.
-1. Regular CSS selectors.

--- a/site/en/docs/devtools/recorder/index.md
+++ b/site/en/docs/devtools/recorder/index.md
@@ -12,7 +12,7 @@ tags:
   - performance
 ---
 
-Take a glance at the new **Recorder** panel with the video below. 
+Take a glance at the new **Recorder** panel (preview feature) with the video below.
 
 {% YouTube id='rMUayh1QPYs' %}
 <!-- {% Video src="video/dPDCek3EhZgLQPGtEG3y0fTn4v82/jDJpU85zWj1dipsUPrMr.mp4", autoplay="true", muted="false", loop="true",  class="screenshot" %} -->

--- a/site/en/docs/devtools/recorder/index.md
+++ b/site/en/docs/devtools/recorder/index.md
@@ -17,7 +17,7 @@ Take a glance at the new **Recorder** panel with the video below.
 {% YouTube id='rMUayh1QPYs' %}
 <!-- {% Video src="video/dPDCek3EhZgLQPGtEG3y0fTn4v82/jDJpU85zWj1dipsUPrMr.mp4", autoplay="true", muted="false", loop="true",  class="screenshot" %} -->
 
-Complete this tutorial to learn how to use the **Recorder** panel to record, replay, measure user flows.
+Complete this tutorial to learn how to use the **Recorder** panel to record, replay, and measure user flows.
 
 {% Aside %}
 This is a preview feature in Chrome 97. Our team is actively working on this feature and we are looking for your [feedback](https://goo.gle/recorder-feedback) for further enhancements. 

--- a/site/en/docs/devtools/recorder/index.md
+++ b/site/en/docs/devtools/recorder/index.md
@@ -17,13 +17,13 @@ Take a glance at the new **Recorder** panel with the video below.
 {% YouTube id='rMUayh1QPYs' %}
 <!-- {% Video src="video/dPDCek3EhZgLQPGtEG3y0fTn4v82/jDJpU85zWj1dipsUPrMr.mp4", autoplay="true", muted="false", loop="true",  class="screenshot" %} -->
 
-Complete this tutorial to learn how to use the **Recorder** panel to record, replay, measure user flows, and edit their steps.
+Complete this tutorial to learn how to use the **Recorder** panel to record, replay, measure user flows.
 
 {% Aside %}
 This is a preview feature in Chrome 97. Our team is actively working on this feature and we are looking for your [feedback](https://goo.gle/recorder-feedback) for further enhancements. 
 {% endAside %}
 
-For more information on **Recorder** capabilities and options, see the [Recorder features reference](/docs/devtools/recorder/reference/).
+For more information on how to share the recorded user flows, edit them and their steps, see the [Recorder features reference](/docs/devtools/recorder/reference/).
 
 ## Open the Recorder panel {: #open }
 
@@ -109,7 +109,9 @@ Learn how to [analyze your page's runtime performance](/devtools/evaluate-perfor
 
 ## Edit steps {: #edit-steps }
 
-Let's walk through the options to edit the steps within a workflow.
+Let's walk through the basic options to edit the steps within the recorded workflow.
+
+For a comprehensive list of editing options, see [Edit steps](/docs/devtools/recorder/reference/##edit-steps) in features reference.
 
 ### Expand steps {: #expand-step }
 
@@ -122,7 +124,7 @@ The step above shows two **selectors**. For more information, see [Understand th
 When replaying the user flow, the **Recorder** tries to query the element with one of the selectors by sequence.
 For example, if the **Recorder** successfully queries the element with the first selector, it will skip the second selector and proceed to the next step.
 
-### Add and remove selectors from a step {: #add-remove-selectors}
+### Add and remove selectors from a step {: #add-remove-selectors }
 
 You can add or remove any selectors. For example, you can remove the *selector #2* because just `aria/Cappuccino` is sufficient in this case. Hover over the *selector #2* and click on **`-`** to remove it.
 

--- a/site/en/docs/devtools/recorder/reference/index.md
+++ b/site/en/docs/devtools/recorder/reference/index.md
@@ -1,0 +1,12 @@
+---
+layout: "layouts/doc-post.njk"
+title: ""
+authors:
+  - sofiayem
+date: 2022-06-10
+#updated: YYYY-MM-DD
+description: ""
+tags:
+  - ?
+---
+

--- a/site/en/docs/devtools/recorder/reference/index.md
+++ b/site/en/docs/devtools/recorder/reference/index.md
@@ -205,7 +205,7 @@ There are two properties that make the replay pause:
 
 - The `waitForElement` property makes the step wait for the presence (or absence) of a number of elements identified by a selector. For example, the following step waits for less than three elements to be on the page that match the selector `.my-class`.
 
-     ```
+     ```json
        "type": "waitForElement",
        "selectors": [".my-class"],
        "operator": "<=",
@@ -214,10 +214,9 @@ There are two properties that make the replay pause:
 
 - The `waitForExpression`  property makes the step wait for a JavaScript expression to resolve to true. For example, the following step pauses for two seconds and then resolves to true allowing the replay to continue.
 
-    ```
+    ```json
        "type": "waitForExpression",
-       "expression": "new Promise(resolve => setTimeout(() => resolve(true),
-     2000))",
+       "expression": "new Promise(resolve => setTimeout(() => resolve(true), 2000))",
      ```
 
 ### Adjust timeouts for steps {: #adjust-timeout }

--- a/site/en/docs/devtools/recorder/reference/index.md
+++ b/site/en/docs/devtools/recorder/reference/index.md
@@ -69,9 +69,9 @@ Learn more about the [stringify feature in Puppeteer Replay](https://github.com/
 
 You can do the following with each export option:
 
-- **JSON**. Edit the human-readable JSON object and [import](#import-flows) the JSON file back to the **Recorder**.
-- **@puppeteer/replay**. Replay the script with the [Puppeteer Replay](https://github.com/puppeteer/replay) library. When exporting as a @puppeteer/replay script, the steps remain a JSON object. This option is perfect if you want to integrate with your CI/CD pipeline but still have the flexibility to edit the steps as JSON, later convert and import them back into the **Recorder**.
-- **Puppeteer** script. Replay the script with [Puppeteer](https://pptr.dev/). Since the steps are converted into JavaScript, you can have more fine-grained customization, for example, looping the steps. One caveat, you can't import this script back into the **Recorder**.
+- **JSON:** Edit the human-readable JSON object and [import](#import-flows) the JSON file back to the **Recorder**.
+- **@puppeteer/replay:** Replay the script with the [Puppeteer Replay](https://github.com/puppeteer/replay) library. When exporting as a @puppeteer/replay script, the steps remain a JSON object. This option is perfect if you want to integrate with your CI/CD pipeline but still have the flexibility to edit the steps as JSON, later convert and import them back into the **Recorder**.
+- **Puppeteer script:** Replay the script with [Puppeteer](https://pptr.dev/). Since the steps are converted into JavaScript, you can have more fine-grained customization, for example, looping the steps. One caveat, you can't import this script back into the **Recorder**.
 
 ### Import a user flow {: #import-flows }
 

--- a/site/en/docs/devtools/recorder/reference/index.md
+++ b/site/en/docs/devtools/recorder/reference/index.md
@@ -1,12 +1,183 @@
 ---
 layout: "layouts/doc-post.njk"
-title: ""
+title: "Recorder features reference"
 authors:
   - sofiayem
-date: 2022-06-10
+date: 2022-06-21
 #updated: YYYY-MM-DD
-description: ""
+description: "A comprehensive reference of Chrome DevTools Recorder panel features."
 tags:
-  - ?
+  - test
+  - performance
 ---
 
+Discover all the capabilities and options in this comprehensive features reference of the Chrome DevTools **Recorder** panel.
+
+To learn the basics of working with the **Recorder** panel, see [Record, replay, and measure user flows](/docs/devtools/recorder/).
+
+## Edit user flows {: #edit-flows }
+
+Let's walk through the options to edit the user flows.
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/gRr2bASlwPtTFFbXnqeM.png", alt="DevTools Recorder panel has a drop-down menu in the header which allows you to select a user flow to edit", width="800", height="500" %}
+
+On the top of the **Recorder** panel, there are options for you to:
+
+1. **Add a new recording**{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/eY8MaTQqlXF3oiT6STmy.svg", alt="Add", width="20", height="20" %}. Click on the **+** icon to [add a new recording](/docs/devtools/recorder/#record).
+1. **View all recordings**{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/4PiXdJcg2fKUF1rZ8Vmg.svg", alt="Expand more", width="20", height="20" %}. The drop-down shows the list of saved recordings. Select the **[number] recording(s)** option to expand and manage the list of saved recordings.
+     {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/0g3cyg48vjubSa6HoSLi.png", alt="View all recordings", width="800", height="490" %}
+1. **Export a recording**{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/4dU9UXvsinS4zbgjd8rK.svg", alt="File download", width="20", height="20" %}. To further customize the script or share it for bug reporting purposes, you can export the user flow in one of the following formats:
+
+   - JSON file.
+   - [Puppeteer](https://pptr.dev) script.
+   - [@puppeteer/replay](https://github.com/puppeteer/replay) script.
+
+   For more information on the formats, see [Export a user flow](/docs/devtools/recorder/reference/#export-flows).
+
+1. **Import a recording**{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/fqErVoYNQMbrdB03sPZp.svg", alt="File upload", width="20", height="20" %}. Only in JSON format.
+1. **Delete a recording**{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/9bkJ0VAuCp9iixG2LUtd.svg", alt="Delete", width="20", height="20" %}. Delete the selected recording.
+
+You can also edit the recording's name by clicking the edit button {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/fFpbDTHPicjesIbiG4Hm.svg", alt="Edit", width="20", height="20" %} next to it.
+
+## Edit steps {: #edit-steps }
+
+### Adjust timeouts for steps {: #adjust-timeout }
+
+In case your page has slow network requests or lengthy animations, the replay can fail on steps that exceed the default timeout of `5000` milliseconds.
+
+To avoid this problem, you can adjust the default timeout for each step at once or set separate timeouts for specific steps. Timeouts on specific steps overwrite the default.
+
+To adjust the default timeout for each step at once:
+
+1. Click on **Replay settings** to make the **Timeout** box editable.
+
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Ys9x9oHiQNATMSJkeYSn.png", alt="Replay settings", width="800", height="506" %}
+
+1. In the **Timeout** box, set the timeout value in milliseconds.
+1. Click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/gjfZMeLnwzpRfOMfXEMY.svg", alt="Replay", width="20", height="20" %}[**Replay**](/docs/devtools/recorder/#replay) to see the adjusted default timeout in action.
+
+To overwrite the default timeout on a specific step:
+
+1. [Expand the step](/docs/devtools/recorder/#expand-step) and click **Add timeout**.
+
+   <div class="elevation--2", style="margin-top: 20px; margin-bottom: 20px;">{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/MEDm7NXPbGe3aObUhVj6.png", alt="Add timeout", width="800", height="542" %}</div>
+
+1. Click on the `timeout: <value>` and set the value in milliseconds.
+
+   <div class="elevation--2", style="margin-top: 20px; margin-bottom: 20px;">{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/8jkQCHfBatGJf8PxrlFi.png", alt="Set the timeout value", width="800", height="580" %}</div>
+
+1. Click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/gjfZMeLnwzpRfOMfXEMY.svg", alt="Replay", width="20", height="20" %}[**Replay**](/docs/devtools/recorder/#replay) to see the step with the timeout in action.
+
+To remove a timeout overwrite on a step, click the **Delete**{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/9bkJ0VAuCp9iixG2LUtd.svg", alt="Delete", width="20", height="20" %} button next to it.
+
+## Share user flows {: #share-flows }
+
+You can export and import user flows. This is useful for bug reporting because you can share an exact record of the steps that reproduce a bug.
+
+### Export a user flow {: #export-flows }
+
+To export a user flow:
+
+1. Open the user flow you want to export.
+2. Click on the **Export**{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/4dU9UXvsinS4zbgjd8rK.svg", alt="File download", width="20", height="20" %}. button at the top of the **Recorder** panel.
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/LJJqpZ0vOEdp6rdDLXmP.png", alt="Download format options", width="800", height="490" %}
+ 1. Select one of the following formats from the drop-down list:
+    - **Export as a JSON file**. Download the recording as a JSON file.
+    - **Export as a @puppeteer/replay script**. Download the recording as a [Puppeteer Replay](https://github.com/puppeteer/replay) script.
+    - **Export as a Puppeteer script**. Download the recording as a [Puppeteer](https://pptr.dev/) script.
+1. Save the file.
+
+{% Aside 'gotchas' %}
+The [@puppeteer/replay](https://github.com/puppeteer/replay) is a library built on top of [Puppeteer](https://pptr.dev/). It is also a command line tool, so you can replay JSON files with it too.
+
+**Advance use case: Integrate with the Puppeteer Replay library**
+
+You can build your own library on top of the Puppeteer Replay library to replay or "stringify" the user flow JSON files, that is, convert them to something else.
+
+For example, [@cypress/chrome-recorder](https://github.com/cypress-io/cypress-chrome-recorder) is a library built on top of Puppeteer Replay. You can use it to convert user flow JSON files to Cypress test scripts. Watch this [demo](https://youtu.be/4qYs2bMz4GI) to see it in action.
+
+Learn more about the [stringify feature in Puppeteer Replay](https://github.com/puppeteer/replay#stringify-a-recording-as-a-puppeteer-script).
+
+{% endAside %}
+
+You can do the following with each export option:
+
+- **JSON**. Edit the human-readable JSON object and [import](#import-flows) the JSON file back to the **Recorder**.
+- **@puppeteer/replay**. Replay the script with the [Puppeteer Replay](https://github.com/puppeteer/replay) library. When exporting as a @puppeteer/replay script, the steps remain a JSON object. This option is perfect if you want to integrate with your CI/CD pipeline but still have the flexibility to edit the steps as JSON, later convert and import them back into the **Recorder**.
+- **Puppeteer** script. Replay the script with [Puppeteer](https://pptr.dev/). Since the steps are converted into JavaScript, you can have more fine-grained customization, for example, looping the steps. One caveat, you can't import this script back into the **Recorder**.
+
+### Import a user flow {: #import-flows }
+
+To import a user flow:
+
+1. Click the **Import**{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/fqErVoYNQMbrdB03sPZp.svg", alt="File upload", width="20", height="20" %} button at the top of the **Recorder** panel.
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/LdIrYNYuKa2OA7PnYVjf.png", alt="Import recording", width="800", height="490" %}
+1. Select the JSON file with the recorded user flow.
+1. Click the {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/gjfZMeLnwzpRfOMfXEMY.svg", alt="Replay", width="20", height="20" %}**Replay** button to run the imported user flow.
+
+## Understand the recording's selector {: #selector }
+
+During recording, the **Recorder** automatically detects two types of selectors for most of the steps: ARIA and CSS.
+
+{% Aside %}
+For more information on ARIA selectors, see [Syntactic vs. semantic selectors](/blog/puppetaria/#syntactic-vs-semantic-selectors).
+{% endAside %}
+
+For simple webpages, `id` attributes and CSS `class` attributes are sufficient for the **Recorder** to detect the selectors. However, that might not always be the case, because:
+
+- Your webpages may use dynamic classes or ID's that change
+- Your selectors may break from development changes to CSS styles or JS behavior
+
+### Common test selectors {: common-test-selector}
+
+For example, the CSS `class` values might be auto-generated for applications developed with modern JavaScript frameworks (for example, [React](https://reactjs.org/), [Angular](https://angular.io/), [Vue](https://vuejs.org/)) and CSS frameworks.
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/ZtK52PaMMzKWiiAcsQfH.png", alt="Auto-generated CSS classes with randomized names", width="800", height="654" %}
+
+In these cases, you can use `data-*` attributes to create more resilient tests. There are already some common `data-*` selectors that people use for automation. The **Recorder** supports them as well. 
+
+If you have the following common test selectors defined, the **Recorder** automatically detects and uses them first:
+
+- `data-testid`
+- `data-test`
+- `data-qa`
+- `data-cy`
+- `data-test-id`
+- `data-qa-id`
+- `data-testing`
+
+For example, inspect the "Cappuccino" element on this [demo page](https://coffee-cart.netlify.app/) and see the test attributes:
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/KsR7XKgLgEM0odQZHcKV.png", alt="Defined test selectors", width="800", height="696" %}
+
+Record a click on "Cappuccino", expand the corresponding step in the recording, and check the detected selectors:
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/sEl538qiomTJGSArag00.png", alt="Detected common test selector", width="800", height="808" %}
+
+### Customize the recording's selector {: #customize-selector }
+
+You can customize the selector of a recording if the above doesn't work for you.
+
+For example, this [demo page](https://jec.fyi/demo/recorder) uses the `data-automate` attribute as the selector. [Start a new recording](/docs/devtools/recorder/reference/#record) and enter the `data-automate` as the selector attribute.
+
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/2PPPt9tOC2ZEz1l9F9AK.png", alt="Customize the recording's selector", width="800", height="524" %}
+
+Fill in an email address and observe the selector value (`[data-automate=email-address]`).
+
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/X8r52vWEu6aC8QHFuknp.png", alt="The result of custom selector selection", width="800", height="579" %}
+
+### Selector priority {: #selector-priority }
+
+In addition to the ARIA selector, the **Recorder** looks for the best CSS selector it can find by the following attributes and in the following order:
+1. Your custom selector attribute if you specified it at the start of the recording.
+1. ARIA selector if found.
+1. The most common attributes used for testing: {: #selectors }
+   - `data-testid`
+   - `data-test`
+   - `data-qa`
+   - `data-cy`
+   - `data-test-id`
+   - `data-qa-id`
+   - `data-testing`
+1. ID attributes, for example, `<div id="some_ID">`.
+1. Regular CSS selectors.

--- a/site/en/docs/devtools/recorder/reference/index.md
+++ b/site/en/docs/devtools/recorder/reference/index.md
@@ -11,13 +11,11 @@ tags:
   - performance
 ---
 
-Discover all the capabilities and options in this comprehensive features reference of the Chrome DevTools **Recorder** panel.
+Discover ways to share user flows, edit them and their steps in this comprehensive features reference of the Chrome DevTools **Recorder** panel.
 
 To learn the basics of working with the **Recorder** panel, see [Record, replay, and measure user flows](/docs/devtools/recorder/).
 
 ## Edit user flows {: #edit-flows }
-
-Let's walk through the options to edit the user flows.
 
 {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/gRr2bASlwPtTFFbXnqeM.png", alt="DevTools Recorder panel has a drop-down menu in the header which allows you to select a user flow to edit", width="800", height="500" %}
 
@@ -38,37 +36,6 @@ On the top of the **Recorder** panel, there are options for you to:
 1. **Delete a recording**{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/9bkJ0VAuCp9iixG2LUtd.svg", alt="Delete", width="20", height="20" %}. Delete the selected recording.
 
 You can also edit the recording's name by clicking the edit button {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/fFpbDTHPicjesIbiG4Hm.svg", alt="Edit", width="20", height="20" %} next to it.
-
-## Edit steps {: #edit-steps }
-
-### Adjust timeouts for steps {: #adjust-timeout }
-
-In case your page has slow network requests or lengthy animations, the replay can fail on steps that exceed the default timeout of `5000` milliseconds.
-
-To avoid this problem, you can adjust the default timeout for each step at once or set separate timeouts for specific steps. Timeouts on specific steps overwrite the default.
-
-To adjust the default timeout for each step at once:
-
-1. Click on **Replay settings** to make the **Timeout** box editable.
-
-   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Ys9x9oHiQNATMSJkeYSn.png", alt="Replay settings", width="800", height="506" %}
-
-1. In the **Timeout** box, set the timeout value in milliseconds.
-1. Click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/gjfZMeLnwzpRfOMfXEMY.svg", alt="Replay", width="20", height="20" %}[**Replay**](/docs/devtools/recorder/#replay) to see the adjusted default timeout in action.
-
-To overwrite the default timeout on a specific step:
-
-1. [Expand the step](/docs/devtools/recorder/#expand-step) and click **Add timeout**.
-
-   <div class="elevation--2", style="margin-top: 20px; margin-bottom: 20px;">{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/MEDm7NXPbGe3aObUhVj6.png", alt="Add timeout", width="800", height="542" %}</div>
-
-1. Click on the `timeout: <value>` and set the value in milliseconds.
-
-   <div class="elevation--2", style="margin-top: 20px; margin-bottom: 20px;">{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/8jkQCHfBatGJf8PxrlFi.png", alt="Set the timeout value", width="800", height="580" %}</div>
-
-1. Click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/gjfZMeLnwzpRfOMfXEMY.svg", alt="Replay", width="20", height="20" %}[**Replay**](/docs/devtools/recorder/#replay) to see the step with the timeout in action.
-
-To remove a timeout overwrite on a step, click the **Delete**{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/9bkJ0VAuCp9iixG2LUtd.svg", alt="Delete", width="20", height="20" %} button next to it.
 
 ## Share user flows {: #share-flows }
 
@@ -115,7 +82,174 @@ To import a user flow:
 1. Select the JSON file with the recorded user flow.
 1. Click the {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/gjfZMeLnwzpRfOMfXEMY.svg", alt="Replay", width="20", height="20" %}**Replay** button to run the imported user flow.
 
-## Understand the recording's selector {: #selector }
+## Edit steps {: #edit-steps }
+
+You can edit any step in the recording by clicking the {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/1UTR0tiSxiKD0YSwAc1g.svg", alt="Expand", width="24", height="24" %} button next to it.
+
+You can also add missing steps and remove accidentally recorded ones as described below.
+
+### Add and remove steps {: #add-and-remove-steps }
+
+To add a step:
+
+1. Click the {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/N5Lkpdwpaz4YqRGFr2Ks.svg", alt="Three-dot button.", width="20", height="20" %} three-dot button next to any existing step.
+
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/vBETaaLND6v4PVtOvPzv.png", alt="Three-dot menu.", width="800", height="842" %}
+
+1. Select **Add step before** or **Add step after** from the drop-down menu.
+1. [Configure the new step](#configure-steps) by specifying its properties.
+
+To remove a step, select **Remove** from the same three-dot menu.
+
+### Configure steps {: #configure-steps }
+
+To configure a step:
+
+1. Specify its type: `click`, `doubleClick`, (input) `change`, `keyUp`, `keyDown`, `scroll`, `close`, `navigate` (to a page), `waitForElement`, or `waitForExpression`.
+   
+   Other properties depend on the `type` value.
+
+1. Specify the required properties below the `type`.
+   <div class="elevation--4" style="margin-top: 20px; margin-bottom: 20px;">{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/GICuzxrYSrsj2zyLdi8X.png", alt="Configuring a step.", width="800", height="388" %}</div>
+1. Click the corresponding buttons to add optional type-specific properties and specify them.
+
+For a list of available properties, see [Step properties](#step-properties).
+
+To remove an optional property, click the {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/G3beoQrG60COzsJM4TNb.svg", alt="Remove.", width="20", height="20" %} **Remove** button next to it.
+
+To add or remove an element to or from an array property, click the **+** or **-** buttons next to the element.
+
+#### Step properties {: #step-properties }
+
+Each step can have the following optional properties:
+
+- `target`—a URL for the [Chrome DevTools Protocol (CDP)](https://chromedevtools.github.io/devtools-protocol/) target, the default `main` keyword refers to the current page.
+- `assertedEvents` that currently can only be a single `navigation` event
+
+Other common properties available for most of the step types are:
+
+- `frame`—an array of zero-based indexes that identify an iframe that can be nested. For example, you can identify the first (0) iframe inside a second (1) iframe of the main target as `[1, 0]`.
+- `timeout`—a number of milliseconds to wait before executing a step. For more information, see [Adjust timeouts for steps](#adjust-timeout).
+- `selectors`—an array of selectors. For more information, see [Understand selectors](#selector).
+
+Type-specific properties are:
+
+<table>
+    <thead>
+        <tr>
+            <td>Type</td>
+            <td>Property</td>
+            <td>Required</td>
+            <td>Description</td>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>click</code>, <code>doubleClick</code></td>
+            <td><code>offsetX</code>, <code>offsetY</code></td>
+            <td>{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/lh0C6z3sePNX1Tiibddr.svg", alt="Check.", width="24", height="24" %}</td>
+            <td>Relative to the top-left of the element content box, in pixels</td>
+        </tr>
+        <tr>
+            <td><code>click</code>, <code>doubleClick</code></td>
+            <td><code>button</code></td>
+            <td></td>
+            <td>Pointer button: primary | auxiliary | second | back | forward</td>
+        </tr>
+        <tr>
+            <td><code>change</code></td>
+            <td><code>value</code></td>
+            <td>{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/lh0C6z3sePNX1Tiibddr.svg", alt="Check.", width="24", height="24" %}</td>
+            <td>Final value</td>
+        </tr>
+        <tr>
+            <td><code>keyDown</code>, <code>keyUp</code></td>
+            <td><code>key</code></td>
+            <td>{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/lh0C6z3sePNX1Tiibddr.svg", alt="Check.", width="24", height="24" %}</td>
+            <td>Key name</td>
+        </tr>
+        <tr>
+            <td><code>scroll</code></td>
+            <td><code>x</code>, <code>y</code></td>
+            <td></td>
+            <td>Absolute scroll x and y positions in pixels, default 0</td>
+        </tr>
+        <tr>
+            <td><code>navigate</code></td>
+            <td><code>url</code></td>
+            <td>{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/lh0C6z3sePNX1Tiibddr.svg", alt="Check.", width="24", height="24" %}</td>
+            <td>Target URL</td>
+        </tr>
+        <tr>
+            <td><code>waitForElement</code></td>
+            <td><code>operator</code></td>
+            <td></td>
+            <td>&gt;= | == (default) | &lt;=</td>
+        </tr>
+        <tr>
+            <td><code>waitForElement</code></td>
+            <td><code>count</code></td>
+            <td></td>
+            <td>Number of elements identified by a selector</td>
+        </tr>
+        <tr>
+            <td><code>waitForExpression</code></td>
+            <td><code>expression</code></td>
+            <td>{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/lh0C6z3sePNX1Tiibddr.svg", alt="Check.", width="24", height="24" %}</td>
+            <td>JavaScript expression that resolves to true</td>
+        </tr>
+    </tbody>
+</table>
+
+There are two properties that make the replay pause:
+
+- The `waitForElement` property makes the step wait for the presence (or absence) of a number of elements identified by a selector. For example, the following step waits for less than three elements to be on the page that match the selector `.my-class`.
+
+     ```
+       "type": "waitForElement",
+       "selectors": [".my-class"],
+       "operator": "<=",
+       "count": 2,
+     ```
+
+- The `waitForExpression`  property makes the step wait for a JavaScript expression to resolve to true. For example, the following step pauses for two seconds and then resolves to true allowing the replay to continue.
+
+    ```
+       "type": "waitForExpression",
+       "expression": "new Promise(resolve => setTimeout(() => resolve(true),
+     2000))",
+     ```
+
+### Adjust timeouts for steps {: #adjust-timeout }
+
+In case your page has slow network requests or lengthy animations, the replay can fail on steps that exceed the default timeout of `5000` milliseconds.
+
+To avoid this problem, you can adjust the default timeout for each step at once or set separate timeouts for specific steps. Timeouts on specific steps overwrite the default.
+
+To adjust the default timeout for each step at once:
+
+1. Click on **Replay settings** to make the **Timeout** box editable.
+
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Ys9x9oHiQNATMSJkeYSn.png", alt="Replay settings", width="800", height="506" %}
+
+1. In the **Timeout** box, set the timeout value in milliseconds.
+1. Click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/gjfZMeLnwzpRfOMfXEMY.svg", alt="Replay", width="20", height="20" %}[**Replay**](/docs/devtools/recorder/#replay) to see the adjusted default timeout in action.
+
+To overwrite the default timeout on a specific step:
+
+1. [Expand the step](/docs/devtools/recorder/#expand-step) and click **Add timeout**.
+
+   <div class="elevation--2", style="margin-top: 20px; margin-bottom: 20px;">{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/MEDm7NXPbGe3aObUhVj6.png", alt="Add timeout", width="800", height="542" %}</div>
+
+1. Click on the `timeout: <value>` and set the value in milliseconds.
+
+   <div class="elevation--2", style="margin-top: 20px; margin-bottom: 20px;">{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/8jkQCHfBatGJf8PxrlFi.png", alt="Set the timeout value", width="800", height="580" %}</div>
+
+1. Click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/gjfZMeLnwzpRfOMfXEMY.svg", alt="Replay", width="20", height="20" %}[**Replay**](/docs/devtools/recorder/#replay) to see the step with the timeout in action.
+
+To remove a timeout overwrite on a step, click the **Delete**{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/9bkJ0VAuCp9iixG2LUtd.svg", alt="Delete", width="20", height="20" %} button next to it.
+
+## Understand selectors {: #selector }
 
 During recording, the **Recorder** automatically detects two types of selectors for most of the steps: ARIA and CSS.
 


### PR DESCRIPTION
Divided the Recorder docs into a tutorial and a features reference.

Documented:
- https://developer.chrome.com/blog/new-in-devtools-103/#recorder
- Missing step editing buttons

Need to publish on Jun 21.