### PR TITLE
DevTools Tips 12 > Animations tab refresh + promo post

### DIFF
--- a/site/en/blog/devtools-tips-12/index.md
+++ b/site/en/blog/devtools-tips-12/index.md
@@ -23,7 +23,7 @@ The Chrome DevTools **Animations** tab is a powerful tool that helps you slow do
 The **Animations** tab, while open, records animations automatically, conveniently groups them, and lets you:
 
 - Replay and slow down animations to better inspect them.
-- Adjust timings and delays by dragging points in a timeline instead of guessing and setting CSS values manually.
+- Adjust durations, timings, and delays by dragging points in a timeline instead of guessing and setting CSS values manually.
 
 Additionally, you can edit the easing timings and set custom `cubic-bezier` curve values with the **Easing Editor** in the **Elements** > **Styles** pane. To learn more, see [Edit animation and transition timings with the **Easing Editor**](/docs/devtools/css/reference/#edit-easing).
 

--- a/site/en/blog/devtools-tips-12/index.md
+++ b/site/en/blog/devtools-tips-12/index.md
@@ -1,0 +1,30 @@
+---
+title: >
+  DevTools Tips: How to inspect and modify CSS animations
+description: >
+  Use the Animations tab to inspect and modify CSS animations, transitions, and more.
+layout: 'layouts/blog-post.njk'
+date: 2022-08-11
+authors:
+  - sofiayem
+hero: 'image/NJdAV9UgKuN8AhoaPBquL7giZQo1/ZcQHNwVHsQ3dIVNWbUAH.png'
+alt: >
+  DevTools Tips hero logo
+tags:
+  - css
+  - devtools
+  - devtools-tips
+---
+
+The Chrome DevTools **Animations** tab is a powerful tool that helps you slow down, replay, nail CSS animation timings, and see the results right away.
+
+{% YouTube id='lVLzkleL_CE' %}
+
+The **Animations** tab, while open, records animations automatically, conveniently groups them, and lets you:
+
+- Replay and slow down animations to better inspect them.
+- Adjust timings and delays by dragging points in a timeline instead of guessing and setting CSS values manually.
+
+Additionally, you can edit the easing timings and set custom `cubic-bezier` curve values with the **Easing Editor** in the **Elements** > **Styles** pane. To learn more, see [Edit animation and transition timings with the **Easing Editor**](/docs/devtools/css/reference/#edit-easing).
+
+For a more hands-on learning experience, follow the [Inspect and modify CSS animation effects](/docs/devtools/css/animations/) guide.

--- a/site/en/blog/devtools-tips-12/index.md
+++ b/site/en/blog/devtools-tips-12/index.md
@@ -16,7 +16,7 @@ tags:
   - devtools-tips
 ---
 
-The Chrome DevTools **Animations** tab is a powerful tool that helps you slow down, replay, nail CSS animation timings, and see the results right away.
+The Chrome DevTools **Animations** tab is a powerful tool that helps you slow down, replay, adjust CSS animation timings, and see the results right away.
 
 {% YouTube id='lVLzkleL_CE' %}
 

--- a/site/en/docs/devtools/css/animations/index.md
+++ b/site/en/docs/devtools/css/animations/index.md
@@ -16,6 +16,8 @@ Inspect and modify animations with the Chrome DevTools **Animations** drawer tab
 
 {% YouTube id='lVLzkleL_CE' %}
 
+{% YouTube id='lVLzkleL_CE' %}
+
 ## Overview {: #overview }
 
 To capture animations, open the **Animations** tab. It automatically detects animations and sorts them into groups.

--- a/site/en/docs/devtools/css/animations/index.md
+++ b/site/en/docs/devtools/css/animations/index.md
@@ -3,8 +3,9 @@ layout: "layouts/doc-post.njk"
 title: "Animations: Inspect and modify CSS animation effects"
 authors:
   - kaycebasques
+  - sofiayem
 date: 2016-05-02
-#updated: YYYY-MM-DD
+updated: 2022-08-11
 description: "Inspect and modify animations with the Chrome DevTools Animation Inspector."
 tags:
   - prototype-fixes
@@ -13,110 +14,96 @@ tags:
 
 Inspect and modify animations with the Chrome DevTools Animation Inspector.
 
-{% Img src="image/admin/NbXydhQGmfbeMOPHCHu9.png", alt="animation inspector", width="800", height="421" %}
-
-## Summary {: #summary }
-
-- Capture animations by opening the Animation Inspector. It automatically detects animations and
-  sorts them into groups.
-- Inspect animations by slowing them down, replaying them, or viewing their source code.
-- Modify animations by changing their timing, delay, duration, or keyframe offsets.
+<div class="elevation--4">{% Img src="image/admin/NbXydhQGmfbeMOPHCHu9.png", alt="Animation inspector.", width="800", height="421" %}</div>
 
 ## Overview {: #overview }
 
-The Chrome DevTools Animation Inspector has two main purposes.
+You can capture animations by opening the Animation Inspector. It automatically detects animations and sorts them into groups.
 
-- Inspecting animations. You want to slow down, replay, or inspect the source code for an animation
+The Animation Inspector has two main purposes:
+
+- **Inspect animations**. Slow down, replay, or inspect the source code for an animation
   group.
-- Modifying animations. You want to modify the timing, delay, duration, or keyframe offsets of an
-  animation group. Bezier editing and keyframe editing are currently not supported.
+- **Modify animations**. Modify the timing, delay, duration, or keyframe offsets of an
+  animation group. Keyframe editing is currently not supported.
+
+  {% Aside 'gotchas' %}
+  Bezier editing link.
+  {% endAside %}
 
 The Animation Inspector supports CSS animations, CSS transitions, and web animations.
 `requestAnimationFrame` animations are currently not supported.
 
 ### What's an animation group? {: #whats_an_animation_group }
 
-An animation group is a group of animations that _appear_ to be related to each other. Currently,
-the web has no real concept of a group animation, so motion designers and developers have to compose
-and time individual animations so that they appear to be one coherent visual effect. The Animation
-Inspector predicts which animations are related based on start time (excluding delays, and so on)
-and groups them all side-by-side. In other words, a set of animations all triggered in the same
-script block are grouped together, but if they're asynchronous then they're grouped separately.
+An animation group is a set of animations that _appear_ to be related to each other. 
+
+Currently, the web has no real concept of a group animation, so motion designers and developers compose and time individual animations to appear as one coherent visual effect. The Animation Inspector predicts related animations based on start time (excluding delays) and groups them side-by-side.
+
+In other words, the Animation Inspector groups together animations triggered in the same script block, but if they're asynchronous, they end up in different groups.
 
 ## Get started {: #get_started }
 
 There are two ways to open the Animation Inspector:
 
-- Through the Main Menu:
+- Select {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/N5Lkpdwpaz4YqRGFr2Ks.svg", alt="More.", width="24", height="24" %} **Customize and control DevTools** > **More tools** > **Animations**.
+  {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/w4767GjJfcHUdokjxB1a.png", alt="Animations in the menu.", width="800", height="572" %}
+- Press <kbd>Command</kbd>+<kbd>Option</kbd>+<kbd>C</kbd> (Mac) or <kbd>Control</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd> (Windows, Linux, ChromeOS) to open the Command Menu, start typing `Show Animations`, and select the corresponding Drawer panel.
+  {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/pbUGqPRe0SlaYNyqVMsO.png", alt="Show Animations.", width="800", height="572" %}
 
-  - Click **More**
-    {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/MU5oyGVk9rFUORcbptoZ.png", alt="More", width="6", height="26" %}
-    to open the Main Menu.
-  - Navigate to the **More tools** sub-menu.
-  - Select **Animations**:  
-    {% Img src="image/admin/VVGz6geZHi4jFJuuUxoT.png", alt="Animations via Main Menu", width="422", height="199" %}
+The Animation Inspector opens up as a tab next to the Console Drawer. Since it's a Drawer tab, you can use it from any DevTools panel.
 
-- Open the Command Menu and type `Show Animations`.
+<div class="elevation--4">{% Img src="image/admin/6dTrFBnaasvcKhrQreDm.png", alt="Empty Animation Inspector.", width="800", height="422" %}</div>
 
-The Animation Inspector opens up as a tab next to the Console Drawer. Since it's a Drawer tab, you
-can use it from any DevTools panel.
+The Animation Inspector is grouped into four main sections (or panes):
 
-{% Img src="image/admin/6dTrFBnaasvcKhrQreDm.png", alt="Empty Animation Inspector", width="800", height="422" %}
-
-The Animation Inspector is grouped into four main sections (or panes). This guide refers to each
-pane as follows:
-
-1.  **Controls**. From here you can clear all currently captured Animation Groups, or change the
+1.  **Controls**. From here, you can clear all currently captured Animation Groups, or change the
     speed of the currently selected Animation Group.
 2.  **Overview**. Select an Animation Group here to inspect and modify it in the **Details** pane.
 3.  **Timeline**. Pause and start an animation from here, or jump to a specific point in the
     animation.
 4.  **Details**. Inspect and modify the currently selected Animation Group.
 
-{% Img src="image/admin/PNT2B9LyO9ZK7O7YPpQV.png", alt="annotation Animation Inspector", width="800", height="437" %}
+<div class="elevation--4">{% Img src="image/admin/PNT2B9LyO9ZK7O7YPpQV.png", alt="Animation Inspector panes.", width="800", height="437" %}</div>
 
-To capture an animation, just perform the interaction that triggers the animation while the
-Animation Inspector is open. If an animation is triggered on page load, you can help the Animation
-Inspector detect the animation by reloading the page.
+To capture an animation, trigger it while the Animation Inspector is open. If an animation is triggered on page load, reload it.
 
 ## Inspect animations {: #inspect }
 
 Once you've captured an animation, there are a few ways to replay it:
 
 - Hover over its thumbnail in the **Overview** pane to view a preview of it.
-- Select the Animation Group from the **Overview** pane (so that it's displayed in the **Details**
-  pane) and press the **replay** button
-  ({% Img src="image/admin/FMABaWsGPXg627w2Ip0d.png", alt="replay button", width="46", height="44" %}). The
-  animation is replayed in the viewport. Click on the **animation speed** buttons
-  {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/0TdVNMElxodMWBFqfRze.png", alt="Animation speed buttons", width="254", height="50" %}
-  to change the preview speed of the currently selected Animation Group. You can use the red
-  vertical bar to change your current position.
 - Click and drag the red vertical bar to scrub the viewport animation.
+- Select the Animation Group from the **Overview** pane (so that it's displayed in the **Details**
+  pane) and press the {% Img src="image/admin/FMABaWsGPXg627w2Ip0d.png", alt="Replay button.", width="23", height="22" %} **Replay** button. The
+  animation is replayed in the viewport.
+
+Click on the {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/0TdVNMElxodMWBFqfRze.png", alt="Animation speed buttons", width="127", height="25" %} **Animation speed** buttons in the **Controls** bar to change the preview speed of the currently selected Animation Group.
 
 ### View animation details {: #view_animation_details }
 
 Once you've captured an Animation Group, click on it from the **Overview** pane to view its details.
-In the **Details** pane each individual animation gets its own row.
+In the **Details** pane, each individual animation gets its own row.
 
-{% Img src="image/admin/vdjLKNjWK79GW3PgiJol.png", alt="animation group details", width="800", height="501" %}
+<div class="elevation--4">{% Img src="image/admin/vdjLKNjWK79GW3PgiJol.png", alt="animation group details", width="800", height="501" %}</div>
 
 Hover over an animation to highlight it in the viewport. Click on the animation to select it in the
 **Elements** panel.
 
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/cwfsRGVqdUx09qYmZGzu.png", alt="Hovering over an animation to highlight it in viewport", width="800", height="431" %}
+<div class="elevation--4">{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/cwfsRGVqdUx09qYmZGzu.png", alt="Hovering over an animation to highlight it in viewport", width="800", height="431" %}</div>
 
 The leftmost, darker section of an animation is its definition. The right, more faded section
 represents iterations. For example, in the screenshot below, sections two and three represent
 iterations of section one.
 
-{% Img src="image/admin/X3dRm6DBme4PfCjPAXZO.png", alt="diagram of animation iterations", width="494", height="110" %}
+<div class="elevation--4" style="width: max-content; margin: 20px auto;">{% Img src="image/admin/X3dRm6DBme4PfCjPAXZO.png", alt="diagram of animation iterations", width="494", height="110" %}</div>
 
 If two elements have the same animation applied to them, the Animation Inspector assigns them the
 same color. The color itself is random and has no significance. For example, in the screenshot below
 the two elements `div.eye.left::after` and `div.eye.right::after` have the same animation (`eyes`)
 applied to them, as do the `div.feet::before` and `div.feet::after` elements.
 
-{% Img src="image/admin/czOX5s4gDuLjnoFl7mmv.png", alt="color-coded animations", width="518", height="268" %}
+<div class="elevation--4" style="width: max-content; margin: 20px auto;">{% Img src="image/admin/czOX5s4gDuLjnoFl7mmv.png", alt="color-coded animations", width="518", height="268" %}</div>
 
 ## Modify animations {: #modify }
 
@@ -126,19 +113,19 @@ There are three ways you can modify an animation with the Animation Inspector:
 - Keyframe timings.
 - Start time delay.
 
-For this section suppose that the screenshot below represents the original animation:
+For this section, suppose that the screenshot below represents the original animation:
 
-{% Img src="image/admin/XKgSjsvRLNrQkapxpekI.png", alt="original animation before modification", width="800", height="423" %}
+<div class="elevation--4">{% Img src="image/admin/XKgSjsvRLNrQkapxpekI.png", alt="original animation before modification", width="800", height="423" %}</div>
 
 To change the duration of an animation, click and drag the first or last circle.
 
-{% Img src="image/admin/ilDNkK4AfTzWeAbe9MZZ.png", alt="modified duration", width="800", height="421" %}
+<div class="elevation--4">{% Img src="image/admin/ilDNkK4AfTzWeAbe9MZZ.png", alt="modified duration", width="800", height="421" %}</div>
 
 If the animation defines any keyframe rules, then these are represented as white inner circles.
 Click and drag one of these to change the timing of the keyframe.
 
-{% Img src="image/admin/jJHtenLps4VT8RYWUDxS.png", alt="modified keyframe", width="800", height="421" %}
+<div class="elevation--4">{% Img src="image/admin/jJHtenLps4VT8RYWUDxS.png", alt="modified keyframe", width="800", height="421" %}</div>
 
 To add a delay to an animation, click and drag it anywhere except the circles.
 
-{% Img src="image/admin/D7OuXdLLAb1iBgPazKd0.png", alt="modified delay", width="800", height="421" %}
+<div class="elevation--4">{% Img src="image/admin/D7OuXdLLAb1iBgPazKd0.png", alt="modified delay", width="800", height="421" %}</div>

--- a/site/en/docs/devtools/css/animations/index.md
+++ b/site/en/docs/devtools/css/animations/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Animations: How to inspect and modify CSS animations"
+title: "Animations: Inspect and modify CSS animation effects"
 authors:
   - kaycebasques
   - sofiayem

--- a/site/en/docs/devtools/css/animations/index.md
+++ b/site/en/docs/devtools/css/animations/index.md
@@ -6,67 +6,69 @@ authors:
   - sofiayem
 date: 2016-05-02
 updated: 2022-08-11
-description: "Inspect and modify animations with the Chrome DevTools Animation Inspector."
+description: "Inspect and modify animations with the Animations tab."
 tags:
   - prototype-fixes
   - css
 ---
 
-Inspect and modify animations with the Chrome DevTools Animation Inspector.
-
-<div class="elevation--4">{% Img src="image/admin/NbXydhQGmfbeMOPHCHu9.png", alt="Animation inspector.", width="800", height="421" %}</div>
+Inspect and modify animations with the Chrome DevTools **Animations** drawer tab.
 
 ## Overview {: #overview }
 
-You can capture animations by opening the Animation Inspector. It automatically detects animations and sorts them into groups.
+To capture animations, open the **Animations** tab. It automatically detects animations and sorts them into groups.
 
-The Animation Inspector has two main purposes:
+The **Animations** tab has two main purposes:
 
 - **Inspect animations**. Slow down, replay, or inspect the source code for an animation
   group.
 - **Modify animations**. Modify the timing, delay, duration, or keyframe offsets of an
-  animation group. Keyframe editing is currently not supported.
+  animation group. Keyframe and Bezier editing isn't supported.
 
-  {% Aside 'gotchas' %}
-  Bezier editing link.
-  {% endAside %}
+{% Aside 'gotchas' %}
+You can edit the timings of CSS transition and animation easings and configure custom Bezier curves with the [Easing Editor](/docs/devtools/css/reference/#edit-easing) in the **Elements** > **Styles** pane.
+{% endAside %}
 
-The Animation Inspector supports CSS animations, CSS transitions, and web animations.
+The **Animations** tab supports CSS animations, CSS transitions, and web animations.
 `requestAnimationFrame` animations are currently not supported.
 
 ### What's an animation group? {: #whats_an_animation_group }
 
 An animation group is a set of animations that _appear_ to be related to each other. 
 
-Currently, the web has no real concept of a group animation, so motion designers and developers compose and time individual animations to appear as one coherent visual effect. The Animation Inspector predicts related animations based on start time (excluding delays) and groups them side-by-side.
+Currently, the web has no real concept of a group animation, so motion designers and developers compose and time individual animations to appear as one coherent visual effect. The **Animations** tab predicts related animations based on start time (excluding delays) and groups them side-by-side.
 
-In other words, the Animation Inspector groups together animations triggered in the same script block, but if they're asynchronous, they end up in different groups.
+In other words, the **Animations** tab groups together animations triggered in the same script block, but if they're asynchronous, they end up in different groups.
 
 ## Get started {: #get_started }
 
-There are two ways to open the Animation Inspector:
+There are two ways to open the **Animations** tab:
 
 - Select {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/N5Lkpdwpaz4YqRGFr2Ks.svg", alt="More.", width="24", height="24" %} **Customize and control DevTools** > **More tools** > **Animations**.
   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/w4767GjJfcHUdokjxB1a.png", alt="Animations in the menu.", width="800", height="572" %}
-- Press <kbd>Command</kbd>+<kbd>Option</kbd>+<kbd>C</kbd> (Mac) or <kbd>Control</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd> (Windows, Linux, ChromeOS) to open the Command Menu, start typing `Show Animations`, and select the corresponding Drawer panel.
+- Open the Command Menu by pressing one of the following:
+  - On macOS: <kbd>Command</kbd>+<kbd>Option</kbd>+<kbd>C</kbd>
+  - On Windows, Linux, or ChromeOS: <kbd>Control</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd> 
+
+  Then start typing `Show Animations` and select the corresponding Drawer panel.
   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/pbUGqPRe0SlaYNyqVMsO.png", alt="Show Animations.", width="800", height="572" %}
 
-The Animation Inspector opens up as a tab next to the Console Drawer. Since it's a Drawer tab, you can use it from any DevTools panel.
+By default, the **Animations** tab opens up as a tab next to the **Console** drawer. As a drawer tab, you can use it with any panel or [move it to the top of DevTools](/docs/devtools/customize/#reorder).
 
-<div class="elevation--4">{% Img src="image/admin/6dTrFBnaasvcKhrQreDm.png", alt="Empty Animation Inspector.", width="800", height="422" %}</div>
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/xTomXEMrcWX94R7u1ivo.png", alt="Empty Animations tab.", width="800", height="560" %}
 
-The Animation Inspector is grouped into four main sections (or panes):
+The **Animations** tab is grouped into four main panes (sections):
 
-1.  **Controls**. From here, you can clear all currently captured Animation Groups, or change the
-    speed of the currently selected Animation Group.
-2.  **Overview**. Select an Animation Group here to inspect and modify it in the **Details** pane.
+<div class="elevation--4">{% Img src="image/admin/PNT2B9LyO9ZK7O7YPpQV.png", alt="Animations tab panes.", width="800", height="437" %}</div>
+
+1.  **Controls**. From here, you can clear all currently captured animation groups, or change the
+    speed of the currently selected animation group.
+2.  **Overview**. Select an animation group here to inspect and modify it in the **Details** pane.
 3.  **Timeline**. Pause and start an animation from here, or jump to a specific point in the
     animation.
-4.  **Details**. Inspect and modify the currently selected Animation Group.
+4.  **Details**. Inspect and modify the currently selected animation group.
 
-<div class="elevation--4">{% Img src="image/admin/PNT2B9LyO9ZK7O7YPpQV.png", alt="Animation Inspector panes.", width="800", height="437" %}</div>
-
-To capture an animation, trigger it while the Animation Inspector is open. If an animation is triggered on page load, reload it.
+To capture an animation, trigger it while the **Animations** tab is open. If an animation is triggered on page load, reload it.
 
 ## Inspect animations {: #inspect }
 
@@ -74,40 +76,46 @@ Once you've captured an animation, there are a few ways to replay it:
 
 - Hover over its thumbnail in the **Overview** pane to view a preview of it.
 - Click and drag the red vertical bar to scrub the viewport animation.
-- Select the Animation Group from the **Overview** pane (so that it's displayed in the **Details**
+- Select the animation group from the **Overview** pane (so that it's displayed in the **Details**
   pane) and press the {% Img src="image/admin/FMABaWsGPXg627w2Ip0d.png", alt="Replay button.", width="23", height="22" %} **Replay** button. The
   animation is replayed in the viewport.
 
-Click on the {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/0TdVNMElxodMWBFqfRze.png", alt="Animation speed buttons", width="127", height="25" %} **Animation speed** buttons in the **Controls** bar to change the preview speed of the currently selected Animation Group.
+Click on the {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/0TdVNMElxodMWBFqfRze.png", alt="Animation speed buttons.", width="127", height="25" %} **Animation speed** buttons in the **Controls** bar to change the preview speed of the currently selected animation group.
 
 ### View animation details {: #view_animation_details }
 
-Once you've captured an Animation Group, click on it from the **Overview** pane to view its details.
+Once you've captured an animation group, click on it from the **Overview** pane to view its details.
 In the **Details** pane, each individual animation gets its own row.
 
-<div class="elevation--4">{% Img src="image/admin/vdjLKNjWK79GW3PgiJol.png", alt="animation group details", width="800", height="501" %}</div>
+<div class="elevation--4">{% Img src="image/admin/NbXydhQGmfbeMOPHCHu9.png", alt="The Details pane.", width="800", height="421" %}</div>
 
 Hover over an animation to highlight it in the viewport. Click on the animation to select it in the
 **Elements** panel.
 
-<div class="elevation--4">{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/cwfsRGVqdUx09qYmZGzu.png", alt="Hovering over an animation to highlight it in viewport", width="800", height="431" %}</div>
+<div class="elevation--4">{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/cwfsRGVqdUx09qYmZGzu.png", alt="Hovering over an animation to highlight it in viewport.", width="800", height="431" %}</div>
 
-The leftmost, darker section of an animation is its definition. The right, more faded section
-represents iterations. For example, in the screenshot below, sections two and three represent
+Some animations repeat indefinitely if their `animation-iteration-count` property is set to `infinite`. The **Animations** tab displays their definitions and iterations.
+
+<div class="elevation--4">{% Img src="image/admin/vdjLKNjWK79GW3PgiJol.png", alt="Animation iterations.", width="800", height="501" %}</div>
+
+The leftmost, darker section of an animation is its definition. The right, more faded sections
+represent iterations.
+
+For example, in the screenshot below, sections two and three represent
 iterations of section one.
 
-<div class="elevation--4" style="width: max-content; margin: 20px auto;">{% Img src="image/admin/X3dRm6DBme4PfCjPAXZO.png", alt="diagram of animation iterations", width="494", height="110" %}</div>
+<div class="elevation--4" style="width: max-content; margin: 20px auto;">{% Img src="image/admin/X3dRm6DBme4PfCjPAXZO.png", alt="Diagram of animation iterations.", width="494", height="110" %}</div>
 
-If two elements have the same animation applied to them, the Animation Inspector assigns them the
+If two elements have the same animation applied to them, the **Animations** tab assigns them the
 same color. The color itself is random and has no significance. For example, in the screenshot below
 the two elements `div.eye.left::after` and `div.eye.right::after` have the same animation (`eyes`)
 applied to them, as do the `div.feet::before` and `div.feet::after` elements.
 
-<div class="elevation--4" style="width: max-content; margin: 20px auto;">{% Img src="image/admin/czOX5s4gDuLjnoFl7mmv.png", alt="color-coded animations", width="518", height="268" %}</div>
+<div class="elevation--4" style="width: max-content; margin: 20px auto;">{% Img src="image/admin/czOX5s4gDuLjnoFl7mmv.png", alt="Color-coded animations.", width="518", height="268" %}</div>
 
 ## Modify animations {: #modify }
 
-There are three ways you can modify an animation with the Animation Inspector:
+There are three ways you can modify an animation with the **Animations** tab:
 
 - Animation duration.
 - Keyframe timings.
@@ -115,17 +123,17 @@ There are three ways you can modify an animation with the Animation Inspector:
 
 For this section, suppose that the screenshot below represents the original animation:
 
-<div class="elevation--4">{% Img src="image/admin/XKgSjsvRLNrQkapxpekI.png", alt="original animation before modification", width="800", height="423" %}</div>
+<div class="elevation--4">{% Img src="image/admin/XKgSjsvRLNrQkapxpekI.png", alt="Original animation before modification.", width="800", height="423" %}</div>
 
 To change the duration of an animation, click and drag the first or last circle.
 
-<div class="elevation--4">{% Img src="image/admin/ilDNkK4AfTzWeAbe9MZZ.png", alt="modified duration", width="800", height="421" %}</div>
+<div class="elevation--4">{% Img src="image/admin/ilDNkK4AfTzWeAbe9MZZ.png", alt="Modified duration.", width="800", height="421" %}</div>
 
 If the animation defines any keyframe rules, then these are represented as white inner circles.
 Click and drag one of these to change the timing of the keyframe.
 
-<div class="elevation--4">{% Img src="image/admin/jJHtenLps4VT8RYWUDxS.png", alt="modified keyframe", width="800", height="421" %}</div>
+<div class="elevation--4">{% Img src="image/admin/jJHtenLps4VT8RYWUDxS.png", alt="Modified keyframe.", width="800", height="421" %}</div>
 
 To add a delay to an animation, click and drag it anywhere except the circles.
 
-<div class="elevation--4">{% Img src="image/admin/D7OuXdLLAb1iBgPazKd0.png", alt="modified delay", width="800", height="421" %}</div>
+<div class="elevation--4">{% Img src="image/admin/D7OuXdLLAb1iBgPazKd0.png", alt="Modified delay.", width="800", height="421" %}</div>

--- a/site/en/docs/devtools/css/animations/index.md
+++ b/site/en/docs/devtools/css/animations/index.md
@@ -124,7 +124,7 @@ There are three ways you can modify an animation with the **Animations** tab:
 - Start time delay.
 
 {% Aside 'gotchas' %}
-Any changes you apply in the **Animations** tab apply inline styles to the corresponding elements, so you can see and replay the resulting animations right away.
+Any changes you make in the **Animations** tab apply inline styles to the corresponding elements, so you can see and replay the resulting animations right away.
 {% endAside %}
 
 For this section, suppose that the screenshot below represents the original animation:

--- a/site/en/docs/devtools/css/animations/index.md
+++ b/site/en/docs/devtools/css/animations/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Animations: Inspect and modify CSS animation effects"
+title: "Animations: How to inspect and modify CSS animations"
 authors:
   - kaycebasques
   - sofiayem
@@ -13,6 +13,8 @@ tags:
 ---
 
 Inspect and modify animations with the Chrome DevTools **Animations** drawer tab.
+
+{% YouTube id='lVLzkleL_CE' %}
 
 ## Overview {: #overview }
 
@@ -121,6 +123,10 @@ There are three ways you can modify an animation with the **Animations** tab:
 - Keyframe timings.
 - Start time delay.
 
+{% Aside 'gotchas' %}
+Any changes you apply in the **Animations** tab apply inline styles to the corresponding elements, so you can see and replay the resulting animations right away.
+{% endAside %}
+
 For this section, suppose that the screenshot below represents the original animation:
 
 <div class="elevation--4">{% Img src="image/admin/XKgSjsvRLNrQkapxpekI.png", alt="Original animation before modification.", width="800", height="423" %}</div>
@@ -134,6 +140,6 @@ Click and drag one of these to change the timing of the keyframe.
 
 <div class="elevation--4">{% Img src="image/admin/jJHtenLps4VT8RYWUDxS.png", alt="Modified keyframe.", width="800", height="421" %}</div>
 
-To add a delay to an animation, click and drag it anywhere except the circles.
+To add a delay to an animation, click the animation itself, not the circles, then drag it anywhere.
 
 <div class="elevation--4">{% Img src="image/admin/D7OuXdLLAb1iBgPazKd0.png", alt="Modified delay.", width="800", height="421" %}</div>

--- a/site/en/docs/devtools/css/animations/index.md
+++ b/site/en/docs/devtools/css/animations/index.md
@@ -16,8 +16,6 @@ Inspect and modify animations with the Chrome DevTools **Animations** drawer tab
 
 {% YouTube id='lVLzkleL_CE' %}
 
-{% YouTube id='lVLzkleL_CE' %}
-
 ## Overview {: #overview }
 
 To capture animations, open the **Animations** tab. It automatically detects animations and sorts them into groups.

--- a/site/en/docs/devtools/css/reference/index.md
+++ b/site/en/docs/devtools/css/reference/index.md
@@ -529,7 +529,7 @@ To open the **Angle Clock**:
 
 The **Shadow Editor** provides a GUI for changing `text-shadow` and `box-shadow` CSS declarations.
 
-To open the **Shadow Editor**:
+To change shadows with the **Shadow Editor**:
 
 1. [Select an element][27] with a shadow declaration. For example, select the element below. {: #shadow-element }
 
@@ -548,7 +548,7 @@ To open the **Shadow Editor**:
       }
     </style>
 
-1. In the **Styles** tab, find a shadow icon next to the `text-shadow` or `box-shadow` declaration.
+1. In the **Styles** tab, find a shadow {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/7cunvJgztQzUZabOjseC.png", alt="Shadow.", width="24", height="24" %} icon next to the `text-shadow` or `box-shadow` declaration.
 
    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/oDpRxRK9of3pxQFkFwgc.png", alt="Shadow icons", width="800", height="513" %}
 
@@ -564,6 +564,104 @@ To open the **Shadow Editor**:
    - **Blur**. Drag the slider or specify a value.
    - **Spread** (only for `box-shadow`). Drag the slider or specify a value.
 1. Observe the changes applied to the [element](#shadow-element).
+
+### Edit animation and transition timings with the Easing Editor {: #edit-easing }
+
+The **Easing Editor** provides a GUI for changing the easing values of [`transition-timing-function`][36] and [`animation-timing-function`][37].
+
+To change the values with the **Easing Editor**:
+
+1. [Select an element][27] with a timing function declaration, like the `<body>` element on this page.
+1. In the **Styles** tab, find the purple {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/U0vVF9a5jrj948Gegu6o.png", alt="Ease.", width="22", height="22" %} icon next to the `transition-timing-function` or `animation-timing-function` declarations.
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/ulG0cDcH3SnYS13kJbuB.png", alt="Ease icon.", width="800", height="434" %}
+1. Click the icon to open the **Easing Editor**:
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/JujOC1By7NK2YzfHT7lD.png", alt="The Easing Editor.", width="800", height="584" %}
+1. To set a [keyword value][38], click one of the picker buttons:
+   - **ease-in-out** {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/a0WRju7wMXvxVXiCqFuc.png", alt="The ease-in-out button.", width="24", height="24" %}
+   - **ease-in** {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/3kjLNBHixVNDmxarpnqF.png", alt="The ease-in button.", width="24", height="24" %}
+   - **ease-out** {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/jlueFxpe3WZ05X2lxp20.png", alt="The ease-out button.", width="24", height="24" %}
+1. In the **Presets switcher**, click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/79O9ggoDdHGLL73Q1tdG.svg", alt="Left.", width="24", height="24" %} or {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/19mp1EDARktd9LnrvI5L.svg", alt="Right.", width="24", height="24" %} buttons to pick one of the following presets:
+
+<table>
+<thead>
+  <tr>
+    <th>Easing type</th>
+    <th>Preset</th>
+    <th>Bezier equivalent</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td rowspan="5">ease-in-out</td>
+    <td>In Out, Sine</td>
+    <td><code>cubic-bezier(0.45, 0.05, 0.55, 0.95)</code></td>
+  </tr>
+  <tr>
+    <td>In Out, Quadratic</td>
+    <td><code>cubic-bezier(0.46, 0.03, 0.52, 0.96)</code></td>
+  </tr>
+  <tr>
+    <td>In Out, Cubic</td>
+    <td><code>cubic-bezier(0.65, 0.05, 0.36, 1)</code></td>
+  </tr>
+  <tr>
+    <td>Fast Out, Slow In</td>
+    <td><code>cubic-bezier(0.4, 0, 0.2, 1)</code></td>
+  </tr>
+  <tr>
+    <td>In Out, Back</td>
+    <td><code>cubic-bezier(0.68, -0.55, 0.27, 1.55)</code></td>
+  </tr>
+  <tr>
+    <td rowspan="5">ease-in</td>
+    <td>In, Sine</td>
+    <td><code>cubic-bezier(0.47, 0, 0.75, 0.72)</code></td>
+  </tr>
+  <tr>
+    <td>In, Quadratic</td>
+    <td><code>cubic-bezier(0.55, 0.09, 0.68, 0.53)</code></td>
+  </tr>
+  <tr>
+    <td>In, Cubic</td>
+    <td><code>cubic-bezier(0.55, 0.06, 0.68, 0.19)</code></td>
+  </tr>
+  <tr>
+    <td>In, Back</td>
+    <td><code>cubic-bezier(0.6, -0.28, 0.74, 0.05)</code></td>
+  </tr>
+  <tr>
+    <td>Fast Out, Linear In</td>
+    <td><code>cubic-bezier(0.4, 0, 1, 1)</code></td>
+  </tr>
+  <tr>
+    <td rowspan="5">ease-out</td>
+    <td>Out, Sine</td>
+    <td><code>cubic-bezier(0.39, 0.58, 0.57, 1)</code></td>
+  </tr>
+  <tr>
+    <td>Out, Quadratic</td>
+    <td><code>cubic-bezier(0.25, 0.46, 0.45, 0.94)</code></td>
+  </tr>
+  <tr>
+    <td>Out, Cubic</td>
+    <td><code>cubic-bezier(0.22, 0.61, 0.36, 1)</code></td>
+  </tr>
+  <tr>
+    <td>Linear Out, Slow In</td>
+    <td><code>cubic-bezier(0, 0, 0.2, 1)</code></td>
+  </tr>
+  <tr>
+    <td>Out, Back</td>
+    <td><code>cubic-bezier(0.18, 0.89, 0.32, 1.28)</code></td>
+  </tr>
+</tbody>
+</table>
+
+Alternatively, in the **Curve editor**, drag the purple circles to set a custom [`cubic-bezier(x1,y1,x2,y2)`](https://www.w3schools.com/cssref/func_cubic-bezier.asp) value.
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/RrpIeYlQURppXdbUXV6C.png", alt="Curve editor.", width="800", height="584" %}
+
+Any change triggers a ball animation in the **Preview** at the top of editor.
 
 ### (Experimental) Copy CSS changes {: #copy-css-changes }
 
@@ -618,3 +716,6 @@ Additionally, you can [track changes](/docs/devtools/changes/) you make with the
 [33]: https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements
 [34]: /blog/auto-dark-theme/
 [35]: https://web.dev/prefers-color-scheme/
+[36]: https://developer.mozilla.org/docs/Web/CSS/transition-timing-function
+[37]: https://developer.mozilla.org/docs/Web/CSS/animation-timing-function
+[38]: https://developer.mozilla.org/docs/Web/CSS/animation-timing-function#values

--- a/site/en/docs/devtools/css/reference/index.md
+++ b/site/en/docs/devtools/css/reference/index.md
@@ -657,7 +657,7 @@ To change the values with the **Easing Editor**:
 </tbody>
 </table>
 
-Alternatively, in the **Curve editor**, drag the purple circles to set a custom [`cubic-bezier(x1,y1,x2,y2)`](https://www.w3schools.com/cssref/func_cubic-bezier.asp) value.
+Alternatively, in the **Curve editor**, drag the purple circles to set a custom [`cubic-bezier(x1,y1,x2,y2)`](https://developer.mozilla.org/docs/Glossary/Bezier_curve) value.
 
 {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/RrpIeYlQURppXdbUXV6C.png", alt="Curve editor.", width="800", height="584" %}
 


### PR DESCRIPTION
Fixes #3205 

Refreshed a 2016 doc about the Animations tab prior to the release of the corresponding DTT 12 video.
Drafted a promo post for the video.
Also, documented the missing Elements > Styles > Easing editor.


Publish on Aug 11.