### PR TITLE
add `datetime` attributes to `<time>` elements

### DIFF
--- a/site/_includes/partials/post-headline.njk
+++ b/site/_includes/partials/post-headline.njk
@@ -7,11 +7,15 @@
 {% if date %}
   <p class="type--caption color-secondary-text">
     {{ 'i18n.common.published_on' | i18n(locale) }}
-    <time>{{ helpers.formatDateLong(date, locale) }}</time>
+    <time datetime="{{ helpers.formatDateNumeric(date) }}">
+      {{ helpers.formatDateLong(date, locale) }}
+    </time>
     {% if updated %}
     <span>•</span>
     {{ 'i18n.common.updated_on' | i18n(locale) }}
-    <time>{{ helpers.formatDateLong(updated, locale) }}</time>
+    <time datetime="{{ helpers.formatDateNumeric(updated) }}">
+      {{ helpers.formatDateLong(updated, locale) }}
+    </time>
   {% endif %}
   </p>
 {% endif %}

--- a/site/_includes/partials/updated.njk
+++ b/site/_includes/partials/updated.njk
@@ -1,8 +1,14 @@
 <p class="color-secondary-text type--caption">
   {% if updated %}
-    Last updated: <time>{{ helpers.formatDateLong(updated, locale) }}</time>
+    Last updated:
+    <time datetime="{{ helpers.formatDateNumeric(updated) }}">
+      {{ helpers.formatDateLong(updated, locale) }}
+    </time>
   {% elif date %}
-    Last updated: <time>{{ helpers.formatDateLong(date, locale) }}</time>
+    Last updated:
+    <time datetime="{{ helpers.formatDateNumeric(date) }}">
+      {{ helpers.formatDateLong(date, locale) }}
+    </time>
     <span>•</span>
   {% endif %}
   <a href="{{ page.inputPath | githubLink }}">


### PR DESCRIPTION
Currently published and updated dates in the article are marked up using `<time>`, but they lack `datetime` attributes.

The HTML spec requires that the date value to be machine-readable; either the text content follows the valid date string (ISO-like patterns), or the element has the `datetime` attribute where the value is a valid date string.
https://whatwg.org/html#the-time-element

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- update published/update dates markup to be spec-compliant