### PR TITLE
Updated link to demo GH repo

### DIFF
--- a/site/de/docs/privacy-sandbox/attribution-reporting-introduction/index.md
+++ b/site/de/docs/privacy-sandbox/attribution-reporting-introduction/index.md
@@ -86,7 +86,7 @@ Es stehen Ihnen einige Demos zum Ausprobieren zur Verfügung.
 - Berichte auf Ereignisebene (nur Klicks betreffend):
 
     - [Live-Demo](https://goo.gle/sppi-devrel-eventlevel).
-    - [Quellcode](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/conversion-measurement) für diese Demo, den Sie nach Bedarf [forken und anpassen](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/conversion-measurement#fork-and-customize) können.
+    - [Quellcode](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/attribution-reporting) für diese Demo, den Sie nach Bedarf [forken und anpassen](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/attribution-reporting#fork-and-customize) können.
 
 ## Anwendungsfälle und Funktionen
 

--- a/site/es/docs/privacy-sandbox/attribution-reporting-introduction/index.md
+++ b/site/es/docs/privacy-sandbox/attribution-reporting-introduction/index.md
@@ -94,7 +94,7 @@ Algunas demostraciones están disponibles para que las pruebe.
 - Informes a nivel de evento, solo de clics:
 
     - [Demostración en vivo](https://goo.gle/sppi-devrel-eventlevel) .
-    - [Código fuente](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/conversion-measurement) para esta demostración, que puede [bifurcar y personalizar](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/conversion-measurement#fork-and-customize) según sea necesario.
+    - [Código fuente](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/attribution-reporting) para esta demostración, que puede [bifurcar y personalizar](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/attribution-reporting#fork-and-customize) según sea necesario.
 
 ## Casos de uso y funciones
 

--- a/site/fr/docs/privacy-sandbox/attribution-reporting-introduction/index.md
+++ b/site/fr/docs/privacy-sandbox/attribution-reporting-introduction/index.md
@@ -87,7 +87,7 @@ Il est possible de tester quelques démos.
 - Rapports basés sur les événements, clics uniquement :
 
     - [Démo en direct](https://goo.gle/sppi-devrel-eventlevel).
-    - [Code source](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/conversion-measurement) de cette démo, que vous pouvez [dupliquer et personnaliser](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/conversion-measurement#fork-and-customize) selon vos besoins.
+    - [Code source](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/attribution-reporting) de cette démo, que vous pouvez [dupliquer et personnaliser](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/attribution-reporting#fork-and-customize) selon vos besoins.
 
 ## Cas d'utilisation et fonctionnalités
 

--- a/site/ja/docs/privacy-sandbox/attribution-reporting-introduction/index.md
+++ b/site/ja/docs/privacy-sandbox/attribution-reporting-introduction/index.md
@@ -86,7 +86,7 @@ Chrome で API を試している方は、**現在**実装されているすべ�
 - イベントレベルのレポート、クリックのみ:
 
     - [ライブ デモ](https://goo.gle/sppi-devrel-eventlevel)。
-    - このデモの[ソース コード](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/conversion-measurement)。必要に応じて[フォークしてカスタマイズできます。](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/conversion-measurement#fork-and-customize)
+    - このデモの[ソース コード](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/attribution-reporting)。必要に応じて[フォークしてカスタマイズできます。](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/attribution-reporting#fork-and-customize)
 
 ## ユース ケースと機能
 

--- a/site/ko/docs/privacy-sandbox/attribution-reporting-introduction/index.md
+++ b/site/ko/docs/privacy-sandbox/attribution-reporting-introduction/index.md
@@ -86,7 +86,7 @@ Chrome에서 API를 실험하는 경우 **현재** 구현된 모든 기능에 �
 - 이벤트 수준 보고서, 클릭만:
 
     - [라이브 데모](https://goo.gle/sppi-devrel-eventlevel)
-    - 필요에 따라 [분기하고 사용자 지정](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/conversion-measurement#fork-and-customize)할 수 있는 이 데모의 [소스 코드](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/conversion-measurement)
+    - 필요에 따라 [분기하고 사용자 지정](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/attribution-reporting#fork-and-customize)할 수 있는 이 데모의 [소스 코드](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/attribution-reporting)
 
 ## 사용 사례 및 기능
 

--- a/site/pt/docs/privacy-sandbox/attribution-reporting-introduction/index.md
+++ b/site/pt/docs/privacy-sandbox/attribution-reporting-introduction/index.md
@@ -86,7 +86,7 @@ Algumas demonstrações estão disponíveis para você experimentar.
 - Relatórios em nível de evento, apenas cliques:
 
     - [Demo em tempo real](https://goo.gle/sppi-devrel-eventlevel).
-    - [Código-fonte](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/conversion-measurement) para esta demonstração, que você pode [duplicar e personalizar](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/conversion-measurement#fork-and-customize) conforme necessário.
+    - [Código-fonte](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/attribution-reporting) para esta demonstração, que você pode [duplicar e personalizar](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/attribution-reporting#fork-and-customize) conforme necessário.
 
 ## Casos de uso e recursos
 

--- a/site/ru/docs/privacy-sandbox/attribution-reporting-introduction/index.md
+++ b/site/ru/docs/privacy-sandbox/attribution-reporting-introduction/index.md
@@ -86,7 +86,7 @@ Attribution Reporting API позволяет отслеживать, когда 
 - Отчеты на уровне событий, только клики:
 
     - [живая демонстрация](https://goo.gle/sppi-devrel-eventlevel);
-    - [исходный код](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/conversion-measurement) этой демонстрации, который при необходимости можно [разветвить и настроить](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/conversion-measurement#fork-and-customize).
+    - [исходный код](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/attribution-reporting) этой демонстрации, который при необходимости можно [разветвить и настроить](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/attribution-reporting#fork-and-customize).
 
 ## Варианты использования и возможности
 

--- a/site/zh/docs/privacy-sandbox/attribution-reporting-introduction/index.md
+++ b/site/zh/docs/privacy-sandbox/attribution-reporting-introduction/index.md
@@ -86,7 +86,7 @@ authors:
 - 事件级报告，仅限点击型转化：
 
     - [实时演示](https://goo.gle/sppi-devrel-eventlevel)。
-    - 该演示的[源代码](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/conversion-measurement)，您可以根据需要[进行复刻和自定义](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/conversion-measurement#fork-and-customize)。
+    - 该演示的[源代码](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/attribution-reporting)，您可以根据需要[进行复刻和自定义](https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/attribution-reporting#fork-and-customize)。
 
 ## 用例和功能
 


### PR DESCRIPTION
This is ready to merge!

@heyawhite This link should also be updated in the "DCC handbook". Happy to make the change if you have a draft to share, or for you to make the change directly in your "DCC Handbook" PR, whatever is easier.

Changed https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/conversion-measurement to fit the actual API name https://github.com/GoogleChromeLabs/trust-safety-demo/tree/main/attribution-reporting