### PR TITLE
Show that "persistent" value is set to true by default

### DIFF
--- a/site/en/docs/extensions/mv2/background_migration/index.md
+++ b/site/en/docs/extensions/mv2/background_migration/index.md
@@ -16,7 +16,7 @@ under [rare circumstances][1] should an extension have a persistent background, 
 consume system resources and can cause a strain on lower-powered devices.
 
 Enhance an extension's performance by migrating a persistent background script to an event-based
-non-persistent model.
+non-persistent model. By default, `"persistent"` is set to true.
 
 ## Designate persistence as false {: #persistence }
 

--- a/site/en/docs/extensions/mv2/background_pages/index.md
+++ b/site/en/docs/extensions/mv2/background_pages/index.md
@@ -67,7 +67,7 @@ Multiple background scripts can be registered for modularized code.
 
 The only occasion to keep a background script persistently active is if the extension uses
 [chrome.webRequest][4] API to block or modify network requests. The webRequest API is incompatible
-with non-persistent background pages.
+with non-persistent background pages. By default, `"persistent"` is set to true.
 
 {% endAside %}
 


### PR DESCRIPTION
Clarity is the key here. It should be completely obvious what the default value is. This is especially important because so many other undefined values make a lot of sense as false by default.