### PR TITLE
Add web custom formats article

### DIFF
--- a/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
+++ b/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
@@ -6,7 +6,7 @@ subtitle: >
   format applications can opt in to if they wish to support such payloads.
 authors:
   - thomassteiner
-date: 2022-07-18
+date: 2022-07-25
 ---
 
 Up until now, the [Async Clipboard API](/async-clipboard/) supported a limited set of MIME types to
@@ -30,18 +30,21 @@ version&nbsp;104.
 ## Writing web custom formats to the clipboard
 
 Writing web custom formats to the clipboard is almost identical to
-[writing sanitized formats](<https://web.dev/async-clipboard/#write()>), except for the requirement to prepend the
-string `"web "` (including the trailing space) to the blob's MIME type.
+[writing sanitized formats](<https://web.dev/async-clipboard/#write()>), except for the requirement
+to prepend the string `"web "` (including the trailing space) to the blob's MIME type.
 
 ```js
-// Fetch a remote JPEG image and obtain its blob representation.
-const blob = await fetch('image.jpg').then((response) => response.blob());
+// Fetch remote JPEG and GIF images and obtain their blob representations.
+const jpegBlob = await fetch('image.jpg').then((response) => response.blob());
+const gifBlob = await fetch('image.gif').then((response) => response.blob());
+
 try {
-  // Write the image data to the clipboard, prepending the blob's actual
-  // type (`"image/jpeg"`) with the string `"web "`, so it becomes
-  // (`"web image/jpeg"`).
+  // Write the image data to the clipboard, prepending the blobs' actual
+  // types (`"image/jpeg"` and "image/gif") with the string `"web "`, so
+  // it becomes `"web image/jpeg"` and `"web image/gif"` respectively.
   const clipboardItem = new ClipboardItem({
-    [`web ${blob.type}`]: blob,
+    [`web ${jpegBlob.type}`]: jpegBlob,
+    [`web ${gifBlob.type}`]: gifBlob,
   });
   await navigator.clipboard.write([clipboardItem]);
 } catch (err) {
@@ -52,10 +55,8 @@ try {
 ## Reading web custom formats from the clipboard
 
 Similar to writing, reading web custom formats from the clipboard is almost identical to
-[reading sanitized formats](<https://web.dev/async-clipboard/#read()>). The only difference is that the app now
-needs to look for clipboard items whose type starts with `"web "`. Since the pasted blob is of a
-pseudo type (like `"web image/jpeg"`) that likely your app doesn't understand, you need to re-encode
-the blob using the original MIME type.
+[reading sanitized formats](<https://web.dev/async-clipboard/#read()>). The only difference is that
+the app now needs to look for clipboard items whose type starts with `"web "`.
 
 ```js
 try {
@@ -80,8 +81,8 @@ try {
 
 Since web custom formats like `web image/jpeg` are not something that typical platform-specific
 applications understand (since they would expect `image/jpeg`), there is the expectation for them to
-over time add support for such formats as an opt-in if their developers deem
-support for web custom formats to be relevant for their users.
+over time add support for such formats as an opt-in if their developers deem support for web custom
+formats to be relevant for their users.
 
 ## Demo
 

--- a/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
+++ b/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
@@ -41,8 +41,8 @@ try {
   // type (`"image/jpeg"`) with the string `"web "`, so it becomes
   // (`"web image/jpeg"`).
   const clipboardItem = new ClipboardItem({
-      [`web ${blob.type}`]: blob,
-    });
+    [`web ${blob.type}`]: blob,
+  });
   await navigator.clipboard.write([clipboardItem]);
 } catch (err) {
   console.error(err.name, err.message);

--- a/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
+++ b/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
@@ -35,7 +35,7 @@ string `" web"` (including the trailing space) to the blob's MIME type.
 
 ```js
 // Fetch a remote JPEG image and obtain its blob representation.
-const blob = await fetch('image.jpg').then((response) => response.blob);
+const blob = await fetch('image.jpg').then((response) => response.blob());
 try {
   // Write the image data to the clipboard, prepending the blob's actual
   // type (`"image/jpeg"`) with the string `"web "`, so it becomes

--- a/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
+++ b/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
@@ -1,10 +1,12 @@
 ---
+layout: 'layouts/blog-post.njk'
 title: Web custom formats for the Async Clipboard API
 subtitle: >
   Web custom formats let websites read and write arbitrary unsanitized payloads using a standardized
   format applications can opt in to if they wish to support such payloads.
 authors:
   - thomassteiner
+date: 2022-07-18
 ---
 
 Up until now, the [Async Clipboard API](/async-clipboard/) supported a limited set of MIME types to
@@ -22,15 +24,16 @@ clipboard.
 ## Writing web custom formats to the clipboard
 
 Writing web custom formats to the clipboard is almost identical to
-[writing sanitized formats](</async-clipboard/#write()>), except for the requirement to prepend the
+[writing sanitized formats](<https://web.dev/async-clipboard/#write()>), except for the requirement to prepend the
 string `" web"` (including the trailing space) to the blob's MIME type.
 
 ```js
 // Fetch a remote JPEG image and obtain its blob representation.
 const blob = await fetch('image.jpg').then((response) => response.blob);
 try {
-  // Write the image data to the clipboard, prepending the blob's actual type
-  // (`"image/jpeg"`) with the string `"web "`, so it becomes (`"web image/jpeg"`).
+  // Write the image data to the clipboard, prepending the blob's actual
+  // type (`"image/jpeg"`) with the string `"web "`, so it becomes
+  // (`"web image/jpeg"`).
   await navigator.clipboard.write([
     new ClipboardItem({
       [`web ${blob.type}`]: blob,
@@ -44,7 +47,7 @@ try {
 ## Reading web custom formats from the clipboard
 
 Similar to writing, reading web custom formats from the clipboard is almost identical to
-[reading sanitized formats](</async-clipboard/#read()>). The only difference is that the app now
+[reading sanitized formats](<https://web.dev/async-clipboard/#read()>). The only difference is that the app now
 needs to look for clipboard items whose type starts with `"web "`. Since the pasted blob is of a
 pseudo type (like `"web image/jpeg"`) that likely your app doesn't understand, you need to re-encode
 the blob using the original MIME type.
@@ -60,7 +63,9 @@ try {
         continue;
       }
       const webBlob = await clipboardItem.getType(type);
-      const blob = new Blob([webBlob], { type: webBlob.type.replace('web ', '') });
+      const blob = new Blob([webBlob], {
+        type: webBlob.type.replace('web ', ''),
+      });
       // Sanitize the blob if you need to, then process it in your app.
     }
   }
@@ -69,18 +74,22 @@ try {
 }
 ```
 
+## Interoperability with platform-specific apps
+
+Since web custom formats like `web image/jpeg` are not something that typical platform-specific
+applications understand (since they would expect `image/jpeg`), there is the expectation for them to
+over time add support for such formats as an opt-in if their developers deem
+support for web custom formats to be relevant for their users.
+
 ## Browser support
 
-The Async Clipboard API per se with image support is supported as of Chromium&nbsp;76.
-
-{% BrowserCompat 'api.Clipboard.write %}
-
-Custom formats for the Async Clipboard API are supported on desktop and on mobile Chromium as of
+The Async Clipboard API per se with image support is supported as of Chromium&nbsp;76. Custom
+formats for the Async Clipboard API are supported on desktop and on mobile Chromium as of
 version&nbsp;104.
 
 ## Demo
 
-<div class="glitch-embed-wrap" style="height: 420px; width: 100%;">
+<div class="glitch-embed-wrap" style="height: 1500px; width: 100%;">
   <iframe
     src="https://glitch.com/embed/#!/embed/custom-async-clipboard?path=script.js&previewSize=100"
     title="custom-async-clipboard on Glitch"

--- a/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
+++ b/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
@@ -93,7 +93,7 @@ version&nbsp;104.
   <iframe
     src="https://glitch.com/embed/#!/embed/custom-async-clipboard?path=script.js&previewSize=100"
     title="custom-async-clipboard on Glitch"
-    allow="clipboard;"
+    allow="clipboard-read; clipboard-write;"
     style="height: 100%; width: 100%; border: 0;">
   </iframe>
 </div>

--- a/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
+++ b/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
@@ -23,9 +23,9 @@ clipboard.
 
 ## Browser support
 
-The Async Clipboard API per se with image support is supported as of Chromium&nbsp;76. Custom
-formats for the Async Clipboard API are supported on desktop and on mobile Chromium as of
-version&nbsp;104.
+The Async Clipboard API per se with image support is supported as of Chromium&nbsp;76. Web
+custom formats for the Async Clipboard API are supported on desktop and on mobile Chromium
+as of version&nbsp;104.
 
 ## Writing web custom formats to the clipboard
 

--- a/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
+++ b/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
@@ -44,6 +44,8 @@ try {
   // Write the image data to the clipboard, prepending the blobs' actual
   // types (`"image/jpeg"` and "image/gif") with the string `"web "`, so
   // they become `"web image/jpeg"` and `"web image/gif"` respectively.
+  // The code elegantly makes use of computed property names:
+  // https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Object_initializer#computed_property_names.
   const clipboardItem = new ClipboardItem({
     [`web ${jpegBlob.type}`]: jpegBlob,
     [`web ${gifBlob.type}`]: gifBlob,

--- a/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
+++ b/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
@@ -9,7 +9,7 @@ authors:
 date: 2022-07-25
 ---
 
-Up until now, the [Async Clipboard API](/async-clipboard/) supported a limited set of MIME types to
+Up until now, the [Async Clipboard API](https://web.dev/async-clipboard/) supported a limited set of MIME types to
 be copied to and pasted from the system clipboard. Namely, these types are `text/plain`,
 `text/html`, and `image/png`, which the browser typically will sanitize, for example, to remove
 embedded `script` elements or `javascript:` links from an HTML string, or to prevent PNG

--- a/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
+++ b/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
@@ -21,6 +21,12 @@ it's crucial for the copied data to be identical with the pasted data. For such 
 Clipboard API now supports web custom formats that let developers write arbitrary data to the
 clipboard.
 
+## Browser support
+
+The Async Clipboard API per se with image support is supported as of Chromium&nbsp;76. Custom
+formats for the Async Clipboard API are supported on desktop and on mobile Chromium as of
+version&nbsp;104.
+
 ## Writing web custom formats to the clipboard
 
 Writing web custom formats to the clipboard is almost identical to
@@ -81,19 +87,13 @@ applications understand (since they would expect `image/jpeg`), there is the exp
 over time add support for such formats as an opt-in if their developers deem
 support for web custom formats to be relevant for their users.
 
-## Browser support
-
-The Async Clipboard API per se with image support is supported as of Chromium&nbsp;76. Custom
-formats for the Async Clipboard API are supported on desktop and on mobile Chromium as of
-version&nbsp;104.
-
 ## Demo
 
 <div class="glitch-embed-wrap" style="height: 1500px; width: 100%;">
   <iframe
-    src="https://glitch.com/embed/#!/embed/custom-async-clipboard?path=script.js&previewSize=100"
+    src="https://custom-async-clipboard.glitch.me/"
     title="custom-async-clipboard on Glitch"
-    allow="clipboard-read; clipboard-write;"
+    allow="clipboard-read; clipboard-write"
     style="height: 100%; width: 100%; border: 0;">
   </iframe>
 </div>

--- a/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
+++ b/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
@@ -43,7 +43,7 @@ const [jpegBlob, gifBlob] = await Promise.all([
 try {
   // Write the image data to the clipboard, prepending the blobs' actual
   // types (`"image/jpeg"` and "image/gif") with the string `"web "`, so
-  // it becomes `"web image/jpeg"` and `"web image/gif"` respectively.
+  // they become `"web image/jpeg"` and `"web image/gif"` respectively.
   const clipboardItem = new ClipboardItem({
     [`web ${jpegBlob.type}`]: jpegBlob,
     [`web ${gifBlob.type}`]: gifBlob,

--- a/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
+++ b/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
@@ -1,0 +1,90 @@
+---
+title: Web custom formats for the Async Clipboard API
+subtitle: >
+  Web custom formats let websites read and write arbitrary unsanitized payloads using a standardized
+  format applications can opt in to if they wish to support such payloads.
+authors:
+  - thomassteiner
+---
+
+Up until now, the [Async Clipboard API](/async-clipboard/) supported a limited set of MIME types to
+be copied to and pasted from the system clipboard. Namely, these types are `text/plain`,
+`text/html`, and `image/png`, which the browser typically will sanitize, for example, to remove
+embedded `script` elements or `javascript:` links from an HTML string, or to prevent PNG
+[decompression bomb](https://en.wikipedia.org/wiki/Zip_bomb) attacks.
+
+In some cases, though, it can be desirable to support unsanitized content on the clipboard, for
+example, when the application the data is thought for deals itself with the sanitization and where
+it's crucial for the copied data to be identical with the pasted data. For such cases, the Async
+Clipboard API now supports web custom formats that let developers write arbitrary data to the
+clipboard.
+
+## Writing web custom formats to the clipboard
+
+Writing web custom formats to the clipboard is almost identical to
+[writing sanitized formats](</async-clipboard/#write()>), except for the requirement to prepend the
+string `" web"` (including the trailing space) to the blob's MIME type.
+
+```js
+// Fetch a remote JPEG image and obtain its blob representation.
+const blob = await fetch('image.jpg').then((response) => response.blob);
+try {
+  // Write the image data to the clipboard, prepending the blob's actual type
+  // (`"image/jpeg"`) with the string `"web "`, so it becomes (`"web image/jpeg"`).
+  await navigator.clipboard.write([
+    new ClipboardItem({
+      [`web ${blob.type}`]: blob,
+    }),
+  ]);
+} catch (err) {
+  console.error(err.name, err.message);
+}
+```
+
+## Reading web custom formats from the clipboard
+
+Similar to writing, reading web custom formats from the clipboard is almost identical to
+[reading sanitized formats](</async-clipboard/#read()>). The only difference is that the app now
+needs to look for clipboard items whose type starts with `"web "`. Since the pasted blob is of a
+pseudo type (like `"web image/jpeg"`) that likely your app doesn't understand, you need to re-encode
+the blob using the original MIME type.
+
+```js
+try {
+  // Iterate over all clipboard items.
+  const clipboardItems = await navigator.clipboard.read();
+  for (const clipboardItem of clipboardItems) {
+    for (const type of clipboardItem.types) {
+      // Discard any types that are not web custom formats.
+      if (!type.startsWith('web ')) {
+        continue;
+      }
+      const webBlob = await clipboardItem.getType(type);
+      const blob = new Blob([webBlob], { type: webBlob.type.replace('web ', '') });
+      // Sanitize the blob if you need to, then process it in your app.
+    }
+  }
+} catch (err) {
+  console.error(err.name, err.message);
+}
+```
+
+## Browser support
+
+The Async Clipboard API per se with image support is supported as of Chromium&nbsp;76.
+
+{% BrowserCompat 'api.Clipboard.write %}
+
+Custom formats for the Async Clipboard API are supported on desktop and on mobile Chromium as of
+version&nbsp;104.
+
+## Demo
+
+<div class="glitch-embed-wrap" style="height: 420px; width: 100%;">
+  <iframe
+    src="https://glitch.com/embed/#!/embed/custom-async-clipboard?path=script.js&previewSize=100"
+    title="custom-async-clipboard on Glitch"
+    allow="clipboard;"
+    style="height: 100%; width: 100%; border: 0;">
+  </iframe>
+</div>

--- a/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
+++ b/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
@@ -35,8 +35,10 @@ to prepend the string `"web "` (including the trailing space) to the blob's MIME
 
 ```js
 // Fetch remote JPEG and GIF images and obtain their blob representations.
-const jpegBlob = await fetch('image.jpg').then((response) => response.blob());
-const gifBlob = await fetch('image.gif').then((response) => response.blob());
+const [jpegBlob, gifBlob] = await Promise.all([
+  fetch('image.jpg').then((response) => response.blob()),
+  fetch('image.gif').then((response) => response.blob()),
+]);
 
 try {
   // Write the image data to the clipboard, prepending the blobs' actual

--- a/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
+++ b/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
@@ -31,7 +31,7 @@ version&nbsp;104.
 
 Writing web custom formats to the clipboard is almost identical to
 [writing sanitized formats](<https://web.dev/async-clipboard/#write()>), except for the requirement to prepend the
-string `" web"` (including the trailing space) to the blob's MIME type.
+string `"web "` (including the trailing space) to the blob's MIME type.
 
 ```js
 // Fetch a remote JPEG image and obtain its blob representation.

--- a/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
+++ b/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
@@ -40,11 +40,10 @@ try {
   // Write the image data to the clipboard, prepending the blob's actual
   // type (`"image/jpeg"`) with the string `"web "`, so it becomes
   // (`"web image/jpeg"`).
-  await navigator.clipboard.write([
-    new ClipboardItem({
+  const clipboardItem = new ClipboardItem({
       [`web ${blob.type}`]: blob,
-    }),
-  ]);
+    });
+  await navigator.clipboard.write([clipboardItem]);
 } catch (err) {
   console.error(err.name, err.message);
 }

--- a/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
+++ b/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
@@ -2,30 +2,32 @@
 layout: 'layouts/blog-post.njk'
 title: Web custom formats for the Async Clipboard API
 subtitle: >
-  Web custom formats let websites read and write arbitrary unsanitized payloads using a standardized
+  Web custom formats let websites read and write arbitrary unsanitized payloads using a standard
   format applications can opt in to if they wish to support such payloads.
 authors:
   - thomassteiner
-date: 2022-07-25
+date: 2022-08-01
 ---
 
-Up until now, the [Async Clipboard API](https://web.dev/async-clipboard/) supported a limited set of MIME types to
-be copied to and pasted from the system clipboard. Namely, these types are `text/plain`,
-`text/html`, and `image/png`, which the browser typically will sanitize, for example, to remove
-embedded `script` elements or `javascript:` links from an HTML string, or to prevent PNG
+Until now, the [Async Clipboard API](https://web.dev/async-clipboard/) supported a limited set of
+MIME types to be copied to and pasted from the system clipboard, specifically: `text/plain`,
+`text/html`, and `image/png`. The browser typically sanitizes this to, for example, remove embedded
+`script` elements or `javascript:` links from an HTML string, or to prevent PNG
 [decompression bomb](https://en.wikipedia.org/wiki/Zip_bomb) attacks.
 
-In some cases, though, it can be desirable to support unsanitized content on the clipboard, for
-example, when the application the data is thought for deals itself with the sanitization and where
-it's crucial for the copied data to be identical with the pasted data. For such cases, the Async
-Clipboard API now supports web custom formats that let developers write arbitrary data to the
-clipboard.
+In some cases, though, it can be desirable to support unsanitized content on the clipboard:
+
+- Situations where the application deals with the sanitization itself.
+- Situations where it's crucial for the copied data to be identical with the pasted data.
+
+For such cases, the Async Clipboard API now supports web custom formats that let developers write
+arbitrary data to the clipboard.
 
 ## Browser support
 
-The Async Clipboard API per se with image support is supported as of Chromium&nbsp;76. Web
-custom formats for the Async Clipboard API are supported on desktop and on mobile Chromium
-as of version&nbsp;104.
+The Async Clipboard API per se with image support is supported as of Chromium&nbsp;76. Web custom
+formats for the Async Clipboard API are supported on desktop and on mobile Chromium as of
+version&nbsp;104.
 
 ## Writing web custom formats to the clipboard
 
@@ -33,7 +35,7 @@ Writing web custom formats to the clipboard is almost identical to
 [writing sanitized formats](<https://web.dev/async-clipboard/#write()>), except for the requirement
 to prepend the string `"web "` (including the trailing space) to the blob's MIME type.
 
-```js
+```js/14-15
 // Fetch remote JPEG and GIF images and obtain their blob representations.
 const [jpegBlob, gifBlob] = await Promise.all([
   fetch('image.jpg').then((response) => response.blob()),
@@ -58,7 +60,7 @@ try {
 
 ## Reading web custom formats from the clipboard
 
-Similar to writing, reading web custom formats from the clipboard is almost identical to
+As with writing, reading web custom formats from the clipboard is almost identical to
 [reading sanitized formats](<https://web.dev/async-clipboard/#read()>). The only difference is that
 the app now needs to look for clipboard items whose type starts with `"web "`.
 
@@ -83,12 +85,15 @@ try {
 
 ## Interoperability with platform-specific apps
 
-Since web custom formats like `web image/jpeg` are not something that typical platform-specific
-applications understand (since they would expect `image/jpeg`), there is the expectation for them to
-over time add support for such formats as an opt-in if their developers deem support for web custom
-formats to be relevant for their users.
+Web custom formats like `web image/jpeg` are not something that typical platform-specific
+applications understand (since they would expect `image/jpeg`). Over time, concerned apps are
+expected to add support for such formats as an opt-in if their developers deem support for web
+custom formats to be relevant for their users.
 
 ## Demo
+
+You can try the demo below and
+[view the source code](https://glitch.com/edit/#!/custom-async-clipboard) to see how the demo works.
 
 <div class="glitch-embed-wrap" style="height: 1500px; width: 100%;">
   <iframe
@@ -98,3 +103,7 @@ formats to be relevant for their users.
     style="height: 100%; width: 100%; border: 0;">
   </iframe>
 </div>
+
+## Acknowledgements
+
+This article was reviewed by [Joe Medley](https://github.com/jpmedley).

--- a/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
+++ b/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
@@ -35,7 +35,7 @@ Writing web custom formats to the clipboard is almost identical to
 [writing sanitized formats](<https://web.dev/async-clipboard/#write()>), except for the requirement
 to prepend the string `"web "` (including the trailing space) to the blob's MIME type.
 
-```js/14-15
+```js/13-14
 // Fetch remote JPEG and GIF images and obtain their blob representations.
 const [jpegBlob, gifBlob] = await Promise.all([
   fetch('image.jpg').then((response) => response.blob()),
@@ -64,7 +64,7 @@ As with writing, reading web custom formats from the clipboard is almost identic
 [reading sanitized formats](<https://web.dev/async-clipboard/#read()>). The only difference is that
 the app now needs to look for clipboard items whose type starts with `"web "`.
 
-```js
+```js/6
 try {
   // Iterate over all clipboard items.
   const clipboardItems = await navigator.clipboard.read();
@@ -106,4 +106,5 @@ You can try the demo below and
 
 ## Acknowledgements
 
-This article was reviewed by [Joe Medley](https://github.com/jpmedley).
+This article was reviewed by [Joe Medley](https://github.com/jpmedley)
+and [François Beaufort](https://github.com/beaufortfrancois).

--- a/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
+++ b/site/en/blog/web-custom-formats-for-the-async-clipboard-api/index.md
@@ -67,10 +67,7 @@ try {
       if (!type.startsWith('web ')) {
         continue;
       }
-      const webBlob = await clipboardItem.getType(type);
-      const blob = new Blob([webBlob], {
-        type: webBlob.type.replace('web ', ''),
-      });
+      const blob = await clipboardItem.getType(type);
       // Sanitize the blob if you need to, then process it in your app.
     }
   }


### PR DESCRIPTION
Fixes https://github.com/GoogleChrome/developer.chrome.com/issues/3245.

Changes proposed in this pull request:

- Add the article.
- [Staging preview](https://deploy-preview-3249--developer-chrome-com.netlify.app/blog/web-custom-formats-for-the-async-clipboard-api/)