### PR TITLE
Console API reference refresh

### DIFF
--- a/site/en/docs/devtools/console/api/index.md
+++ b/site/en/docs/devtools/console/api/index.md
@@ -5,7 +5,7 @@ authors:
   - kaycebasques
   - sofiayem
 date: 2016-03-21
-updated: 2022-06-28
+updated: 2022-06-22
 description: "Use the Console API to write messages to the Console."
 ---
 

--- a/site/en/docs/devtools/console/api/index.md
+++ b/site/en/docs/devtools/console/api/index.md
@@ -5,7 +5,7 @@ authors:
   - kaycebasques
   - sofiayem
 date: 2016-03-21
-updated: 2022-06-22
+updated: 2022-07-22
 description: "Use the Console API to write messages to the Console."
 ---
 

--- a/site/en/docs/devtools/console/api/index.md
+++ b/site/en/docs/devtools/console/api/index.md
@@ -3,14 +3,20 @@ layout: "layouts/doc-post.njk"
 title: "Console API reference"
 authors:
   - kaycebasques
+  - sofiayem
 date: 2016-03-21
-#updated: YYYY-MM-DD
+updated: 2022-06-28
 description: "Use the Console API to write messages to the Console."
 ---
 
 Use the Console API to write messages to the Console from your JavaScript. See [Get Started With
-Logging Messages To The Console][1] for an interactive introduction to the topic. See [Console
-Utilities API Reference][2] if you're looking for the convenience methods like `debug(function)` or
+Logging Messages To The Console][1] for an interactive introduction to the topic.
+
+{% Aside 'gotchas' %}
+DevTools assigns a severity level to most of the `console.*` methods. These levels allow you to filter logged messages. For more information, see [Filter by log level](/docs/devtools/console/reference/#level).
+{% endAside %}
+
+See [Console Utilities API Reference][2] if you're looking for the convenience methods like `debug(function)` or
 `monitorEvents(node)` which are only available from the Console.
 
 ## console.assert(expression, object) {: #assert }
@@ -28,8 +34,6 @@ console.assert(x < y, {x, y, reason});
 
 {% Img src="image/admin/cS62AuHJfLVVaDYf3OEL.png", alt="The result of the console.assert() example above.", width="800", height="447" %}
 
-**Figure 1**. The result of the `console.assert()` example above.
-
 ## console.clear() {: #clear }
 
 Clears the console.
@@ -40,7 +44,7 @@ console.clear();
 
 If [**Preserve Log**][5] is enabled, `console.clear()` is disabled.
 
-See also: [Clear the Console][6]
+Alternatively, you can [Clear the Console][6] by clicking the {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Nh5W7S7oEdlTcjarzxKC.svg", alt="ALT_TEXT_HERE", width="20", height="20" %} icon.
 
 ## console.count(\[label\]) {: #count }
 
@@ -57,8 +61,6 @@ console.count();
 ```
 
 {% Img src="image/admin/XNCvcoyyu8TabN0K1pjL.png", alt="The result of the console.count() example above.", width="800", height="507" %}
-
-**Figure 2**. The result of the `console.count()` example above.
 
 ## console.countReset(\[label\]) {: #countreset }
 
@@ -81,8 +83,6 @@ console.debug('debug');
 
 {% Img src="image/admin/GuN0auKEMAdVW9j8wW7J.png", alt="The result of the console.debug() example above.", width="800", height="526" %}
 
-**Figure 3**. The result of the `console.debug()` example above.
-
 ## console.dir(object) {: #dir }
 
 [Log level][11]: `Info`
@@ -94,8 +94,6 @@ console.dir(document.head);
 ```
 
 {% Img src="image/admin/2aLQxuFHsyzYIuBzz5Mp.png", alt="The result of the console.dir() example above.", width="800", height="590" %}
-
-**Figure 4**. The result of the `console.dir()` example above.
 
 ## console.dirxml(node) {: #dirxml }
 
@@ -109,8 +107,6 @@ console.dirxml(document);
 
 {% Img src="image/admin/JIDSgSq8UQf7YIt6w1vw.png", alt="The result of the console.dirxml() example above.", width="800", height="561" %}
 
-**Figure 5**. The result of the `console.dirxml()` example above.
-
 ## console.error(object \[, object, ...\]) {: #error }
 
 [Log level][13]: `Error`
@@ -122,8 +118,6 @@ console.error("I'm sorry, Dave. I'm afraid I can't do that.");
 ```
 
 {% Img src="image/admin/Pfsjy00hVaI53iAhOhNt.png", alt="The result of the console.error() example above.", width="800", height="550" %}
-
-**Figure 6**. The result of the `console.error()` example above.
 
 ## console.group(label) {: #group }
 
@@ -142,12 +136,10 @@ console.groupEnd(label);
 
 {% Img src="image/admin/nXx5Fyu0l3p3jm3ooD77.png", alt="The result of the console.group() example above.", width="800", height="513" %}
 
-**Figure 7**. The result of the `console.group()` example above.
-
 ## console.groupCollapsed(label) {: #groupcollapsed }
 
 Same as [`console.group(label)`][14], except the group is initially collapsed when it's logged to
-the Console.
+the **Console**.
 
 ## console.groupEnd(label) {: #groupend }
 
@@ -165,8 +157,6 @@ console.info('info');
 
 {% Img src="image/admin/tIWshweM0G6hiTKzhfCw.png", alt="The result of the console.info() example above.", width="800", height="477" %}
 
-**Figure 8**. The result of the `console.info()` example above.
-
 ## console.log(object \[, object, ...\]) {: #log }
 
 [Log level][18]: `Info`
@@ -178,8 +168,6 @@ console.log('log');
 ```
 
 {% Img src="image/admin/4NsJDaAjDpipnzkmkfDU.png", alt="The result of the console.log() example above.", width="800", height="477" %}
-
-**Figure 9**. The result of the `console.log()` example above.
 
 ## console.table(array [, columns]) {: #table }
 
@@ -206,11 +194,13 @@ var people = [
 console.table(people);
 ```
 
-The result of the `console.table()` example above:
-
 {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/VWHZBsZYJIhdoSh2efcu.png", alt="The result of the console.table() example above.", width="800", height="455" %}
 
 By default, `table.console()` logs all table data. To display a single column or a subset of columns, you can use the second optional parameter and specify column name or names as a string or an array of strings. For example:
+
+```js
+console.table(people, ['last'], 'birthday');
+```
 
 {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/S3lXtYbN6K0IqFBvKj19.png", alt="A subset of columns in a table logged with console.table().", width="800", height="455" %}
 
@@ -228,8 +218,6 @@ console.timeEnd();
 ```
 
 {% Img src="image/admin/9yLfjQpQZ9fBNdRCI7U1.png", alt="The result of the console.time() example above.", width="800", height="514" %}
-
-**Figure 11**. The result of the `console.time()` example above.
 
 ## console.timeEnd(\[label\]) {: #timeend }
 
@@ -253,8 +241,6 @@ first();
 
 {% Img src="image/admin/uO2xhv9WrEjpUHpT3lLN.png", alt="The result of the console.trace() example above.", width="800", height="498" %}
 
-**Figure 12**. The result of the `console.trace()` example above.
-
 ## console.warn(object \[, object, ...\]) {: #warn }
 
 [Log level][23]: `Warning`
@@ -266,8 +252,6 @@ console.warn('warn');
 ```
 
 {% Img src="image/admin/CsGNmsnQn4GnJRaR339w.png", alt="The result of the console.warn() example above.", width="800", height="481" %}
-
-**Figure 13**. The result of the `console.warn()` example above.
 
 [1]: /docs/devtools/console/log
 [2]: /docs/devtools/console/utilities

--- a/site/en/docs/devtools/console/api/index.md
+++ b/site/en/docs/devtools/console/api/index.md
@@ -12,6 +12,8 @@ description: "Use the Console API to write messages to the Console."
 Use the Console API to write messages to the Console from your JavaScript. See [Get started with
 logging messages to the Console][1] for an interactive introduction to the topic.
 
+{% YouTube id='76U0gtuV9AY' %}
+
 {% Aside 'gotchas' %}
 DevTools assigns a severity level to most of the `console.*` methods. These levels allow you to filter logged messages. For more information, see [Filter by log level](/docs/devtools/console/reference/#level).
 {% endAside %}

--- a/site/en/docs/devtools/console/api/index.md
+++ b/site/en/docs/devtools/console/api/index.md
@@ -9,14 +9,14 @@ updated: 2022-07-22
 description: "Use the Console API to write messages to the Console."
 ---
 
-Use the Console API to write messages to the Console from your JavaScript. See [Get Started With
-Logging Messages To The Console][1] for an interactive introduction to the topic.
+Use the Console API to write messages to the Console from your JavaScript. See [Get started with
+logging messages to the Console][1] for an interactive introduction to the topic.
 
 {% Aside 'gotchas' %}
 DevTools assigns a severity level to most of the `console.*` methods. These levels allow you to filter logged messages. For more information, see [Filter by log level](/docs/devtools/console/reference/#level).
 {% endAside %}
 
-See [Console Utilities API Reference][2] if you're looking for the convenience methods like `debug(function)` or
+See [Console utilities API reference][2] if you're looking for the convenience methods like `debug(function)` or
 `monitorEvents(node)` which are only available from the Console.
 
 ## console.assert(expression, object) {: #assert }
@@ -135,6 +135,23 @@ console.groupEnd(label);
 ```
 
 {% Img src="image/admin/nXx5Fyu0l3p3jm3ooD77.png", alt="The result of the console.group() example above.", width="800", height="513" %}
+
+Additionally, you can nest groups.
+
+```js
+const timeline1 = 'New York 2012';
+const timeline2 = 'Camp Lehigh 1970';
+console.group(timeline1);
+console.info('Mind');
+console.info('Time');
+console.group(timeline2);
+console.info('Space');
+console.info('Extra Pym Particles');
+console.groupEnd(timeline2);
+console.groupEnd(timeline1);
+```
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/yxxuBrVHlHj7kIEYLSJB.png", alt="Nested groups.", width="800", height="549" %}
 
 ## console.groupCollapsed(label) {: #groupcollapsed }
 

--- a/site/en/docs/devtools/console/log/index.md
+++ b/site/en/docs/devtools/console/log/index.md
@@ -44,7 +44,7 @@ you physically follow along, you're more likely to remember the workflows later.
 
 ## View messages logged from JavaScript {: #javascript }
 
-Most messages that you see in the Console come from the web developers who wrote the page's
+Most messages that you see in the **Console** come from the web developers who wrote the page's
 JavaScript. The goal of this section is to introduce you to the different message types that you're
 likely to see in the Console, and explain how you can log each message type yourself from your own
 JavaScript.
@@ -53,18 +53,18 @@ JavaScript.
 
     {% Img src="image/admin/lSamfDnGqrNC6rau3zvT.png", alt="The Console after clicking Log Info.", width="800", height="503" %}
 
-2.  Next to the `Hello, Console!` message in the Console click **log.js:2**. The **Sources** panel opens
+2.  Next to the `Hello, Console!` message in the **Console**, click **log.js:2**. The **Sources** panel opens
     and highlights the line of code that caused the message to get logged to the Console. 
 
     {% Img src="image/admin/VjLF6UMfP0uWeDahvUVo.png", alt="DevTools opens the Sources panel after you click log.js:2.", width="800", height="503" %}
 
     The message was logged when the page's JavaScript called `console.log('Hello, Console!')`.
 
-3.  Navigate back to the Console using any of the following workflows:
+3.  Navigate back to the **Console** using any of the following workflows:
 
     - Click the **Console** tab.
     - Press <kbd>Control</kbd>+<kbd>[</kbd> or <kbd>Command</kbd>+<kbd>[</kbd> (Mac) until the
-      Console panel is in focus.
+      **Console** is in focus.
     - [Open the Command Menu][4], start typing `Console`, select the **Show Console Panel** command,
       and then press <kbd>Enter</kbd>.
 
@@ -76,7 +76,7 @@ JavaScript.
     Messages formatted like this are warnings.
 
 5.  Optional: Click **log.js:12** to view the code that caused the message to get formatted like
-    this, and then navigate back to Console when you're finished. Do this whenever you want to see
+    this, and then navigate back to **Console** when you're finished. Do this whenever you want to see
     the code that caused a message to get logged a certain way.
 6.  Click the **Expand** {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/bJ1ZWs8NN8S0NaZnCHyQ.svg", alt="Expand.", width="20", height="20" %} icon in
     front of `Abandon Hope All Ye Who Enter`. DevTools shows the [stack trace][5] leading up to the
@@ -109,7 +109,7 @@ JavaScript.
 
     {% Img src="image/admin/azaXNJ5WC6rN1NVFAN3m.png", alt="A message with custom formatting in the Console.", width="800", height="490" %}
 
-The main idea here is that when you want to log messages to the Console from your JavaScript, you
+The main idea here is that when you want to log messages to the **Console** from your JavaScript, you
 use one of the `console` methods. Each method formats messages differently.
 
 There are even more methods than what has been demonstrated in this section. At the end of the
@@ -130,9 +130,9 @@ page.
 
     {% Img src="image/admin/lMl9U6EJBQDLBVYKbxX9.png", alt="A TypeError in the Console.", width="800", height="518" %}
 
-3.  Click the **Log Levels** dropdown and enable the **Verbose** option if it's disabled. You'll
+3.  Click the **Log Levels** drop-down and enable the **Verbose** option if it's disabled. You'll
     learn more about filtering in the next section. You need to do this to make sure that the next
-    message you log is visible. **Note:** If the Default Levels dropdown is disabled, you may need
+    message you log is visible. **Note:** If the Default Levels drop-down is disabled, you may need
     to close the Console Sidebar. Filter by Message Source below for more information about the
     Console Sidebar.
 
@@ -146,22 +146,34 @@ page.
 
 ## Filter messages {: #filter }
 
-On some pages you'll see the Console get flooded with messages. DevTools provides many different
+On some pages you'll see the **Console** get flooded with messages. DevTools provides many different
 ways to filter out messages that aren't relevant to the task at hand.
+
+{% Aside 'gotchas' %}
+The **Console** filters out only the output messages, all inputs that you typed into the **Console** stay there.
+{% endAside %}
 
 ### Filter by log level {: #level }
 
-Each `console` method is assigned a severity level: `Verbose`, `Info`, `Warning`, or `Error`. For
-example, `console.log()` is an `Info`\-level message, whereas `console.error()` is an `Error`\-level
-message.
+Each `console.*` method is assigned a severity level: `Verbose`, `Info`, `Warning`, or `Error`. For example, `console.log()` is an `Info`\-level message, whereas `console.error()` is an `Error`\-level message.
 
-1.  Click the **Log Levels** dropdown and disable **Errors**. A level is disabled when there is no
+{% Aside %}
+**Note**: For a full list of `console.*` methods and their severity levels, see the [Console API reference](/docs/devtools/console/api/).
+{% endAside %}
+
+To filter by log level:
+
+1.  Click the **Log Levels** drop-down and disable **Errors**. A level is disabled when there is no
     longer a checkmark next to it. The `Error`\-level messages disappear.
 
     {% Img src="image/admin/t1U5iAP8oKCS0nlwaOZy.png", alt="Disabling Error-level messages in the Console.", width="800", height="518" %}
 
-2.  Click the **Log Levels** dropdown again and re-enable **Errors**. The `Error`\-level messages
+2.  Click the **Log Levels** drop-down again and re-enable **Errors**. The `Error`\-level messages
     reappear.
+
+{% Aside 'gotchas' %}
+The **Console** always remembers the drop-down filter you apply. It persists across all pages as well as page, DevTools, and Chrome reloads. To quickly apply a temporary filter, use the [Sidebar](#source).
+{% endAside %}
 
 ### Filter by text {: #text }
 
@@ -191,6 +203,10 @@ use a [regular expression][6].
 
 When you want to only view the messages that came from a certain URL, use the **Sidebar**.
 
+{% Aside 'gotchas' %}
+Sidebar filters are temporary. The **Console** doesn't persist such filters across all pages as well as page, DevTools, and Chrome reloads.
+{% endAside %}
+
 1.  Click **Show Console Sidebar**
     {% Img src="image/admin/WCuENTqHgjAR2Be3Hdqq.png", alt="Show Console Sidebar.", width="25", height="20" %}.
 
@@ -216,22 +232,22 @@ messages_. You can use the **Sidebar** to filter out browser messages and only s
 
 2.  Click **12 Messages** to show all messages again.
 
-## Use the Console alongside any other panel {: #drawer }
+## Use the **Console** alongside any other panel {: #drawer }
 
-What if you're editing styles, but you need to quickly check the Console log for something? Use the
+What if you're editing styles, but you need to quickly check the **Console** log for something? Use the
 Drawer.
 
 1.  Click the **Elements** tab.
-2.  Press <kbd>Escape</kbd>. The Console tab of the **Drawer** opens. It has all of the features of
-    the Console panel that you've been using throughout this tutorial.
+2.  Press <kbd>Escape</kbd>. The **Console** tab of the **Drawer** opens. It has all of the features of
+    the **Console** that you've been using throughout this tutorial.
 
-    {% Img src="image/admin/99RTlD6HWxthbGdiHtrw.png", alt="The Console tab in the Drawer.", width="800", height="602" %}
+    {% Img src="image/admin/99RTlD6HWxthbGdiHtrw.png", alt="The **Console** tab in the Drawer.", width="800", height="602" %}
 
 ## Next steps {: #next }
 
 Congratulations, you have completed the tutorial. Click **Dispense Trophy** to receive your trophy.
 
-- See [Console Reference][8] to explore more features and workflows related to the Console UI.
+- See [Console Reference][8] to explore more features and workflows related to the **Console** UI.
 - See [Console API Reference][9] to learn more about all of the `console` methods that were
   demonstrated in [View messages logged from JavaScript][10] and explore the other `console` methods
   that weren't covered in this tutorial.

--- a/site/en/docs/devtools/console/log/index.md
+++ b/site/en/docs/devtools/console/log/index.md
@@ -15,8 +15,6 @@ Console.
 
 {% Img src="image/admin/aF8rn6sy0FguTyfh8LXU.png", alt="Messages in the Console.", width="800", height="536" %}
 
-**Figure 1**. Messages in the Console.
-
 This tutorial is intended to be completed in order. It assumes that you understand the fundamentals
 of web development, such as how to use JavaScript to add interactivity to a page.
 
@@ -26,11 +24,9 @@ This tutorial is designed so that you can open up the demo and try all the workf
 you physically follow along, you're more likely to remember the workflows later.
 
 1.  Open the [demo][2].
-2.  Optional: Move the demo to a separate window.
+2.  Optional: Move the demo to a separate window. In this example, the tutorial is on the left, and the demo is on the right.
 
     {% Img src="image/admin/Up8If5tGO9V1yQ45uKBI.png", alt="This tutorial on the left, and the demo on the right.", width="800", height="482" %}
-
-    **Figure 2**. This tutorial on the left, and the demo on the right.
 
 3.  Focus the demo and then press <kbd>Control</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd> or
     <kbd>Command</kbd>+<kbd>Option</kbd>+<kbd>J</kbd> (Mac) to open DevTools. By default DevTools opens to the
@@ -38,17 +34,13 @@ you physically follow along, you're more likely to remember the workflows later.
 
     {% Img src="image/admin/DMOW45O6ocuz4p6MyOGd.png", alt="DevTools opens to the right of the demo.", width="800", height="482" %}
 
-    **Figure 3**. DevTools opens to the right of the demo.
-
 4.  Optional: [Dock DevTools to the bottom of the window or undock it into a separate window][3].
 
+    DevTools docked to the bottom of the demo:
     {% Img src="image/admin/fhMeiN5WiQzVTS674o6X.png", alt="DevTools docked to the bottom of the demo.", width="800", height="482" %}
 
-    **Figure 4**. DevTools docked to the bottom of the demo.
-
+    DevTools undocked in a separate window:
     {% Img src="image/admin/ZAHbFZR2Ao4BNl82sNzx.png", alt="DevTools undocked in a separate window.", width="800", height="482" %}
-
-    **Figure 5**. DevTools undocked in a separate window.
 
 ## View messages logged from JavaScript {: #javascript }
 
@@ -61,15 +53,12 @@ JavaScript.
 
     {% Img src="image/admin/lSamfDnGqrNC6rau3zvT.png", alt="The Console after clicking Log Info.", width="800", height="503" %}
 
-    **Figure 6**. The Console after clicking **Log Info**.
-
-2.  Next to the `Hello, Console!` message in the Console click **log.js:2**. The Sources panel opens
-    and highlights the line of code that caused the message to get logged to the Console. The
-    message was logged when the page's JavaScript called `console.log('Hello, Console!')`.
+2.  Next to the `Hello, Console!` message in the Console click **log.js:2**. The **Sources** panel opens
+    and highlights the line of code that caused the message to get logged to the Console. 
 
     {% Img src="image/admin/VjLF6UMfP0uWeDahvUVo.png", alt="DevTools opens the Sources panel after you click log.js:2.", width="800", height="503" %}
 
-    **Figure 7**. DevTools opens the Sources panel after you click **log.js:2**.
+    The message was logged when the page's JavaScript called `console.log('Hello, Console!')`.
 
 3.  Navigate back to the Console using any of the following workflows:
 
@@ -80,22 +69,20 @@ JavaScript.
       and then press <kbd>Enter</kbd>.
 
 4.  Click the **Log Warning** button in the demo. `Abandon Hope All Ye Who Enter` gets logged to the
-    Console. Messages formatted like this are warnings.
+    Console.
 
     {% Img src="image/admin/77aEDWR3djItzJLVcq9f.png", alt="The Console after clicking Log Warning.", width="800", height="503" %}
 
-    **Figure 8**. The Console after clicking **Log Warning**.
+    Messages formatted like this are warnings.
 
 5.  Optional: Click **log.js:12** to view the code that caused the message to get formatted like
     this, and then navigate back to Console when you're finished. Do this whenever you want to see
     the code that caused a message to get logged a certain way.
-6.  Click the **Expand** {% Img src="image/admin/kNA03JXX9dff86Eftn9Z.png", alt="Expand", width="14", height="16" %} icon in
+6.  Click the **Expand** {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/bJ1ZWs8NN8S0NaZnCHyQ.svg", alt="Expand.", width="20", height="20" %} icon in
     front of `Abandon Hope All Ye Who Enter`. DevTools shows the [stack trace][5] leading up to the
     call.
 
     {% Img src="image/admin/WTobwoP7z9Iv09On34Io.png", alt="A stack trace.", width="800", height="503" %}
-
-    **Figure 9**. A stack trace.
 
     The stack trace is telling you that a function named `logWarning` was called, which in turn
     called a function named `quoteDante`. In other words, the call that happened first is at the
@@ -106,28 +93,21 @@ JavaScript.
 
     {% Img src="image/admin/mfrXFockwLgV5Bnm6xDM.png", alt="An error message.", width="800", height="532" %}
 
-    **Figure 10**. An error message.
-
-8.  Click **Log Table**. A table about famous artists gets logged to the Console. Note how the
-    `birthday` column is only populated for one row. Check the code to figure out why that is.
+8.  Click **Log Table**. A table about famous artists gets logged to the Console.
 
     {% Img src="image/admin/2xQw31zpHKiachWLsYSi.png", alt="A table in the Console.", width="800", height="490" %}
 
-    **Figure 11**. A table in the Console.
+    Note how the `birthday` column is only populated for one row. Check the code to figure out why that is.
 
 9.  Click **Log Group**. The names of 4 famous, crime-fighting turtles are grouped under the
     `Adolescent Irradiated Espionage Tortoises` label.
 
     {% Img src="image/admin/p6Qo0HrDhdObOJGgoEOA.png", alt="A group of messages in the Console.", width="800", height="490" %}
 
-    **Figure 12**. A group of messages in the Console.
-
 10. Click **Log Custom**. A message with a red border and blue background gets logged to the
     Console.
 
     {% Img src="image/admin/azaXNJ5WC6rN1NVFAN3m.png", alt="A message with custom formatting in the Console.", width="800", height="490" %}
-
-    **Figure 13**. A message with custom formatting in the Console.
 
 The main idea here is that when you want to log messages to the Console from your JavaScript, you
 use one of the `console` methods. Each method formats messages differently.
@@ -145,14 +125,10 @@ page.
 
     {% Img src="image/admin/EypVyz8F9a1eNlEkjvro.png", alt="A 404 error in the Console.", width="800", height="518" %}
 
-    **Figure 14**. A 404 error in the Console.
-
 2.  Click **Cause Error**. The browser logs an uncaught `TypeError` because the JavaScript is trying
     to update a DOM node that doesn't exist.
 
     {% Img src="image/admin/lMl9U6EJBQDLBVYKbxX9.png", alt="A TypeError in the Console.", width="800", height="518" %}
-
-    **Figure 15**. A TypeError in the Console.
 
 3.  Click the **Log Levels** dropdown and enable the **Verbose** option if it's disabled. You'll
     learn more about filtering in the next section. You need to do this to make sure that the next
@@ -162,15 +138,11 @@ page.
 
     {% Img src="image/admin/YZ9nzR7Gm4xJWkcJM2Jt.png", alt="Enabling the Verbose log level.", width="800", height="518" %}
 
-    **Figure 16**. Enabling the **Verbose** log level.
-
 4.  Click **Cause Violation**. The page becomes unresponsive for a few seconds and then the browser
     logs the message `[Violation] 'click' handler took 3000ms` to the Console. The exact duration
     may vary.
 
     {% Img src="image/admin/9mzXfbfY3s7aFzfUWG4H.png", alt="A violation in the Console.", width="800", height="518" %}
-
-    **Figure 17**. A violation in the Console.
 
 ## Filter messages {: #filter }
 
@@ -188,8 +160,6 @@ message.
 
     {% Img src="image/admin/t1U5iAP8oKCS0nlwaOZy.png", alt="Disabling Error-level messages in the Console.", width="800", height="518" %}
 
-    **Figure 18**. Disabling `Error`\-level messages in the Console.
-
 2.  Click the **Log Levels** dropdown again and re-enable **Errors**. The `Error`\-level messages
     reappear.
 
@@ -203,8 +173,6 @@ When you want to only view messages that include an exact string, type that stri
 
     {% Img src="image/admin/8LQhiX8sS9tLJbMZZOWi.png", alt="Filtering out any message that does not include `Dave`.", width="800", height="518" %}
 
-    **Figure 19**. Filtering out any message that does not include `Dave`.
-
 2.  Delete `Dave` from the **Filter** text box. All the messages reappear.
 
 ### Filter by regular expression {: #regex }
@@ -217,8 +185,6 @@ use a [regular expression][6].
 
     {% Img src="image/admin/3xsXUFoTlcJSrLzJ97GR.png", alt="Filtering out any message that does not match the pattern `/^[AH]/`.", width="800", height="518" %}
 
-    **Figure 20**. Filtering out any message that does not match the pattern `/^[AH]/`.
-
 2.  Delete `/^[AH]/` from the **Filter** text box. All messages are visible again.
 
 ### Filter by message source {: #source }
@@ -226,19 +192,15 @@ use a [regular expression][6].
 When you want to only view the messages that came from a certain URL, use the **Sidebar**.
 
 1.  Click **Show Console Sidebar**
-    {% Img src="image/admin/WCuENTqHgjAR2Be3Hdqq.png", alt="Show Console Sidebar", width="30", height="26" %}.
+    {% Img src="image/admin/WCuENTqHgjAR2Be3Hdqq.png", alt="Show Console Sidebar.", width="25", height="20" %}.
 
     {% Img src="image/admin/llVewt58uHx4kJzlAlH5.png", alt="The Sidebar.", width="800", height="471" %}
 
-    **Figure 21**. The Sidebar.
-
-2.  Click the **Expand** {% Img src="image/admin/kNA03JXX9dff86Eftn9Z.png", alt="Expand", width="14", height="16" %} icon next to
+2.  Click the **Expand** {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/bJ1ZWs8NN8S0NaZnCHyQ.svg", alt="Expand.", width="20", height="20" %} icon next to
     **12 Messages**. The **Sidebar** shows a list of URLs that caused messages to be logged. For
     example, `log.js` caused 11 messages.
 
     {% Img src="image/admin/tfiHp74glhbCmiTfxEhw.png", alt="Viewing the source of messages in the Sidebar.", width="800", height="471" %}
-
-    **Figure 22**. Viewing the source of messages in the Sidebar.
 
 ### Filter by user messages {: #user }
 
@@ -252,8 +214,6 @@ messages_. You can use the **Sidebar** to filter out browser messages and only s
 
     {% Img src="image/admin/mQcoTFv0mA1bhDnLx8lz.png", alt="Filtering out browser messages.", width="800", height="471" %}
 
-    **Figure 23**. Filtering out browser messages.
-
 2.  Click **12 Messages** to show all messages again.
 
 ## Use the Console alongside any other panel {: #drawer }
@@ -266,8 +226,6 @@ Drawer.
     the Console panel that you've been using throughout this tutorial.
 
     {% Img src="image/admin/99RTlD6HWxthbGdiHtrw.png", alt="The Console tab in the Drawer.", width="800", height="602" %}
-
-    **Figure 24**. The Console tab in the Drawer.
 
 ## Next steps {: #next }
 

--- a/site/en/docs/devtools/console/log/index.md
+++ b/site/en/docs/devtools/console/log/index.md
@@ -13,6 +13,7 @@ tags:
 This interactive tutorial shows you how to log and filter messages in the [Chrome DevTools][1]
 Console.
 
+{% YouTube id='76U0gtuV9AY' %}
 {% Img src="image/admin/aF8rn6sy0FguTyfh8LXU.png", alt="Messages in the Console.", width="800", height="536" %}
 
 This tutorial is intended to be completed in order. It assumes that you understand the fundamentals

--- a/site/en/docs/devtools/console/reference/index.md
+++ b/site/en/docs/devtools/console/reference/index.md
@@ -30,7 +30,7 @@ Press <kbd>Control</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd> or
 
 {% Img src="image/admin/yA07vZPXixZWv2jHdE6W.png", alt="The Console.", width="800", height="493" %}
 
-To open the Console panel from the [Command Menu][6], start typing `Console` and then run the **Show
+To open the Console from the [Command Menu][6], start typing `Console` and then run the **Show
 Console** command that has the **Panel** badge next to it.
 
 {% Img src="image/admin/QXom109Oiui7fgVBj38Y.png", alt="The command for showing the Console panel.", width="800", height="413" %}

--- a/site/en/docs/devtools/console/reference/index.md
+++ b/site/en/docs/devtools/console/reference/index.md
@@ -5,7 +5,7 @@ authors:
   - kaycebasques
   - sofiayem
 date: 2019-04-18
-updated: 2022-05-30
+updated: 2022-06-22
 description:
   "A comprehensive reference on every feature and behavior related to the Console UI in Chrome
   DevTools."
@@ -30,46 +30,34 @@ Press <kbd>Control</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd> or
 
 {% Img src="image/admin/yA07vZPXixZWv2jHdE6W.png", alt="The Console panel.", width="800", height="493" %}
 
-**Figure 1**. The Console panel.
-
 To open the Console panel from the [Command Menu][6], start typing `Console` and then run the **Show
 Console** command that has the **Panel** badge next to it.
 
 {% Img src="image/admin/QXom109Oiui7fgVBj38Y.png", alt="The command for showing the Console panel.", width="800", height="413" %}
 
-**Figure 2**. The command for showing the Console panel.
-
 ### Open the Console tab in the Drawer {: #drawer }
 
 Press <kbd>Escape</kbd> or click **Customize And Control DevTools**
-{% Img src="image/admin/Pw9x0BpjZoeW2Wb5nmTH.png", alt="Customize And Controls DevTools", width="6", height="26" %} and then
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/N5Lkpdwpaz4YqRGFr2Ks.svg", alt="Customize And Controls DevTools.", width="24", height="24" %} and then
 select **Show Console Drawer**.
 
 {% Img src="image/admin/KJTO8aoQihf8hrpNdhvD.png", alt="Show Console Drawer.", width="800", height="501" %}
 
-**Figure 3**. Show Console Drawer.
-
 The Drawer pops up at the bottom of your DevTools window, with the **Console** tab open.
 
 {% Img src="image/admin/anf99vgXPq5x3KV21nX0.png", alt="The Console tab in the Drawer.", width="800", height="568" %}
-
-**Figure 4**. The Console tab in the Drawer.
 
 To open the Console tab from the [Command Menu][7], start typing `Console` and then run the **Show
 Console** command that has the **Drawer** badge next to it.
 
 {% Img src="image/admin/Zo8atFvEFrTm619HsdRU.png", alt="The command for showing the Console tab in the Drawer.", width="800", height="413" %}
 
-**Figure 5**. The command for showing the Console tab in the Drawer.
-
 ### Open Console Settings {: #settings }
 
 Click **Console Settings**
-{% Img src="image/admin/X3iDnXdnzdBTOrbaZiP7.png", alt="Console Settings", width="28", height="28" %}.
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/9gzXiTYY0nZzBxGI6KrV.svg", alt="Console Settings.", width="24", height="24" %}.
 
 {% Img src="image/admin/MMPCv1S2FqQVG6qJvByI.png", alt="Console Settings.", width="800", height="541" %}
-
-**Figure 6**. Console Settings.
 
 The links below explain each setting:
 
@@ -84,12 +72,10 @@ The links below explain each setting:
 ### Open the Console Sidebar {: #sidebar }
 
 Click **Show Console Sidebar**
-{% Img src="image/admin/JWC9AxhF6aRjxKLTIfEv.png", alt="Show Console Sidebar", width="30", height="26" %} to show
+{% Img src="image/admin/JWC9AxhF6aRjxKLTIfEv.png", alt="Show Console Sidebar.", width="30", height="26" %} to show
 the Sidebar, which is useful for filtering.
 
 {% Img src="image/admin/SgCPLaYCtxNBclGXHz0Q.png", alt="Console Sidebar.", width="800", height="530" %}
-
-**Figure 7**. Console Sidebar.
 
 ## View messages {: #view }
 
@@ -108,14 +94,10 @@ grouping behavior. See [Log XHR and Fetch requests][17] for an example.
 
 {% Img src="image/admin/t9sLCbiL3KrQW9MdLZoV.png", alt="Logging XMLHttpRequest and Fetch requests.", width="800", height="490" %}
 
-**Figure 8**. Logging `XMLHttpRequest` and `Fetch` requests.
-
-The top message in **Figure 8** shows the Console's default grouping behavior. **Figure 9** shows
+The top message in the example above shows the Console's default grouping behavior. The example below shows
 how the same log looks after [disabling message grouping][19].
 
 {% Img src="image/admin/5uz4gBdOGdW2RO58Wkui.png", alt="How the logged XMLHttpRequest and Fetch requests look after ungrouping.", width="800", height="589" %}
-
-**Figure 9**. How the logged `XMLHttpRequest` and `Fetch` requests look after ungrouping.
 
 ### Persist messages across page loads {: #persist }
 
@@ -125,11 +107,9 @@ By default the Console clears whenever you load a new page. To persist messages 
 ### Hide network messages {: #network }
 
 By default the browser logs network messages to the **Console**. For example, the top message in
-**Figure 10** represents a 404.
+the following example represents a 404.
 
 {% Img src="image/admin/rlMckNNbRXvT4xln5jTQ.png", alt="A 404 message in the Console.", width="800", height="497" %}
-
-**Figure 10**. A 404 message in the Console.
 
 To hide network messages:
 
@@ -147,56 +127,55 @@ page's JavaScript.
 
 {% Img src="image/admin/mYDvN18HyYlZszVGzp1F.png", alt="Viewing user messages.", width="800", height="588" %}
 
-**Figure 11**. Viewing user messages.
-
 ### Filter by log level {: #level }
 
-DevTools assigns each `console.*` method a severity level. There are 4 levels: `Verbose`, `Info`,
-`Warning`, and `Error`. For example, `console.log()` is in the `Info` group, whereas
-`console.error()` is in the `Error` group. The [Console API Reference][23] describes the severity
-level of each applicable method. Every message that the browser logs to the Console has a severity
+DevTools assigns most of `console.*` methods severity levels.
+
+There are four levels: 
+
+- `Verbose`
+- `Info`
+- `Warning`
+- `Error`
+
+For example, `console.log()` is in the `Info` group, whereas
+`console.error()` is in the `Error` group.  The [Console API Reference][23] describes the severity
+level of each applicable method.
+
+Every message that the browser logs to the Console has a severity
 level too. You can hide any level of messages that you're not interested in. For example, if you're
 only interested in `Error` messages, you can hide the other 3 groups.
 
-Click the **Log Levels** dropdown to enable or disable `Verbose`, `Info`, `Warning` or `Error`
+Click the **Log Levels** drop-down to enable or disable `Verbose`, `Info`, `Warning` or `Error`
 messages.
 
-{% Img src="image/admin/PX52vbEI6gTFqSmTZNVB.png", alt="The Log Levels dropdown.", width="800", height="529" %}
+{% Img src="image/admin/PX52vbEI6gTFqSmTZNVB.png", alt="The Log Levels drop-down.", width="800", height="529" %}
 
-**Figure 12**. The **Log Levels** dropdown.
-
-You can also filter by log level by [opening the Console Sidebar][24] and then clicking **Errors**,
+You can also filter by log level by {% Img src="image/admin/JWC9AxhF6aRjxKLTIfEv.png", alt="Show Console Sidebar.", width="30", height="26" %}  [opening the Console Sidebar][24] and then clicking **Errors**,
 **Warnings**, **Info**, or **Verbose**.
 
 {% Img src="image/admin/osvdtWq0DGX1yjkFDGLZ.png", alt="Using the Sidebar to view warnings.", width="800", height="588" %}
 
-**Figure 13**. Using the Sidebar to view warnings.
-
 ### Filter messages by URL {: #url }
 
 Type `url:` followed by a URL to only view messages that came from that URL. After you type `url:`
-DevTools shows all relevant URLs. Domains also work. For example, if `https://example.com/a.js` and
-`https://example.com/b.js` are logging messages, `url:https://example.com` enables you to focus on
-the messages from these 2 scripts.
+DevTools shows all relevant URLs.
 
 {% Img src="image/admin/VEumwMRJ7kuQDV3JFtQk.png", alt="A URL filter.", width="800", height="514" %}
 
-**Figure 14**. A URL filter.
+Domains also work. For example, if `https://example.com/a.js` and
+`https://example.com/b.js` are logging messages, `url:https://example.com` enables you to focus on
+the messages from these 2 scripts.
 
-Type `-url:` to hide messages from that URL. This is called a negative URL filter.
+To hide all messages from a specified URL, type `-url:`  followed by the URL, for example, `https://b.wal.co`. This is a negative URL filter.
 
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/hyalP82Gj2k0Op3gkfEH.png", alt="A negative URL filter. DevTools is hiding all messages that match the URL https://b.wal.co", width="800", height="447" %}
-
-**Figure 15**. A negative URL filter. DevTools is hiding all messages that match the URL
-`https://b.wal.co`.
+{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/hyalP82Gj2k0Op3gkfEH.png", alt="A negative URL filter. DevTools is hiding all messages that match the specified URL.", width="800", height="447" %}
 
 You can also show messages from a single URL by [opening the Console Sidebar][25], expanding the
 **User Messages** section, and then clicking the URL of the script containing the messages you want
 to focus on.
 
-{% Img src="image/admin/7d3qjmCPUgkXVsg1rVf1.png", alt="Viewing the messages that came from wp-ad.min.js.", width="800", height="447" %}
-
-**Figure 16**. Viewing the messages that came from `wp-ad.min.js`.
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/cW0559gsIaUJ1HwTLivi.png", alt="Viewing the messages from a specific script.", width="800", height="435" %}
 
 ### Filter out messages from different contexts {: #filtercontext }
 
@@ -211,17 +190,17 @@ Type a regular expression such as `/[foo]\s[bar]/` in the **Filter** text box to
 messages that don't match that pattern. Spaces are not supported, use `\s` instead. DevTools checks if the pattern is found in the message text
 or the script that caused the message to be logged.
 
-{% Img src="image/admin/1FvJQi69s6J7nHtKUIDy.png", alt="Filtering out any messages that don't match /[gm][ta][mi]/.", width="800", height="512" %}
+For example, the following filters out all messages that don't match `/[gm][ta][mi]/`.
 
-**Figure 17**. Filtering out any messages that don't match `/[gm][ta][mi]/`.
+{% Img src="image/admin/1FvJQi69s6J7nHtKUIDy.png", alt="Filtering out any messages that don't match /[gm][ta][mi]/.", width="800", height="512" %}
 
 ## Search for text in logs {: #search }
 
 To search for text in log messages:
 
 1. To open a built-in search bar, press <kbd>Command</kbd>+<kbd>F</kbd> (Mac) or <kbd>Ctrl</kbd>+<kbd>F</kbd> (Windows, Linux) 
-1. In the bar, enter your query.
-    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/rLEzbmZU3zU3rE3OWNli.png", alt="ALT_TEXT_HERE", width="800", height="426" %}
+1. In the bar, type your query. In this example the query is `legacy`.
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/rLEzbmZU3zU3rE3OWNli.png", alt="Typing a query.", width="800", height="426" %}
     Optionally, you can:
     - Click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/egjnpBbgTvj6FDiIbfoc.png", alt="Match case.", width="25", height="20" %} **Match Case** to make your query case-sensitive.
     - Click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/97kuRQETaw1jnAfMHrbQ.png", alt="RegEx button.", width="17", height="18" %} **Use Regular Expression** to search using a RegEx expression.
@@ -240,7 +219,7 @@ ran earlier in the Console. Press <kbd>Enter</kbd> to run that expression again.
 ### Watch an expression's value in real-time with Live Expressions {: #live }
 
 If you find yourself typing the same JavaScript expression in the Console repeatedly, you might find
-it easier to create a **Live Expression**. With **Live Expressions** you type an expression once and
+it easier to create a **Live Expression**. With **Live Expressions**, you type an expression once and
 then pin it to the top of your Console. The value of the expression updates in near real-time. See
 [Watch JavaScript Expression Values In Real-Time With Live Expressions][29].
 
@@ -253,30 +232,25 @@ to turn off the return value previews.
 ### Disable autocomplete from history {: #autocomplete }
 
 As you type out an expression, the Console's autocomplete popup shows expressions that you ran
-earlier. These expressions are prepended with the `>` character. [Open Console Settings][31] and
-disable the **Autocomplete From History** checkbox to stop showing expressions from your history.
+earlier. These expressions are prepended with the `>` character. In the following example, DevTools earlier evaluated `document.querySelector('a')` and `document.querySelector('img')`.
 
 {% Img src="image/admin/7HsvmvxxZifd5ZqkP4Hg.png", alt="The autocomplete popup showing expressions from history.", width="800", height="512" %}
 
-**Figure 18**. `document.querySelector('a')` and `document.querySelector('img')` are expressions
-that were evaluated earlier.
+[Open Console Settings][31] and
+disable the **Autocomplete From History** checkbox to stop showing expressions from your history.
 
 ### Select JavaScript context {: #context }
 
-By default the **JavaScript Context** dropdown is set to **top**, which represents the main
+By default the **JavaScript Context** drop-down is set to **top**, which represents the main
 document's [browsing context][32].
 
-{% Img src="image/admin/V87tEcP23yWQwPhRlSsR.png", alt="The JavaScript Context dropdown.", width="800", height="512" %}
-
-**Figure 19**. The **JavaScript Context** dropdown.
+{% Img src="image/admin/V87tEcP23yWQwPhRlSsR.png", alt="The JavaScript Context drop-down.", width="800", height="512" %}
 
 Suppose you have an ad on your page embedded in an `<iframe>`. You want to run JavaScript in order
 to tweak the ad's DOM. To do this, you first need to select the ad's browsing context from the
-**JavaScript Context** dropdown.
+**JavaScript Context** drop-down.
 
 {% Img src="image/admin/Vl95VEu6LEV6X2cpgyAv.png", alt="Selecting a different JavaScript context.", width="800", height="650" %}
-
-**Figure 20**. Selecting a different JavaScript context.
 
 ## Inspect object properties {: #inspect-object-properties }
 
@@ -335,7 +309,7 @@ You might see the following internal properties on different objects:
 - In addition to `ArrayBuffer`-specific properties, `WebAssembly.Memory` objects have a `[[WebAssemblyMemory]]` property.
    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/DKbH651INnLPj4IZhhbp.png", alt="WebAssemblyMemory object.", width="800", height="562" %}
 - [Keyed collections](https://tc39.es/ecma262/#sec-keyed-collections) (maps and sets) have an `[[Entries]]` property that contains their keyed entries.
-   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/PBHT8RBNIVA6iWrBQCz9.png", alt="Keyed collections", width="800", height="637" %}
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/PBHT8RBNIVA6iWrBQCz9.png", alt="Keyed collections.", width="800", height="637" %}
 - [`Promise` objects][46] have the following properties:
    - [`[[PromiseState]]`][43]: pending, fulfilled, or rejected
    - [`[[PromiseResult]]`][43]: `undefined` if pending, `<value>` if fulfilled, `<reason>` if rejected
@@ -374,7 +348,7 @@ Functions have the following properties:
 You can use any of the following workflows to clear the Console:
 
 - Click **Clear Console**
-  {% Img src="image/admin/PleTkKOHeF03hC4BxBvM.png", alt="Clear Console", width="26", height="26" %}.
+  {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Nh5W7S7oEdlTcjarzxKC.svg", alt="Clear.", width="20", height="20" %}.
 - Right-click a message and then select **Clear Console**.
 - Type `clear()` in the Console and then press <kbd>Enter</kbd>.
 - Call `console.clear()` from your webpage's JavaScript.

--- a/site/en/docs/devtools/console/reference/index.md
+++ b/site/en/docs/devtools/console/reference/index.md
@@ -5,7 +5,7 @@ authors:
   - kaycebasques
   - sofiayem
 date: 2019-04-18
-updated: 2022-06-22
+updated: 2022-07-22
 description:
   "A comprehensive reference on every feature and behavior related to the Console UI in Chrome
   DevTools."

--- a/site/en/docs/devtools/console/reference/index.md
+++ b/site/en/docs/devtools/console/reference/index.md
@@ -35,7 +35,7 @@ Console** command that has the **Panel** badge next to it.
 
 {% Img src="image/admin/QXom109Oiui7fgVBj38Y.png", alt="The command for showing the Console panel.", width="800", height="413" %}
 
-### Open the Console tab in the Drawer {: #drawer }
+### Open the Console in the Drawer {: #drawer }
 
 Press <kbd>Escape</kbd> or click **Customize And Control DevTools**
 {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/N5Lkpdwpaz4YqRGFr2Ks.svg", alt="Customize And Controls DevTools.", width="24", height="24" %} and then

--- a/site/en/docs/devtools/console/reference/index.md
+++ b/site/en/docs/devtools/console/reference/index.md
@@ -28,7 +28,7 @@ You can open the Console as a [panel][4] or as a [tab in the Drawer][5].
 Press <kbd>Control</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd> or
 <kbd>Command</kbd>+<kbd>Option</kbd>+<kbd>J</kbd> (Mac).
 
-{% Img src="image/admin/yA07vZPXixZWv2jHdE6W.png", alt="The Console panel.", width="800", height="493" %}
+{% Img src="image/admin/yA07vZPXixZWv2jHdE6W.png", alt="The Console.", width="800", height="493" %}
 
 To open the Console panel from the [Command Menu][6], start typing `Console` and then run the **Show
 Console** command that has the **Panel** badge next to it.


### PR DESCRIPTION
Doc refresh ahead of DevTools Tips 11 video. Required for #3204 but doesn't fully close that one yet.

Updated the Console docs to better comply with:
- [Developer documentation style guide](https://developers.google.com/style)
- [web.dev handbook](https://web.dev/handbook/)

Can be published prior to DTT 11 video release.