### PR TITLE
[ext-docs] Add "Has warning" to Chrome API reference metadata

### DIFF
--- a/site/_includes/layouts/namespace-reference.njk
+++ b/site/_includes/layouts/namespace-reference.njk
@@ -78,7 +78,19 @@
                   {% for permission in f.permissions %}
                     <code>{{ permission }}</code><br />
                   {% endfor %}
-                  {{ extra_permissions_html | safe }}
+                </div>
+              </li>
+              <li>
+                <div class="code-sections__label">Has warning?</div>
+                <div>    
+                  {{ has_warning | safe }}
+                </div>
+              </li>
+            {% else %}
+            <li>
+                <div class="code-sections__label">Permission</div>
+                <div>
+                {{ extra_permissions_html | safe }}
                 </div>
               </li>
             {% endif %}

--- a/site/_includes/layouts/namespace-reference.njk
+++ b/site/_includes/layouts/namespace-reference.njk
@@ -78,6 +78,7 @@
                   {% for permission in f.permissions %}
                     <code>{{ permission }}</code><br />
                   {% endfor %}
+                  {{ extra_permissions_html | safe }}
                 </div>
               </li>
               <li>
@@ -90,7 +91,7 @@
             <li>
                 <div class="code-sections__label">Permission</div>
                 <div>
-                {{ extra_permissions_html | safe }}
+                {{ special_permissions_html | safe }}
                 </div>
               </li>
             {% endif %}

--- a/site/en/docs/extensions/reference/bookmarks/index.md
+++ b/site/en/docs/extensions/reference/bookmarks/index.md
@@ -1,5 +1,7 @@
 ---
 api: bookmarks
+has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
+
 ---
 
 ![Clicking the star adds a bookmark](bookmarks.png)
