### PR TITLE
Remove link to try-puppeteer.appspot.com

### DIFF
--- a/site/_data/docs/puppeteer/toc.yml
+++ b/site/_data/docs/puppeteer/toc.yml
@@ -11,8 +11,6 @@
     - url: /blog/headless-karma-mocha-chai/
     - url: https://chromedevtools.github.io/devtools-protocol/
       title: i18n.docs.puppeteer.resources_protocol
-    - url: https://try-puppeteer.appspot.com/
-      title: i18n.docs.puppeteer.resources_try
 
 - title: i18n.docs.puppeteer.project
   sections:

--- a/site/_data/i18n/docs/puppeteer.yml
+++ b/site/_data/i18n/docs/puppeteer.yml
@@ -24,6 +24,3 @@ project_contribute:
 
 resources_protocol:
   en: 'DevTools Protocol APIs'
-
-resources_try:
-  en: 'Try Puppeteer!'


### PR DESCRIPTION
try-puppeteer.appspot.com is no longer supported 