### PR TITLE
Devtools 104 > Elements > Badges reference

### DIFF
--- a/site/_data/docs/devtools/toc.yml
+++ b/site/_data/docs/devtools/toc.yml
@@ -23,6 +23,7 @@
     - url: /docs/devtools/css/flexbox/
     - url: /docs/devtools/css/container-queries/
     - url: /docs/devtools/css/reference/
+    - url: /docs/devtools/elements/badges/
 - title: i18n.docs.devtools.console
   sections:
     - url: /docs/devtools/console/

--- a/site/en/docs/devtools/elements/badges/index.md
+++ b/site/en/docs/devtools/elements/badges/index.md
@@ -3,7 +3,7 @@ layout: "layouts/doc-post.njk"
 title: "Badges reference"
 date: 2022-08-02
 #updated: YYYY-MM-DD
-description: "Toogle various overlays and speed up DOM tree navigation with badges."
+description: "Toggle various overlays and speed up DOM tree navigation with badges."
 authors:
   - sofiayem
 tags:
@@ -12,7 +12,7 @@ tags:
   - css
 ---
 
-Toogle various overlays and speed up DOM tree navigation with this comprehensive reference of badges in the **Elements** panel.
+Toggle various overlays and speed up DOM tree navigation with this comprehensive reference of badges in the **Elements** panel.
 
 ## Show or hide badges
 