@@ -68,7 +70,7 @@ chrome.bookmarks.create({
 For an example of using this API, see the [basic bookmarks sample][5]. For other examples and for
 help in viewing the source code, see [Samples][6].
 
-[1]: /docs/extensions/mv2/tabs
+[1]: /docs/extensions/mv3/manifest
 [2]: #type-BookmarkTreeNode
 [3]: #method-create
 [4]: #type-BookmarkTreeNode

--- a/site/en/docs/extensions/reference/browserAction/index.md
+++ b/site/en/docs/extensions/reference/browserAction/index.md
@@ -126,7 +126,7 @@ You can find simple examples of using browser actions in the [examples/api/brows
 directory. For other examples and for help in viewing the source code, see [Samples][19].
 
 [1]: /docs/extensions/pageAction
-[2]: /docs/extensions/mv2/tabs
+[2]: /docs/extensions/mv3/manifest
 [3]: #icon
 [4]: #tooltip
 [5]: #badge

--- a/site/en/docs/extensions/reference/browsingData/index.md
+++ b/site/en/docs/extensions/reference/browsingData/index.md
@@ -172,6 +172,6 @@ extension removes data on their behalf.
 
 Samples for the `browsingData` API are available [on the samples page][3].
 
-[1]: /docs/extensions/mv2/tabs
+[1]: /docs/extensions/mv3/manifest
 [2]: https://chrome.google.com/webstore/detail/aknpkdffaafgjchaibgeefbgmgeghloj
 [3]: /docs/extensions/mv2/samples#search:browsingData

--- a/site/en/docs/extensions/reference/contentSettings/index.md
+++ b/site/en/docs/extensions/reference/contentSettings/index.md
@@ -1,5 +1,7 @@
 ---
 api: contentSettings
+has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
+
 ---
 
 ## Manifest

--- a/site/en/docs/extensions/reference/debugger/index.md
+++ b/site/en/docs/extensions/reference/debugger/index.md
@@ -1,5 +1,6 @@
 ---
 api: debugger
+has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
 ---
 
 ## Notes

--- a/site/en/docs/extensions/reference/declarativeNetRequest/index.md
+++ b/site/en/docs/extensions/reference/declarativeNetRequest/index.md
@@ -2,7 +2,9 @@
 api: declarativeNetRequest
 extra_permissions_html:
   <code>declarativeNetRequestFeedback</code><br/>
-  <a href="declare_permissions#host-permissions">host permissions</a><br />
+  <a href="/docs/extensions/mv3/declare_permissions#host-permissions">host permissions</a><br />
+has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
+
 ---
 
 ## Manifest
@@ -387,8 +389,8 @@ is determined based on the priority of each rule and the operations specified.
   `h1` was removed by (10), `h2` was set by (10) then appended by (11), and `h3` was appended by
   (10) and (11).
 
-[1]: /docs/extensions/mv2/tabs
-[2]: /docs/extensions/mv2/declare_permissions
+[1]: /docs/extensions/mv3/manifest
+[2]: /docs/extensions/mv3/declare_permissions
 [3]: #type-Ruleset
 [4]: #type-Ruleset
 [5]: #property-MAX_NUMBER_OF_STATIC_RULESETS

--- a/site/en/docs/extensions/reference/declarativeWebRequest/index.md
+++ b/site/en/docs/extensions/reference/declarativeWebRequest/index.md
@@ -169,7 +169,7 @@ stages][9]. All conditions of all rules are evaluated at each stage of a web req
 `IgnoreRules` action is executed, it applies only to other actions that are executed for the same
 web request in the same stage.
 
-[1]: /docs/extensions/mv2/tabs
+[1]: /docs/extensions/mv3/manifest
 [2]: /docs/extensions/mv2/declare_permissions
 [3]: /docs/extensions/events#declarative
 [4]: /docs/extensions/events#performance

--- a/site/en/docs/extensions/reference/desktopCapture/index.md
+++ b/site/en/docs/extensions/reference/desktopCapture/index.md
@@ -1,5 +1,7 @@
 ---
 api: desktopCapture
+has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
+
 ---
 
 <!-- Intentionally blank -->

--- a/site/en/docs/extensions/reference/downloads/index.md
+++ b/site/en/docs/extensions/reference/downloads/index.md
@@ -1,5 +1,6 @@
 ---
 api: downloads
+has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
 ---
 
 ## Manifest
@@ -22,6 +23,6 @@ You must declare the `"downloads"` permission in the [extension manifest][1] to 
 You can find simple examples of using the `chrome.downloads` API in the [examples/api/downloads][2]
 directory. For other examples and for help in viewing the source code, see [Samples][3].
 
-[1]: /docs/extensions/mv2/tabs
+[1]: /docs/extensions/mv3/manifest
 [2]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/downloads/
 [3]: /docs/extensions/mv2/samples

--- a/site/en/docs/extensions/reference/fontSettings/index.md
+++ b/site/en/docs/extensions/reference/fontSettings/index.md
@@ -62,7 +62,7 @@ chrome.fontSettings.setFont(
 You can find a sample extension using the Font Settings API in the [examples/api/fontSettings][3]
 directory. For other examples and for help in viewing the source code, see [Samples][4].
 
-[1]: /docs/extensions/mv2/tabs
+[1]: /docs/extensions/mv3/manifest
 [2]: https://www.w3.org/TR/CSS21/fonts.html#generic-font-families
 [3]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/fontSettings/
 [4]: /docs/extensions/mv2/samples

--- a/site/en/docs/extensions/reference/history/index.md
+++ b/site/en/docs/extensions/reference/history/index.md
@@ -1,5 +1,6 @@
 ---
 api: history
+has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
 ---
 
 ## Manifest
@@ -33,7 +34,7 @@ The following table describes each transition type.
 For examples of using this API, see the [history sample directory][8] and the [history API test
 directory][9]. For other examples and for help in viewing the source code, see [Samples][10].
 
-[1]: /docs/extensions/mv2/tabs
+[1]: /docs/extensions/mv3/manifest
 [2]: #tt_generated
 [3]: #tt_manual_subframe
 [4]: #tt_typed

--- a/site/en/docs/extensions/reference/input_ime/index.md
+++ b/site/en/docs/extensions/reference/input_ime/index.md
@@ -45,6 +45,6 @@ chrome.input.ime.onKeyEvent.addListener(
 For an example of using this API, see the [basic input.ime sample][2]. For other examples and for
 help in viewing the source code, see [Samples][3].
 
-[1]: /docs/extensions/mv2/tabs
+[1]: /docs/extensions/mv3/manifest
 [2]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/input.ime/basic/
 [3]: /docs/extensions/mv2/samples

--- a/site/en/docs/extensions/reference/management/index.md
+++ b/site/en/docs/extensions/reference/management/index.md
@@ -1,5 +1,6 @@
 ---
 api: management
+has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
 ---
 
 ## Manifest
@@ -21,7 +22,7 @@ API. For example:
 [`management.getPermissionWarningsByManifest`][2], [`management.uninstallSelf`][3], and
 [`management.getSelf`][4] do not require the management permission.
 
-[1]: /docs/extensions/mv2/tabs
+[1]: /docs/extensions/mv3/manifest
 [2]: #method-getPermissionWarningsByManifest
 [3]: #method-uninstallSelf
 [4]: #method-getSelf

--- a/site/en/docs/extensions/reference/notifications/index.md
+++ b/site/en/docs/extensions/reference/notifications/index.md
@@ -1,5 +1,6 @@
 ---
 api: notifications
+has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
 ---
 
 <!-- Intentionally blank -->

--- a/site/en/docs/extensions/reference/omnibox/index.md
+++ b/site/en/docs/extensions/reference/omnibox/index.md
@@ -45,6 +45,6 @@ example, the [context menus API][2] also uses a 16x16-pixel icon, but it is disp
 
 You can find samples of this API on the [sample page][3].
 
-[1]: /docs/extensions/mv2/tabs
+[1]: /docs/extensions/mv3/manifest
 [2]: /docs/extensions/contextMenus
 [3]: /docs/extensions/mv2/samples#search:omnibox

--- a/site/en/docs/extensions/reference/pageAction/index.md
+++ b/site/en/docs/extensions/reference/pageAction/index.md
@@ -88,7 +88,7 @@ You can find simple examples of using page actions in the [examples/api/pageActi
 For other examples and for help in viewing the source code, see [Samples][8].
 
 [1]: /docs/extensions/browserAction
-[2]: /docs/extensions/mv2/tabs
+[2]: /docs/extensions/mv3/manifest
 [3]: /docs/extensions/browserAction#ui
 [4]: #method-show
 [5]: #method-hide

--- a/site/en/docs/extensions/reference/pageCapture/index.md
+++ b/site/en/docs/extensions/reference/pageCapture/index.md
@@ -1,5 +1,6 @@
 ---
 api: pageCapture
+has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
 ---
 
 MHTML is a [standard format][1] supported by most browsers. It encapsulates in a single file a page
@@ -25,4 +26,4 @@ API. For example:
 ```
 
 [1]: https://tools.ietf.org/html/rfc2557
-[2]: /docs/extensions/mv2/tabs
+[2]: /docs/extensions/mv3/manifest

--- a/site/en/docs/extensions/reference/permissions/index.md
+++ b/site/en/docs/extensions/reference/permissions/index.md
@@ -183,7 +183,7 @@ chrome.permissions.remove({
 });
 ```
 
-[1]: /docs/extensions/mv2/tabs
+[1]: /docs/extensions/mv3/manifest
 [2]: /docs/extensions/mv2/declare_permissions#manifest
 [3]: #property-Permissions-origins
 [4]: /docs/extensions/debugger

--- a/site/en/docs/extensions/reference/privacy/index.md
+++ b/site/en/docs/extensions/reference/privacy/index.md
@@ -1,5 +1,6 @@
 ---
 api: privacy
+has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
 ---
 
 {% Aside %}
@@ -96,6 +97,6 @@ chrome.privacy.services.autofillEnabled.onChange.addListener(
 For example code, see the [Privacy API samples][4].
 
 [1]: https://www.google.com/intl/en/landing/chrome/google-chrome-privacy-whitepaper.pdf
-[2]: /docs/extensions/mv2/tabs
+[2]: /docs/extensions/mv3/manifest
 [3]: /docs/extensions/types#ChromeSetting
 [4]: /docs/extensions/mv2/samples#search:privacy

--- a/site/en/docs/extensions/reference/proxy/index.md
+++ b/site/en/docs/extensions/reference/proxy/index.md
@@ -1,5 +1,6 @@
 ---
 api: proxy
+has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
 ---
 
 ## Manifest
@@ -179,7 +180,7 @@ chrome.proxy.settings.get(
 Note that the `value` object passed to `set()` is not identical to the `value` object passed to
 callback function of `get()`. The latter will contain a `rules.proxyForHttp.port` element.
 
-[1]: /docs/extensions/mv2/tabs
+[1]: /docs/extensions/mv3/manifest
 [2]: #type-ProxyConfig
 [3]: #type-ProxyRules
 [4]: #type-PacScript

--- a/site/en/docs/extensions/reference/storage/index.md
+++ b/site/en/docs/extensions/reference/storage/index.md
@@ -20,7 +20,7 @@ storage capabilities as the [localStorage API][local-storage] with the following
 
 ## Manifest
 
-You must declare the "storage" permission in the [extension manifest][api-tabs] to use the storage
+You must declare the "storage" permission in the [extension manifest][doc-manifest] to use the storage
 API. For example:
 
 ```json
@@ -203,7 +203,7 @@ function getAllStorageSyncData() {
 ```
 
 [api-storage]: /docs/extensions/mv2/manifest/storage
-[api-tabs]: /docs/extensions/mv2/tabs
+[doc-manifest]: /docs/extensions/mv3/manifest
 [incognito]: /docs/extensions/mv2/manifest/incognito
 [local-storage]: https://developer.mozilla.org/docs/Web/API/Window/localStorage
 [options-page]: https://developer.chrome.com/docs/extensions/mv3/options/

--- a/site/en/docs/extensions/reference/system_storage/index.md
+++ b/site/en/docs/extensions/reference/system_storage/index.md
@@ -1,5 +1,6 @@
 ---
 api: system.storage
+has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
 ---
 
 <!-- Intentionally blank -->

--- a/site/en/docs/extensions/reference/tabCapture/index.md
+++ b/site/en/docs/extensions/reference/tabCapture/index.md
@@ -1,5 +1,6 @@
 ---
 api: tabCapture
+has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
 ---
 
 <!-- Intentionally blank -->

--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -1,7 +1,5 @@
 ---
 api: tabs
-extra_permissions_html:
-  The majority of the <code>chrome.tabs</code> API can be used without declaring any permission. However, the <code>"tabs"</code> permission is required in order to populate the <code>url</code>, <code>pendingUrl</code>, <code>title</code>, and <code>favIconUrl</code> properties of <code><a href="#type-Tab">Tab</a></code>.
 ---
 
 ## Manifest

--- a/site/en/docs/extensions/reference/topSites/index.md
+++ b/site/en/docs/extensions/reference/topSites/index.md
@@ -1,10 +1,12 @@
 ---
 api: topSites
+has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
+
 ---
 
 ## Manifest
 
-You must declare the "topSites" permission in your extension's manifest to use this API.
+You must declare the "topSites" permission in your [extension's manifest][2] to use this API.
 
 ```json
 {
@@ -22,3 +24,4 @@ You must declare the "topSites" permission in your extension's manifest to use t
 You can find samples of this API in [Samples][1].
 
 [1]: /docs/extensions/mv2/samples#search:topsites
+[2]: /docs/extensions/mv3/manifest

--- a/site/en/docs/extensions/reference/ttsEngine/index.md
+++ b/site/en/docs/extensions/reference/ttsEngine/index.md
@@ -1,5 +1,6 @@
 ---
 api: ttsEngine
+has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
 ---
 
 ## Overview

--- a/site/en/docs/extensions/reference/wallpaper/index.md
+++ b/site/en/docs/extensions/reference/wallpaper/index.md
@@ -35,4 +35,4 @@ chrome.wallpaper.setWallpaper(
 );
 ```
 
-[1]: /docs/extensions/mv2/tabs
+[1]: /docs/extensions/mv3/manifest

--- a/site/en/docs/extensions/reference/webNavigation/index.md
+++ b/site/en/docs/extensions/reference/webNavigation/index.md
@@ -1,5 +1,6 @@
 ---
 api: webNavigation
+has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
 ---
 
 ## Manifest

--- a/site/en/docs/extensions/reference/webRequest/index.md
+++ b/site/en/docs/extensions/reference/webRequest/index.md
@@ -354,7 +354,7 @@ chrome.webRequest.onBeforeSendHeaders.addListener(
 
 For more example code, see the [web request samples][16].
 
-[1]: /docs/extensions/mv2/tabs
+[1]: /docs/extensions/mv3/manifest
 [2]: /docs/extensions/mv2/declare_permissions
 [3]: #life_cycle_footnote
 [4]: #implementation-details

--- a/site/en/docs/extensions/reference/windows/index.md
+++ b/site/en/docs/extensions/reference/windows/index.md
@@ -1,7 +1,5 @@
 ---
 api: windows
-special_permissions_html:
-  In many cases, this API does not require any permissions. See the <a href="#manifest">Manifest</a> section for details on permission use. 
 ---
 ## Manifest
 

--- a/site/en/docs/extensions/reference/windows/index.md
+++ b/site/en/docs/extensions/reference/windows/index.md
@@ -1,9 +1,8 @@
 ---
 api: windows
-extra_permissions_html:
-  The <code>chrome.windows</code> API can be used without declaring any permission. However, the <code>"tabs"</code> permission is required in order to populate the <code>url</code>, <code>pendingUrl</code>, <code>title</code>, and <code>favIconUrl</code> properties of <code><a href="../tabs/#type-Tab">Tab</a></code>.
+special_permissions_html:
+  In many cases, this API does not require any permissions. See the <a href="#manifest">Manifest</a> section for details on permission use. 
 ---
-
 ## Manifest
 
 When requested, a [`windows.Window`][1] will contain an array of [`tabs.Tab`][2] objects. You must

--- a/types/site/_data/postsData.d.ts
+++ b/types/site/_data/postsData.d.ts
@@ -52,6 +52,7 @@ declare global {
     api?: string;
     extra_permissions?: string[];
     extra_permissions_html?: string;
+    has_warning?: string;
     // The following properties are added dynamically
     locale: string;
     url: string;

--- a/types/site/_data/postsData.d.ts
+++ b/types/site/_data/postsData.d.ts
@@ -52,6 +52,7 @@ declare global {
     api?: string;
     extra_permissions?: string[];
     extra_permissions_html?: string;
+    special_permissions_html?: string;
     has_warning?: string;
     // The following properties are added dynamically
     locale: string;


### PR DESCRIPTION
Fixes #3063

## PR Scope

- Adds a "Has warning?" metadata to Chrome APIs that have permissions that trigger a warning message on installation.
  - It includes a link to the permission warnings list so that developers can check the warning content. 

    <img width="500" alt="Screen Shot 2022-06-20 at 16 46 03" src="https://user-images.githubusercontent.com/37001393/174854640-a0bbcfef-49b6-4a3c-949f-add385ad6970.png">

- Fixes incorrect manifest link.
- Adds the _ability_ to include a "special permissions" metadata for APIs that most of the time can be used without permissions. However they only require permissions to access special data, like the Tabs API and Windows API (these can request "tabs" or host permissions to access privileged tabs data).

## ❌ Does NOT include:

- Changes to **Tabs API** or **Windows API** metadata. These permission require more explanation, that will be addressed on a separate PR.
- Improvements to the content or information structure on any APIs.

## Staged links
[Downloads API](https://deploy-preview-3064--developer-chrome-com.netlify.app/docs/extensions/reference/downloads)