### PR TITLE
Fix build error

### DIFF
--- a/site/en/blog/progress-in-the-privacy-sandbox-2022-06/index.md
+++ b/site/en/blog/progress-in-the-privacy-sandbox-2022-06/index.md
@@ -199,7 +199,7 @@ site response should then specify the `Content-Language` of the response and
 indicate if there are multiple languages available by using the `Vary` and
 `Variants` headers. For example:
 
-```plaintext
+```diff
 Get / HTTP/1.1
 Host: example.com
 Accept-Language: fr


### PR DESCRIPTION
`Error` was thrown:
    Error: "plaintext" is not a valid Prism.js language for eleventy-plugin-syntaxhighlight
 

Using suggestion from https://www.11ty.dev/docs/plugins/syntaxhighlight/:

> Alternatively, you can use diff without another language name to enable plaintext line highlighting.