### PR TITLE
Added events page

### DIFF
--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -7,6 +7,8 @@
       title: i18n.docs.privacy-sandbox.blog
     - url: https://privacysandbox.com/timeline
       title: i18n.docs.privacy-sandbox.timeline
+    - url: /docs/privacy-sandbox/events
+      title: i18n.docs.privacy-sandbox.events
     - url: /docs/privacy-sandbox/proposal-lifecycle
 - title: i18n.docs.privacy-sandbox.start
   sections:

--- a/site/_data/i18n/docs/privacy-sandbox.yml
+++ b/site/_data/i18n/docs/privacy-sandbox.yml
@@ -28,6 +28,9 @@ start:
 timeline:
   en: 'Timeline'
   ja: 'タイムライン'
+events:
+  en: 'Events'
+  ja: 'イベント'
 blog:
   en: 'Blog'
   ja: 'ブログ'

--- a/site/en/docs/privacy-sandbox/events/index.md
+++ b/site/en/docs/privacy-sandbox/events/index.md
@@ -1,0 +1,38 @@
+---
+layout: layouts/doc-post.njk
+title: Privacy Sandbox events
+subhead: >
+  Information and resources for online and in-person events.
+description: >
+  Information and resources for online and in-person events.
+date: 2022-08-17
+authors:
+  - samdutton
+---
+
+This page provides information about forthcoming events and links to resources for events that have
+already taken place.
+
+## Future events
+
+### Attribution end-to-end demo with summary reports {: #oh03}
+**Privacy Sandbox Developer Office Hours #3**
+* Thursday, August 11, 2022
+* 8:00am–9:30am PDT (5:00pm–6:30pm CEST)
+* [Find out more](https://groups.google.com/a/chromium.org/g/attribution-reporting-api-dev/c/s3QYro6SjeE/m/R6jI9TseAgAJ)
+
+---
+
+## Past events
+
+### An Introduction to Attribution Reporting {: #oh02}
+**Privacy Sandbox Developer Office Hours #2**
+* Thursday, June 30, 2022
+* 11:30–12:30 pm EDT
+* [Find out more](https://groups.google.com/u/2/a/chromium.org/g/attribution-reporting-api-dev/c/NLbPwiwj3BE)
+
+### Learn about Chrome origin trials  {: #oh01}
+**Privacy Sandbox Developer Office Hours #1**
+
+* April 20, 27 and 28, 2022
+* [Find out more](/blog/privacy-sandbox-office-hours-1/)


### PR DESCRIPTION
* As per comment on Chat, I couldn't build this locally after I changed privacy-sandbox/toc.yml. 

* Japanese in site/_data/i18n/docs/privacy-sandbox.yml is from Google Translate. @agektmr — is イベント OK as a translation of 'Events'?