### PR TITLE
Add “Modern Web Debugging in Chrome DevTools” and “Case Study: Better Angular Debugging with DevTools” posts

### DIFF
--- a/site/en/blog/devtools-better-angular-debugging/index.md
+++ b/site/en/blog/devtools-better-angular-debugging/index.md
@@ -187,7 +187,7 @@ The [PR to use this updated version also in `angular-cli`](https://github.com/an
 
 ## Friendly Call Frames
 
-Frameworks often generate code from all kinds of templating languages when building a project, such as Angular templates, or JSX templates, that turn HTML-looking code into plain JavaScript code that eventually runs in the browser. Sometimes, these kinds of generated functions are given names that aren’t very friendly – either single letter names after they’re minified, or some obscure or unfamiliar name even when they’re not.
+Frameworks often generate code from all kinds of templating languages when building a project, such as Angular or JSX templates that turn HTML-looking code into plain JavaScript that eventually runs in the browser. Sometimes, these kinds of generated functions are given names that aren’t very friendly — either single letter names after they’re minified or some obscure or unfamiliar names even when they’re not.
 
 In Angular it’s not uncommon to see call frames with names such as `AppComponent_Template_app_button_handleClick_1_listener` in stack traces.
 

--- a/site/en/blog/devtools-better-angular-debugging/index.md
+++ b/site/en/blog/devtools-better-angular-debugging/index.md
@@ -203,7 +203,7 @@ While parsing the HTML templates that authors have written, the Angular compiler
 
 As part of this code generation process, source maps are also created. We are currently exploring ways of including function names in the “names” field of source maps, and referencing those names in the mappings between the generated code and original code.
 
-For example, if a function for an event listener is generated and its name is either unfriendly or removed during minification, source maps can now include the more friendly name for this function in the “names” field, and the mapping for the beginning of the function scope can now refer to this name (that is, the left paren of the parameter list). Chrome DevTools will then use these names to rename call frames in stack traces.
+For example, if a function for an event listener is generated and its name is either unfriendly or removed during minification, source maps can now include the more friendly name for this function in the “names” field and the mapping for the beginning of the function scope can now refer to this name (that is, the left paren of the parameter list). Chrome DevTools will then use these names to rename call frames in stack traces.
 
 ## Looking ahead
 

--- a/site/en/blog/devtools-better-angular-debugging/index.md
+++ b/site/en/blog/devtools-better-angular-debugging/index.md
@@ -92,7 +92,7 @@ In a more complex example the indices 2, 4 and 5 specify that regions mapped to 
 If you’re a framework or bundler developer, make sure the source maps generated during the build process include this field in order to hook into these new capabilities in Chrome DevTools.
 
 {% Aside %}
-There may be regions in the generated code that aren’t mapped to any original code at all. We are open to exploring the possibility of such granular ignore-listing regions. Please reach out if your framework or bundler would benefit from fine-grained ignore-listing!
+There may be regions in the generated code that aren’t mapped to any original code at all. We are open to exploring the possibility of such granular ignore-listing regions. Reach out if your framework or bundler would benefit from fine-grained ignore-listing!
 {% endAside %}
 
 ### `x_google_ignoreList` in Angular

--- a/site/en/blog/devtools-better-angular-debugging/index.md
+++ b/site/en/blog/devtools-better-angular-debugging/index.md
@@ -1,7 +1,7 @@
 ---
 layout: "layouts/blog-post.njk"
 title: "Case Study: Better Angular Debugging with DevTools"
-Authors:
+authors:
   - victorporof
   - bramus
 description: >

--- a/site/en/blog/devtools-better-angular-debugging/index.md
+++ b/site/en/blog/devtools-better-angular-debugging/index.md
@@ -12,6 +12,7 @@ alt: Better Angular Debugging with DevTools
 tags:
   - javascript
   - devtools
+  - devtools-engineering
 ---
 
 ## An improved debugging experience

--- a/site/en/blog/devtools-better-angular-debugging/index.md
+++ b/site/en/blog/devtools-better-angular-debugging/index.md
@@ -167,7 +167,7 @@ task.run(f);
 
 The asynchronous operations can also be nested, and the “root causes” will be displayed in the stack trace in sequence.
 
-Tasks can be run any number of times, and the work payload can differ between each run. The call stack at the scheduling site will be remembered until the task object is garbage collected.
+Tasks can be run any number of times and the work payload can differ between each run. The call stack at the scheduling site will be remembered until the task object is garbage collected.
 
 {% Aside %}
 This example is covered in more detail in [“Modern web debugging in Chrome DevTools: Linked Stack Traces”](/blog/devtools-modern-web-debugging#linked-stack-traces).

--- a/site/en/blog/devtools-better-angular-debugging/index.md
+++ b/site/en/blog/devtools-better-angular-debugging/index.md
@@ -193,7 +193,7 @@ In Angular it’s not uncommon to see call frames with names such as `AppCompone
 
 {% Img src="image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/uZRLE8JDRbS0YUTplPxt.png", alt="Screenshot of stack trace with an auto-generated function name.", width="800", height="529" %}
 
-To address this, Chrome DevTools now supports renaming these functions through source maps: if a source map has a name entry for the start of a function scope (that is, the left paren of the parameter list) of a function, the call frame should display that name in the stack trace.
+To address this, Chrome DevTools now supports renaming these functions through source maps. If a source map has a name entry for the start of a function scope (that is, the left paren of the parameter list), the call frame should display that name in the stack trace.
 
 ### Friendly Call Frames in Angular
 

--- a/site/en/blog/devtools-better-angular-debugging/index.md
+++ b/site/en/blog/devtools-better-angular-debugging/index.md
@@ -123,7 +123,7 @@ compilation.updateAsset(name, new RawSource(JSON.stringify(map)));
 
 ## Linked stack traces
 
-Stack traces answer the question of _“how did I get here”_, but oftentimes this is from the machine’s perspective, and not necessarily something that matches the developer’s perspective or their mental model of the application runtime. This is especially true when some operations are scheduled to happen asynchronously later: it could still be interesting to know the “root cause” or the scheduling side of such operations, but that’s exactly something that won’t be part of a synchronous stack trace.
+Stack traces answer the question of _“how did I get here”_, but oftentimes this is from the machine’s perspective, and not necessarily something that matches the developer’s perspective or their mental model of the application runtime. This is especially true when some operations are scheduled to happen asynchronously later: it could still be interesting to know the “root cause” or the scheduling side of such operations, but that’s exactly something that won’t be part of an asynchronous stack trace.
 
 V8 internally has a mechanism for keeping track of such asynchronous tasks when standard browser scheduling primitives are used, such as `setTimeout`. This is done by default in those cases, so the developers can inspect these already! But in more complex projects, it’s not as simple as that, especially when using a framework with more advanced scheduling mechanisms—for example, one that performs zone tracking, custom task queueing, or that splits updates into several units of work that are run over time.
 

--- a/site/en/blog/devtools-better-angular-debugging/index.md
+++ b/site/en/blog/devtools-better-angular-debugging/index.md
@@ -209,4 +209,4 @@ For example, if a function for an event listener is generated and its name is ei
 
 Using Angular as a test pilot to verify our work has been a wonderful experience. We would love to hear from framework developers and [provide us feedback on these extension points](https://goo.gle/call-stacks-feedback).
 
-There are more areas that we would like to explore, in particular how to improve the profiling experience in DevTools.
+There are more areas that we would like to explore. In particular, how to improve the profiling experience in DevTools.

--- a/site/en/blog/devtools-better-angular-debugging/index.md
+++ b/site/en/blog/devtools-better-angular-debugging/index.md
@@ -45,7 +45,7 @@ The outcome for authors is covered in more detail in [“Modern web debugging in
 In source maps, the new `x_google_ignoreList` field refers to the `sources` array, and lists the indices of all the known third-party sources in that source map. When parsing the source map, **Chrome DevTools will use this to figure out which sections of the code should be ignore-listed.**
 
 {% Aside %}
-You can learn more about source map extensions [here](https://sourcemaps.info/spec.html#h.ghqpj1ytqjbm)
+Learn more about [source map extensions](https://sourcemaps.info/spec.html#h.ghqpj1ytqjbm).
 {% endAside %}
 
 

--- a/site/en/blog/devtools-better-angular-debugging/index.md
+++ b/site/en/blog/devtools-better-angular-debugging/index.md
@@ -63,7 +63,11 @@ Below is a source map for a generated file `out.js`. There are two original `sou
 }
 ```
 
-The `sourcesContent` is included for both of these original sources, and Chrome DevTools would display these files by default across the Debugger: as files in the Sources tree, as results in the Quick Open dialog, or as mapped call frame locations in error stack traces, while paused on a breakpoint, and while stepping.
+The `sourcesContent` is included for both of these original sources and Chrome DevTools would display these files by default across the Debugger: 
+
+- As files in the Sources tree.
+- As results in the Quick Open dialog.
+-  As mapped call frame locations in error stack traces while paused on a breakpoint and while stepping.
 
 There is one additional piece of information that can now be included in source maps to identify which of those sources is first or third-party code:
 

--- a/site/en/blog/devtools-better-angular-debugging/index.md
+++ b/site/en/blog/devtools-better-angular-debugging/index.md
@@ -63,11 +63,11 @@ Below is a source map for a generated file `out.js`. There are two original `sou
 }
 ```
 
-The `sourcesContent` is included for both of these original sources and Chrome DevTools would display these files by default across the Debugger: 
+The `sourcesContent` is included for both of these original sources and Chrome DevTools would display these files by default across the Debugger:
 
 - As files in the Sources tree.
 - As results in the Quick Open dialog.
--  As mapped call frame locations in error stack traces while paused on a breakpoint and while stepping.
+- As mapped call frame locations in error stack traces while paused on a breakpoint and while stepping.
 
 There is one additional piece of information that can now be included in source maps to identify which of those sources is first or third-party code:
 

--- a/site/en/blog/devtools-better-angular-debugging/index.md
+++ b/site/en/blog/devtools-better-angular-debugging/index.md
@@ -16,9 +16,7 @@ tags:
 
 ## An improved debugging experience
 
-Over the past few months the Chrome DevTools team collaborated with the Angular team to launch improvements to the debugging experience in Chrome DevTools.
-
-As a result, Chrome DevTools [now allows developers to debug and profile web applications from the authoring perspective](/blog/devtools-modern-web-debugging): in terms of their source language and project structure, with access to information that is familiar and relevant to them.
+Over the past few months the Chrome DevTools team collaborated with the Angular team to launch improvements to the debugging experience in Chrome DevTools. People from both teams worked together and took steps towards [enabling developers to debug and profile web applications from the **authoring perspective**](/blog/devtools-modern-web-debugging): in terms of their source language and project structure, with access to information that is familiar and relevant to them.
 
 This post takes a look under the hood to see which changes in Angular and Chrome DevTools were required to achieve this. Even though some of these changes are demonstrated through Angular, they can be applied to other frameworks as well. The Chrome DevTools team encourages other frameworks to adopt the new console APIs and source map extension points so they too can offer a better debugging experience to their users.
 
@@ -82,7 +80,7 @@ There is one additional piece of information that can now be included in source 
 
 The new `x_google_ignoreList` field contains a single index referring to the `sources` array: 1. This specifies that the regions mapped to `lib.js` are in fact third-party code that should be automatically added to the ignore list.
 
-In a more complex example the indices 2, 4, and 5 specify that regions mapped to `lib1.ts`, `lib2.coffee`, and `hmr.js` are all third-party code that should be automatically added to the ignore list.
+In a more complex example, shown below, the indices 2, 4, and 5 specify that regions mapped to `lib1.ts`, `lib2.coffee`, and `hmr.js` are all third-party code that should be automatically added to the ignore list.
 
 ```json/3
 {

--- a/site/en/blog/devtools-better-angular-debugging/index.md
+++ b/site/en/blog/devtools-better-angular-debugging/index.md
@@ -49,7 +49,7 @@ You can learn more about source map extensions [here](https://sourcemaps.info/sp
 {% endAside %}
 
 
-Shown below is a source map for a generated file `out.js`. There are two original `sources` that contributed to generating the output file, namely `foo.js` and `lib.js`, the former being something that the web site developer wrote, and the latter being a framework that they used.
+Below is a source map for a generated file `out.js`. There are two original `sources` that contributed to generating the output file: `foo.js` and `lib.js`. The former is something a web site developer wrote and the latter is a framework they used.
 
 ```json
 {

--- a/site/en/blog/devtools-better-angular-debugging/index.md
+++ b/site/en/blog/devtools-better-angular-debugging/index.md
@@ -78,7 +78,7 @@ There is one additional piece of information that can now be included in source 
 
 The new `x_google_ignoreList` field contains a single index referring to the `sources` array: 1. This specifies that the regions mapped to `lib.js` are in fact third-party code that should be automatically added to the ignore list.
 
-In a more complex example the indices 2, 4 and 5 specify that regions mapped to `lib1.ts`, `lib2.coffee` and `hmr.js` are all third-party code that should be automatically added to the ignore list.
+In a more complex example the indices 2, 4, and 5 specify that regions mapped to `lib1.ts`, `lib2.coffee`, and `hmr.js` are all third-party code that should be automatically added to the ignore list.
 
 ```json/3
 {

--- a/site/en/blog/devtools-better-angular-debugging/index.md
+++ b/site/en/blog/devtools-better-angular-debugging/index.md
@@ -1,0 +1,208 @@
+---
+layout: "layouts/blog-post.njk"
+title: "Case Study: Better Angular Debugging with DevTools"
+Authors:
+  - victorporof
+  - bramus
+description: >
+  Using Angular as a test pilot, the Chrome DevTools and Angular teams collaborated to offer you a better debugging experience. Other frameworks can ship similar changes.
+date: 2022-08-31
+hero: 'image/dPDCek3EhZgLQPGtEG3y0fTn4v82/Egfwsk7s0uM7XCLC4nEv.jpg'
+alt: Better Angular Debugging with DevTools
+tags:
+  - javascript
+  - devtools
+---
+
+## An improved debugging experience
+
+Over the past few months the Chrome DevTools team collaborated with the Angular team to launch improvements to the debugging experience in Chrome DevTools.
+
+As a result, Chrome DevTools [now allows developers to debug and profile web applications from the authoring perspective](/blog/devtools-modern-web-debugging): in terms of their source language and project structure, with access to information that is familiar and relevant to them.
+
+This post takes a look under the hood to see which changes in Angular and Chrome DevTools were required to achieve this. Even though some of these changes are demonstrated through Angular, they can be applied to other frameworks as well. The Chrome DevTools team encourages other frameworks to adopt the new console APIs and source map extension points so they too can offer a better debugging experience to their users.
+
+## Ignore-listing code
+
+When debugging applications using Chrome DevTools, authors generally only want to see **just their code**, not that of the framework underneath or some dependency tucked away in the `node_modules` folder.
+
+To achieve this, the DevTools team has introduced an extension to [source maps](/blog/sourcemaps/), called `x_google_ignoreList`. This extension is used to identify third-party sources such as framework code or bundler-generated code. When a framework uses this extension, authors now automatically avoid code that they don't want to see or step through **without having to manually configure this beforehand**.
+
+{% Aside %}
+The `x_google_ignoreList` source map extension is supported by Chrome DevTools starting with Chrome 106.
+{% endAside %}
+
+In practice, Chrome DevTools can automatically hide code identified as such in stack traces, the Sources tree, the Quick Open dialog, and also improve the stepping and resuming behavior in the debugger.
+
+{% Img src="image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/nqkhr5MgrFyXhA8RTDC7.gif", alt="An animated GIF showing DevTools before and after. Note how in the after image DevTools shows the Authored Code in the tree, no longer suggests any of the framework files in the “Quick Open” menu, and shows a much cleaner stack trace on the right.", width="800", height="511" %}
+
+{% Aside %}
+The outcome for authors is covered in more detail in [“Modern web debugging in Chrome DevTools: “Just my code””](/blog/devtools-modern-web-debugging#just-my-code).
+{% endAside %}
+
+### The `x_google_ignoreList` source map extension
+
+In source maps, the new `x_google_ignoreList` field refers to the `sources` array, and lists the indices of all the known third-party sources in that source map. When parsing the source map, **Chrome DevTools will use this to figure out which sections of the code should be ignore-listed.**
+
+{% Aside %}
+You can learn more about source map extensions [here](https://sourcemaps.info/spec.html#h.ghqpj1ytqjbm)
+{% endAside %}
+
+
+Shown below is a source map for a generated file `out.js`. There are two original `sources` that contributed to generating the output file, namely `foo.js` and `lib.js`, the former being something that the web site developer wrote, and the latter being a framework that they used.
+
+```json
+{
+  "version" : 3,
+  "file": "out.js",
+  "sourceRoot": "",
+  "sources": ["foo.js", "lib.js"],
+  "sourcesContent": ["...", "..."],
+  "names": ["src", "maps", "are", "fun"],
+  "mappings": "A,AAAB;;ABCDE;"
+}
+```
+
+The `sourcesContent` is included for both of these original sources, and Chrome DevTools would display these files by default across the Debugger: as files in the Sources tree, as results in the Quick Open dialog, or as mapped call frame locations in error stack traces, while paused on a breakpoint, and while stepping.
+
+There is one additional piece of information that can now be included in source maps to identify which of those sources is first or third-party code:
+
+```json/3
+{
+  ...
+  "sources": ["foo.js", "lib.js"],
+  "x_google_ignoreList": [1],
+  ...
+}
+```
+
+The new `x_google_ignoreList` field contains a single index referring to the `sources` array: 1. This specifies that the regions mapped to `lib.js` are in fact third-party code that should be automatically added to the ignore list.
+
+In a more complex example the indices 2, 4 and 5 specify that regions mapped to `lib1.ts`, `lib2.coffee` and `hmr.js` are all third-party code that should be automatically added to the ignore list.
+
+```json/3
+{
+  ...
+  "sources": ["foo.html", "bar.css", "lib1.ts", "baz.js", "lib2.coffee", "hmr.js"],
+  "x_google_ignoreList": [2, 4, 5],
+  ...
+}
+```
+
+If you’re a framework or bundler developer, make sure the source maps generated during the build process include this field in order to hook into these new capabilities in Chrome DevTools.
+
+{% Aside %}
+There may be regions in the generated code that aren’t mapped to any original code at all. We are open to exploring the possibility of such granular ignore-listing regions. Please reach out if your framework or bundler would benefit from fine-grained ignore-listing!
+{% endAside %}
+
+### `x_google_ignoreList` in Angular
+
+As of [Angular v14.1.0](https://github.com/angular/angular-cli/releases/tag/14.1.0), the contents of the `node_modules` and `webpack` folders have been marked as _“to ignore”_.
+
+This was achieved through [a change in `angular-cli`](https://github.com/angular/angular-cli/commit/b5f6d862b95afd0ec42d9b3968e963f59b1b1658) by [creating a plugin that hooks into  webpack’s `Compiler` module](https://webpack.js.org/api/compiler-hooks/)
+
+The [webpack plugin](https://github.com/angular/angular-cli/blob/main/packages/angular_devkit/build_angular/src/webpack/plugins/devtools-ignore-plugin.ts) that our engineers created hooks into the `PROCESS_ASSETS_STAGE_DEV_TOOLING` stage and populates the `x_google_ignoreList` field in the source maps for the final assets  that webpack generates and the browser loads.
+
+```js
+const map = JSON.parse(mapContent) as SourceMap;
+const ignoreList = [];
+
+for (const [index, path] of map.sources.entries()) {
+  if (path.includes('/node_modules/') || path.startsWith('webpack/')) {
+    ignoreList.push(index);
+  }
+}
+
+map[`x_google_ignoreList`] = ignoreList;
+compilation.updateAsset(name, new RawSource(JSON.stringify(map)));
+```
+
+## Linked stack traces
+
+Stack traces answer the question of _“how did I get here”_, but oftentimes this is from the machine’s perspective, and not necessarily something that matches the developer’s perspective or their mental model of the application runtime. This is especially true when some operations are scheduled to happen asynchronously later: it could still be interesting to know the “root cause” or the scheduling side of such operations, but that’s exactly something that won’t be part of a synchronous stack trace.
+
+V8 internally has a mechanism for keeping track of such asynchronous tasks when standard browser scheduling primitives are used, such as `setTimeout`. This is done by default in those cases, so the developers can inspect these already! But in more complex projects, it’s not as simple as that, especially when using a framework with more advanced scheduling mechanisms—for example, one that performs zone tracking, custom task queueing, or that splits updates into several units of work that are run over time.
+
+To address this, DevTools exposes a mechanism called the “Async Stack Tagging API” on the `console` object, that enables framework developers to hint both the locations where operations are scheduled as well as where these operations are executed.
+
+{% Aside %}
+The Async Stack Tagging API is available in Chrome DevTools starting with Chrome 106.
+{% endAside %}
+
+### The Async Stack Tagging API
+
+Without Async Stack Tagging, stack traces for code that is asynchronously executed in complex ways by frameworks, shows up with no connection to the code where it was scheduled.
+
+{% Img src="image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/R3R4rAjQCSqe1qKmAENC.png", alt="A stack trace of some async executed code with no information about when it was scheduled. It only shows the stack trace starting from `requestAnimationFrame` but holds no information from when it was scheduled.", width="512", height="262" %}
+
+With Async Stack Tagging it is possible to provide this context, and the stack trace looks like this:
+
+{% Img src="image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/YYi8lLXUbAf4aOZ3kBG7.png", alt="A stack trace of some async executed code with information about when it was scheduled. Note how, unlike before, it includes `businessLogic` and `schedule` in the stack trace.", width="512", height="345" %}
+
+To achieve this, use a new [`console` method](/docs/devtools/console/api/) named `console.createTask()` which the Async Stack Tagging API provides. Its signature is as follows:
+
+```js
+interface Console {
+  createTask(name: string): Task;
+}
+
+interface Task {
+  run<T>(f: () => T): T;
+}
+```
+
+Invoking `console.createTask()` returns a `Task` instance which you can later use to run the async code.
+
+```js
+// Task Creation
+const task = console.createTask(name);
+
+// Task Execution
+task.run(f);
+```
+
+The asynchronous operations can also be nested, and the “root causes” will be displayed in the stack trace in sequence.
+
+Tasks can be run any number of times, and the work payload can differ between each run. The call stack at the scheduling site will be remembered until the task object is garbage collected.
+
+{% Aside %}
+This example is covered in more detail in [“Modern web debugging in Chrome DevTools: Linked Stack Traces”](/blog/devtools-modern-web-debugging#linked-stack-traces).
+{% endAside %}
+
+### The Async Stack Tagging API in Angular
+
+In Angular, changes have been made to [NgZone](https://angular.io/guide/zone) – Angular’s execution context that persists across async tasks.
+
+When scheduling a task it uses `console.createTask()` when available. The resulting `Task` instance is stored for further use. Upon invoking the task, NgZone will use the stored `Task` instance to run it.
+
+These changes landed in Angular’s NgZone 0.11.8 through pull requests [#46693](https://github.com/angular/angular/pull/46693) and [#46958](https://github.com/angular/angular/pull/46958).
+
+{% Aside %}
+The [PR to use this updated version also in `angular-cli`](https://github.com/angular/angular-cli/pull/23750) is expected to land soon.
+{% endAside %}
+
+## Friendly Call Frames
+
+Frameworks often generate code from all kinds of templating languages when building a project, such as Angular templates, or JSX templates, that turn HTML-looking code into plain JavaScript code that eventually runs in the browser. Sometimes, these kinds of generated functions are given names that aren’t very friendly – either single letter names after they’re minified, or some obscure or unfamiliar name even when they’re not.
+
+In Angular it’s not uncommon to see call frames with names such as `AppComponent_Template_app_button_handleClick_1_listener` in stack traces.
+
+{% Img src="image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/uZRLE8JDRbS0YUTplPxt.png", alt="Screenshot of stack trace with an auto-generated function name.", width="800", height="529" %}
+
+To address this, Chrome DevTools now supports renaming these functions through source maps: if a source map has a name entry for the start of a function scope (that is, the left paren of the parameter list) of a function, the call frame should display that name in the stack trace.
+
+### Friendly Call Frames in Angular
+
+Renaming call frames in Angular is an ongoing effort. We expect these improvements to land gradually over time.
+
+While parsing the HTML templates that authors have written, the Angular compiler generates TypeScript code, which is eventually transpiled into JavaScript code that the browser loads and runs.
+
+As part of this code generation process, source maps are also created. We are currently exploring ways of including function names in the “names” field of source maps, and referencing those names in the mappings between the generated code and original code.
+
+For example, if a function for an event listener is generated and its name is either unfriendly or removed during minification, source maps can now include the more friendly name for this function in the “names” field, and the mapping for the beginning of the function scope can now refer to this name (that is, the left paren of the parameter list). Chrome DevTools will then use these names to rename call frames in stack traces.
+
+## Looking ahead
+
+Using Angular as a test pilot to verify our work has been a wonderful experience. We would love to hear from framework developers and [provide us feedback on these extension points](https://goo.gle/call-stacks-feedback).
+
+There are more areas that we would like to explore, in particular how to improve the profiling experience in DevTools.

--- a/site/en/blog/devtools-modern-web-debugging/index.md
+++ b/site/en/blog/devtools-modern-web-debugging/index.md
@@ -45,13 +45,11 @@ Currently, when navigating the file tree in the [Sources Panel](/docs/devtools/j
 
 This is not very handy and often hard to grasp. As an author, you want to see and debug the code that you wrote, not the _Deployed Code_.
 
-To make up for it, you can now have the tree show the _Authored Code_ instead. They are similar to the source files you get to see in your IDE and separated from the _Deployed Code_.
+To make up for it, you can now have the tree show the _Authored Code_ instead. This makes the tree more closely resemble source files you get to see in your IDE, and these files are now separated from the _Deployed Code_.
 
 {% Img src="image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/MtGlolFG9ucxykvbOEB9.png", alt="Screenshot of the file tree in Chrome DevTools showing the Authored Code.", width="800", height="479" %}
 
 To enable this option in Chrome DevTools, go to **Settings** > **Experiments** and check **Group sources into Authored and Deployed trees**.
-
-With the option enabled, the file tree now looks like this:
 
 {% Img src="image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/XCJVoG5N9DY4Uav7cTa1.png", alt="Screenshot of DevTools’s Settings.", width="800", height="465" %}
 
@@ -89,7 +87,7 @@ One place where these ignore-listed files no longer show up is in stack traces. 
 
 Should you want to see all call frames of the stack trace, you can always click the **Show more frames** link.
 
-The same applies for the call stacks that you see while [debugging and stepping through your code](/docs/devtools/javascript/). DevTools now hides all irrelevant call frames and jumps over any ignore-listed code while step-debugging.
+The same applies for the call stacks that you see while [debugging and stepping through your code](/docs/devtools/javascript/). When frameworks or bundlers inform DevTools about third-party scripts, DevTools automatically hides all irrelevant call frames and jumps over any ignore-listed code while step-debugging.
 
 {% Img src="image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/DAKhEbhZjni4VKoAr9NA.png", alt="Screenshot of the DevTools Sources Debugger while debugging.", width="800", height="529" %}
 

--- a/site/en/blog/devtools-modern-web-debugging/index.md
+++ b/site/en/blog/devtools-modern-web-debugging/index.md
@@ -62,7 +62,7 @@ We plan to enable this experiment by default soon. Send us feedback [here](https
 ## “Just my code”
 
 {% Aside %}
-Note: This is a preview feature available in Chrome Canary from version 106.
+**Note**: This is a preview feature available in [Chrome Canary](https://www.google.com/chrome/canary/) from version 106.
 {% endAside %}
 
 When using dependencies or building on top of a framework, the third party files can get in your way. Most of the time you only want to see just your code, not that of some third-party library tucked away in the `node_modules` folder.

--- a/site/en/blog/devtools-modern-web-debugging/index.md
+++ b/site/en/blog/devtools-modern-web-debugging/index.md
@@ -61,6 +61,10 @@ We plan to enable this experiment by default soon. Send us feedback [here](https
 
 ## “Just my code”
 
+{% Aside %}
+Note: This is a preview feature available in Chrome Canary from version 106.
+{% endAside %}
+
 When using dependencies or building on top of a framework, the third party files can get in your way. Most of the time you only want to see just your code, not that of some third-party library tucked away in the `node_modules` folder.
 
 To make up for it, DevTools has an extra setting enabled by default: **Automatically add known third-party scripts to ignore list**. You can find it in **DevTools** > **Settings** > **Ignore List**.

--- a/site/en/blog/devtools-modern-web-debugging/index.md
+++ b/site/en/blog/devtools-modern-web-debugging/index.md
@@ -5,7 +5,7 @@ authors:
   - bramus
   - victorporof
 description: >
-  We are releasing a set of features to improve your debugging and profiling experience in Chrome DevTools.
+  Take a look at some of the recent changes in Chrome DevTools which improve your debugging and profiling experience when working with bundlers, frameworks, and third party code.
 date: 2022-08-31
 hero: 'image/dPDCek3EhZgLQPGtEG3y0fTn4v82/p5rc94lS6rpR6xBwzT8k.jpg'
 alt: Modern web debugging in Chrome DevTools
@@ -54,7 +54,7 @@ To enable this option in Chrome DevTools, go to **Settings** > **Experiments** a
 {% Img src="image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/XCJVoG5N9DY4Uav7cTa1.png", alt="Screenshot of DevTools’s Settings.", width="800", height="465" %}
 
 {% Aside %}
-We plan to enable this experiment by default soon. Send us feedback [here](https://bugs.chromium.org/p/chromium/issues/detail?id=1334670).
+The Chrome DevTools team plans to enable this experiment by default soon. Send us feedback [here](https://bugs.chromium.org/p/chromium/issues/detail?id=1334670).
 {% endAside %}
 
 ## “Just my code”
@@ -76,7 +76,7 @@ As of [Angular v14.1.0](https://github.com/angular/angular-cli/releases/tag/14.1
 As an author, you don’t need to do anything to enable this new behavior. It is up to the framework to implement this change.
 
 {% Aside %}
-The ignore-listing is enabled by populating an extra `x_google_ignoreList` field in the source map that Angular generates when compiling the project. We encourage other framework authors to implement a similar change. Refer to the [Case Study: Better Angular Debugging with DevTools](/blog/devtools-better-angular-debugging) post for more details.
+The ignore-listing is enabled by populating an extra `x_google_ignoreList` field in the source map that Angular generates when compiling the project. The Chrome DevTools team encourages other framework authors to implement a similar change. Refer to the [Case Study: Better Angular Debugging with DevTools](/blog/devtools-better-angular-debugging) post for more details.
 {% endAside %}
 
 ### Ignore-listed code in stack traces
@@ -241,6 +241,6 @@ As an author, you don’t need to do anything to enable this new behavior. It is
 
 ## Looking ahead
 
-Thanks to the additions outlined in this post, we can offer you a better debugging experience in Chrome DevTools. There are more areas that we would like to explore. In particular, how to improve the profiling experience in DevTools.
+Thanks to the additions outlined in this post, Chrome DevTools can offer you a better debugging experience. There are more areas that the team would like to explore. In particular, how to improve the profiling experience in DevTools.
 
-We encourage framework authors to adopt these new capabilities. The [Case Study: Better Angular Debugging with DevTools](/blog/devtools-better-angular-debugging) offers guidance on how to implement this.
+The Chrome DevTools team encourages framework authors to adopt these new capabilities. The [Case Study: Better Angular Debugging with DevTools](/blog/devtools-better-angular-debugging) offers guidance on how to implement this.

--- a/site/en/blog/devtools-modern-web-debugging/index.md
+++ b/site/en/blog/devtools-modern-web-debugging/index.md
@@ -1,0 +1,244 @@
+---
+layout: "layouts/blog-post.njk"
+title: Modern web debugging in Chrome DevTools
+authors:
+  - bramus
+  - victorporof
+description: >
+  We are releasing a set of features to improve your debugging and profiling experience in Chrome DevTools.
+date: 2022-08-31
+hero: 'image/dPDCek3EhZgLQPGtEG3y0fTn4v82/p5rc94lS6rpR6xBwzT8k.jpg'
+alt: Modern web debugging in Chrome DevTools
+tags:
+  - javascript
+  - devtools
+  - devtools-engineering
+---
+
+## Introduction
+
+Today, authors can use many abstractions to build their Web applications. Instead of directly interfacing with the lower-level APIs that the Web Platform provides, many authors leverage frameworks, build tools and compilers to write their applications from a higher-level perspective.
+
+For example, components built on top of the Angular framework are authored in TypeScript with HTML templates. Underneath the hood, the Angular CLI and webpack compile everything to JavaScript and into a so-called _bundle_, which is then shipped to the browser.
+
+When debugging or profiling Web applications in DevTools, you currently get to see and debug this compiled version of your code instead of the code you actually wrote. As an author, this is not want you want, though:
+
+- You don’t want to debug minified JavaScript code, you want to debug your original JavaScript code.
+- When using TypeScript, you don’t want to debug JavaScript, you want to debug your original TypeScript code.
+- When you use templating like with Angular, Lit, or JSX, you don’t always want to debug the resulting DOM. You might want to debug the components themselves.
+
+Overall, you likely want to debug your own code _as you wrote it_.
+
+While [source maps](/blog/sourcemaps/) already close this gap to some extent, there is more that Chrome DevTools and the ecosystem can do in this area.
+
+Let’s take a look!
+
+{% Aside %}
+[This sample Angular project on GitHub](https://github.com/victorporof/demo-angular) demonstrates the improvements to Chrome DevTools. These improvements aren’t limited to Angular but [apply to any framework](/blog/devtools-better-angular-debugging).
+{% endAside %}
+
+## Authored versus Deployed Code
+
+Currently, when navigating the file tree in the [Sources Panel](/docs/devtools/javascript/sources/), you get to see the contents of the compiled—and often minified—_bundle_. These are the actual files that the browser downloads and runs. DevTools calls this the _Deployed Code_.
+
+{% Img src="image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/mpwwAkQyzexbBK3Bqxs8.png", alt="Screenshot of the file tree in Chrome DevTools showing the Deployed Code.", width="800", height="465" %}
+
+This is not very handy and often hard to grasp. As an author, you want to see and debug the code that you wrote, not the _Deployed Code_.
+
+To make up for it, you can now have the tree show the _Authored Code_ instead. They are similar to the source files you get to see in your IDE and separated from the _Deployed Code_.
+
+{% Img src="image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/MtGlolFG9ucxykvbOEB9.png", alt="Screenshot of the file tree in Chrome DevTools showing the Authored Code.", width="800", height="479" %}
+
+To enable this option in Chrome DevTools, go to **Settings** > **Experiments** and check **Group sources into Authored and Deployed trees**.
+
+With the option enabled, the file tree now looks like this:
+
+{% Img src="image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/XCJVoG5N9DY4Uav7cTa1.png", alt="Screenshot of DevTools’s Settings.", width="800", height="465" %}
+
+{% Aside %}
+We plan to enable this experiment by default soon. Send us feedback [here](https://bugs.chromium.org/p/chromium/issues/detail?id=1334670).
+{% endAside %}
+
+## “Just my code”
+
+When using dependencies or building on top of a framework, the third party files can get in your way. Most of the time you only want to see just your code, not that of some third-party library tucked away in the `node_modules` folder.
+
+To make up for it, DevTools has an extra setting enabled by default: **Automatically add known third-party scripts to ignore list**. You can find it in **DevTools** > **Settings** > **Ignore List**.
+
+{% Img src="image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/vxWNHcsRUh95fSq6tGd4.png", alt="Screenshot of DevTools’s Settings.", width="800", height="529" %}
+
+With this setting enabled, DevTools hides any file or folder that a framework or build tool has marked as _to ignore_.
+
+As of [Angular v14.1.0](https://github.com/angular/angular-cli/releases/tag/14.1.0), the contents of its `node_modules` and `webpack` folders have been marked as such. Therefore, these folders, the files within them, and other such third-party artifacts don’t show up in various places in DevTools.
+
+As an author, you don’t need to do anything to enable this new behavior. It is up to the framework to implement this change.
+
+{% Aside %}
+The ignore-listing is enabled by populating an extra `x_google_ignoreList` field in the source map that Angular generates when compiling the project. We encourage other framework authors to implement a similar change. Refer to the [Case Study: Better Angular Debugging with DevTools](/blog/devtools-better-angular-debugging) post for more details.
+{% endAside %}
+
+### Ignore-listed code in stack traces
+
+One place where these ignore-listed files no longer show up is in stack traces. As an author, you now get to see more **relevant stack traces**.
+
+{% Img src="image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/pDAWNCm8KFlvvEIhtoUG.png", alt="Screenshot of a stack trace in DevTools.", width="800", height="529" %}
+
+Should you want to see all call frames of the stack trace, you can always click the **Show more frames** link.
+
+The same applies for the call stacks that you see while [debugging and stepping through your code](/docs/devtools/javascript/). DevTools now hides all irrelevant call frames and jumps over any ignore-listed code while step-debugging.
+
+{% Img src="image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/DAKhEbhZjni4VKoAr9NA.png", alt="Screenshot of the DevTools Sources Debugger while debugging.", width="800", height="529" %}
+
+### Ignore-listed code in the file tree
+
+To hide the ignore-listed files and folders from the **Authored Code** file tree in the **Sources** panel, check **Hide ignore-listed code in sources tree view** in **Settings** > **Experiments** in DevTools.
+
+{% Img src="image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/v5tcnNXKWc2WTXKjaXWz.png", alt="Screenshot of DevTools’s Settings.", width="800", height="465" %}
+
+In the sample Angular project, the `node_modules` and `webpack` folders are now hidden.
+
+{% Img src="image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/7ifFIxD09qHDaYMcYQPx.png", alt="Screenshot of the file tree in Chrome DevTools showing the Authored Code but not showing node_modules.", width="800", height="465" %}
+
+### Ignore-listed code in the “Quick Open” menu
+
+Ignored-listed code is not only hidden from the file tree, but is also hidden from the “Quick Open” menu (<kbd>Control</kbd>+<kbd>P</kbd> _(Linux/Windows)_ or <kbd>Command</kbd>+<kbd>P</kbd> _(Mac)_).
+
+{% Img src="image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/PfdALSlPsFgNs1aTrnzM.png", alt="Screenshot of DevTools with the “Quick Open” menu.", width="800", height="465" %}
+
+## More improvements to stack traces
+
+Having already covered _relevant_ stack traces, Chrome DevTools introduces even more improvements to stack traces.
+
+### Linked Stack Traces
+
+When some operations are scheduled to happen asynchronously, the stack traces in DevTools currently tell only part of the story.
+
+For example, here’s a very simple scheduler in a hypothetical `framework.js` file:
+
+```js
+function makeScheduler() {
+  const tasks = [];
+
+  return {
+    schedule(f) {
+      tasks.push({ f });
+    },
+
+    work() {
+      while (tasks.length) {
+        const { f } = tasks.shift();
+        f();
+      }
+    },
+  };
+}
+
+const scheduler = makeScheduler();
+
+function loop() {
+  scheduler.work();
+  requestAnimationFrame(loop);
+};
+
+loop();
+```
+
+… and how a developer might use it in their own code in an `example.js` file:
+
+```js
+function someTask() {
+  console.trace("done!");
+}
+
+function businessLogic() {
+  scheduler.schedule(someTask);
+}
+
+businessLogic();
+```
+
+When adding a breakpoint inside the `someTask` method or when inspecting the trace printed in the console, you don’t see any mention of the `businessLogic()` call that was the “root cause” of this operation.
+
+Instead, you see only the framework scheduling logic that led to task execution and no breadcrumbs in stack trace to help you figure out the causal links between events leading to this task.
+
+{% Img src="image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/R3R4rAjQCSqe1qKmAENC.png", alt="A stack trace of some async executed code with no information about when it was scheduled.", width="512", height="262" %}
+
+Thanks to a new feature called “Async Stack Tagging”, it is possible to tell the whole story after all by linking both parts of the async code together.
+
+The Async Stack Tagging API introduces a new [`console` method](/docs/devtools/console/api/) named `console.createTask()`. The API signature is as follows:
+
+```js
+interface Console {
+  createTask(name: string): Task;
+}
+
+interface Task {
+  run<T>(f: () => T): T;
+}
+```
+
+The `console.createTask()` call returns a `Task` instance that you can later use to run the task’s content `f`.
+
+```js
+// Task Creation
+const task = console.createTask(name);
+
+// Task Execution
+task.run(f);
+```
+
+The task forms the link between the context where it was created and the context of the async function that is being executed.
+
+{% Aside %}
+The async stack tagging API is available from Chrome 106.
+{% endAside %}
+
+Applied to the `makeScheduler` function from above, the code becomes the following:
+
+```js/5,12
+function makeScheduler() {
+  const tasks = [];
+
+  return {
+    schedule(f) {
+      const task = console.createTask(f.name);
+      tasks.push({ task, f });
+    },
+
+    work() {
+      while (tasks.length) {
+        const { task, f } = tasks.shift();
+        task.run(f); // instead of f();
+      }
+    },
+  };
+}
+```
+
+Thanks to this, Chrome DevTools is now able to show a better stack trace.
+
+{% Img src="image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/YYi8lLXUbAf4aOZ3kBG7.png", alt="A stack trace of some async executed code with information about when it was scheduled.", width="512", height="345" %}
+
+Notice how `businessLogic()` is now included in the stack trace! Not only that, but the task has a familiar name `someTask` instead of the generic `requestAnimationFrame` as before.
+
+{% Aside %}
+Most of the time you don’t need to worry about the Async Stack Tagging API because the framework you are using handles the scheduling and async execution. In that case, it is up to the framework to implement the API.
+{% endAside %}
+
+### Friendly Call Frames
+
+Frameworks often generate code from all kinds of templating languages when building a project, such as Angular or JSX templates that turn HTML-looking code into plain JavaScript that eventually runs in the browser. Sometimes, these kinds of generated functions are given names that aren’t very friendly — either single letter names after they’re minified or some obscure or unfamiliar names even when they’re not.
+
+In the sample project, an example of this is `AppComponent_Template_app_button_handleClick_1_listener` which you see in the stack trace.
+
+{% Img src="image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/uZRLE8JDRbS0YUTplPxt.png", alt="Screenshot of stack trace with an auto-generated function name.", width="800", height="529" %}
+
+To address this, Chrome DevTools now supports renaming these functions through source maps. If a source map has a name entry for the start of a function scope, the call frame should display that name in the stack trace.
+
+As an author, you don’t need to do anything to enable this new behavior. It is up to the framework to implement this change.
+
+## Looking ahead
+
+Thanks to the additions outlined in this post, we can offer you a better debugging experience in Chrome DevTools. There are more areas that we would like to explore. In particular, how to improve the profiling experience in DevTools.
+
+We encourage framework authors to adopt these new capabilities. The [Case Study: Better Angular Debugging with DevTools](/blog/devtools-better-angular-debugging) offers guidance on how to implement this.


### PR DESCRIPTION
I combined both posts in one PR because these posts link to each other and need to be deployed together.

Fixes #3312.
Fixes #3520.