### PR TITLE
Fix jump links in devtools blog post

### DIFF
--- a/site/en/blog/devtools-timeline-now-providing-the-full-story/index.md
+++ b/site/en/blog/devtools-timeline-now-providing-the-full-story/index.md
@@ -14,9 +14,9 @@ The DevTools [Timeline panel](https://developers.google.com/web/tools/chrome-dev
 
 We’ve added the following features:
 
-* integrated [JavaScript profiler](#integrated_javascript_profiler). (Flame chart included!)
-* [frame viewer](#frame_viewer) to help you visualize composited layers.
-* [paint profiler](#paint_profiler) for detailed drill-downs into the browser’s painting activity.
+* integrated [JavaScript profiler](#integrated-javascript-profiler). (Flame chart included!)
+* [frame viewer](#frame-viewer) to help you visualize composited layers.
+* [paint profiler](#paint-profiler) for detailed drill-downs into the browser’s painting activity.
 
 Note that using the __Paint__ capture options described in this article do incur some performance overhead, so flip them on only when you want 'em.
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Replace underscores with dashes