### PR TITLE
Use a PAT for repo-sync

### DIFF
--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -21,4 +21,4 @@ jobs:
           source_repo: 'GoogleChrome/developer.chrome.com'
           source_branch: 'main'
           destination_branch: 'main'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.REPO_SYNC_PAT }}


### PR DESCRIPTION
As per https://github.com/repo-sync/github-sync/issues/23#issuecomment-650741359 this is the recommended approach for sync'ing a source repo that might contain updates to GitHub Actions workflow definitions.