### PR TITLE
DevTools Tips 7 promo post backfill + doc upd

### DIFF
--- a/site/en/blog/devtools-tips-7/index.md
+++ b/site/en/blog/devtools-tips-7/index.md
@@ -1,0 +1,36 @@
+---
+title: >
+  DevTools Tips: How to inspect CSS grid
+description: >
+  Learn how to use Chrome DevTools to view and change CSS grid layouts.
+layout: 'layouts/blog-post.njk'
+date: 2022-08-18
+authors:
+  - sofiayem
+hero: 'image/NJdAV9UgKuN8AhoaPBquL7giZQo1/jNBfye8r6ptj0agIHneP.png'
+alt: >
+  DevTools Tips hero logo
+tags:
+  - css
+  - devtools
+  - devtools-tips
+---
+
+Chrome DevTools makes debugging CSS grid layouts intuitive with a variety of visualization options.
+
+{% YouTube id='M8SlBgul8ao' %}
+
+Watch the video to learn how to toggle the grid overlay in the **Elements** panel and use it to:
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/I2PqMSLelhTdl7lng4Yu.png", alt="Grid overlay.", width="800", height="424" %}
+
+- Visualize and inspect grid layouts.
+- See row and column numbers to refer to when placing grid items.
+- Use line and area names and see them on the overlay if you have a lot of grid items and the numbers are confusing.
+- Check track sizes.
+
+Additionally, with the [**Grid Editor**](/docs/devtools/css/grid/#grid-editor) in the **Elements** > **Styles** pane, you can align items and their content in a grid layout with a click of a button instead of typing CSS rules.
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Qg4gEmRCgnC2qfMhzfsJ.png", alt="The Grid Editor.", width="800", height="673" %}
+
+For a more hands-on learning experience, follow the [Inspect CSS Grid](/docs/devtools/css/grid/) tutorial.

--- a/site/en/docs/devtools/css/grid/index.md
+++ b/site/en/docs/devtools/css/grid/index.md
@@ -1,17 +1,18 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Inspect CSS Grid"
+title: "Inspect CSS grid"
 authors:
   - jecelynyeen
+  - sofiayem
 date: 2021-06-08
-#updated: YYYY-MM-DD
-description: "Learn how to use Chrome DevTools to view and change a page's CSS."
+updated: 2022-08-18
+description: "Learn how to use Chrome DevTools to view and change CSS grids."
 tags:
   - prototype-fixes
   - css
 ---
 
-This guide shows you how to discover CSS grids on a page, examining them and debugging layout issues
+This guide shows you how to discover CSS grids on a page, examine them, and debug layout issues
 in the **Elements** panel of Chrome DevTools.
 
 {% YouTube id='M8SlBgul8ao' %}
@@ -29,12 +30,28 @@ can see a `grid` badge next to it in the [**Elements**][3] panel.
 Clicking the badge to toggle the display of a grid overlay on the page. The overlay appears over the
 element, laid out like a grid to show the position of its grid lines and tracks:
 
-{% Img src="image/admin/YwKMuoODL6eFMvfJOzlF.png", alt="Toggle grid badge", width="800", height="524" %}
+{% Img src="image/admin/YwKMuoODL6eFMvfJOzlF.png", alt="Toggle grid badge.", width="800", height="524" %}
 
 Open the **Layout** pane. When grids are included on a page, the Layout pane includes a **Grid**
 section containing a number of options for viewing those grids.
 
-{% Img src="image/admin/r4Ignwcmy4VzFqs3Zzb1.png", alt="Layout pane", width="800", height="524" %}
+{% Img src="image/admin/r4Ignwcmy4VzFqs3Zzb1.png", alt="Layout pane.", width="800", height="524" %}
+
+## Align grid items and their content with the Grid Editor {: #grid-editor }
+
+You can align grid items and their content with a click of a button instead of typing CSS rules.
+
+To align grid items and their content:
+
+1. In the **Elements** > **Styles** pane, click the {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/JFbQddgayUhHoW6jtlXe.png", alt="Grid Editor.", width="22", height="22" %} **Grid Editor** button next to `display: grid`.
+
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/l185BjeN8O7LBbMZxNY7.png", alt="Grid Editor button.", width="800", height="424" %}
+
+1. In the **Grid Editor**, click the corresponding buttons to set the `align-*` and `justify-*` CSS properties for the grid items and their content.
+
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/cMNZJ8oMcxjzOH5s63u1.png", alt="Setting CSS properties.", width="800", height="424" %}
+
+1. Observe the adjusted grid items and content in the viewport.
 
 ## Grid viewing options {: #options }
 
@@ -47,9 +64,9 @@ Let's look into each of these sub sections in detail.
 
 ## Overlay display settings {: #display-settings }
 
-The **Overlay display settings** consists of 2 parts:
+The **Overlay display settings** consists of two parts:
 
-a. A dropdown menu with options within:
+a. A drop-down menu with the following options:
 
 - **Hide line labels**: Hide the line labels for each grid overlay.
 - **Show lines number**: Show the line numbers for each grid overlay (selected by default).
@@ -71,23 +88,23 @@ Let's examine these settings in more detail.
 
 By default, the positive and negative line numbers are displayed on the grid overlay.
 
-{% Img src="image/admin/KEEXn0ipZF0I7Y1qNuZs.png", alt="Show line numbers", width="800", height="524" %}
+{% Img src="image/admin/KEEXn0ipZF0I7Y1qNuZs.png", alt="Show line numbers.", width="800", height="524" %}
 
 ### Hide line labels {: #line-labels }
 
 Select **Hide line labels** to hide the line numbers.
 
-{% Img src="image/admin/I1QJnFZDFcIflsKBSK8J.png", alt="Hide line labels", width="800", height="524" %}
+{% Img src="image/admin/I1QJnFZDFcIflsKBSK8J.png", alt="Hide line labels.", width="800", height="524" %}
 
 ### Show line names {: #line-names }
 
 You can select **Show line names** to view the line names instead of numbers. In this example, we
-have 4 lines with names: left, middle1, middle2 and right.
+have four lines with names: left, middle1, middle2 and right.
 
 In this demo, **orange** element spans from left to right, with CSS `grid-column: left / right`.
 Showing line names make it easier to visualize the start and end position of the element.
 
-{% Img src="image/admin/fiQzqCmGbD0acgVNXWyR.png", alt="Show line names", width="800", height="524" %}
+{% Img src="image/admin/fiQzqCmGbD0acgVNXWyR.png", alt="Show line names.", width="800", height="524" %}
 
 ### Show track sizes {: #track-sizes }
 
@@ -103,21 +120,21 @@ Therefore, the column line labels show both authored and computed sizes: **1fr -
 The row line labels show only computed sizes: **80px** and **80px** since there are no row sizes
 defined in the stylesheet.
 
-{% Img src="image/admin/RknbkSjXv9ZKgL83nx8N.png", alt="Show track sizes", width="800", height="524" %}
+{% Img src="image/admin/RknbkSjXv9ZKgL83nx8N.png", alt="Show track sizes.", width="800", height="524" %}
 
 ### Show area names {: #area-names }
 
-To view the area names, enable the **Show area names** checkbox. In this example, there are 3 areas
+To view the area names, enable the **Show area names** checkbox. In this example, there are three areas
 in the grid - **top**, **bottom1** and **bottom2**.
 
-{% Img src="image/admin/iPPMOUBJFtsTyKr0ZcMh.png", alt="Show area names", width="800", height="524" %}
+{% Img src="image/admin/iPPMOUBJFtsTyKr0ZcMh.png", alt="Show area names.", width="800", height="524" %}
 
 ### Extend grid lines {: #extend-grid-lines }
 
 Enable the **Extend grid lines** checkbox to extend the grid lines to the edge of the viewport along
 each axis.
 
-{% Img src="image/admin/OlajZ73i2Y8hlAIZAwFD.png", alt="Extend grid lines", width="800", height="524" %}
+{% Img src="image/admin/OlajZ73i2Y8hlAIZAwFD.png", alt="Extend grid lines.", width="800", height="524" %}
 
 ## Grid overlays {: #overlays }
 
@@ -126,10 +143,10 @@ checkbox, along with various options.
 
 ### Enable overlay views of multiple grids {: #view-multiple-grids }
 
-You can enable overlay views of multiple grids. In this example, there are 2 grid overlays enabled -
+You can enable overlay views of multiple grids. In this example, there are two grid overlays enabled -
 `main` and `div.snack-box`, each represented with different colors.
 
-{% Img src="image/admin/GMCjbEkrzZXFfskAqlUe.png", alt="Enable overlay views of multiple grids", width="800", height="524" %}
+{% Img src="image/admin/GMCjbEkrzZXFfskAqlUe.png", alt="Enable overlay views of multiple grids.", width="800", height="524" %}
 
 ### Customize the grid overlay color {: #customize-overlay-color }
 

--- a/site/en/docs/devtools/css/reference/index.md
+++ b/site/en/docs/devtools/css/reference/index.md
@@ -482,6 +482,10 @@ To toggle a single declaration on or off:
 
 **Figure 20**. The `color` property for the currently-selected element has been toggled off
 
+### Align grid items and their content with the Grid Editor {: #grid-editor }
+
+See the corresponding [section in Inspect CSS grid](/docs/devtools/css/grid/#grid-editor).
+
 ### Change colors with the Color Picker {: #color-picker }
 
 {% YouTube id='TuR27BxCRVk' %}


### PR DESCRIPTION
Backfilling DevTools Tips 7: Grid.

- Added promo a post
- Documented missing https://developer.chrome.com/en/blog/new-in-devtools-92/#grid-editor
- Plus, cosmetic changes

Related #3263 

Merge on Aug 18