### PR TITLE
Updated index.md

### DIFF
--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -304,7 +304,7 @@ chrome.tabs.query(queryOptions)
 
 // async-await
 async function queryTab() {
-  let tabs = await chrome.tabs.query(queryOptions});
+  let tabs = await chrome.tabs.query(queryOptions);
   chrome.tabs.update(tabs[0].id, {url: newUrl});
   someOtherFunction();
 }


### PR DESCRIPTION
Removed the unnecessary closing bracket ( } ) from the line: 307 ( chrome.tabs.query(queryOptions) ).

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

-
-
-