### PR TITLE
Increase color contrast by using shades one level darker

### DIFF
--- a/site/_scss/_theme.scss
+++ b/site/_scss/_theme.scss
@@ -3,8 +3,8 @@
   --color-mode: 'light';
   --color-bg: #{get-color('white')};
   --color-bg-shade: #{get-color('grey-100')};
-  --color-text: #{get-color('grey-800')};
-  --color-secondary-text: #{get-color('grey-700')};
+  --color-text: #{get-color('grey-900')};
+  --color-secondary-text: #{get-color('grey-800')};
   --color-primary: #{get-color('blue-600')};
   --rgb-primary: 26, 115, 232;
   --color-primary-shade: #{get-color('blue-700')};


### PR DESCRIPTION
Resolves #275. This PR makes all text and secondary text on the site use the grey one level darker as before. Other than suggested in the PR it does not alter the actual color values to stay in the Google Color Swatch.