### PR TITLE
Fix typo in return statement of OffscreenCanvas blog example

### DIFF
--- a/site/en/blog/offscreen-canvas/index.md
+++ b/site/en/blog/offscreen-canvas/index.md
@@ -66,7 +66,7 @@ to calculate a gradient color in a worker:
         ctx.fillRect(0, 0, ctx.canvas.width, 1);
         const imgd = ctx.getImageData(0, 0, ctx.canvas.width, 1);
         const colors = imgd.data.slice(percent * 4, percent * 4 + 4);
-        return `rgba(${colors[0]}, ${colors[1]}, ${colors[2]}, ${colors[])`;
+        return `rgba(${colors[0]}, ${colors[1]}, ${colors[2]}, ${colors[3]})`;
     }
 
     getGradientColor(40);  // rgba(152, 0, 104, 255 )


### PR DESCRIPTION
**Fixes issue no. 1 of #3141** [ Bug in example code on OffscreenCanvas blog page ]

**Bug details :** 
Code example given in **Use OffscreenCanvas in a worker** section has problem in return statement where indexing the colors Uint8ClampedArray is missing for 4th element and closing curly brace } is missing too.
![Screenshot from 2022-07-06 19-29-22](https://user-images.githubusercontent.com/24647310/177572986-0035eca5-335c-4877-9913-9cf7674ff2bc.png)

**Change done :**
Indexed the colors array properly for 4th element and added missing curly brace.
![Screenshot from 2022-07-06 19-28-10](https://user-images.githubusercontent.com/24647310/177573027-c98b83c2-2d4f-4232-9291-5abcf90b9856.png)


**Tests done :**
- Tested changes locally by running the example code
- Tested locally whether the UI changes are properly done