### PR TITLE
Add compression streams API article

### DIFF
--- a/site/en/blog/compression-streams-api/index.md
+++ b/site/en/blog/compression-streams-api/index.md
@@ -31,7 +31,7 @@ const decompressedReadableStream = compressedReadableStream.pipeThrough(new Deco
 
 ## Demo
 
-{% Glitch 'compressionstream-demo' %}
+{% Glitch { id: 'compressionstream-demo' } %}
 
 ## Browser support
 

--- a/site/en/blog/compression-streams-api/index.md
+++ b/site/en/blog/compression-streams-api/index.md
@@ -1,4 +1,5 @@
 ---
+layout: 'layouts/blog-post.njk'
 title: Compression and decompression in the browser with the Compression Streams API
 subhead: >
   Write smaller web apps that don't need to ship their owm compression or decompression library

--- a/site/en/blog/compression-streams-api/index.md
+++ b/site/en/blog/compression-streams-api/index.md
@@ -2,7 +2,7 @@
 layout: 'layouts/blog-post.njk'
 title: Compression and decompression in the browser with the Compression Streams API
 subhead: >
-  Write smaller web apps that don't need to ship their owm compression or decompression library
+  Write smaller web apps that don't need to ship their own compression or decompression library
 date: 2022-08-26
 hero: image/8WbTDNrhLsU0El80frMBGE4eMCD3/koW7cNlWa6BUlJsQR4wI.jpg
 alt: Clamp to symbolize how data gets compressed.
@@ -17,17 +17,23 @@ deflate (or deflate-raw) formats.
 
 Built in compression means that JavaScript applications will not need to include a compression
 library, which makes the download size of the application smaller. After Chrome, now Safari, too,
-supports this useful API. You can use it as shown in the snippet below.
+supports this useful API. To compress, you can use the API as shown in the snippet below.
 
 ```js
-const readableStream = await fetch('lorem.txt').then((response) => response.body);
-const compressedReadableStream = readableStream.pipeThrough(new CompressionStream('gzip'));
+const readableStream = await fetch('lorem.txt').then(
+  (response) => response.body
+);
+const compressedReadableStream = readableStream.pipeThrough(
+  new CompressionStream('gzip')
+);
 ```
 
 To decompress, pipe the compressed stream through the decompression stream.
 
 ```js
-const decompressedReadableStream = compressedReadableStream.pipeThrough(new DecompressionStream('gzip'));
+const decompressedReadableStream = compressedReadableStream.pipeThrough(
+  new DecompressionStream('gzip')
+);
 ```
 
 ## Demo
@@ -37,6 +43,7 @@ const decompressedReadableStream = compressedReadableStream.pipeThrough(new Deco
 ## Browser support
 
 The Compression Streams API is supported since Chromium&nbsp;80 and Safari Technology Preview&nbsp;152.
+For other browsers, check [CanIUse](https://caniuse.com/mdn-api_compressionstream).
 
 ## Acknowledgements
 

--- a/site/en/blog/compression-streams-api/index.md
+++ b/site/en/blog/compression-streams-api/index.md
@@ -3,7 +3,7 @@ layout: 'layouts/blog-post.njk'
 title: Compression and decompression in the browser with the Compression Streams API
 subhead: >
   Write smaller web apps that don't need to ship their own compression or decompression library
-date: 2022-08-26
+date: 2022-08-29
 hero: image/8WbTDNrhLsU0El80frMBGE4eMCD3/koW7cNlWa6BUlJsQR4wI.jpg
 alt: Clamp to symbolize how data gets compressed.
 author: thomassteiner

--- a/site/en/blog/compression-streams-api/index.md
+++ b/site/en/blog/compression-streams-api/index.md
@@ -36,7 +36,7 @@ const decompressedReadableStream = compressedReadableStream.pipeThrough(new Deco
 
 ## Browser support
 
-{% BrowserCompat 'api.CompressionStream' %}
+The Compression Streams API is supported since Chromium&nbsp;80 and Safari Technology Preview&nbsp;152.
 
 ## Acknowledgements
 

--- a/site/en/blog/compression-streams-api/index.md
+++ b/site/en/blog/compression-streams-api/index.md
@@ -12,12 +12,12 @@ tags:
 ---
 
 The [Compression Streams API](https://developer.mozilla.org/docs/Web/API/Compression_Streams_API)
-provides a JavaScript API for compressing and decompressing streams of data using the gzip or
+is for compressing and decompressing streams of data using the gzip or
 deflate (or deflate-raw) formats.
 
 With built in compression JavaScript applications do not need to include a compression
-library, making the download size of the application smaller. Chrome and Safari Technology Preview now
-support this useful API. To compress, you can use the API as shown in the snippet below.
+library, making the download size of the application smaller. Stable Chrome and Safari Technology Preview now
+support this useful API. Compressing data is shown below.
 
 ```js
 const readableStream = await fetch('lorem.txt').then(
@@ -28,7 +28,7 @@ const compressedReadableStream = readableStream.pipeThrough(
 );
 ```
 
-To decompress, pipe the compressed stream through the decompression stream.
+To decompress, pipe a compressed stream through the decompression stream.
 
 ```js
 const decompressedReadableStream = compressedReadableStream.pipeThrough(

--- a/site/en/blog/compression-streams-api/index.md
+++ b/site/en/blog/compression-streams-api/index.md
@@ -7,7 +7,7 @@ hero: image/8WbTDNrhLsU0El80frMBGE4eMCD3/koW7cNlWa6BUlJsQR4wI.jpg
 alt: Clamp to symbolize how data gets compressed.
 author: thomassteiner
 tags:
-  - blog
+  - capabilities
 ---
 
 The [Compression Streams API](https://developer.mozilla.org/docs/Web/API/Compression_Streams_API)

--- a/site/en/blog/compression-streams-api/index.md
+++ b/site/en/blog/compression-streams-api/index.md
@@ -15,9 +15,9 @@ The [Compression Streams API](https://developer.mozilla.org/docs/Web/API/Compres
 provides a JavaScript API for compressing and decompressing streams of data using the gzip or
 deflate (or deflate-raw) formats.
 
-Built in compression means that JavaScript applications will not need to include a compression
-library, which makes the download size of the application smaller. After Chrome, now Safari, too,
-supports this useful API. To compress, you can use the API as shown in the snippet below.
+With built in compression JavaScript applications do not need to include a compression
+library, making the download size of the application smaller. Chrome and Safari Technology Preview now
+support this useful API. To compress, you can use the API as shown in the snippet below.
 
 ```js
 const readableStream = await fetch('lorem.txt').then(
@@ -42,7 +42,7 @@ const decompressedReadableStream = compressedReadableStream.pipeThrough(
 
 ## Browser support
 
-The Compression Streams API is supported since Chromium&nbsp;80 and Safari Technology Preview&nbsp;152.
+The Compression Streams API is supported from Chromium&nbsp;80 and Safari Technology Preview&nbsp;152.
 For other browsers, check [CanIUse](https://caniuse.com/mdn-api_compressionstream).
 
 ## Acknowledgements

--- a/site/en/blog/compression-streams-api/index.md
+++ b/site/en/blog/compression-streams-api/index.md
@@ -1,0 +1,43 @@
+---
+title: Compression and decompression in the browser with the Compression Streams API
+subhead: >
+  Write smaller web apps that don't need to ship their owm compression or decompression library
+date: 2022-08-26
+hero: image/8WbTDNrhLsU0El80frMBGE4eMCD3/koW7cNlWa6BUlJsQR4wI.jpg
+alt: Clamp to symbolize how data gets compressed.
+author: thomassteiner
+tags:
+  - blog
+---
+
+The [Compression Streams API](https://developer.mozilla.org/docs/Web/API/Compression_Streams_API)
+provides a JavaScript API for compressing and decompressing streams of data using the gzip or
+deflate (or deflate-raw) formats.
+
+Built in compression means that JavaScript applications will not need to include a compression
+library, which makes the download size of the application smaller. After Chrome, now Safari, too,
+supports this useful API. You can use it as shown in the snippet below.
+
+```js
+const readableStream = await fetch('lorem.txt').then((response) => response.body);
+const compressedReadableStream = readableStream.pipeThrough(new CompressionStream('gzip'));
+```
+
+To decompress, pipe the compressed stream through the decompression stream.
+
+```js
+const decompressedReadableStream = compressedReadableStream.pipeThrough(new DecompressionStream('gzip'));
+```
+
+## Demo
+
+{% Glitch 'compressionstream-demo' %}
+
+## Browser support
+
+{% BrowserCompat 'api.CompressionStream' %}
+
+## Acknowledgements
+
+Hero image by [Matt Artz](https://unsplash.com/@mattartz) on
+[Unsplash](https://unsplash.com/photos/7_zxKAWCDQI).


### PR DESCRIPTION
Changes proposed in this pull request:

- Add the article ([staging preview](https://deploy-preview-3557--developer-chrome-com.netlify.app/blog/compression-streams-api/)). 

Replaces https://github.com/GoogleChrome/web.dev/pull/8597