### PR TITLE
Add a caution about `Referer` header check on FedCM

### DIFF
--- a/site/en/blog/fedcm-origin-trial/index.md
+++ b/site/en/blog/fedcm-origin-trial/index.md
@@ -567,7 +567,8 @@ On the server, the IdP should confirm:
 
 1. that the claimed account ID matches the ID for the account that is already
    signed in. 
-2. that the `Referer` header matches the origin the RP registered in advance.
+2. that the `Referer` header matches the origin the RP registered in advance
+   for the given client ID.
 
 {% Aside 'caution' %}
 

--- a/site/en/blog/fedcm-origin-trial/index.md
+++ b/site/en/blog/fedcm-origin-trial/index.md
@@ -6,7 +6,7 @@ authors:
 description: >
   A Web Platform API that allows users to login to websites with their federated accounts in a privacy preserving manner.
 date: 2022-04-25
-updated: 2022-08-08
+updated: 2022-08-10
 tags:
   - privacy
   - security
@@ -16,7 +16,11 @@ tags:
 
 {% Aside %}
 
-**Update, July 2022**
+**Update, August 2022**
+
+* Added an important security information that the IdP needs to check if the
+  `Referer` header matches the origin the RP registered in advance on [the ID
+  token endpoint](#id-token-endpoint).
 
 Starting from Chrome 105:
 * The top-level manifest is renamed from `/.well-known/fedcm.json` to
@@ -559,8 +563,19 @@ Sec-FedCM-CSRF: ?1
 account_id=123&client_id=client1234&nonce=Ct60bD&disclosure_text_shown=true
 ```
 
-On the server, the IdP should confirm if the claimed account ID matches the 
-ID for the account that is already signed in. 
+On the server, the IdP should confirm:
+
+1. that the claimed account ID matches the ID for the account that is already
+   signed in. 
+2. that the `Referer` header matches the origin the RP registered in advance.
+
+{% Aside 'caution' %}
+
+Since the domain verification on OAuth or OpenID Connect relies on a browser
+redirect, it's critical in FedCM that the IdP server checks a `Referer` header value
+matches the RP's registered origin.
+
+{% endAside %}
 
 The browser expects a JSON response that includes the following property:
 

--- a/site/en/blog/fedcm-origin-trial/index.md
+++ b/site/en/blog/fedcm-origin-trial/index.md
@@ -18,7 +18,7 @@ tags:
 
 **Update, August 2022**
 
-* Added an important security information that the IdP needs to check if the
+* Added an important security information. The identity provider (IdP) needs to check if the
   `Referer` header matches the origin the RP registered in advance on [the ID
   token endpoint](#id-token-endpoint).
 
@@ -563,11 +563,11 @@ Sec-FedCM-CSRF: ?1
 account_id=123&client_id=client1234&nonce=Ct60bD&disclosure_text_shown=true
 ```
 
-On the server, the IdP should confirm:
+On the server, the IdP should confirm that:
 
-1. that the claimed account ID matches the ID for the account that is already
+1. The claimed account ID matches the ID for the account that is already
    signed in. 
-2. that the `Referer` header matches the origin the RP registered in advance
+2. The `Referer` header matches the origin the RP, registered in advance
    for the given client ID.
 
 {% Aside 'caution' %}


### PR DESCRIPTION
Add a caution about `Referer` header check on FedCM.
Small but critical security information.