### PR TITLE
Update CrUX docs with API and BigQuery access info

### DIFF
--- a/site/_data/authorsData.json
+++ b/site/_data/authorsData.json
@@ -780,5 +780,12 @@
     "github": "christianliebel",
     "glitch": "christianliebel",
     "image": "image/8WbTDNrhLsU0El80frMBGE4eMCD3/pguQ0oykD0nNu9jM5OcP.jpeg"
+  },
+  "tunetheweb": {
+    "country": "IE",
+    "twitter": "tunetheweb",
+    "github": "tunetheweb",
+    "homepage": "https://www.tunetheweb.com",
+    "image": "image/W3z1f5ZkBJSgL1V1IfloTIctbIF3/FzCdsVVLfgdqxfgs6BDc.jpeg"
   }
 }

--- a/site/_data/i18n/authors.yaml
+++ b/site/_data/i18n/authors.yaml
@@ -861,3 +861,20 @@ sidlall:
     en: Sid Lall
   description:
     en: Product Manager at Google
+tunetheweb:
+  title:
+    en: Barry Pollard
+    es: Barry Pollard
+    ja: Barry Pollard
+    ko: Barry Pollard
+    pt: Barry Pollard
+    ru: Barry Pollard
+    zh: Barry Pollard
+  description:
+    en: Web Performance Developer Advocate for Google
+    es: Rendimiento web aesarrollador partidario para Google
+    ja: Google を対象とした Developer Advocate
+    ko: Google의 개발자 애드버킷
+    pt: Developer Advocate para o Google
+    ru: Developer Advocate по вопросам Google
+    zh: 负责 Google 的开发技术推广工程师

--- a/site/en/blog/crux-2018-01/index.md
+++ b/site/en/blog/crux-2018-01/index.md
@@ -20,7 +20,7 @@ date: 2018-01-24
 
 # Optional
 # Include an updated date when you update your post
-updated: 2018-03-05
+updated: 2022-07-19
 
 # Optional
 # How to add a new tag
@@ -31,7 +31,7 @@ updated: 2018-03-05
 ---
 
 The
