### PR TITLE
Add info about author profile

### DIFF
--- a/site/en/docs/handbook/how-to/add-an-author/index.md
+++ b/site/en/docs/handbook/how-to/add-an-author/index.md
@@ -30,7 +30,7 @@ updated: 2022-04-15
        es: Una descripción relevante traducida por Google sobre usted que le gustaría compartir.
    ```
 
-2. If you want links to your online accounts to appear in your author lockup add a new object to [`authorsData.json`](https://github.com/GoogleChrome/developer.chrome.com/blob/main/site/_data/authorsData.json) with the following structure. Make sure to use the same author slug used in the [`authors.yaml`](https://github.com/GoogleChrome/developer.chrome.com/blob/main/site/_data/i18n/authors.yaml).
+2. If you want links to your online accounts to appear in your author lookup add a new object to [`authorsData.json`](https://github.com/GoogleChrome/developer.chrome.com/blob/main/site/_data/authorsData.json) with the following structure. Make sure to use the same author slug used in the [`authors.yaml`](https://github.com/GoogleChrome/developer.chrome.com/blob/main/site/_data/i18n/authors.yaml).
 
    ```json
    "jaimiesmith": {

--- a/site/en/docs/handbook/how-to/add-an-author/index.md
+++ b/site/en/docs/handbook/how-to/add-an-author/index.md
@@ -41,6 +41,10 @@ updated: 2022-04-15
    }
    ```
 
+{% Aside %}
+When you add an author, the author profile won't show on the [relevant page](/authors) immediately. You have to associate some content with the profile to see any changes to the authors' page.
+{% endAside %}
+
 ## Create a profile image
 
 1. Follow the [Images and video](/docs/handbook/how-to/add-media/) guide to upload your photo to the CDN.


### PR DESCRIPTION
Add an aside noting that author profiles only appear on the authors' page(s) when there's some content associated with the profiles.

Preview: https://deploy-preview-3430--developer-chrome-com.netlify.app/docs/handbook/how-to/add-an-author/