### PR TITLE
Add PiP support on Chrome for Android

### DIFF
--- a/site/en/blog/watch-video-using-picture-in-picture/index.md
+++ b/site/en/blog/watch-video-using-picture-in-picture/index.md
@@ -1,10 +1,10 @@
 ---
 layout: 'layouts/blog-post.njk'
-title: Restricting Wasm module sharing to same-origin
+title: Watch video using Picture-in-Picture
 description: >
   Control Picture-in-Picture for video elements on your website.
 date: 2018-10-19
-updated: 2019-05-08
+updated: 2022-07-20
 authors:
   - beaufortfrancois
 hero: 'image/C47gYyWYVMMhDmtYSLOWazuyePF2/8wfOD3xpMPTZ2KxvZUaz.png'
@@ -18,7 +18,7 @@ Picture-in-Picture (PiP) allows users to watch videos in a floating window
 (always on top of other windows) so they can keep an eye on what they’re
 watching while interacting with other sites, or applications.
 
-With the new [Picture-in-Picture Web API], you can initiate and control
+With the [Picture-in-Picture Web API], you can initiate and control
 Picture-in-Picture for video elements on your website. Try it out on our
 official [Picture-in-Picture sample].
 
@@ -349,8 +349,13 @@ API are currently implemented in Chrome and other browsers.
 
 Here's what you can expect to see in the near future:
 
-- Picture-in-Picture will be supported in Android O.
 - Web developers will be able to [add custom Picture-in-Picture controls].
+- A [new Web API] will be provided to display arbitrary `HTMLElement`s in a floating window.
+
+## Browser support
+
+The Picture-in-Picture Web API is supported in Chrome, Edge, Opera, and Safari.
+See [MDN] for details.
 
 ## Resources {: #resources }
 
@@ -395,3 +400,5 @@ involved in the [standardization effort].
 [jennifer apacible]: https://twitter.com/japacible
 [media session api]: /media-session
 [audio playlist sample]: https://googlechrome.github.io/samples/picture-in-picture/audio-playlist
+[new web api]: https://github.com/steimelchrome/document-pip-explainer/blob/main/explainer.md
+[mdn]: https://developer.mozilla.org/docs/Web/API/Picture-in-Picture_API#browser_compatibility

--- a/site/en/blog/watch-video-using-picture-in-picture/index.md
+++ b/site/en/blog/watch-video-using-picture-in-picture/index.md
@@ -18,7 +18,7 @@ Picture-in-Picture (PiP) allows users to watch videos in a floating window
 (always on top of other windows) so they can keep an eye on what they’re
 watching while interacting with other sites, or applications.
 
-With the [Picture-in-Picture Web API], you can initiate and control
+With the [Picture-in-Picture Web API], you can start and control
 Picture-in-Picture for video elements on your website. Try it out on our
 official [Picture-in-Picture sample].
 
@@ -350,7 +350,7 @@ API are currently implemented in Chrome and other browsers.
 Here's what you can expect to see in the near future:
 
 - Web developers will be able to [add custom Picture-in-Picture controls].
-- A [new Web API] will be provided to display arbitrary `HTMLElement`s in a floating window.
+- A [new Web API] will be provided to display arbitrary `HTMLElement` objects in a floating window.
 
 ## Browser support
 


### PR DESCRIPTION
With upcoming Picture-in-Picture support coming on Chrome for Android, this PR updates the article content and its title which was incorrect due to https://github.com/GoogleChrome/developer.chrome.com/pull/2321.

Live preview: https://deploy-preview-3273--developer-chrome-com.netlify.app/blog/watch-video-using-picture-in-picture/

FYI @liberato-at-chromium

I'm updating MDN compat data at https://github.com/mdn/browser-compat-data/pull/17047 as well.