### PR TITLE
Clarify that MV3 uses a single sw.

### DIFF
--- a/site/en/docs/extensions/mv3/migrating_to_service_workers/index.md
+++ b/site/en/docs/extensions/mv3/migrating_to_service_workers/index.md
@@ -2,7 +2,7 @@
 layout: 'layouts/doc-post.njk'
 title: "Migrating from background pages to service workers"
 date: 2020-07-29
-updated: 2020-10-06
+updated: 2022-09-12
 description: >
   How to migrate your Chrome Extension from background pages to service workers,
   which is a prerequisite for using Manifest V3.

--- a/site/en/docs/extensions/mv3/migrating_to_service_workers/index.md
+++ b/site/en/docs/extensions/mv3/migrating_to_service_workers/index.md
@@ -2,7 +2,7 @@
 layout: 'layouts/doc-post.njk'
 title: "Migrating from background pages to service workers"
 date: 2020-07-29
-updated: 2022-09-12
+updated: 2022-10-04
 description: >
   How to migrate your Chrome Extension from background pages to service workers,
   which is a prerequisite for using Manifest V3.


### PR DESCRIPTION
Clarify that only a single service worker can be used in Manifest V3, and fix other minor issues.

[Staged link](https://deploy-preview-3693--developer-chrome-com.netlify.app/docs/extensions/mv3/migrating_to_service_workers/)