### PR TITLE
[CRX] Refactor permissions warning

### DIFF
--- a/site/_includes/layouts/namespace-reference.njk
+++ b/site/_includes/layouts/namespace-reference.njk
@@ -79,19 +79,7 @@
                     <code>{{ permission }}</code><br />
                   {% endfor %}
                   {{ extra_permissions_html | safe }}
-                </div>
-              </li>
-              <li>
-                <div class="code-sections__label">Has warning?</div>
-                <div>    
                   {{ has_warning | safe }}
-                </div>
-              </li>
-            {% else %}
-            <li>
-                <div class="code-sections__label">Permission</div>
-                <div>
-                {{ special_permissions_html | safe }}
                 </div>
               </li>
             {% endif %}

--- a/site/en/docs/extensions/reference/bookmarks/index.md
+++ b/site/en/docs/extensions/reference/bookmarks/index.md
@@ -1,6 +1,6 @@
 ---
 api: bookmarks
-has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
+has_warning: This permission <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">triggers a warning</a>.
 
 ---
 

--- a/site/en/docs/extensions/reference/contentSettings/index.md
+++ b/site/en/docs/extensions/reference/contentSettings/index.md
@@ -1,7 +1,6 @@
 ---
 api: contentSettings
-has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
-
+has_warning: This permission <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">triggers a warning</a>.
 ---
 
 ## Manifest

--- a/site/en/docs/extensions/reference/debugger/index.md
+++ b/site/en/docs/extensions/reference/debugger/index.md
@@ -1,6 +1,6 @@
 ---
 api: debugger
-has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
+has_warning: This permission <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">triggers a warning</a>.
 ---
 
 ## Notes

--- a/site/en/docs/extensions/reference/declarativeNetRequest/index.md
+++ b/site/en/docs/extensions/reference/declarativeNetRequest/index.md
@@ -3,7 +3,7 @@ api: declarativeNetRequest
 extra_permissions_html:
   <code>declarativeNetRequestFeedback</code><br/>
   <a href="/docs/extensions/mv3/declare_permissions#host-permissions">host permissions</a><br />
-has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
+has_warning: One or more of these permissions <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">triggers a warning</a>.
 
 ---
 

--- a/site/en/docs/extensions/reference/desktopCapture/index.md
+++ b/site/en/docs/extensions/reference/desktopCapture/index.md
@@ -1,6 +1,6 @@
 ---
 api: desktopCapture
-has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
+has_warning: This permission <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">triggers a warning</a>.
 
 ---
 

--- a/site/en/docs/extensions/reference/downloads/index.md
+++ b/site/en/docs/extensions/reference/downloads/index.md
@@ -1,6 +1,6 @@
 ---
 api: downloads
-has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
+has_warning: This permission <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">triggers a warning</a>.
 ---
 
 ## Manifest

--- a/site/en/docs/extensions/reference/history/index.md
+++ b/site/en/docs/extensions/reference/history/index.md
@@ -1,6 +1,6 @@
 ---
 api: history
-has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
+has_warning: This permission <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">triggers a warning</a>.
 ---
 
 ## Manifest

--- a/site/en/docs/extensions/reference/management/index.md
+++ b/site/en/docs/extensions/reference/management/index.md
@@ -1,6 +1,6 @@
 ---
 api: management
-has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
+has_warning: This permission <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">triggers a warning</a>.
 ---
 
 ## Manifest

--- a/site/en/docs/extensions/reference/notifications/index.md
+++ b/site/en/docs/extensions/reference/notifications/index.md
@@ -1,6 +1,6 @@
 ---
 api: notifications
-has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
+has_warning: This permission <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">triggers a warning</a>.
 ---
 
 <!-- Intentionally blank -->

--- a/site/en/docs/extensions/reference/pageCapture/index.md
+++ b/site/en/docs/extensions/reference/pageCapture/index.md
@@ -1,6 +1,6 @@
 ---
 api: pageCapture
