### PR TITLE
Devtools 103 add missing anchor link

### DIFF
--- a/site/en/blog/new-in-chrome-103/index.md
+++ b/site/en/blog/new-in-chrome-103/index.md
@@ -128,7 +128,7 @@ const pickedFonts = await self.queryLocalFonts(opts);
 Check out Tom's article [Use advanced typography with local fonts](https://web.dev/local-fonts/)
 on web.dev for complete details.
 
-## Easier Timeouts with AbortSignal.timeout()
+## Easier Timeouts with AbortSignal.timeout() {: #abort-timeout }
 
 In JavaScript, `AbortController` and `AbortSignal` are used to cancel an
 asynchronous call.


### PR DESCRIPTION
Add missing `#abort-timeout` link that causing non-working anchor in https://developer.chrome.com/blog/new-in-chrome-103/#abort-timeout