### PR TITLE
Add FPS update banners

### DIFF
--- a/site/en/blog/first-party-sets-sameparty/index.md
+++ b/site/en/blog/first-party-sets-sameparty/index.md
@@ -19,7 +19,7 @@ authors:
 ---
 
 {% Aside 'caution' %}
-First-Party Sets proposal is being updated with a [new design based on
+First-Party Sets proposal is being updated with a [new design based on use case specific definition and 
 the Storage Access API](https://github.com/WICG/first-party-sets/issues/92). You can [follow the discussion in the repo](https://github.com/WICG/first-party-sets/issues)
 and we will update this content as the work progresses.
 {% endAside %}

--- a/site/en/blog/first-party-sets-sameparty/index.md
+++ b/site/en/blog/first-party-sets-sameparty/index.md
@@ -6,6 +6,7 @@ description: >
   the same entity to be treated as first-party in situations where first party and
   third party are otherwise treated differently. 
 date: 2021-08-26
+updated: 2022-08-04
 thumbnail: 'image/vgdbNJBYHma2o62ZqYmcnkq3j0o1/JL7L7S2qKI53pTWACfcv.jpg'
 alt: A diagram showing First-Party Sets. One set contains domains example.com,
   example.rs, and example.co.uk. The other set containts brandx.site,
@@ -17,6 +18,11 @@ authors:
   - mihajlija
 ---
 
+{% Aside 'caution' %}
+First-Party Sets proposal is being updated with a [new design based on
+the Storage Access API](https://github.com/WICG/first-party-sets/issues/92). You can [follow the discussion in the repo](https://github.com/WICG/first-party-sets/issues)
+and we will update this content as the work progresses.
+{% endAside %}
 
 Many organizations have related sites with different domain names, such as
 `brandx.site` and `fly-brandx.site`—or domains for different countries such as

--- a/site/en/docs/privacy-sandbox/first-party-sets/index.md
+++ b/site/en/docs/privacy-sandbox/first-party-sets/index.md
@@ -12,7 +12,7 @@ authors:
 ---
 
 {% Aside 'caution' %}
-First-Party Sets proposal is being updated with a [new design based on
+First-Party Sets proposal is being updated with a [new design based on use case specific definition and 
 the Storage Access API](https://github.com/WICG/first-party-sets/issues/92). You can [follow the discussion in the repo](https://github.com/WICG/first-party-sets/issues)
 and we will update this content as the work progresses.
 {% endAside %}

--- a/site/en/docs/privacy-sandbox/first-party-sets/index.md
+++ b/site/en/docs/privacy-sandbox/first-party-sets/index.md
@@ -6,15 +6,21 @@ subhead: >
 description: >
   First-Party Sets enables related domain names owned and operated by the same entity to declare themselves as belonging to the same first party.
 date: 2021-05-18
-updated: 2021-10-18
+updated: 2022-08-04
 authors:
   - samdutton
 ---
 
-<!--lint disable no-smart-quotes-->
+{% Aside 'caution' %}
+First-Party Sets proposal is being updated with a [new design based on
+the Storage Access API](https://github.com/WICG/first-party-sets/issues/92). You can [follow the discussion in the repo](https://github.com/WICG/first-party-sets/issues)
+and we will update this content as the work progresses.
+{% endAside %}
+
 
 ## Implementation status
 
+* First-Party Sets [design change proposal, July 2022](https://github.com/WICG/first-party-sets/issues/92).
 * The initial [origin trial](/origintrials/#/view_trial/988540118207823873) 
 for First-Party Sets and SameParty was available in Chrome from versions 89 to 93 and is now closed.
 * [Chrome Platform Status](https://chromestatus.com/feature/5640066519007232).
@@ -111,6 +117,6 @@ follow discussion](https://github.com/privacycg/first-party-sets/issues).
 ## Find out more
 
 * [First-Party Sets and the SameParty attribute](/blog/first-party-sets-sameparty/)
-* [First-Party Sets technical explainer](https://github.com/privacycg/first-party-sets)
-* [Chrome Platform Status](https://chromestatus.com/feature/5640066519007232).
-* [Chromium Projects](https://www.chromium.org/updates/first-party-sets).
+* [First-Party Sets technical explainer](https://github.com/WICG/first-party-sets#introduction)
+* [Chrome Platform Status](https://chromestatus.com/feature/5640066519007232)
+* [Chromium Projects](https://www.chromium.org/updates/first-party-sets)


### PR DESCRIPTION
Preview: 
- https://deploy-preview-3379--developer-chrome-com.netlify.app/docs/privacy-sandbox/first-party-sets/
- https://deploy-preview-3379--developer-chrome-com.netlify.app/blog/first-party-sets-sameparty/

Changes proposed in this pull request:

- Add a banner announcing the design change to docs/first-party-sets
- Add the banner to FPS blog post
- Update explainer links