### PR TITLE
Remove .toc-container width to fix article body centering

### DIFF
--- a/site/_scss/blocks/_toc.scss
+++ b/site/_scss/blocks/_toc.scss
@@ -1,6 +1,5 @@
 .toc-container {
   max-width: 100%;
-  width: px-to-rem(320px);
 }
 
 .toc > summary {
@@ -37,10 +36,9 @@ toc-active {
 
   [toc--active] {
     font-weight: 600;
-    letter-spacing: -0.35px;  // makes the text roughly the same width
+    letter-spacing: -0.35px; // makes the text roughly the same width
   }
 }
-
 
 // The eleventy-plugin-toc doesn't let us put classes on ul/ol or li children
 // so we have to style them all with descendant selectors.


### PR DESCRIPTION
Fixes #2747 by removing the explicit width on the `.toc-container` element. This should shift the overall article body to the right, which then makes everything look properly centered. (The issue was not with the hero image being off-center, it was with the article body.)

CC: @tomayac and @maudnals to check the pages they reported issues with and confirm that the new layout matches what they'd expect.