### PR TITLE
Correct mention of web standard in background-fetch

### DIFF
--- a/site/en/blog/background-fetch/index.md
+++ b/site/en/blog/background-fetch/index.md
@@ -21,7 +21,7 @@ date: 2018-12-03
 
 # Optional
 # Include an updated date when you update your post
-updated: 2020-12-17
+updated: 2022-07-28
 
 # Optional
 # How to add a new tag
@@ -31,7 +31,7 @@ updated: 2020-12-17
 
 ---
 
-In 2015 we [introduced Background Sync](https://developers.google.com/web/updates/2015/12/background-sync) which allows the
+In 2015 we [introduced Background Sync](/blog/background-sync/) which allows the
 service worker to defer work until the user has connectivity. This means the user could type a
 message, hit send, and leave the site knowing that the message will be sent either now, or when they
 have connectivity.
@@ -42,8 +42,9 @@ too long the browser will kill the service worker, otherwise it's a risk to the 
 battery.
 
 So, what if you need to download something that might take a long time, like a movie, podcasts, or
-levels of a game. That's what Background Fetch is for. Background Fetch is a [web
-standard](https://wicg.github.io/background-fetch/) available by default since Chrome 74.
+levels of a game. That's what [Background Fetch](https://developer.mozilla.org/docs/Web/API/Background_Fetch_API) is for. 
+
+Background Fetch is available by default since Chrome 74.
 
 Here's a quick two minute demo showing the traditional state of things, vs using Background Fetch:
 
@@ -51,11 +52,7 @@ Here's a quick two minute demo showing the traditional state of things, vs using
 
 
 [Try the demo yourself](https://bgfetch-http203.glitch.me/) and [browse the
-code](https://glitch.com/edit/#!/bgfetch-http203?path=public/client.js). It requires Chrome 71, and
-the *Experimental Web Platform features* flag to be enabled.
-
-This is also being run as an Origin Trial. If you're interested in testing this API with real users
-without a flag, [see below](#origin-trial).
+code](https://glitch.com/edit/#!/bgfetch-http203?path=public/client.js). 
 
 ## How it works
 
@@ -92,7 +89,7 @@ if ('BackgroundFetchManager' in self) {
 
 ### Starting a background fetch
 
-The main API hangs off a [service worker](https://developers.google.com/web/fundamentals/primers/service-workers/) registration,
+The main API hangs off a [service worker](/docs/workbox/service-worker-overview/) registration,
 so make sure you've registered a service worker first. Then:
 
 ```js
@@ -111,7 +108,7 @@ navigator.serviceWorker.ready.then(async (swReg) => {
 
 {% Aside %}
 Many examples in this article use async functions. If you aren't familiar with them, [check
-out the guide](https://developers.google.com/web/fundamentals/primers/async-functions).
+out the guide](https://web.dev/javascript-async-functions/).
 {% endAside %}
 
 `backgroundFetch.fetch` takes three arguments:
@@ -469,26 +466,10 @@ addEventListener('backgroundfetchclick', (event) => {
 });
 ```
 
-## Origin trial
-
-To get access to this new API on your site, please [sign up](http://bit.ly/OriginTrialSignup) for
-the "Background Fetch API" Origin Trial. If you just want to try it out locally, the API can be
-enabled on the command line:
-
-```shell
-chrome --enable-blink-features=BackgroundFetch
-```
-
-Passing this flag on the command line enables the API globally in Chrome for the current session.
-
-If you give this API a try, please let us know what you think! Please direct feedback on the API
-shape to [the specification repository](https://github.com/WICG/background-fetch/issues), and report
-implementation bugs to [the BackgroundFetch Blink
-component](https://bugs.chromium.org/p/chromium/issues/entry?template=Defect+report+from+developer&components=Blink%3EBackgroundFetch).
-
 ## Additional resources
 
 * [Explainer](https://github.com/WICG/background-fetch/blob/main/README.md)
 * [Specification](https://wicg.github.io/background-fetch/)
 * [chromestatus.com entry](https://www.chromestatus.com/features/5712608971718656)
 
+_Correction: A previous version of this article incorrectly referred to Background Fetch as being a "web standard". The API is not currently on the standards track, the [specification](https://wicg.github.io/background-fetch/) can be found in WICG as a Draft Community Group Report._


### PR DESCRIPTION
Reported to me by @cwilso, the Background Fetch article incorrectly refers to the spec as a web standard.

I've updated the article, added a correction note at the bottom, I also fixed some links that now redirect due to the Web Fundamentals migration and removed outdated origin trial info while I was in there. 

Preview: https://deploy-preview-3330--developer-chrome-com.netlify.app/blog/background-fetch