### PR TITLE
Switch from light grey to dark blue for code comment highlighting

### DIFF
--- a/site/_scss/_theme.scss
+++ b/site/_scss/_theme.scss
@@ -24,7 +24,7 @@
   --rgb-button-overlay: 60, 64, 67;
 
   --color-code-bg: #{get-color('grey-50')};
-  --color-code-comment: #{get-color('grey-500')};
+  --color-code-comment: #{get-color('blue-900')};
   --color-code-string: #{get-color('blue-900')};
   --color-code-tag: #{get-color('green-600')};
   --color-code-number: #{get-color('blue-700')};


### PR DESCRIPTION
Fixes #3357. I would have liked to use green, but the darkest shade from the blue palette is the only color that satisfies a11y. 

<img width="1023" alt="image" src="https://user-images.githubusercontent.com/12857772/189614741-64d7f1f1-fa71-4a6d-b158-db814a3dfca3.png">