### PR TITLE
Add support for anchor redirects

### DIFF
--- a/site/_data/docs/handbook/toc.yml
+++ b/site/_data/docs/handbook/toc.yml
@@ -14,6 +14,7 @@
     - url: /docs/handbook/how-to/add-a-glitch-embed
     - url: /docs/handbook/how-to/add-a-youtube-embed
     - url: /docs/handbook/how-to/display-a-banner
+    - url: /docs/handbook/how-to/create-anchor-redirects
     - url: /docs/handbook/style-guide
 - url: /docs/handbook/extensions
 - url: /docs/handbook/web-platform

--- a/site/_includes/layouts/base.njk
+++ b/site/_includes/layouts/base.njk
@@ -40,6 +40,31 @@
     {# This needs to be include'd, because it expands 11ty variables #}
     <script>{% include 'partials/script.js' %}</script>
 
+    {# Some articles may have previously used lists with anchors for their
+    content (like FAQs) which may have evolved into their own articles by now. 
+    Such anchors should be able to link to those new articles #}
+    {% if anchorRedirects %}
+    <script>
+      (() => {
+        let anchorRedirects = {{ anchorRedirects|dump|safe }};
+
+        function redirect(targetURL) {
+          let {hash} = new URL(targetURL);
+          if (!hash) {
+            return;
+          }
+
+          hash = hash.substring(1);
+
+          if (anchorRedirects[hash]) {
+            window.location.replace(anchorRedirects[hash]);
+          }
+        }
+        redirect(window.location.href);
+        window.addEventListener('hashchange', (event) => redirect(event.newURL));
+      })();
+    </script>
+    {% endif %}
   </head>
   <body>
     <div class="scaffold">

--- a/site/en/docs/handbook/how-to/create-anchor-redirects/index.md
+++ b/site/en/docs/handbook/how-to/create-anchor-redirects/index.md
@@ -1,0 +1,19 @@
+---
+layout: 'layouts/doc-post.njk'
+title: Create anchor redirects
+description: 'Redirect previously used anchors to new pages.'
+date: 2022-09-08
+---
+
+Sometimes a page using anchors to link to content on the same page grows
+to an extent where it makes sense to extract that content to new pages.
+
+To keep anchor links which have been potentially shared working you
+are able to redirect previously used anchors to new pages. Simply add
+an `anchorRedirects` key to the page's frontmatter.
+
+```yaml
+anchorRedirects:
+  your-old-anchor: https://your-new-fully-qualified-page-url.com
+  your-old-anchor-2: /docs/webstore/faq/#how-can-i-raise-p2b-concerns
+```


### PR DESCRIPTION
Resolves #1249. This allows allows defining a set of redirects for existing anchors on the page inside the frontmatter key `anchorRedirects`. If that key is present a tiny bit of client side logic is added to the head of the page to redirect the user to the new page either on hash change or if a hash is present on page load.