### PR TITLE
Extend WebGPU origin trial

### DIFF
--- a/site/en/docs/web-platform/webgpu/index.md
+++ b/site/en/docs/web-platform/webgpu/index.md
@@ -7,7 +7,7 @@ authors:
   - beaufortfrancois
   - cwallez
 date: 2021-08-26
-updated: 2022-03-23
+updated: 2022-07-20
 ---
 
 ## What is WebGPU? {: #what }
@@ -73,7 +73,12 @@ To experiment with WebGPU locally, without an origin trial token, enable the
 ### Enabling support during the origin trial phase
 
 Starting in Chrome&nbsp;94, WebGPU is available as an origin trial in Chrome. The
-origin trial is expected to end in Chrome&nbsp;105 (Sep 21, 2022).
+origin trial is expected to end in Chrome&nbsp;109 (Feb 1, 2023).
+
+{% Aside 'caution' %}
+The origin trial is expected to [pause for 2 weeks](https://groups.google.com/a/chromium.org/g/blink-dev/c/gBMsYQ1Aurw/m/xl1znc7fAAAJ)
+starting in Chrome&nbsp;106 (Sep 20, 2022).
+{% endAside %}
 
 {% include 'content/origin-trials.njk' %}
 

--- a/site/en/docs/web-platform/webgpu/index.md
+++ b/site/en/docs/web-platform/webgpu/index.md
@@ -77,7 +77,7 @@ origin trial is expected to end in Chrome&nbsp;109 (Feb 1, 2023).
 
 {% Aside 'caution' %}
 The origin trial is expected to [pause for 2 weeks](https://groups.google.com/a/chromium.org/g/blink-dev/c/gBMsYQ1Aurw/m/xl1znc7fAAAJ)
-starting in Chrome&nbsp;106 (Sep 20, 2022).
+starting in Chrome&nbsp;106 (Sep 27, 2022).
 {% endAside %}
 
 {% include 'content/origin-trials.njk' %}


### PR DESCRIPTION
This PR updates the WebGPU documentation to mention the extension of the WebGPU origin trial.

Live preview: https://deploy-preview-3274--developer-chrome-com.netlify.app/docs/web-platform/webgpu/#enabling-support-during-the-origin-trial-phase

@Kangz Please review.