### PR TITLE
Update popup link

### DIFF
--- a/site/en/blog/top-layer-devtools/index.md
+++ b/site/en/blog/top-layer-devtools/index.md
@@ -31,7 +31,7 @@ The [top layer](https://fullscreen.spec.whatwg.org/#new-stacking-layer) can be d
 Multiple elements can be inside the top layer at the same time. When that happens, they stack on top of each other, the last one on top. In other words, all of the top layer elements are placed in a *last in, first out* (LIFO) stack in the top layer.
 
 The `<dialog>` element is not the only element that the browser renders into a top layer. Currently, the top layer elements are:
-[popups](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/user_interface/Popups), [modal dialogs](https://developer.mozilla.org/docs/Web/HTML/Element/dialog), and elements in a [fullscreen mode](https://developer.mozilla.org/docs/Web/API/Fullscreen_API).
+[popups](https://open-ui.org/components/popup.research.explainer), [modal dialogs](https://developer.mozilla.org/docs/Web/HTML/Element/dialog), and elements in a [fullscreen mode](https://developer.mozilla.org/docs/Web/API/Fullscreen_API).
 
 Examine the following dialog implementation:
 

--- a/site/en/blog/top-layer-devtools/index.md
+++ b/site/en/blog/top-layer-devtools/index.md
@@ -31,7 +31,7 @@ The [top layer](https://fullscreen.spec.whatwg.org/#new-stacking-layer) can be d
 Multiple elements can be inside the top layer at the same time. When that happens, they stack on top of each other, the last one on top. In other words, all of the top layer elements are placed in a *last in, first out* (LIFO) stack in the top layer.
 
 The `<dialog>` element is not the only element that the browser renders into a top layer. Currently, the top layer elements are:
-[popups](https://open-ui.org/components/popup.research.explainer), [modal dialogs](https://developer.mozilla.org/docs/Web/HTML/Element/dialog), and elements in a [fullscreen mode](https://developer.mozilla.org/docs/Web/API/Fullscreen_API).
+[pop-ups](https://open-ui.org/components/popup.research.explainer), [modal dialogs](https://developer.mozilla.org/docs/Web/HTML/Element/dialog), and elements in a [fullscreen mode](https://developer.mozilla.org/docs/Web/API/Fullscreen_API).
 
 Examine the following dialog implementation:
 

--- a/site/en/blog/top-layer-devtools/index.md
+++ b/site/en/blog/top-layer-devtools/index.md
@@ -31,8 +31,7 @@ The [top layer](https://fullscreen.spec.whatwg.org/#new-stacking-layer) can be d
 Multiple elements can be inside the top layer at the same time. When that happens, they stack on top of each other, the last one on top. In other words, all of the top layer elements are placed in a *last in, first out* (LIFO) stack in the top layer.
 
 The `<dialog>` element is not the only element that the browser renders into a top layer. Currently, the top layer elements are:
-[popups](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/user_interface/Popups)
-[modal dialogs](https://developer.mozilla.org/docs/Web/HTML/Element/dialog) elements in a [fullscreen mode](https://developer.mozilla.org/docs/Web/API/Fullscreen_API).
+[popups](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/user_interface/Popups), [modal dialogs](https://developer.mozilla.org/docs/Web/HTML/Element/dialog), and elements in a [fullscreen mode](https://developer.mozilla.org/docs/Web/API/Fullscreen_API).
 
 Examine the following dialog implementation:
 


### PR DESCRIPTION
The popup link in this top layer blog post is not correct. This PR updates the link and as a drive-by adjusts the sentence a little bit to make it clear what are top-layer-eligible elements.