### PR TITLE
Replace deprecated tag that is causing a build error

### DIFF
--- a/site/en/blog/removing-push/index.md
+++ b/site/en/blog/removing-push/index.md
@@ -13,7 +13,7 @@ alt: Dust covered button labeled Push
 tags:
   - news
   - performance
-  - removals
+  - deprecations-removals
 ---
 
 Following on from [the previous announcement](https://groups.google.com/a/chromium.org/g/blink-dev/c/K3rYLvmQUBY/m/vOWBKZGoAQAJ), support of HTTP/2 Server Push will be disabled by default in Chrome 106 and other Chromium-based browsers in their next releases.


### PR DESCRIPTION
The 'removals' tag was replaced with 'deprecations-removals' in #3383. This commit updates posts that referenced the old tag in order to fix build errors.
