### PR TITLE
[EXT-DOC] Add placeholder convention to Handbook 

### DIFF
--- a/site/en/docs/handbook/extensions/index.md
+++ b/site/en/docs/handbook/extensions/index.md
@@ -203,12 +203,6 @@ chrome.runtime.sendMessage('<extension id>', <message>, function() {
 }
 ```
 
-{% CompareCaption %}
-
-Automatically generated IDs are brittle. If this header were renamed in a future revision, it would
-be given a new ID and all existing links to this section would break. 
-
-{% endCompareCaption %}
 {% endCompare %}
 
 

--- a/site/en/docs/handbook/extensions/index.md
+++ b/site/en/docs/handbook/extensions/index.md
@@ -8,8 +8,8 @@ updated: 2021-02-02
 ## Metadata {: #metadata }
 
 Extensions documents should follow the conventions outlined in the [Add a Doc][add-a-doc] and [Add a
-Blog Post][add-a-blog] guides. One notable exception to that guidance is that we do not use the
-`tags` and `author` YAML front matter properties in extensions docs.
+Blog Post][add-a-blog] guides. One notable exception is that we do not use the `tags` and `author`
+YAML front matter properties in extensions docs.
 
 ## Line wrapping {: #line-wrapping }
 
@@ -55,7 +55,7 @@ content of the section rather than a [kebab cased][kebab-case] version of the he
 
 ## Link conventions {: #links }
 
-### Footer links
+### Footer links {: #footer-links }
 
 By convention, extensions docs strongly prefer named footer links over inline links. Named links
 have a couple of advantages over inline links.
@@ -170,6 +170,47 @@ clang-format][clang-format] for additional details.
 # Use this command to format JS files and code samples
 git cl format --js <filename>
 ```
+
+## Placeholder convention {: #placeholder }
+
+Placeholders should be styled with `<code><var>PLACEHOLDER_NAME</var></code>` in body copy and `PLACEHOLDER_NAME` in code blocks and inline code.  New content and updates to existing content must
+follow this convention. 
+
+{% Compare 'better' %}
+
+```js
+chrome.runtime.sendMessage('EXTENSION_ID', MESSAGE, function() {
+  if (chrome.runtime.lastError) {
+    // Extension is not installed.
+  }
+}
+```
+
+Replace the following:
+
+- <code><var>EXTENSION_ID</var></code>: the ID of your extension.
+- <code><var>MESSAGE</var></code>: The message string or object to send to the extension.
+
+{% endCompare %}
+
+{% Compare 'worse' %}
+
+```js
+chrome.runtime.sendMessage('<extension id>', <message>, function() {
+  if (chrome.runtime.lastError) {
+    // Extension is not installed.
+  }
+}
+```
+
+{% CompareCaption %}
+
+Automatically generated IDs are brittle. If this header were renamed in a future revision, it would
+be given a new ID and all existing links to this section would break. 
+
+{% endCompareCaption %}
+{% endCompare %}
+
 
 [clang-format]: https://chromium.googlesource.com/chromium/src/+/main/docs/clang_format.md
 [depot-tools]: https://commondatastorage.googleapis.com/chrome-infra-docs/flat/depot_tools/docs/html/depot_tools_tutorial.html


### PR DESCRIPTION
Adds placeholder convention to Handbook. Based on agreement on [issue#1940](https://github.com/GoogleChrome/developer.chrome.com/issues/1940)

> Based on discussion in the [comment thread on #1860](https://github.com/GoogleChrome/developer.chrome.com/pull/1860#r782481406), the current plan is to replace `<placeholderName>` style placeholders with `<var>PLACEHOLDER_NAME</var>` in body copy and `PLACEHOLDER_NAME` in code blocks and inline code. This should conform to the [Google developer documentation style guide](https://developers.google.com/style/placeholders#placeholders-in-code-blocks).

