### PR TITLE
Use public Lighthouse CI storage and fix avatar causing `image-aspect-ratio` error

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -37,6 +37,4 @@ jobs:
           ELEVENTY_ENV: production
         run: |
           npx lhci autorun \
-          --config=./lighthouserc.js \
-          --upload.serverBaseUrl=${{ secrets.LHCI_SERVER }} \
-          --upload.token=${{ secrets.LHCI_TOKEN }}
+          --config=./lighthouserc.js

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -1,5 +1,8 @@
 module.exports = {
   ci: {
+    upload: {
+      target: 'temporary-public-storage',
+    },
     collect: {
       startServerCommand: 'npm start',
       startServerTimeout: 60 * 1000, // allow our build to take 60s

--- a/site/_data/authorsData.json
+++ b/site/_data/authorsData.json
@@ -735,11 +735,11 @@
   "sbc": {
     "country": "US",
     "github": "sbc100"
-   },
-   "ericsl": {
-     "country": "DE",
-     "github": "ericsl"
-   },
+  },
+  "ericsl": {
+    "country": "DE",
+    "github": "ericsl"
+  },
   "rkochman": {
     "country": "US",
     "twitter": "rkochman",
@@ -847,7 +847,7 @@
     "country": "US"
   },
   "leenasohoni": {
-    "image": "image/vgdbNJBYHma2o62ZqYmcnkq3j0o1/VXCjCzLEGWApTkZkNZkR.JPG",
+    "image": "image/lKgJZH2YLpV46uAKAtfp4jfvXhx2/oALg7ACRUlSyXj7xGbOR.jpeg",
     "twitter": "leena_sohoni",
     "country": "US"
   },
@@ -872,5 +872,4 @@
     "image": "image/Or7Bgsqru3MxJHvMtp68LKOjxkH3/UbfmJ8kJwfT9FVLHjX3r.jpeg",
     "github": "kyliau"
   }
-  
 }


### PR DESCRIPTION
This PR makes Lighthouse CI use the public storage instead of one that is potentially configured via GitHub Action secrets. I dug through all d.c.c docs I could find internally but didn't find any reference to an instance that we own. As we don't have confidential content on that site it also might not make sense to maintain one.

It also fixes the original cause that made me look into this: https://github.com/GoogleChrome/developer.chrome.com/pull/3544 introduced a new avatar for leenasohoni that didn't have a 1:1 aspect ratio but was shown at 1:1 which made Lighthouse complain.