### PR TITLE
Add Chrome-106 tag to HTTP/2 Push removal post

### DIFF
--- a/site/en/blog/removing-push/index.md
+++ b/site/en/blog/removing-push/index.md
@@ -13,7 +13,8 @@ alt: Dust covered button labeled Push
 tags:
   - news
   - performance
-  - removals
+  - deprecations-removals
+  - chrome-106
 ---
 
 Following on from [the previous announcement](https://groups.google.com/a/chromium.org/g/blink-dev/c/K3rYLvmQUBY/m/vOWBKZGoAQAJ), support of HTTP/2 Server Push will be disabled by default in Chrome 106 and other Chromium-based browsers in their next releases.


### PR DESCRIPTION
Fixes the build broken by #3383 as one post was missed.

Also adds Chrome-106 tag to this build while we're at it.