### PR TITLE
Fix local build

### DIFF
--- a/site/en/blog/shared-element-transitions-for-spas/index.md
+++ b/site/en/blog/shared-element-transitions-for-spas/index.md
@@ -113,7 +113,7 @@ Once that's complete, the callback passed to `.start()` is called. That's where 
 
 Once the state is captured, the API constructs a pseudo-element tree like this:
 
-```plain
+```diff
 ::page-transition
 └─ ::page-transition-container(root)
    └─ ::page-transition-image-wrapper(root)
@@ -237,7 +237,7 @@ Now the header stays in place and cross-fades.
 
 That CSS declaration caused the pseudo-element tree to change:
 
-```plain
+```diff
 ::page-transition
 ├─ ::page-transition-container(root)
 │  └─ ::page-transition-image-wrapper(root)
@@ -271,7 +271,7 @@ That hasn't mattered until now, as the header is the same size and position both
 
 So now we have three parts to play with:
 
-```plain
+```diff
 ::page-transition
 ├─ ::page-transition-container(root)
 │  └─ …


### PR DESCRIPTION
Local build errors out:
```
Problem writing Eleventy templates: (more in DEBUG output)
> Having trouble rendering njk (and markdown) template ./site/en/blog/shared-element-transitions-for-spas/index.md

`TemplateContentRenderError` was thrown
> "plain" is not a valid Prism.js language for eleventy-plugin-syntaxhighlight

`Error` was thrown:
    Error: "plain" is not a valid Prism.js language for eleventy-plugin-syntaxhighlight
```

From [11ty docs](https://www.11ty.dev/docs/plugins/syntaxhighlight/#show-changes-using-diff-syntax):

```
Alternatively, you can use diff without another language name to enable plaintext line highlighting.
```