### PR TITLE
Fix priority hints on the site

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "typedoc": "^0.22.7",
         "typescript": "^4.4.4",
         "unistore": "^3.5.2",
-        "webdev-infra": "^1.0.31"
+        "webdev-infra": "^1.0.32"
       },
       "devDependencies": {
         "@ava/babel": "^1.0.1",
@@ -26551,9 +26551,9 @@
       }
     },
     "node_modules/webdev-infra": {
-      "version": "1.0.31",
-      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.31.tgz",
-      "integrity": "sha512-Z+8Z4UB8SjJJDX2FRdmNBuGlQ1ezcm37s1kCgwI2IczryGDqgP1Soxa5idPOfFwbOPh/wyh2hO3EQTlgzAkxZg==",
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.32.tgz",
+      "integrity": "sha512-lGxr9z+5FdTmzVvo/YkOCeOvv8wuPdz/pz+fuZbmN4rhlvC1XkzJoKf50Tis7vSH2cXoOLULTqAoR3ip2zOBDg==",
       "dependencies": {
         "@imgix/js-core": "^3.1.3",
         "@justinribeiro/lite-youtube": "^0.9.1",
@@ -26565,7 +26565,7 @@
         "striptags": "^3.1.1"
       },
       "engines": {
-        "node": "14.x"
+        "node": ">=14"
       }
     },
     "node_modules/webdev-infra/node_modules/argparse": {
@@ -47854,9 +47854,9 @@
       }
     },
     "webdev-infra": {
-      "version": "1.0.31",
-      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.31.tgz",
-      "integrity": "sha512-Z+8Z4UB8SjJJDX2FRdmNBuGlQ1ezcm37s1kCgwI2IczryGDqgP1Soxa5idPOfFwbOPh/wyh2hO3EQTlgzAkxZg==",
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.32.tgz",
+      "integrity": "sha512-lGxr9z+5FdTmzVvo/YkOCeOvv8wuPdz/pz+fuZbmN4rhlvC1XkzJoKf50Tis7vSH2cXoOLULTqAoR3ip2zOBDg==",
       "requires": {
         "@imgix/js-core": "^3.1.3",
         "@justinribeiro/lite-youtube": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "typedoc": "^0.22.7",
     "typescript": "^4.4.4",
     "unistore": "^3.5.2",
-    "webdev-infra": "^1.0.31"
+    "webdev-infra": "^1.0.32"
   },
   "devDependencies": {
     "@ava/babel": "^1.0.1",

--- a/site/_includes/layouts/author-individual.njk
+++ b/site/_includes/layouts/author-individual.njk
@@ -17,7 +17,8 @@
       width="192",
       class="rounded-full display-inline-block",
       sizes="(min-width: 481px) 192px, 128px",
-      options={minWidth: 128}
+      options={minWidth: 128},
+      fetchpriority="high"
     %}
     <h1 class="lg:gap-top-400 type--h4">{{ paged.title | i18n(locale) }}</h1>
     <p class="type gap-top-300">{{ paged.description | i18n(locale) }}</p>

--- a/site/_includes/layouts/blog-post.njk
+++ b/site/_includes/layouts/blog-post.njk
@@ -18,7 +18,8 @@
         alt=alt,
         width="960",
         height="480",
-        sizes="(min-width: 960px) 960px, 100vw"
+        sizes="(min-width: 960px) 960px, 100vw",
+        fetchpriority="high"
       %}
     </div>
   {% endif %}

--- a/site/_includes/macros/cards/hero-card-wide.njk
+++ b/site/_includes/macros/cards/hero-card-wide.njk
@@ -14,7 +14,8 @@
                 src=titleIcon,
                 alt="Abstract icon",
                 width="56",
-                height="56"
+                height="56",
+                fetchpriority="high"
               %}
             </div>
           </div>

--- a/site/_includes/macros/cards/hero-card.njk
+++ b/site/_includes/macros/cards/hero-card.njk
@@ -14,7 +14,8 @@
                 src=titleIcon,
                 alt="Abstract icon",
                 width="56",
-                height="56"
+                height="56",
+                fetchpriority="high"
               %}
             </div>
           </div>
@@ -38,7 +39,8 @@
           alt=imgAlt,
           width="264",
           height="132",
-          sizes="(min-width: 592px) 597px, calc(100vw - 96px)"
+          sizes="(min-width: 592px) 597px, calc(100vw - 96px)",
+          fetchpriority="high"
         %}
       </div>
     {% endif %}

--- a/site/en/blog/new-in-chrome-96/index.md
+++ b/site/en/blog/new-in-chrome-96/index.md
@@ -9,6 +9,7 @@ description: >
   plenty more!
 layout: 'layouts/blog-post.njk'
 date: 2021-11-16
+updated: 2022-08-24
 authors:
   - petelepage
 hero: 'image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/gyhkrKnrs5TxwcF0Ybke.jpg'
@@ -131,6 +132,10 @@ Priority Hints are an experimental feature, available as an
 [origin trial][ph-ot] starting in Chrome 96, and can help optimize the Core
 Web Vitals. The `importance` attribute allows you to specify the priority
 for resource types such as CSS, fonts, scripts, images, and iframes.
+
+{% Aside 'warning' %}
+The `importance` attribute has been renamed `fetchpriority`. Read [Optimizing resource loading with Priority Hints](https://web.dev/priority-hints/) for the latest on this feature.
+{% endAside %}
 
 ```html
 <!-- We don't want a high priority for this above-the-fold image -->


### PR DESCRIPTION
Changes proposed in this pull request:

- Updates `webdev-infra` to `1.0.32` which now supports `fetchpriority`
- Sets `fetchpriority="high"` on hero images similar to web.dev
- Adds a note about the name change from `importance` to `fetchpriority` to Chrome 96 post