@@ -21,13 +21,17 @@ To show or hide badges:
 1. [Open DevTools](/docs/devtools/open/#elements).
 1. Right-click an element in the DOM tree and select **Badge settings...**.
    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/xpRsrsvl9BxxANM4Xuiy.png", alt="Badge settings.", width="800", height="337" %}
-1. Select or clear checkboxes next to the desired badges. The **Elements** panel shows the selected badges next to the corresponding elements in the DOM tree.
+1. Select or clear checkboxes next to the desired badges.
+
+The **Elements** panel shows the selected badges next to the appropriate elements in the DOM tree.
 
 The next section explain what every badge does.
 
 ## Grid
 
-Toggle the grid overlay with the `grid` badge on the following preview:
+An HTML element is a [grid container](https://developer.mozilla.org/docs/Web/CSS/CSS_Grid_Layout) if its `display` CSS property is set to `grid` or `inline-grid`. Such elements have `grid` badges next to them that toggle the corresponding overlays.
+
+Toggle the overlay on the following preview:
 
 {% Codepen {
  user: 'sofiayem',
@@ -36,10 +40,10 @@ Toggle the grid overlay with the `grid` badge on the following preview:
  allow: ['geolocation']
 } %}
 
-1. [Inspect the element in the preview][1].
+1. [Inspect the element][1] in the preview.
 1. In the DOM tree, click the `grid` badge next to the element and observe the overlay.
 
-{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/pGJNxibLKoaTmkgAqsyR.png", alt="Grid overlay.", width="800", height="657" %}
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/WMZrfd1AVdMjkgCDqSK8.png", alt="Grid overlay.", width="800", height="674" %}
 
 The overlay shows columns, rows, their numbers, and gaps.
 
@@ -47,7 +51,9 @@ To learn how to debug grid layout, see [Inspect CSS grid](/docs/devtools/css/gri
 
 ## Flex
 
-Toggle the flex overlay with the `flex` badge on the following preview:
+An HTML element is a [flexbox](https://developer.mozilla.org/docs/Web/CSS/CSS_Flexible_Box_Layout) if its `display` CSS property is set to `flex` or `inline-flex`. Such elements have `flex` badges next to them that toggle the corresponding overlays.
+
+Toggle the overlay on the following preview:
 
 {% Codepen {
   user: 'sofiayem',
@@ -56,18 +62,20 @@ Toggle the flex overlay with the `flex` badge on the following preview:
   allow: ['geolocation']
 } %}
 
-1. [Inspect the element in the preview][1].
+1. [Inspect the element][1] in the preview.
 1. In the DOM tree, click the `flex` badge next to the element and observe the overlay.
 
-{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/IgxIyFsXTjEPvTEStsMj.png", alt="Flex overlay.", width="800", height="613" %}
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/MmkJORNp3sOKHHK1CI4h.png", alt="Flex overlay.", width="800", height="646" %}
 
 The overlay shows child element positions. 
 
-To learn how to debug flex laylouts, see [Inspect and debug CSS flexbox](/docs/devtools/css/flexbox/).
+To learn how to debug flex layouts, see [Inspect and debug CSS flexbox](/docs/devtools/css/flexbox/).
 
 ## Ad
 
-Discover ads with the `ad` badge:
+DevTools can detect most ad frames. Such frames have `ad` badges next to them. 
+
+Discover an ad in the following preview:
 
 {% Codepen {
   user: 'sofiayem',
@@ -76,7 +84,7 @@ Discover ads with the `ad` badge:
   allow: ['geolocation']
 } %}
 
-1. [Inspect the element in the preview][1].
+1. [Inspect the element][1] in the preview.
 1. In the DOM tree, find an element with the `ad` badge next to it.
 
 {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/EqJVqe8nqFApED6q1udz.png", alt="Ad badge.", width="800", height="659" %}
@@ -85,7 +93,9 @@ The `ad` badge is not clickable but you can use the **Rendering** tab to [highli
 
 ## Scroll-snap
 
-Toggle the scroll-snap overlay with the `scroll-snap` badge on the following preview:
+An HTML element is a [scroll container](https://developer.mozilla.org/docs/Glossary/Scroll_container) if its `overflow` CSS property is set to `scroll`, or `auto` when there's enough content to cause overflow. Scroll containers can have [CSS properties that configure snap points](https://developer.mozilla.org/docs/Web/CSS/CSS_Scroll_Snap). Such elements have `scroll-snap` badges next to them that toggle the corresponding overlays.
+
+Toggle the overlay on the following preview:
 
 {% Codepen {
   user: 'sofiayem',
@@ -94,17 +104,19 @@ Toggle the scroll-snap overlay with the `scroll-snap` badge on the following pre
   allow: ['geolocation']
 } %}
 
-1. [Inspect the element in the preview][1].
+1. [Inspect the element][1] in the preview.
 1. In the DOM tree, click the `scroll-snap` badge next to the element.
-1. Try scrolling to the right and ovserve the overlay.
+1. Try scrolling the element to the right and observe the overlay.
 
-{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/2rK1YxBm1ycHBCnEbvkG.png", alt="Scroll-snap overlay.", width="800", height="656" %}
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/r3qAHP29BF4Gjeacn7cN.png", alt="Scroll-snap overlay.", width="800", height="646" %}
 
-The overlay shows element positions and align points.
+The overlay shows element positions and snap points.
 
 ## Container
 
-Toggle the container overlay with the `container` badge on the following preview:
+An HTML element is a [container](https://developer.mozilla.org/docs/Web/CSS/CSS_Container_Queries) if it has the `container-type` CSS property. Such elements have `container` badges next to them that toggle the corresponding overlays.
+
+Toggle the overlay on the following preview:
 
 {% Codepen {
   user: 'sofiayem',
@@ -113,11 +125,11 @@ Toggle the container overlay with the `container` badge on the following preview
   allow: ['geolocation']
 } %}
 
-1. [Inspect the element in the preview][1].
+1. [Inspect the element][1] in the preview.
 1. In the DOM tree, click the `container` badge next to the element.
 1. Try resizing the element by dragging its bottom-right corner and observe the layout change and overlay.
 
-{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/D1fMidi9ihzOANGjP51J.png", alt="Container overlay.", width="800", height="583" %}
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/zT2tNGGCrQDDBgGJEdLd.png", alt="Container overlay.", width="800", height="646" %}
 
 The overlay shows child element positions.
 
@@ -125,6 +137,9 @@ To learn how to debug container queries, see [Inspect and debug CSS container qu
 
 ## Slot
 
+The [`<slot>` HTML element](https://developer.mozilla.org/docs/Web/HTML/Element/slot) is a placeholder that you can fill with your own content. Together with the `<template>` element,  `<slot>` lets you create separate DOM trees and present them together. Slot content elements have {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Zml4roc9tWR2DU1Yb9ix.svg", alt="Slot.", width="20", height="20" %}`slot` badges next to them that serve as links to the corresponding slots.
+
+Discover the {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Zml4roc9tWR2DU1Yb9ix.svg", alt="Slot.", width="20", height="20" %}`slot` badge in the following preview:
 
 {% Codepen {
   user: 'sofiayem',
@@ -132,5 +147,13 @@ To learn how to debug container queries, see [Inspect and debug CSS container qu
   height: 150,
   allow: ['geolocation']
 } %}
+
+1. [Inspect the element][1] in the preview.
+1. In the DOM tree, click the {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Zml4roc9tWR2DU1Yb9ix.svg", alt="Slot.", width="20", height="20" %}`slot` badge next to the element to locate the corresponding slot.
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/xO7HvYKsDgYjQ2xbO8jL.png", alt="Slot and reveal badges.", width="800", height="699" %}
+   {% Aside 'gotchas' %}
+   The {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Zml4roc9tWR2DU1Yb9ix.svg", alt="Slot.", width="20", height="20" %}`slot` badge has a paired {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Zml4roc9tWR2DU1Yb9ix.svg", alt="Reveal.", width="20", height="20" %}`reveal` badge that takes you back.
+   {% endAside %}
+1. Get back to the slot's content by clicking the {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Zml4roc9tWR2DU1Yb9ix.svg", alt="Reveal.", width="20", height="20" %}`reveal` badge.
 
 [1]: /docs/devtools/open/#elements

--- a/site/en/docs/devtools/elements/badges/index.md
+++ b/site/en/docs/devtools/elements/badges/index.md
@@ -7,9 +7,9 @@ description: "Toggle various overlays and speed up DOM tree navigation with badg
 authors:
   - sofiayem
 tags:
-  - html
   - dom
   - css
+  - html
 ---
 
 Toggle various overlays and speed up DOM tree navigation with this comprehensive reference of badges in the **Elements** panel.
@@ -23,9 +23,7 @@ To show or hide badges:
    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/xpRsrsvl9BxxANM4Xuiy.png", alt="Badge settings.", width="800", height="337" %}
 1. Select or clear checkboxes next to the desired badges.
 
-The **Elements** panel shows the selected badges next to the appropriate elements in the DOM tree.
-
-The next section explain what every badge does.
+The **Elements** panel shows the selected badges next to the appropriate elements in the DOM tree. The next sections explain every badge.
 
 ## Grid
 
@@ -116,6 +114,11 @@ The overlay shows element positions and snap points.
 
 An HTML element is a [container](https://developer.mozilla.org/docs/Web/CSS/CSS_Container_Queries) if it has the `container-type` CSS property. Such elements have `container` badges next to them that toggle the corresponding overlays.
 
+{% Aside %}
+CSS container queries is an experimental feature. To enable its support in DevTools, under [`chrome://flags`](chrome://flags), set the `Enable CSS Container Queries` experiment to `Enabled`.
+Otherwise, the preview below doesn't work.
+{% endAside %}
+
 Toggle the overlay on the following preview:
 
 {% Codepen {
@@ -138,6 +141,10 @@ To learn how to debug container queries, see [Inspect and debug CSS container qu
 ## Slot
 
 The [`<slot>` HTML element](https://developer.mozilla.org/docs/Web/HTML/Element/slot) is a placeholder that you can fill with your own content. Together with the `<template>` element,  `<slot>` lets you create separate DOM trees and present them together. Slot content elements have {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Zml4roc9tWR2DU1Yb9ix.svg", alt="Slot.", width="20", height="20" %}`slot` badges next to them that serve as links to the corresponding slots.
+
+{% Aside %}
+The slot badge is a new DevTools feature available from Chrome version 104. In earlier versions, the preview below doesn't work.
+{% endAside %}
 
 Discover the {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Zml4roc9tWR2DU1Yb9ix.svg", alt="Slot.", width="20", height="20" %}`slot` badge in the following preview:
 

--- a/site/en/docs/devtools/elements/badges/index.md
+++ b/site/en/docs/devtools/elements/badges/index.md
@@ -115,7 +115,7 @@ Toggle the container overlay with the `container` badge on the following preview
 
 1. [Inspect the element in the preview][1].
 1. In the DOM tree, click the `container` badge next to the element.
-1. Try resizing the element by dragging its bottom-left corner and observe the layout change and overlay.
+1. Try resizing the element by dragging its bottom-right corner and observe the layout change and overlay.
 
 {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/D1fMidi9ihzOANGjP51J.png", alt="Container overlay.", width="800", height="583" %}
 

--- a/site/en/docs/devtools/elements/badges/index.md
+++ b/site/en/docs/devtools/elements/badges/index.md
@@ -1,0 +1,136 @@
+---
+layout: "layouts/doc-post.njk"
+title: "Badges reference"
+date: 2022-08-02
+#updated: YYYY-MM-DD
+description: "Toogle various overlays and speed up DOM tree navigation with badges."
+authors:
+  - sofiayem
+tags:
+  - html
+  - dom
+  - css
+---
+
+Toogle various overlays and speed up DOM tree navigation with this comprehensive reference of badges in the **Elements** panel.
+
+## Show or hide badges
+
+To show or hide badges:
+
+1. [Open DevTools](/docs/devtools/open/#elements).
+1. Right-click an element in the DOM tree and select **Badge settings...**.
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/xpRsrsvl9BxxANM4Xuiy.png", alt="Badge settings.", width="800", height="337" %}
+1. Select or clear checkboxes next to the desired badges. The **Elements** panel shows the selected badges next to the corresponding elements in the DOM tree.
+
+The next section explain what every badge does.
+
+## Grid
+
+Toggle the grid overlay with the `grid` badge on the following preview:
+
+{% Codepen {
+ user: 'sofiayem',
+ id: 'YzarzKV',
+ height: 270,
+ allow: ['geolocation']
+} %}
+
+1. [Inspect the element in the preview][1].
+1. In the DOM tree, click the `grid` badge next to the element and observe the overlay.
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/pGJNxibLKoaTmkgAqsyR.png", alt="Grid overlay.", width="800", height="657" %}
+
+The overlay shows columns, rows, their numbers, and gaps.
+
+To learn how to debug grid layout, see [Inspect CSS grid](/docs/devtools/css/grid/).
+
+## Flex
+
+Toggle the flex overlay with the `flex` badge on the following preview:
+
+{% Codepen {
+  user: 'sofiayem',
+  id: 'XWEeWdb',
+  height: 200,
+  allow: ['geolocation']
+} %}
+
+1. [Inspect the element in the preview][1].
+1. In the DOM tree, click the `flex` badge next to the element and observe the overlay.
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/IgxIyFsXTjEPvTEStsMj.png", alt="Flex overlay.", width="800", height="613" %}
+
+The overlay shows child element positions. 
+
+To learn how to debug flex laylouts, see [Inspect and debug CSS flexbox](/docs/devtools/css/flexbox/).
+
+## Ad
+
+Discover ads with the `ad` badge:
+
+{% Codepen {
+  user: 'sofiayem',
+  id: 'rNdGNYx',
+  height: 200,
+  allow: ['geolocation']
+} %}
+
+1. [Inspect the element in the preview][1].
+1. In the DOM tree, find an element with the `ad` badge next to it.
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/EqJVqe8nqFApED6q1udz.png", alt="Ad badge.", width="800", height="659" %}
+
+The `ad` badge is not clickable but you can use the **Rendering** tab to [highlight ad frames](/docs/devtools/rendering/apply-effects/#highlight-ad-frames) in red.
+
+## Scroll-snap
+
+Toggle the scroll-snap overlay with the `scroll-snap` badge on the following preview:
+
+{% Codepen {
+  user: 'sofiayem',
+  id: 'eYMGYLz',
+  height: 200,
+  allow: ['geolocation']
+} %}
+
+1. [Inspect the element in the preview][1].
+1. In the DOM tree, click the `scroll-snap` badge next to the element.
+1. Try scrolling to the right and ovserve the overlay.
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/2rK1YxBm1ycHBCnEbvkG.png", alt="Scroll-snap overlay.", width="800", height="656" %}
+
+The overlay shows element positions and align points.
+
+## Container
+
+Toggle the container overlay with the `container` badge on the following preview:
+
+{% Codepen {
+  user: 'sofiayem',
+  id: 'mdxByda',
+  height: 350,
+  allow: ['geolocation']
+} %}
+
+1. [Inspect the element in the preview][1].
+1. In the DOM tree, click the `container` badge next to the element.
+1. Try resizing the element by dragging its bottom-left corner and observe the layout change and overlay.
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/D1fMidi9ihzOANGjP51J.png", alt="Container overlay.", width="800", height="583" %}
+
+The overlay shows child element positions.
+
+To learn how to debug container queries, see [Inspect and debug CSS container queries](/docs/devtools/css/container-queries/).
+
+## Slot
+
+
+{% Codepen {
+  user: 'sofiayem',
+  id: 'OJvxyzB',
+  height: 150,
+  allow: ['geolocation']
+} %}
+
+[1]: /docs/devtools/open/#elements

--- a/site/en/docs/devtools/elements/badges/index.md
+++ b/site/en/docs/devtools/elements/badges/index.md
@@ -49,7 +49,7 @@ To learn how to debug grid layout, see [Inspect CSS grid](/docs/devtools/css/gri
 
 ## Flex
 
-An HTML element is a [flexbox](https://developer.mozilla.org/docs/Web/CSS/CSS_Flexible_Box_Layout) if its `display` CSS property is set to `flex` or `inline-flex`. Such elements have `flex` badges next to them that toggle the corresponding overlays.
+An HTML element is a [flex container](https://developer.mozilla.org/docs/Web/CSS/CSS_Flexible_Box_Layout) if its `display` CSS property is set to `flex` or `inline-flex`. Such elements have `flex` badges next to them that toggle the corresponding overlays.
 
 Toggle the overlay on the following preview:
 

--- a/site/en/docs/devtools/elements/badges/index.md
+++ b/site/en/docs/devtools/elements/badges/index.md
@@ -71,7 +71,7 @@ To learn how to debug flex layouts, see [Inspect and debug CSS flexbox](/docs/de
 
 ## Ad
 
-DevTools can detect most ad frames. Such frames have `ad` badges next to them. 
+DevTools can detect some [ad frames and tag them](https://chromium.googlesource.com/chromium/src/+/master/docs/ad_tagging.md). Such frames have `ad` badges next to them. 
 
 Discover an ad in the following preview:
 
@@ -151,7 +151,7 @@ Discover the {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Zml4roc9tWR2DU1Yb9ix
 {% Codepen {
   user: 'sofiayem',
   id: 'OJvxyzB',
-  height: 150,
+  height: 250,
   allow: ['geolocation']
 } %}
 


### PR DESCRIPTION
Documented:
- https://developer.chrome.com/blog/new-in-devtools-104/#slot
- https://developer.chrome.com/blog/new-in-devtools-91/#css-croll-snap
- https://developer.chrome.com/blog/new-in-devtools-94/#container-queries
- https://developer.chrome.com/blog/new-in-devtools-91/#badge-settings
Also documented all other badges.

Publish on Aug 2.