### PR TITLE
[authorsData.json] Remove trailing comma

### DIFF
--- a/site/_data/authorsData.json
+++ b/site/_data/authorsData.json
@@ -819,6 +819,6 @@
   "joelewis": {
     "country": "US",
     "image": "image/VbsHyyQopiec0718rMq2kTE1hke2/aS7reiLcBKY52w1HUU3m.jpeg",
-    "github": "sanbeiji",
+    "github": "sanbeiji"
   }
 }


### PR DESCRIPTION
Quick fix: removes trailing comma from `authorsData.json`