-has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
+has_warning: This permission <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">triggers a warning</a>.
 ---
 
 MHTML is a [standard format][1] supported by most browsers. It encapsulates in a single file a page

--- a/site/en/docs/extensions/reference/privacy/index.md
+++ b/site/en/docs/extensions/reference/privacy/index.md
@@ -1,6 +1,6 @@
 ---
 api: privacy
-has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
+has_warning: This permission <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">triggers a warning</a>.
 ---
 
 {% Aside %}

--- a/site/en/docs/extensions/reference/proxy/index.md
+++ b/site/en/docs/extensions/reference/proxy/index.md
@@ -1,6 +1,6 @@
 ---
 api: proxy
-has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
+has_warning: This permission <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">triggers a warning</a>.
 ---
 
 ## Manifest

--- a/site/en/docs/extensions/reference/system_storage/index.md
+++ b/site/en/docs/extensions/reference/system_storage/index.md
@@ -1,6 +1,6 @@
 ---
 api: system.storage
-has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
+has_warning: This permission <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">triggers a warning</a>.
 ---
 
 <!-- Intentionally blank -->

--- a/site/en/docs/extensions/reference/tabCapture/index.md
+++ b/site/en/docs/extensions/reference/tabCapture/index.md
@@ -1,6 +1,6 @@
 ---
 api: tabCapture
-has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
+has_warning: This permission <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">triggers a warning</a>.
 ---
 
 <!-- Intentionally blank -->

--- a/site/en/docs/extensions/reference/topSites/index.md
+++ b/site/en/docs/extensions/reference/topSites/index.md
@@ -1,6 +1,6 @@
 ---
 api: topSites
-has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
+has_warning: This permission <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">triggers a warning</a>.
 
 ---
 

--- a/site/en/docs/extensions/reference/ttsEngine/index.md
+++ b/site/en/docs/extensions/reference/ttsEngine/index.md
@@ -1,6 +1,6 @@
 ---
 api: ttsEngine
-has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
+has_warning: This permission <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">triggers a warning</a>.
 ---
 
 ## Overview

--- a/site/en/docs/extensions/reference/webNavigation/index.md
+++ b/site/en/docs/extensions/reference/webNavigation/index.md
@@ -1,6 +1,6 @@
 ---
 api: webNavigation
-has_warning: Yes. See <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">permissions with warnings</a> for details.
+has_warning: This permission <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">triggers a warning</a>.
 ---
 
 ## Manifest


### PR DESCRIPTION
## Problem
APIs that don't have permission warnings display an empty "Has warning" metadata:
<img width="567" alt="Screen Shot 2022-07-19 at 11 51 15" src="https://user-images.githubusercontent.com/37001393/179842193-52aeccf8-594a-46e6-820a-3b75cb69ad60.png">

## Solution

### APIs with no permission warning

Do not display a message. 

<img width="402" alt="Screen Shot 2022-07-19 at 15 08 00" src="https://user-images.githubusercontent.com/37001393/179841740-d4ff5595-26f5-4ea4-ba61-82bda1cd741b.png">

### APIs with one permission warning

Display message in new line

<img width="457" alt="Screen Shot 2022-07-19 at 15 07 38" src="https://user-images.githubusercontent.com/37001393/179841789-84699c20-b106-4557-873a-3adb0434f84e.png">

### APIs with multiple permissions with or without warnings

Display message in new line

<img width="383" alt="Screen Shot 2022-07-19 at 15 26 23" src="https://user-images.githubusercontent.com/37001393/179842010-b357f610-8f28-4dd3-8217-31abb62aad4a.png">

## Staged Links

- [Alarms API](https://deploy-preview-3258--developer-chrome-com.netlify.app/docs/extensions/reference/alarms)
- [Bookmarks API](https://deploy-preview-3258--developer-chrome-com.netlify.app/docs/extensions/reference/bookmarks)
- [DeclarativeNetRequest API](https://deploy-preview-3258--developer-chrome-com.netlify.app/docs/extensions/reference/declarativeNetRequest)
