### PR TITLE
Correct bug label on feedback link for storage partitioning trial

### DIFF
--- a/site/en/blog/storage-partitioning-dev-trial/index.md
+++ b/site/en/blog/storage-partitioning-dev-trial/index.md
@@ -89,5 +89,5 @@ owners have the support they need.
 ## Reporting bugs
 
 The best way to give feedback is to file a
-[new issue](https://bugs.chromium.org/p/chromium/issues/entry?labels=StoragePartitioning-trial-bugs&components=Blink%3EStorage),
+[new issue](https://bugs.chromium.org/p/chromium/issues/entry?labels=Proj-StoragePartitioningTrial&components=Blink%3EStorage),
 either with a link to a publicly accessible URL or a reduced test case.


### PR DESCRIPTION
We've created a persistent bug label for this project -- correcting to use the new label.