-[Chrome User Experience Report](https://developers.google.com/web/tools/chrome-user-experience-report/)
+[Chrome User Experience Report](/docs/crux/)
 (CrUX) is a public dataset of real user performance data. Since we
 [announced](https://blog.chromium.org/2017/10/introducing-chrome-user-experience-report.html)
 the report, one of the most requested additions has been the ability to better
@@ -40,7 +40,7 @@ feedback, we are expanding the existing CrUX dataset––which provides a globa
 view across all geographic regions––to also include a collection of separate
 country-specific datasets!
 
-  
+
 <figure>
 {% Img src="image/T4FyVKpzu4WKF1kBNvXepbi08t52/64Hyz3kg8A4LSqmCNYkK.png", alt="Map of countries included in the CrUX dataset", width="800", height="929" %}
   <figcaption>
@@ -64,7 +64,7 @@ The familiar `all` dataset is still there to capture the global aggregate
 performance data. Within each dataset there are monthly tables starting with
 the most recent report, `201712`. For a detailed walkthrough on how to get
 started, please refer to our updated
-[CrUX documentation](https://developers.google.com/web/tools/chrome-user-experience-report/).
+[CrUX documentation](/docs/crux/).
 
 We’re excited to share this new data with you and hope to see you use it in
 ways to improve the user experience on the web. To get help, ask questions,

--- a/site/en/blog/crux-rank-magnitude/index.md
+++ b/site/en/blog/crux-rank-magnitude/index.md
@@ -21,20 +21,20 @@ date: 2021-03-09
 
 # Optional
 # Include an updated date when you update your post
-updated: 2021-03-09
+updated: 2022-07-19
 
 # Optional
 # How to add a new tag
 # https://developer.chrome.com/docs/handbook/how-to/add-a-tag/
 #tags:
-  
+
 
 ---
 
 Starting with the [February 2021
-dataset](https://developers.google.com/web/tools/chrome-user-experience-report/bigquery/changelog#202101),
+dataset](/docs/crux/release-notes/#202101),
 we’re adding an experimental metric to the [CrUX report in
-BigQuery](https://developers.google.com/web/tools/chrome-user-experience-report/bigquery/getting-started)
+BigQuery](/docs/crux/bigquery/)
 which distinguishes the popularity of origins by orders of magnitude: The top 1k
 origins, top 10k, top 100k, top 1M, ... Let’s see how this looks in practice:
 

--- a/site/en/blog/first-input-delay-in-crux/index.md
+++ b/site/en/blog/first-input-delay-in-crux/index.md
@@ -2,7 +2,7 @@
 layout: 'layouts/blog-post.njk'
 title: Experimenting with First Input Delay in the Chrome UX Report
 date: 2018-07-10
-updated: 2018-07-10
+updated: 2022-07-19
 authors:
   - rviscomi
 description: Announcing the addition of the First Input Delay (FID) experimental metric to the Chrome User Experience Report.
@@ -11,7 +11,7 @@ description: Announcing the addition of the First Input Delay (FID) experimental
 
 
 The goal of the
-[Chrome User Experience Report](https://developers.google.com/web/tools/chrome-user-experience-report/)
+[Chrome User Experience Report](/docs/crux/)
 is to help the web community understand the distribution and evolution of real
 user performance. To date, our focus has been on paint and page load metrics
 like First Contentful Paint (FCP) and Onload (OL), which have helped us
@@ -43,7 +43,7 @@ announcement blog post:
 <figure>
   {% YouTube id="5mo8JfIi3HI" %}
 	<figcaption class="clearfix align-center">
-			Animation showing how a busy main thread delays the response to a 
+			Animation showing how a busy main thread delays the response to a
 			user interaction.
 	</figcaption>
 </figure>
@@ -207,7 +207,7 @@ of interactivity experiences. Using this baseline, we can observe its change in
 future releases or benchmark individual origins. If you’d like to start
 collecting FID in your own site’s field measurements, sign up for the origin
 trial by going to [bit.ly/event-timing-ot](http://bit.ly/event-timing-ot)
-and select the Event Timing feature. And of course, [start exploring](https://developers.google.com/web/tools/chrome-user-experience-report/getting-started)
+and select the Event Timing feature. And of course, [start exploring](/docs/crux/)
 the dataset for interesting insights into the state of interactivity on the web.
 This is still an experimental metric, so please give us your feedback and share
 your analysis on the [Chrome UX Report discussion group](https://groups.google.com/a/chromium.org/forum/#!forum/chrome-ux-report)

--- a/site/en/blog/notification-permission-data-in-crux/index.md
+++ b/site/en/blog/notification-permission-data-in-crux/index.md
@@ -22,19 +22,19 @@ date: 2020-02-11
 
 # Optional
 # Include an updated date when you update your post
-updated: 2020-02-11
+updated: 2022-07-19
 
 # Optional
 # How to add a new tag
 # https://developer.chrome.com/docs/handbook/how-to/add-a-tag/
 #tags:
-  
+
 
 ---
 
 Chrome 80 introduced [quieter permission UI for notifications][quieter-not-post].
 To help site owners understand notification permission metrics, we’re adding this
-data to the [Chrome User Experience Report](https://developers.google.com/web/tools/chrome-user-experience-report/)
+data to the [Chrome User Experience Report](/docs/crux/)
 (CrUX) in the [202001 dataset][202001-crux-dataset], released on February 11,
 2020. This will allow site owners gain a better understanding of typical user
 notification permission responses for their sites and comparable sites in
@@ -74,17 +74,17 @@ table below.
       <td><i>Dismiss</i></td>
       <td>
         The user closes the permission prompt without any explicit
-        response. Tab close counts as a dismiss.  On mobile, tab switch also 
-        counts as a dismiss action, and the quiet UI has an explicit user 
-		    dismiss option.  
+        response. Tab close counts as a dismiss.  On mobile, tab switch also
+        counts as a dismiss action, and the quiet UI has an explicit user
+		    dismiss option.
       </td>
     </tr>
     <tr>
       <td><i>Ignore</i></td>
       <td>
         The user does not interact with the prompt at all. Navigation events
-        also count as an ignore, such as the back button or navigation using the 
-        omnibox.  
+        also count as an ignore, such as the back button or navigation using the
+        omnibox.
       </td>
     </tr>
   </tbody>
@@ -109,17 +109,17 @@ are a clear indicator that the website should review the
 
 It is normal and expected that different types of sites will have different
 Accept and Block rates. For example, a chat app or email app has a very strong
-use case and we could expect Accept rates to be quite high. 
+use case and we could expect Accept rates to be quite high.
 
-It’s also normal that rates for the same site may vary significantly between 
-desktop and mobile, as the use cases can be different and users may have a 
-strong preference for notification on one type of device over the other. The 
-large variance between mobile and desktop is the reason that automatic site 
-enrollment in quiet notification permission UI is separated by device type. 
-Some sites may be enrolled in quiet UI only on mobile or only on desktop.  
+It’s also normal that rates for the same site may vary significantly between
+desktop and mobile, as the use cases can be different and users may have a
+strong preference for notification on one type of device over the other. The
+large variance between mobile and desktop is the reason that automatic site
+enrollment in quiet notification permission UI is separated by device type.
+Some sites may be enrolled in quiet UI only on mobile or only on desktop.
 
 As more users enroll in quieter notifications UI we expect that Ignore
-rates will increase over time relative to other metrics. You should view this 
+rates will increase over time relative to other metrics. You should view this
 trend as normal and expected.
 
 
@@ -130,7 +130,7 @@ trend as normal and expected.
 Let your users take the initiative and turn on notifications at their own
 pace. Introduce toggles or buttons discretely as part of preexisting UI
 surfaces so that they are shown at steps of the user’s workflow where there
-is good reason to believe that they might want to opt in to receiving timely 
+is good reason to believe that they might want to opt in to receiving timely
 updates.
 
 Avoid showing prompts and/or overlays without context or immediately after a

--- a/site/en/docs/crux/api/index.md
+++ b/site/en/docs/crux/api/index.md
@@ -22,7 +22,7 @@ date: 2022-06-23
 
 # Optional
 # Include an updated date when you update your post
-updated: 2022-07-16
+updated: 2022-07-19
 
 # Optional
 # How to add a new author
@@ -284,7 +284,7 @@ The CrUX dataset is processed through a pipeline to consolidate, aggregate and f
 
 The data in the Chrome UX Report is a 28-day rolling average of aggregated metrics. This means that the data presented in the Chrome UX Report at any given time is actually data for the past 28 days aggregated together.
 
-This is similar to how the [CrUX dataset on BigQuery](https://developers.google.com/web/tools/chrome-user-experience-report/bigquery/getting-started) aggregates monthly reports.
+This is similar to how the [CrUX dataset on BigQuery](../bigquery/) aggregates monthly reports.
 
 ### Daily updates
 

--- a/site/en/docs/crux/api/index.md
+++ b/site/en/docs/crux/api/index.md
@@ -22,7 +22,7 @@ date: 2022-06-23
 
 # Optional
 # Include an updated date when you update your post
-# updated: 2020-10-16
+updated: 2022-07-16
 
 # Optional
 # How to add a new author
@@ -41,6 +41,14 @@ tags:
 ## Common use case
 
 The CrUX API allows for the querying of user experience metrics for a specific URI like "Get metrics for the `https://example.com` origin."
+
+## CrUX API Key
+
+Using CrUX requires a Google Cloud API key. You can create one in the [Credentials page](https://console.developers.google.com/apis/credentials) and permission it for `Chrome UX Report API` usage.
+
+After you have an API key, your application can append the query parameter key=yourAPIKey to all request URLs.
+
+The API key is safe for embedding in URLs; it doesn't need any encoding.
 
 ## Data model
 

--- a/site/en/docs/crux/api/index.md
+++ b/site/en/docs/crux/api/index.md
@@ -44,9 +44,9 @@ The CrUX API allows for the querying of user experience metrics for a specific U
 
 ## CrUX API Key
 
-Using CrUX requires a Google Cloud API key. You can create one in the [Credentials page](https://console.developers.google.com/apis/credentials) and permission it for `Chrome UX Report API` usage.
+Using the CrUX API requires a Google Cloud API key. You can create one in the [Credentials](https://console.developers.google.com/apis/credentials) page and provision it for `Chrome UX Report API` usage.
 
-After you have an API key, your application can append the query parameter key=yourAPIKey to all request URLs.
+After you have an API key, your application can append the query parameter `key=[YOUR_API_KEY]` to all request URLs.
 
 The API key is safe for embedding in URLs; it doesn't need any encoding.
 

--- a/site/en/docs/crux/bigquery/index.md
+++ b/site/en/docs/crux/bigquery/index.md
@@ -22,7 +22,7 @@ date: 2022-06-23
 
 # Optional
 # Include an updated date when you update your post
-updated: 2022-07-18
+updated: 2022-07-19
 
 # Optional
 # How to add a new author
@@ -47,7 +47,7 @@ The data is structured by monthly release, as well as a number of summary tables
 
 ## Accessing the dataset in GCP
 
-Using BigQuery requires a [GCP project](https://developers.google.com/web/tools/chrome-user-experience-report/getting-started#getting-started) and basic knowledge of SQL. The [CrUX dataset on BigQuery](https://console.cloud.google.com/bigquery?p=chrome-ux-report&d=all&page=dataset) is free to access and explore up to the limits of the [free tier](https://cloud.google.com/bigquery/pricing#queries), which is renewed monthly and provided by BigQuery. Additionally, new GCP users may be eligible for a [signup credit](https://cloud.google.com/free/docs/frequently-asked-questions#free-trial) to cover expenses beyond the free tier. Note that a credit card must be provided for the GCP project, see [Why do I need to provide a credit card?](https://cloud.google.com/free/docs/frequently-asked-questions#why-credit-card).
+Using BigQuery requires a [GCP project](https://cloud.google.com/) and basic knowledge of SQL. The [CrUX dataset on BigQuery](https://console.cloud.google.com/bigquery?p=chrome-ux-report&d=all&page=dataset) is free to access and explore up to the limits of the [free tier](https://cloud.google.com/bigquery/pricing#queries), which is renewed monthly and provided by BigQuery. Additionally, new GCP users may be eligible for a [signup credit](https://cloud.google.com/free/docs/frequently-asked-questions#free-trial) to cover expenses beyond the free tier. Note that a credit card must be provided for the GCP project, see [Why do I need to provide a credit card?](https://cloud.google.com/free/docs/frequently-asked-questions#why-credit-card).
 
 If this is your first time using BigQuery then follow below steps to set up a project:
 1. Navigate to [Google Cloud Platform](https://console.cloud.google.com/projectcreate).

--- a/site/en/docs/crux/bigquery/index.md
+++ b/site/en/docs/crux/bigquery/index.md
@@ -22,7 +22,7 @@ date: 2022-06-23
 
 # Optional
 # Include an updated date when you update your post
-# updated: 2020-10-16
+updated: 2022-07-18
 
 # Optional
 # How to add a new author
@@ -45,7 +45,18 @@ CrUX on BigQuery allows users to directly query the full dataset going back to 2
 
 The data is structured by monthly release, as well as a number of summary tables to provide simple access for querying the data. These are documented further below.
 
-Using BigQuery requires a [GCP project](https://developers.google.com/web/tools/chrome-user-experience-report/getting-started#getting-started) and basic knowledge of SQL. The CrUX dataset on BigQuery is free to access and explore up to the limits of the [free tier](https://cloud.google.com/bigquery/pricing#queries), which is renewed monthly and provided by BigQuery. Additionally, new GCP users may be eligible for a [signup credit](https://cloud.google.com/free/docs/frequently-asked-questions#free-trial) to cover expenses beyond the free tier. Note that a credit card must be provided for the GCP project, see [Why do I need to provide a credit card?](https://cloud.google.com/free/docs/frequently-asked-questions#why-credit-card).
+## Accessing the dataset in GCP
+
+Using BigQuery requires a [GCP project](https://developers.google.com/web/tools/chrome-user-experience-report/getting-started#getting-started) and basic knowledge of SQL. The [CrUX dataset on BigQuery](https://console.cloud.google.com/bigquery?p=chrome-ux-report&d=all&page=dataset) is free to access and explore up to the limits of the [free tier](https://cloud.google.com/bigquery/pricing#queries), which is renewed monthly and provided by BigQuery. Additionally, new GCP users may be eligible for a [signup credit](https://cloud.google.com/free/docs/frequently-asked-questions#free-trial) to cover expenses beyond the free tier. Note that a credit card must be provided for the GCP project, see [Why do I need to provide a credit card?](https://cloud.google.com/free/docs/frequently-asked-questions#why-credit-card).
+
+If this is your first time using BigQuery then follow below steps to set up a project:
+1. Navigate to [Google Cloud Platform](https://console.cloud.google.com/projectcreate).
+2. Click **Create a Project**.
+3. Give your new project a name like “My Chrome UX Report” and click Create.
+4. Provide your billing information if prompted.
+5. Navigate to the [CrUX dataset on BigQuery](https://console.cloud.google.com/bigquery?p=chrome-ux-report&d=all&page=dataset)
+
+Now you’re ready to start querying the dataset.
 
 {% Aside %}
 For example queries see the [getting started guide on web.dev](https://web.dev/chrome-ux-report-bigquery/).

--- a/site/en/docs/crux/release-notes/index.md
+++ b/site/en/docs/crux/release-notes/index.md
@@ -21,7 +21,7 @@ date: 2017-10-01
 
 # Optional
 # Include an updated date when you update your post
-updated: 2022-06-14
+updated: 2022-06-19
 
 # Optional
 # How to add a new author
@@ -470,8 +470,8 @@ Notable stats
  : - 5,821,306 origins
 
 What's new
- : - The [FID](https://developers.google.com/web/tools/chrome-user-experience-report/bigquery/#first-input-delay) metric was moved from `experimental.first_input_delay` to `first_input.delay`
- : - The [CLS](https://developers.google.com/web/tools/chrome-user-experience-report/bigquery/#cumulative-layout-shift) metric was moved from `experimental.cumulative_layout_shift` to `layout_instability.cumulative_layout_shift`
+ : - The [FID](/docs/crux/methodology/#fid-metric) metric was moved from `experimental.first_input_delay` to `first_input.delay`
+ : - The [CLS](/docs/crux/methodology/#cls-metric) metric was moved from `experimental.cumulative_layout_shift` to `layout_instability.cumulative_layout_shift`
 
 ## 201910
 
@@ -484,8 +484,8 @@ Notable stats
  : - 6,008,004 origins
 
 What's new
- : - The [LCP](https://developers.google.com/web/tools/chrome-user-experience-report/bigquery/#largest-contentful-paint) metric was launched as `largest_contentful_paint`
- : - [CLS](https://developers.google.com/web/tools/chrome-user-experience-report/bigquery/#cumulative-layout-shift) was updated to take [move distance](https://github.com/WICG/layout-instability/blob/main/README.md#distance-fraction) into account. Coverage may be lower while Chrome users upgrade to the latest version of the Layout Instability API
+ : - The [LCP](/docs/crux/methodology/#lcp-metric) metric was launched as `largest_contentful_paint`
+ : - [CLS](/docs/crux/methodology/#cls-metric) was updated to take [move distance](https://github.com/WICG/layout-instability/blob/main/README.md#distance-fraction) into account. Coverage may be lower while Chrome users upgrade to the latest version of the Layout Instability API
 
 ## 201908
 
@@ -493,7 +493,7 @@ Notable stats
  : - 6,011,463 origins
 
 What's new
- : - [FID](https://developers.google.com/web/tools/chrome-user-experience-report/bigquery/#first-input-delay) coverage has returned to normal
+ : - [FID](/docs/crux/methodology/#fid-metric) coverage has returned to normal
  : - The average percent of fast experiences for most metrics dropped by about 2%, this appears to be due to a [bug in Chrome](https://chromium.googlesource.com/chromium/src/+/main/docs/speed/metrics_changelog/2019_12_fcp.md)
 
 ## 201907
@@ -502,7 +502,7 @@ Notable stats
  : - 5,612,504 origins
 
 What's new
- : - There was an [incremental update](https://chromium.googlesource.com/chromium/src/+/main/docs/speed/metrics_changelog/2019_07_fid.md) to Chrome's [FID](https://developers.google.com/web/tools/chrome-user-experience-report/bigquery/#first-input-delay) implementation, which included pointer events on mobile. Coverage will be lower while Chrome users update to the latest version
+ : - There was an [incremental update](https://chromium.googlesource.com/chromium/src/+/main/docs/speed/metrics_changelog/2019_07_fid.md) to Chrome's [FID](/docs/crux/methodology/#fid-metric) implementation, which included pointer events on mobile. Coverage will be lower while Chrome users update to the latest version
 
 ## 201906
 
@@ -510,7 +510,7 @@ Notable stats
  : - 5,624,797 origins
 
 What's new
- : - The [TTFB](https://developers.google.com/web/tools/chrome-user-experience-report/bigquery/#time-to-first-byte) metric was added to the list of experimental metrics as `experimental.time_to_first_byte`
+ : - The [TTFB](/docs/crux/methodology/#ttfb-metric) metric was added to the list of experimental metrics as `experimental.time_to_first_byte`
 
 ## 201905
 
@@ -518,7 +518,7 @@ Notable stats
  : - 5,884,155 origins
 
 What's new
- : - The [CLS](https://developers.google.com/web/tools/chrome-user-experience-report/bigquery/#cumulative-layout-shift) metric was added to the list of experimental metrics as `experimental.cumulative_layout_shift`
+ : - The [CLS](/docs/crux/methodology/#cls-metric) metric was added to the list of experimental metrics as `experimental.cumulative_layout_shift`
 
 ## 201904
 
@@ -526,7 +526,7 @@ Notable stats
  : - 5,744,982 origins
 
 What's new
- : - There was an incremental update to Chrome's [FID](https://developers.google.com/web/tools/chrome-user-experience-report/bigquery/#first-input-delay) implementation. Coverage will be lower while Chrome users update to the latest version
+ : - There was an incremental update to Chrome's [FID](/docs/crux/methodology/#fid-metric) implementation. Coverage will be lower while Chrome users update to the latest version
 
 ## 201903
 
@@ -534,7 +534,7 @@ Notable stats
  : - 5,703,255 origins
 
 What's new
- : - There was an incremental update to Chrome's [FID](https://developers.google.com/web/tools/chrome-user-experience-report/bigquery/#first-input-delay) implementation. Coverage will be lower while Chrome users update to the latest version
+ : - There was an incremental update to Chrome's [FID](/docs/crux/methodology/#fid-metric) implementation. Coverage will be lower while Chrome users update to the latest version
 
 ## 201902
 
@@ -585,7 +585,7 @@ Notable stats
  : - 4,134,123 origins
 
 What's new
- : - The [FID](https://developers.google.com/web/tools/chrome-user-experience-report/bigquery/#first-input-delay) metric was added to the list of experimental metrics as `experimental.first_input_delay` ([learn more](https://developers.google.com/web/updates/2018/07/first-input-delay-in-crux))
+ : - The [FID](/docs/crux/methodology/#fid-metric) metric was added to the list of experimental metrics as `experimental.first_input_delay` ([learn more](https://developers.google.com/web/updates/2018/07/first-input-delay-in-crux))
 
 ## 201805
 


### PR DESCRIPTION
While updating the docs one web.dev in https://github.com/GoogleChrome/web.dev/pull/8355 we discovered a few things on the old CrUX docs that didn't make it across but probably should have.

Changes proposed in this pull request:
- Update the API docs to give a little guidance on how to get an API key. Similar to https://developers.google.com/web/tools/chrome-user-experience-report/api/guides/getting-started#APIKey (but without the one click solution 😔).
- Update the BigQuery docs to give a little guidance eon how to get BigQuery GCP access similar to https://developers.google.com/web/tools/chrome-user-experience-report/bigquery/getting-started