### PR TITLE
note "session" storage area shipped

### DIFF
--- a/site/en/docs/extensions/mv3/intro/mv3-overview/index.md
+++ b/site/en/docs/extensions/mv3/intro/mv3-overview/index.md
@@ -142,13 +142,14 @@ There are a number of other changes introduced in Manifest V3:
 * [Web accessible resources](/docs/extensions/mv3/intro/mv3-migration#web-accessible-resources): These resources are now available only to specified sites and extensions.
 * [Content security policy (CSP)](/docs/extensions/mv3/intro/mv3-migration#content-security-policy): You now specify separate CSP for different execution contexts in a single object, and certain policies are disallowed.
 * [executeScript() changes](/docs/extensions/mv3/intro/mv3-migration#executing-arbitrary-strings): Extensions can no longer execute arbitrary strings, only script files and functions. This method is also migrating from the Tabs API to the new Scripting API.
+* [A new in-memory StorageArea][2] that can be used to store values in-memory across service worker restarts.
 
 The following features will be added to Manifest V3 soon:
 
 * **Dynamic content scripts:** the new [Scripting API][1] lets extensions register and unregister content scripts at runtime.
 * **New favicon API:** this new JavaScript API replaces "chrome://favicons" and gives  developers a way to retrieve websites' favicons.
-* **In-memory storage:** a new StorageArea on the Storage API that can be used to store values in memory across service worker restarts.
 
 Look for announcements of these and other Manifest V3 features as they become available.
 
 [1]: /docs/extensions/reference/scripting/
+[2]: /docs/extensions/reference/storage/#property-session


### PR DESCRIPTION
MV3's "session" context for storage has shipped in v102.