### PR TITLE
Replaced/Fixed link

### DIFF
--- a/site/en/blog/attribution-reporting-updates-june-2022/index.md
+++ b/site/en/blog/attribution-reporting-updates-june-2022/index.md
@@ -14,10 +14,9 @@ tags:
   - experiment
 ---
 
-The Attribution Reporting proposal is changing for Chrome version 104,
-with new API mechanisms, functionality, and updates to the aggregation service.
-To get the latest information on versions, sign up for [Chrome OS release
-notifications](https://groups.google.com/a/google.com/g/cros-rel-notify).
+The Attribution Reporting proposal is changing for [Chrome version
+104](https://chromiumdash.appspot.com/schedule), with new API mechanisms, functionality, and updates
+to the aggregation service.
 
 ## Who are these updates for?
 


### PR DESCRIPTION
Replaced the ChromeOS link, which is incorrect, with a link to Chrome browser version.
Thanks!
Feel free to tweak at your convenience.