### PR TITLE
Update dependencies to pick up yaml-redirect bugfix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "npm-run-all": "^4.1.5",
         "querystring": "^0.2.0",
         "readdirp": "^3.4.0",
-        "redirects-yaml": "^2.0.3",
+        "redirects-yaml": "^2.0.4",
         "rollup": "^2.22.2",
         "striptags": "^3.1.1",
         "typedoc": "^0.22.7",
@@ -19506,9 +19506,9 @@
       }
     },
     "node_modules/redirects-yaml": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/redirects-yaml/-/redirects-yaml-2.0.3.tgz",
-      "integrity": "sha512-TSsSYr/MdcJ5unXrI+0S/kDTZwhzo0jpM0WxXB0zdVopWG75G2cbdzp1ZJuPYY/FMyaPyXZFhBLqrMKficLouQ=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/redirects-yaml/-/redirects-yaml-2.0.4.tgz",
+      "integrity": "sha512-ReJJbFvP99S62JYjBnxIQYYz2almNW+ISu35ZtZ3D0s/HcReN9zch4Qhy9C9QqH8Xx6TudL9dHs4miSWvWrzkQ=="
     },
     "node_modules/regex-cache": {
       "version": "0.4.4",
@@ -42281,9 +42281,9 @@
       }
     },
     "redirects-yaml": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/redirects-yaml/-/redirects-yaml-2.0.3.tgz",
-      "integrity": "sha512-TSsSYr/MdcJ5unXrI+0S/kDTZwhzo0jpM0WxXB0zdVopWG75G2cbdzp1ZJuPYY/FMyaPyXZFhBLqrMKficLouQ=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/redirects-yaml/-/redirects-yaml-2.0.4.tgz",
+      "integrity": "sha512-ReJJbFvP99S62JYjBnxIQYYz2almNW+ISu35ZtZ3D0s/HcReN9zch4Qhy9C9QqH8Xx6TudL9dHs4miSWvWrzkQ=="
     },
     "regex-cache": {
       "version": "0.4.4",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "npm-run-all": "^4.1.5",
     "querystring": "^0.2.0",
     "readdirp": "^3.4.0",
-    "redirects-yaml": "^2.0.3",
+    "redirects-yaml": "^2.0.4",
     "rollup": "^2.22.2",
     "striptags": "^3.1.1",
     "typedoc": "^0.22.7",

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -137,7 +137,7 @@ redirects:
 # The new site doesn't break out Platform Apps APIs, but instead just locates them at the bottom of
 # the main Extensions reference page.
 - from: /apps/api_index
-  to: /docs/extensions/reference/#platform-apis
+  to: /docs/extensions/reference/#platform_apps_apis
 
 - from: /apps/app_codelab1_setup
   to: /docs/apps/app_codelab_intro

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -68,7 +68,7 @@ redirects:
 
 - from: /docs/privacy-sandbox/attribution-reporting-event-introduction/
   to: /docs/privacy-sandbox/attribution-reporting-experiment/
-  
+
 - from: /docs/privacy-sandbox/attribution-reporting-changes-january-2022/
   to: /blog/attribution-reporting-jan-2022-updates/
 


### PR DESCRIPTION
Version 2.0.4 of `yaml-redirect` allows the server to redirect requests to a given anchor on a page.