### PR TITLE
Add Key/Value service info to the FLEDGE docs

### DIFF
--- a/site/en/blog/fledge-api/index.md
+++ b/site/en/blog/fledge-api/index.md
@@ -789,7 +789,7 @@ There are three main roles described in the FLEDGE proposal explainer:
 The ad auction is likely to be run by the publisher's [SSP](/docs/privacy-sandbox/fledge#ssp), or
 the publisher itself. The purpose of the auction is to select the most appropriate ad for a single
 available ad slot on the current page. The auction takes into account the interest groups the
-browser is a member of, along with data from ad-space buyers and the sellers from the [Key/Value services].
+browser is a member of, along with data from ad-space buyers and the sellers from the [Key/Value services](#keyvalue-service).
 
 The ad-space **seller** makes a request to the user's browser to begin an ad auction by calling
 `navigator.runAdAuction()`.
@@ -1198,7 +1198,7 @@ FLEDGE grew out of TURTLEDOVE and a collection of related proposals for modifica
 
 -   In [SPARROW](https://github.com/WICG/sparrow):
    [Criteo](https://www.admonsters.com/what-is-sparrow/) proposed the addition of a
-   ("Gatekeeper") service model running in a [trusted execution environment](https://github.com/privacysandbox/fledge-docs/blob/main/trusted_services_overview.md#trusted-execution-environment).  FLEDGE includes a more limited use of TEEs, for real-time data lookup and aggregated reporting.
+   ("Gatekeeper") service model running in a [trusted execution environment (TEE)](https://github.com/privacysandbox/fledge-docs/blob/main/trusted_services_overview.md#trusted-execution-environment).  FLEDGE includes a more limited use of TEEs, for real-time data lookup and aggregated reporting.
 -  NextRoll's [TERN](https://github.com/WICG/turtledove/blob/main/TERN.md) and Magnite's
    [PARRROT](https://github.com/prebid/identity-gatekeeper/blob/master/proposals/PARRROT.md)
    proposals described the different roles that buyers and sellers had in the on-device auction.

--- a/site/en/blog/fledge-api/index.md
+++ b/site/en/blog/fledge-api/index.md
@@ -3,10 +3,11 @@ layout: 'layouts/blog-post.njk'
 title: FLEDGE API developer guide
 authors:
   - samdutton
+  - kevinkiklee
 description: >
   FLEDGE is a Privacy Sandbox proposal to serve remarketing and custom audience use cases, designed so it cannot be used by third parties to track user browsing behavior across sites. 
 date: 2022-01-27
-updated: 2022-05-13
+updated: 2022-08-24
 thumbnail: image/80mq7dk16vVEg8BBhsVe42n6zn82/UiyBX61nCLHExFoy0eEn.jpg
 alt: Photograph of a piping plover bird with a chick on a sandy beach in Middletown, New Jersey, United States.
 tags:
@@ -191,17 +192,20 @@ anywhere in a page, even from cross-domain iframes. In the future, once site own
 to adjust their cross-domain iframe [permissions policies](/docs/privacy-sandbox/permissions-policy/), the plan is to disallow calls from
 cross-domain iframes, as the explainer describes.
 
-#### Trusted servers
+#### Key/Value service
 
 As part of a FLEDGE ad auction, the browser can access a
-[trusted server](https://github.com/WICG/turtledove/blob/main/FLEDGE.md#31-fetching-real-time-data-from-a-trusted-server)
+[key/value service](https://github.com/WICG/turtledove/blob/main/FLEDGE.md#31-fetching-real-time-data-from-a-trusted-server)
 that returns simple key-value pairs to provide information to an ad buyer, such as remaining
 campaign budget. The FLEDGE proposal [mandates](https://github.com/WICG/turtledove/blob/main/FLEDGE.md#design-elements)
 that this server "performs no event-level logging and has no other side effects based on these
-requests".  However, in the current initial experimental phase for testing FLEDGE, the seller
-and buyers can run trusted servers themselves (a
-"[Bring Your Own Server](https://github.com/WICG/turtledove/blob/main/FLEDGE.md#:~:text=bring%20your%20own%20server)"
-model). Discussion is underway about how trusted servers are managed and owned.
+requests".  
+
+The FLEDGE Key/Value service code is now available in a [Privacy Sandbox GitHub repository](https://github.com/privacysandbox/fledge-key-value-service). This service can be used by Chrome and Android developers. Check out the [announcement blog post](/blog/open-sourcing-fledge-key-value-service/) for the status update. Learn more about the FLEDGE Key/Value service from the [API explainer](https://github.com/WICG/turtledove/blob/main/FLEDGE_Key_Value_Server_API.md) and the [trust model explainer](https://github.com/privacysandbox/fledge-docs/blob/main/key_value_service_trust_model.md).  
+
+For initial testing, ["Bring Your Own Server"](https://github.com/WICG/turtledove/blob/main/FLEDGE.md#3-buyers-provide-ads-and-bidding-functions-byos-for-now) model is used. In the long-term, adtechs will need to use the open-source FLEDGE Key/Value services running in [trusted execution environments](https://github.com/privacysandbox/fledge-docs/blob/main/trusted_services_overview.md#trusted-execution-environment) for retrieving real-time data.
+
+To ensure that the ecosystem has sufficient time to test, we don’t expect to require the use of the open-source Key/Value services or TEEs until sometime after third-party cookie deprecation. We will provide substantial notice for developers to begin testing and adoption before this transition takes place.
 
 ### Detect feature support
 
@@ -785,8 +789,7 @@ There are three main roles described in the FLEDGE proposal explainer:
 The ad auction is likely to be run by the publisher's [SSP](/docs/privacy-sandbox/fledge#ssp), or
 the publisher itself. The purpose of the auction is to select the most appropriate ad for a single
 available ad slot on the current page. The auction takes into account the interest groups the
-browser is a member of, along with data from ad-space buyers and the seller—from trusted servers in
-the next step.
+browser is a member of, along with data from ad-space buyers and the sellers from the [Key/Value services].
 
 The ad-space **seller** makes a request to the user's browser to begin an ad auction by calling
 `navigator.runAdAuction()`.
@@ -966,7 +969,7 @@ knows and which the seller's auction script might want to verify:
   renderUrl: 'https://cdn.example/render',
   adComponents: ['https://cdn.com/ad-component-1', ...],
   biddingDurationMsec: 12,
-  dataVersion: 1 /* Data-Version value from the trusted scoring signals server response. */
+  dataVersion: 1 /* Data-Version value from the Key/Value service response. */
 }
 ```
 
@@ -975,22 +978,21 @@ its `scoreAd()` logic is to reject any ad that can't beat the contextual winner.
 
 <p style="color: #547fc0; font-size: 4rem; text-align: center;" aria-hidden="true">⬇︎</p>
 
-### 5. The seller and participating buyers receive realtime data from trusted servers
+### 5. The seller and participating buyers receive realtime data from the Key/Value service
 
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/rn0slzXLZNSzGHMm6w7Y.png",
   alt="Illustration showing a person viewing a news website in a browser on their laptop. An ad
-  auction using the FLEDGE API is taking place, with a participant getting data from a trusted
-  server.", width="400", height="126" %}
+  auction using the FLEDGE API is taking place, with a participant getting data from the Key/Value service.", width="400", height="126" %}
 
-**Explainer section:** [Fetching Real-Time Data from a Trusted Server](https://github.com/WICG/turtledove/blob/main/FLEDGE.md#31-fetching-real-time-data-from-a-trusted-server)
+**Explainer section:** [Fetching Real-Time Data from the FLEDGE Key/Value service](https://github.com/WICG/turtledove/blob/main/FLEDGE.md#31-fetching-real-time-data-from-a-trusted-server).
 
 During an ad auction, the ad-space **seller** can get realtime data about specific ad creatives by
-making a request to a trusted server using the `trustedScoringSignalsUrl` property of
+making a request to a [Key/Value service](#keyvalue-service) using the `trustedScoringSignalsUrl` property of
 [auction configuration](#ad-auction) argument passed to `navigator.runAdAuction()`, along with the keys
 from the `renderUrl` properties of all entries in the `ads` and `adComponents` fields of all
 interest groups in the auction.
 
-Likewise, an ad-space **buyer** can request realtime data from a trusted server using the
+Likewise, an ad-space **buyer** can request realtime data from the Key/Value service using the
 `trustedBiddingSignalsUrl` and `trustedBiddingSignalsKeys` properties of the interest group argument
 passed to `navigator.joinAdInterestGroup()`.
 
@@ -998,7 +1000,7 @@ When  `runAdAuction()` is called, the browser makes a request to each ad buyer's
 URL for the request might look like this:
 
 ```javascript
-https://trusted-server.example/getvalues?hostname=publisher.example&keys=key1,key2
+https://kv-service.example/getvalues?hostname=publisher.example&keys=key1,key2
 ```
 
 * The base URL comes from `trustedBiddingSignalsUrl`.
@@ -1161,11 +1163,11 @@ see [Fenced Frames Ads Reporting](https://github.com/WICG/turtledove/blob/main/F
 {: #auction-diagram}
 
 The diagram below outlines each stage of a FLEDGE [ad auction](#ad-auction):
-<a href="https://wd.imgix.net/image/80mq7dk16vVEg8BBhsVe42n6zn82/roes4NP2gaUcEFD2uVlW.png?auto=format&w=1600"
+<a href="https://wd.imgix.net/image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/M8lyXt6JbwFncB16mTb0.png?auto=format&w=1600"
   target="_blank">view a larger version</a>.
 
 <figure class="w-figure">
-  {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/roes4NP2gaUcEFD2uVlW.png", alt="Illustration providing
+  {% Img src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/M8lyXt6JbwFncB16mTb0.png", alt="Illustration providing
   an overview of each stage of a FLEDGE ad auction",
   width="800", height="481" %}
 </figure>
@@ -1195,9 +1197,8 @@ The TURTLEDOVE effort is about offering a new API to address this use case while
 FLEDGE grew out of TURTLEDOVE and a collection of related proposals for modifications to better served the developers who would be using the API:
 
 -   In [SPARROW](https://github.com/WICG/sparrow):
-   [Criteo](https://www.admonsters.com/what-is-sparrow/) proposed the addition of a trusted-server
-   ("Gatekeeper") model.  FLEDGE includes a more limited use of trusted servers, for real-time data
-   lookup and aggregated reporting.
+   [Criteo](https://www.admonsters.com/what-is-sparrow/) proposed the addition of a
+   ("Gatekeeper") service model running in a [trusted execution environment](https://github.com/privacysandbox/fledge-docs/blob/main/trusted_services_overview.md#trusted-execution-environment).  FLEDGE includes a more limited use of TEEs, for real-time data lookup and aggregated reporting.
 -  NextRoll's [TERN](https://github.com/WICG/turtledove/blob/main/TERN.md) and Magnite's
    [PARRROT](https://github.com/prebid/identity-gatekeeper/blob/master/proposals/PARRROT.md)
    proposals described the different roles that buyers and sellers had in the on-device auction.
@@ -1206,7 +1207,7 @@ FLEDGE grew out of TURTLEDOVE and a collection of related proposals for modifica
    [Product-level](https://github.com/WICG/turtledove/blob/main/PRODUCT_LEVEL.md) TURTLEDOVE
    modifications improved the anonymity model and personalization capabilities of the on-device auction
 -  [PARAKEET](https://github.com/WICG/privacy-preserving-ads/blob/main/Parakeet.md) is
-   Microsoft's proposal for a TURTLEDOVE-like ad service that relies on a trusted proxy server
+   Microsoft's proposal for a TURTLEDOVE-like ad service that relies on a proxy server turnning in a TEE
    between the browser and the adtech providers, to anonymize ad requests and enforce privacy
    properties.  FLEDGE has not adopted this proxying model.  We are bringing the JavaScript APIs
    for PARAKEET and FLEDGE into alignment, in support of future work to further combine the best

--- a/site/en/blog/fledge-api/index.md
+++ b/site/en/blog/fledge-api/index.md
@@ -690,7 +690,7 @@ The `browserSignals` object has the following properties:
   bidCount: 17,
   prevWins: [[time1,ad1],[time2,ad2],...],
   wasmHelper: ... /* WebAssembly.Module object based on interest group's biddingWasmHelperUrl. */
-  dataVersion: 1, /* Data-Version value from the trusted bidding signals server's response(s). */
+  dataVersion: 1, /* Data-Version value from the buyer's Key/Value service response(s). */
 }
 ```
 
@@ -969,7 +969,7 @@ knows and which the seller's auction script might want to verify:
   renderUrl: 'https://cdn.example/render',
   adComponents: ['https://cdn.com/ad-component-1', ...],
   biddingDurationMsec: 12,
-  dataVersion: 1 /* Data-Version value from the Key/Value service response. */
+  dataVersion: 1 /* Data-Version value from the seller's Key/Value service response. */
 }
 ```
 
@@ -1207,7 +1207,7 @@ FLEDGE grew out of TURTLEDOVE and a collection of related proposals for modifica
    [Product-level](https://github.com/WICG/turtledove/blob/main/PRODUCT_LEVEL.md) TURTLEDOVE
    modifications improved the anonymity model and personalization capabilities of the on-device auction
 -  [PARAKEET](https://github.com/WICG/privacy-preserving-ads/blob/main/Parakeet.md) is
-   Microsoft's proposal for a TURTLEDOVE-like ad service that relies on a proxy server turnning in a TEE
+   Microsoft's proposal for a TURTLEDOVE-like ad service that relies on a proxy server running in a TEE
    between the browser and the adtech providers, to anonymize ad requests and enforce privacy
    properties.  FLEDGE has not adopted this proxying model.  We are bringing the JavaScript APIs
    for PARAKEET and FLEDGE into alignment, in support of future work to further combine the best

--- a/site/en/docs/privacy-sandbox/fledge/index.md
+++ b/site/en/docs/privacy-sandbox/fledge/index.md
@@ -6,9 +6,10 @@ subhead: >
 description: >
   A Privacy Sandbox proposal to serve remarketing and custom audience use cases, designed so it cannot be used by third-parties to track user browsing behavior across sites. The API enables on-device auctions by the browser, to choose relevant ads from websites the user has previously visited.
 date: 2022-01-27
-updated: 2022-05-23
+updated: 2022-08-23
 authors:
   - samdutton
+  - kevinkiklee
 ---
 
 {% YouTube
@@ -58,11 +59,11 @@ information for FLEDGE and other Privacy Sandbox proposals.
 <br>
 
 <figure class="w-figure">
-  {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/XLqHPEchhnDcrXGzbby6.png", alt="Illustration providing
+  {% Img src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/zXKEk8OymLJp6KpOwwbk.png", alt="Illustration providing
   an overview of each stage of the FLEDGE lifecycle",
   width="800", height="366" %}
   <br>
-  <figcaption class="w-figcaption">The FLEDGE lifecycle: <a href="https://wd.imgix.net/image/80mq7dk16vVEg8BBhsVe42n6zn82/XLqHPEchhnDcrXGzbby6.png?auto=format&w=1600"
+  <figcaption class="w-figcaption">The FLEDGE lifecycle: <a href="https://wd.imgix.net/image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/zXKEk8OymLJp6KpOwwbk.png?auto=format&w=1600"
 title="Click to view a larger version of image" target="_blank">view a larger version</a></figcaption>
 </figure>
 
@@ -104,7 +105,7 @@ When calling the `navigator.runAdAuction()` function, the seller provides code t
 `scoreAd()` function. This function is run for each bidder in the auction: to score each of the bids
 returned by `generateBid()`. During the ad auction, the bidding code run for each buyer
 (`generateBid()`) and the ad scoring code run for the seller (`scoreAd()`) can receive realtime data
-from a [trusted server](#trusted-server).
+from the [FLEDGE Key/Value service](#key-value-service).
 
 The bid with the highest score wins the auction. The ad associated with the bid is displayed in
 a [`<fencedframe>`](#fenced-frame) element, using the ad URL specified by the bid (which must be one of the ad URLs from the list provided in the interest group's configuration information).
@@ -264,18 +265,17 @@ give it a score and choose the most desirable bid.
 
 <p style="color: #547fc0; font-size: 4rem; text-align: center;" aria-hidden="true">⬇︎</p>
 
-### 5. The seller and participating buyers receive realtime data from trusted servers
+### 5. The seller and participating buyers receive realtime data from the Key/Value service
 
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/rn0slzXLZNSzGHMm6w7Y.png",
   alt="Illustration showing a person viewing a news website in a browser on their laptop. An ad
-  auction using the FLEDGE API is taking place, with a participant getting data from a trusted
-  server.", width="600", height="189" %}
+  auction using the FLEDGE API is taking place, with a participant getting data from the Key/Value service.", width="600", height="189" %}
 
 During the ad auction, the ad-space [seller](#seller) or bidding ad-space [buyers](#buyer) may need
 to access realtime data. For example, the seller may be required to check that [ad creatives](#creative)
 comply with publisher policies, or bidders may need to calculate the remaining budget in an ad
 campaign. To meet the privacy requirements of FLEDGE, this data is supplied using
-[trusted servers](#trusted-server).
+[Key/Value service](#key-value-service).
 
 <p style="color: #547fc0; font-size: 4rem; text-align: center;" aria-hidden="true">⬇︎</p>
 
@@ -429,7 +429,7 @@ JavaScript function `navigator.joinAdInterestGroup()`) the buyer provides the br
 * A URL for bidding code, that will be used when the [seller](#seller) runs an [ad auction](#ad-auction).
 * Potentially, URLs for [ad creatives](#creative) for the interest group. (Ad URLs may be added
 later via an update.)
-* A list of data [keys](#key-value), and the URL of the buyer's [trusted server](#trusted-server),
+* A list of data [keys](#key-value) to be queried, and the URL of the buyer's [Key/Value service](#key-value-service),
 to enable bidding code to get realtime data during an auction.
 
 The buyer's code can also include a `reportWin()` function to report the auction outcome.
@@ -479,11 +479,11 @@ auction by calling the JavaScript function `navigator.runAdAuction()`.
 
 {: #auction-diagram}
 
-The diagram below outlines each stage of a FLEDGE ad auction: <a href="https://wd.imgix.net/image/80mq7dk16vVEg8BBhsVe42n6zn82/roes4NP2gaUcEFD2uVlW.png?auto=format&w=1600"
+The diagram below outlines each stage of a FLEDGE ad auction: <a href="https://wd.imgix.net/image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/M8lyXt6JbwFncB16mTb0.png?auto=format&w=1600"
 title="Click to view a larger version of image" target="_blank">view a larger version</a>.
 
 <figure class="w-figure">
-  {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/roes4NP2gaUcEFD2uVlW.png", alt="Illustration providing
+  {% Img src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/M8lyXt6JbwFncB16mTb0.png", alt="Illustration providing
   an overview of each stage of a FLEDGE ad auction",
   width="800", height="481" %}
 </figure>
@@ -502,7 +502,7 @@ owner of an interest group.
 The seller provides the browser with code to score bids, which includes each bid's value, the
 [ad creative](#creative) URL, and other data returned from each buyer. During the auction, bidding
 code from buyers and bid-scoring code from the seller can receive data from their
-[trusted servers](#trusted-server). Once an ad is chosen and displayed (in a
+[Key/Value services](#key-value-service). Once an ad is chosen and displayed (in a
 [fenced frame](#fenced-frame) to preserve privacy) the seller and the winning bidder can report the
 auction result.
 
@@ -521,9 +521,7 @@ sale and who can bid, and provides a URL for code that scores bids.
 As explained in [How does FLEDGE work?](#joinAdInterestGroup), each interest group owner provides a
 URL for code that can be used to bid in an ad auction, when the group owner called
 `navigator.joinAdInterestGroup()`. That code must include a `generateBid()` function, which returns
-a numerical bid and a URL for an [ad creative](#creative), along with other data. Bidding code can
-receive realtime data from each bidder's [trusted server](#trusted-server), such as remaining ad
-campaign budget.
+a numerical bid and a URL for an [ad creative](#creative), along with other data. Each bidding script can receive realtime data from its [Key/Value service](#key-value-service) that was defined in the interest group config. The Key/Value service can be queried for data such as remaining ad campaign budget.
 
 ### 4. The seller's code evaluates each buyer's bid
 
@@ -532,7 +530,7 @@ once for each ad and accompanying bid, to determine its desirability. The `score
 run for every candidate ad, in the auction logic JavaScript code provided by the seller. This
 function uses the bid value and other data returned by the `generateBid()` function in each buyer's
 code (in the previous step). The seller may also receive realtime data from its
-[trusted server](#trusted-server).
+[Key/Value service](#key-value-service).
 
 For each ad, the `scoreAd()` function returns a number indicating its desirability. The most
 desirable ad is the winner. Before an auction starts, the seller finds the best contextual ad for
@@ -561,26 +559,28 @@ A reporting mechanism for losing bidders is [under discussion](https://github.co
 {% endDetails %}
 
 
-{: #trusted-server-detail}
+{: #key-value-service-detail}
 
 {% Details %}
 
 {% DetailsSummary %}
-## What is a trusted server?
+## What is a FLEDGE Key/Value service?
 
 {% endDetailsSummary %}
 
-In the context of the Privacy Sandbox, a trusted server is a secure environment to enable access to
-data, while preserving privacy. A request to a trusted server cannot result in event-level logging,
-or have other side effects.
+FLEDGE Key/Value service allows adtechs to query for realtime data when a bid is made by the buyer or when an ad is scored by the seller while preserving privacy. FLEDGE Key/Value service is one of the [FLEDGE services](/blog/fledge-service-overview/). 
 
-To enable a party (such as a web browser during a FLEDGE auction) to ask questions that might reveal
-sensitive information, a trusted server must provide:
+The Key/Value service is deployed to the adtech's own cloud infrastructure, and the service runs on a [trusted execution environment](#trusted-execution-environment). A request to a Key/Value service cannot result in event-level logging or have other side effects. The Key/Value service will also support [user-defined functions (UDFs)](https://github.com/WICG/turtledove/blob/main/FLEDGE_Key_Value_Server_trust_model.md#support-for-user-defined-functions-udfs) that allows adtechs to execute their own custom logic within the Key/Value service. 
 
--  **Policy approaches** such as mandatory code audits, or usage of servers only from trusted
-   third parties.
--  **Technical guarantees** such as [secure multi-party computation](https://en.wikipedia.org/wiki/Secure_multi-party_computation)
-or [secure enclaves](https://support.apple.com/en-gb/guide/security/sec59b0b31ff/web).
+{: #key-value}
+
+When a buyer or seller makes a request to a FLEDGE Key/Value service, they specify the data they require from the server as a list of 'keys'. The Key/Value service responds with a value for each key.
+
+The FLEDGE Key/Value service code is now available in a [Privacy Sandbox GitHub repository](https://github.com/privacysandbox/fledge-key-value-service). This service can be used by Chrome and Android developers. 
+
+Check out the [announcement blog post](/blog/open-sourcing-fledge-key-value-service/) for the status update. Learn more about the FLEDGE Key/Value service from the [API explainer](https://github.com/WICG/turtledove/blob/main/FLEDGE_Key_Value_Server_API.md) and the [trust model explainer](https://github.com/privacysandbox/fledge-docs/blob/main/key_value_service_trust_model.md).  
+
+
 
 {% endDetails %}
 
@@ -596,17 +596,11 @@ The [buyers](#buyer-detail) or [seller](#seller-detail) in an ad auction may nee
 data. For example, bidders may want to calculate the remaining budget in an ad campaign, or the
 seller may be required to check ad creatives against publisher policies.
 
-To meet the privacy requirements of FLEDGE, realtime data required during an ad auction is provided
-by [trusted servers](#trusted-server-detail). When each buyer calls `navigator.joinAdInterestGroup()`,
-the buyer specifies a trusted server URL and specifies the data it will require from the
-server during an auction. Likewise, when the seller runs an ad auction by calling
-`navigator.runAdAuction()`, the seller provides a URL for its trusted server, and specifies the
-data that will be required from the server.
+To meet the privacy requirements of FLEDGE, realtime data required during an ad auction is provided by the [Key/Value service](#key-value-service-detail). When each buyer calls `navigator.joinAdInterestGroup()`,the buyer specifies a Key/Value service URL and specifies the keys to be queried to the service during an auction. Likewise, when the seller runs an ad auction by calling `navigator.runAdAuction()`, the seller provides a URL for its Key/Value service. The seller's Key/Value service will be queried with the render URL of the creative.
 
-The role and the ownership of the trusted server is still under discussion, so initial testing of
-FLEDGE temporarily uses a ["Bring Your Own Server"](https://github.com/WICG/turtledove/blob/main/FLEDGE.md#3-buyers-provide-ads-and-bidding-functions-byos-for-now)
-model.
+For initial testing, ["Bring Your Own Server"](https://github.com/WICG/turtledove/blob/main/FLEDGE.md#3-buyers-provide-ads-and-bidding-functions-byos-for-now) model is used. In the long-term, adtechs will need to use the open-source FLEDGE Key/Value services running in [trusted execution environments](https://github.com/privacysandbox/fledge-docs/blob/main/trusted_services_overview.md#trusted-execution-environment) for retrieving real-time data.
 
+To ensure that the ecosystem has sufficient time to test, we don’t expect to require the use of the open-source Key/Value services or TEEs until sometime after third-party cookie deprecation. We will provide substantial notice for developers to begin testing and adoption before this transition takes place.
 {% endDetails %}
 
 
@@ -697,9 +691,11 @@ the user's browser to join their interest group.
 
 {: #publisher}
 
-### Key-value
+{: #key-value-service}
 
-See [Trusted server](#key-value).
+### Key/Value service
+
+The Key/Value service allows the buyers and sellers to receive realtime data when a bid is made or an ad is scored. See [FLEDGE Key/Value service](#key-value-service-detail) for details.
 
 ### Publisher
 
@@ -735,19 +731,13 @@ An adtech service used to automate selling ad inventory. SSPs allow publishers t
 inventory (empty rectangles where ads will go) to multiple ad exchanges, DSPs, and networks. This
 enables a wide range of potential buyers to bid for ad space.
 
-{: #trusted-server}
+{: #trusted-execution-environment}
 
-### Trusted server
+### Trusted execution environment
 
-A server used to provide data, but with major restrictions to safeguard privacy, backed by technical
-and policy guarantees. A request to a trusted server—such as a bidder in a FLEDGE ad auction
-checking on the remaining budget for an ad campaign—cannot result in event-level logging, or have
-other side effects.
+A [trusted execution environment (TEE)](https://confidentialcomputing.io/wp-content/uploads/sites/85/2021/03/confidentialcomputing_outreach_whitepaper-8-5x11-1.pdf) provides a level of assurance for data integrity, data confidentiality, and code integrity. Services for FLEDGE, including the Key/Value service, runs on a TEE.
 
-{: #key-value}
-
-When a buyer or seller makes a request to a trusted server, they specify the data they require from
-the server as a list of 'keys'. The trusted server responds with a value for each key.
+To learn more about TEE, see the [FLEDGE services explainer](https://github.com/privacysandbox/fledge-docs/blob/main/trusted_services_overview.md#trusted-execution-environment).
 
 {: #worklet}
 

--- a/site/en/docs/privacy-sandbox/fledge/index.md
+++ b/site/en/docs/privacy-sandbox/fledge/index.md
@@ -568,13 +568,13 @@ A reporting mechanism for losing bidders is [under discussion](https://github.co
 
 {% endDetailsSummary %}
 
-FLEDGE Key/Value service allows adtechs to query for realtime data when a bid is made by the buyer or when an ad is scored by the seller while preserving privacy. FLEDGE Key/Value service is one of the [FLEDGE services](/blog/fledge-service-overview/). 
+FLEDGE Key/Value service allows adtechs to query for realtime data when a bid is made by the buyer, and for sellers to score ads while preserving privacy. FLEDGE Key/Value service is one of the [FLEDGE services](/blog/fledge-service-overview/). 
 
-The Key/Value service is deployed to the adtech's own cloud infrastructure, and the service runs on a [trusted execution environment](#trusted-execution-environment). A request to a Key/Value service cannot result in event-level logging or have other side effects. The Key/Value service will also support [user-defined functions (UDFs)](https://github.com/WICG/turtledove/blob/main/FLEDGE_Key_Value_Server_trust_model.md#support-for-user-defined-functions-udfs) that allows adtechs to execute their own custom logic within the Key/Value service. 
+The Key/Value service is deployed to the adtech's own cloud infrastructure, and the service runs on a [trusted execution environment](#trusted-execution-environment). A request to a Key/Value service cannot result in event-level logging or have other side effects. The Key/Value service will also support [user-defined functions (UDFs)](https://github.com/WICG/turtledove/blob/main/FLEDGE_Key_Value_Server_trust_model.md#support-for-user-defined-functions-udfs) that allow adtechs to execute their own custom logic within the Key/Value service. 
 
 {: #key-value}
 
-When a buyer or seller makes a request to a FLEDGE Key/Value service, they specify the data they require from the server as a list of 'keys'. The Key/Value service responds with a value for each key.
+A buyer or seller provides a list of 'keys' to specify the data they require from a FLEDGE Key/Value service. The Key/Value service responds with a value for each key.
 
 The FLEDGE Key/Value service code is now available in a [Privacy Sandbox GitHub repository](https://github.com/privacysandbox/fledge-key-value-service). This service can be used by Chrome and Android developers. 
 


### PR DESCRIPTION
This PR adds information about the open sourced FLEDGE Key/Value service, and also updates the phrase "trusted servers" throughout the documentation to fix the issue #3359

* FLEDGE landing page: https://deploy-preview-3542--developer-chrome-com.netlify.app/docs/privacy-sandbox/fledge/
* FLEDGE API doc: https://deploy-preview-3542--developer-chrome-com.netlify.app/blog/fledge-api/

