### PR TITLE
Add note about restricted CDP domains

### DIFF
--- a/site/en/docs/extensions/reference/debugger/index.md
+++ b/site/en/docs/extensions/reference/debugger/index.md
@@ -8,6 +8,12 @@ As of today, attaching to the tab by means of the debugger API and using embedde
 with that tab are mutually exclusive. If user invokes Chrome DevTools while extension is attached to
 the tab, debugging session is terminated. Extension can re-establish it later.
 
+For security reasons, the `chrome.debugger` API does not provide access to all Chrome DevTools
+Protocol Domains. The available domains are: [Audits][1], [DOM][2], [Emulation][3], [Fetch][4],
+[IO][5], [Input][6], [Inspector][7], [Log][8], [Network][9], [Overlay][10], [Page][11],
+[Storage][12], [Target][13], [Tracing][14] and [WebAuthn][15].
+
+
 ## Manifest
 
 You must declare the "debugger" permission in your extension's manifest to use this API.
@@ -25,6 +31,21 @@ You must declare the "debugger" permission in your extension's manifest to use t
 
 ## Examples
 
-You can find samples of this API in [Samples][1].
+You can find samples of this API in [Samples][16].
 
-[1]: /docs/extensions/mv2/samples#search:debugger
+[1]: https://chromedevtools.github.io/devtools-protocol/tot/Audits
+[2]: https://chromedevtools.github.io/devtools-protocol/tot/DOM
+[3]: https://chromedevtools.github.io/devtools-protocol/tot/Emulation
+[4]: https://chromedevtools.github.io/devtools-protocol/tot/Fetch
+[5]: https://chromedevtools.github.io/devtools-protocol/tot/IO
+[6]: https://chromedevtools.github.io/devtools-protocol/tot/Input
+[7]: https://chromedevtools.github.io/devtools-protocol/tot/Inspector
+[8]: https://chromedevtools.github.io/devtools-protocol/tot/Log
+[9]: https://chromedevtools.github.io/devtools-protocol/tot/Network
+[10]: https://chromedevtools.github.io/devtools-protocol/tot/Overlay
+[11]: https://chromedevtools.github.io/devtools-protocol/tot/Page
+[12]: https://chromedevtools.github.io/devtools-protocol/tot/Storage
+[13]: https://chromedevtools.github.io/devtools-protocol/tot/Target
+[14]: https://chromedevtools.github.io/devtools-protocol/tot/Tracing
+[15]: https://chromedevtools.github.io/devtools-protocol/tot/WebAuthn
+[16]: /docs/extensions/mv2/samples#search:debugger


### PR DESCRIPTION
Not all Chrome DevTools Protocol Domains are available for use by the
chrome.debugger extension API. Add a list of the available domains to
aid extension developers.

See also:
 - https://crbug.com/1313437
 - https://source.chromium.org/search?q=IsDomainAvailableToUntrustedClient