### PR TITLE
Update the extension version rules to match the API response

### DIFF
--- a/site/en/docs/extensions/mv3/manifest/version/index.md
+++ b/site/en/docs/extensions/mv3/manifest/version/index.md
@@ -9,9 +9,10 @@ description: Reference documentation for the version property of manifest.json.
 One to four dot-separated integers identifying the version of this extension. A couple of rules
 apply to the integers:
 
-- They must be between 0 and 65535, inclusive.
-- Non-zero integers can't start with 0. For example, 99999 and 032 are both invalid.
-- They must not be all zero. For example, 0.0 and 0.0.0.0 are invalid versions.
+- They must be between 0 and 65535, inclusive. For example, 99999 is invalid because it is too
+  large.
+- Non-zero integers can't start with 0. For example, 032 is invalid because it starts with a zero.
+- They must not be all zero. For example, 0 and 0.0.0.0 are invalid while 0.1.0.0 is valid.
 
 Here are some examples of valid versions:
 

--- a/site/en/docs/extensions/mv3/manifest/version/index.md
+++ b/site/en/docs/extensions/mv3/manifest/version/index.md
@@ -2,13 +2,16 @@
 layout: "layouts/doc-post.njk"
 title: "Manifest - Version"
 date: 2013-05-12
-updated: 2018-04-26
+updated: 2022-07-13
 description: Reference documentation for the version property of manifest.json.
 ---
 
 One to four dot-separated integers identifying the version of this extension. A couple of rules
-apply to the integers: they must be between 0 and 65535, inclusive, and non-zero integers can't
-start with 0. For example, 99999 and 032 are both invalid.
+apply to the integers:
+
+- They must be between 0 and 65535, inclusive.
+- Non-zero integers can't start with 0. For example, 99999 and 032 are both invalid.
+- They must not be all zero. For example, 0.0 and 0.0.0.0 are invalid versions.
 
 Here are some examples of valid versions:
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update the extension version rules to match the API response

## Why do we need this change?

The Chrome Web Store Publish API returns an error when an extension version is all zeroes. For example, 0, 0.0, 0.0.0, or 0.0.0.0. The error message includes a link to this document which does not help.

Here is an example for `"version": "0"`:

```
{
  "kind": "chromewebstore#item",
  "id": "null",
  "uploadState": "FAILURE",
  "itemError": [
    {
      "error_code": "PKG_MANIFEST_PARSE_ERROR",
      "error_detail": "The manifest has an invalid version: 0. Please format the version as defined \n      \u003ca href=\"https://developer.chrome.com/extensions/manifest/version\" target=\"_blank\"\u003e here\u003c/a\u003e."
    }
  ]
}
```
