### PR TITLE
Add new authors

### DIFF
--- a/site/_data/authorsData.json
+++ b/site/_data/authorsData.json
@@ -827,5 +827,11 @@
     "github": "bramus",
     "country": "BE",
     "image": "image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/CQMqvg5UkY4weDnJij3b.jpeg"
+  },
+  "victorporof": {
+    "image": "image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/ltT5ZFZLzSdlecQmoxMK.jpg",
+    "github": "victorporof",
+    "twitter": "victorporof",
+    "country": "DE"
   }
 }

--- a/site/_data/authorsData.json
+++ b/site/_data/authorsData.json
@@ -820,5 +820,12 @@
     "country": "US",
     "image": "image/VbsHyyQopiec0718rMq2kTE1hke2/aS7reiLcBKY52w1HUU3m.jpeg",
     "github": "sanbeiji"
+  },
+  "bramus": {
+    "homepage": "https://www.bram.us/",
+    "twitter": "bramus",
+    "github": "bramus",
+    "country": "BE",
+    "image": "image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/CQMqvg5UkY4weDnJij3b.jpeg"
   }
 }

--- a/site/_data/i18n/authors.yaml
+++ b/site/_data/i18n/authors.yaml
@@ -925,3 +925,8 @@ bramus:
     pt: Developer Advocate para CSS, UI e DevTools no Chrome
     ru: Developer Advocate по вопросам CSS, UI и DevTools в команде Chrome
     zh: Chrome 的 CSS、UI 和 DevTools 开发技术推广工程师
+victorporof:
+  title:
+    en: Victor Porof
+  description:
+    en: Software Engineer working on Chrome DevTools at Google

--- a/site/_data/i18n/authors.yaml
+++ b/site/_data/i18n/authors.yaml
@@ -908,3 +908,20 @@ joelewis:
     en: Joseph Lewis
   description:
     en: Technical Writer, Android DevRel
+bramus:
+  title:
+    en: Bramus
+    es: Bramus
+    ja: Bramus
+    ko: Bramus
+    pt: Bramus
+    ru: Bramus
+    zh: Bramus
+  description:
+    en: Developer Advocate for CSS, UI, and DevTools at Chrome
+    es: Desarrollador partidario para CSS, UI y DevTools en Chrome
+    ja: Chrome の CSS、UI、DevTools を対象とした Developer Advocate
+    ko: Chrome의 CSS, UI 및 DevTools 개발자 애드버킷
+    pt: Developer Advocate para CSS, UI e DevTools no Chrome
+    ru: Developer Advocate по вопросам CSS, UI и DevTools в команде Chrome
+    zh: Chrome 的 CSS、UI 和 DevTools 开发技术推广工程师


### PR DESCRIPTION
This PR adds new authors `bramus` and `victorporof`, in preparation of the upcoming articles https://github.com/GoogleChrome/developer.chrome.com/issues/3312 and https://github.com/GoogleChrome/developer.chrome.com/issues/3520 _(and https://github.com/GoogleChrome/developer.chrome.com/issues/3522)_