### PR TITLE
Theme Documentation: Correct manifest documentation link and source links

### DIFF
--- a/site/en/docs/extensions/mv2/themes/index.md
+++ b/site/en/docs/extensions/mv2/themes/index.md
@@ -2,7 +2,7 @@
 layout: "layouts/doc-post.njk"
 title: "What are themes?"
 date: 2012-09-18
-updated: 2018-09-18
+updated: 2022-07-14
 description: Guidelines on how to create a theme.
 ---
 
@@ -28,6 +28,7 @@ Here is an example [`manifest.json`][3] file for a theme:
 
 ```json
 {
+  "manifest_version": 2,
   "version": "2.6",
   "name": "camo theme",
   "theme": {
@@ -64,7 +65,8 @@ Colors are in RGB format. To find the strings you can use within the "colors" fi
 ### images {: #images }
 
 Image resources use paths relative to the root of the extension. You can override any of the images
-that are specified by the strings in [`kPersistingImages`][5].
+that are specified by the strings in [`kPersistingImages`][5]. All images must be stored in PNG
+format or they [will not render properly][8].
 
 ### properties {: #properties }
 
@@ -89,10 +91,11 @@ Tints are in Hue-Saturation-Lightness (HSL) format, using floating-point numbers
 
 You can alternatively use `-1.0` for any of the HSL values to specify _no change_.
 
-[1]: /docs/extensions/packaging
+[1]: /docs/extensions/mv2/linux_hosting/#packaging
 [2]: https://chrome.google.com/webstore/category/themes
-[3]: /docs/extensions/mv2/tabs
-[4]: https://cs.chromium.org/search/?q=file:chrome/browser/themes%20symbol:kOverwritableColorTable
-[5]: https://cs.chromium.org/search/?q=file:chrome/browser/themes%20symbol:kPersistingImages$
-[6]: https://cs.chromium.org/search/?q=file:chrome/browser/themes%20symbol:kDisplayProperties$
-[7]: https://cs.chromium.org/search/?q=file:chrome/browser/themes%20symbol:kTintTable$
+[3]: /docs/extensions/mv2/manifest/
+[4]: https://source.chromium.org/search/?q=file:chrome/browser/themes%20symbol:kOverwritableColorTable
+[5]: https://source.chromium.org/search/?q=file:chrome/browser/themes%20symbol:kPersistingImages$
+[6]: https://source.chromium.org/search/?q=file:chrome/browser/themes%20symbol:kDisplayProperties$
+[7]: https://source.chromium.org/search/?q=file:chrome/browser/themes%20symbol:kTintTable$
+[8]: https://bugs.chromium.org/p/chromium/issues/detail?id=1200459

--- a/site/en/docs/extensions/mv3/themes/index.md
+++ b/site/en/docs/extensions/mv3/themes/index.md
@@ -26,6 +26,7 @@ Here is an example [`manifest.json`][3] file for a theme:
 
 ```json
 {
+  "manifest_version": 3,
   "version": "2.6",
   "name": "camo theme",
   "theme": {

--- a/site/en/docs/extensions/mv3/themes/index.md
+++ b/site/en/docs/extensions/mv3/themes/index.md
@@ -2,7 +2,7 @@
 layout: "layouts/doc-post.njk"
 title: "What are themes?"
 date: 2012-09-18
-updated: 2018-09-18
+updated: 2022-07-14
 description: Guidelines on how to create a theme.
 ---
 
@@ -90,9 +90,9 @@ You can alternatively use `-1.0` for any of the HSL values to specify _no change
 
 [1]: /docs/extensions/mv3/linux_hosting/#packaging
 [2]: https://chrome.google.com/webstore/category/themes
-[3]: /docs/extensions/reference/tabs
-[4]: https://cs.chromium.org/search/?q=file:chrome/browser/themes%20symbol:kOverwritableColorTable
-[5]: https://cs.chromium.org/search/?q=file:chrome/browser/themes%20symbol:kPersistingImages$
-[6]: https://cs.chromium.org/search/?q=file:chrome/browser/themes%20symbol:kDisplayProperties$
-[7]: https://cs.chromium.org/search/?q=file:chrome/browser/themes%20symbol:kTintTable$
+[3]: /docs/extensions/mv3/manifest/
+[4]: https://source.chromium.org/search/?q=file:chrome/browser/themes%20symbol:kOverwritableColorTable
+[5]: https://source.chromium.org/search/?q=file:chrome/browser/themes%20symbol:kPersistingImages$
+[6]: https://source.chromium.org/search/?q=file:chrome/browser/themes%20symbol:kDisplayProperties$
+[7]: https://source.chromium.org/search/?q=file:chrome/browser/themes%20symbol:kTintTable$
 [8]: https://bugs.chromium.org/p/chromium/issues/detail?id=1200459


### PR DESCRIPTION
Linking `manifest.json` to the `tabs` API page doesn't seem to make sense, so this PR changes the link to point to the Manifest page. However, the Manifest page doesn't mention the `theme` key so maybe somewhere else would be a better place to link?

Additionally, this PR adds a `manifest_version` to the sample theme manifest.

This PR also updates the cs.chromium.org links to source.chromium.org links.

This PR updates both the manifest v2 and manifest v3 theme pages.