### PR TITLE
[Anonymous iframes article] Call out `require-corp` is not a typo

### DIFF
--- a/site/en/blog/anonymous-iframe-origin-trial/index.md
+++ b/site/en/blog/anonymous-iframe-origin-trial/index.md
@@ -30,8 +30,12 @@ and
 To enable cross-origin isolation, websites must send the following two HTTP
 headers:
 
+{% Aside %}
+The header value `require-corp` below is not a typo. COEP does require CORP for third-party resources to opt-in.
+{% endAside %}
+
 ```text
-Cross-Origin-Embedder-Policy: require-coep
+Cross-Origin-Embedder-Policy: require-corp
 Cross-Origin-Opener-Policy: same-origin
 ```
 {% Aside %}

--- a/site/en/blog/anonymous-iframe-origin-trial/index.md
+++ b/site/en/blog/anonymous-iframe-origin-trial/index.md
@@ -31,7 +31,7 @@ To enable cross-origin isolation, websites must send the following two HTTP
 headers:
 
 ```text
-Cross-Origin-Embedder-Policy: require-corp
+Cross-Origin-Embedder-Policy: require-coep
 Cross-Origin-Opener-Policy: same-origin
 ```
 {% Aside %}


### PR DESCRIPTION
Changes proposed in this pull request:

- `s/require-corp/require-coep`
