### PR TITLE
Update CrUX release notes for 202208.

### DIFF
--- a/site/en/docs/crux/release-notes/index.md
+++ b/site/en/docs/crux/release-notes/index.md
@@ -43,6 +43,17 @@ The CrUX dataset on BigQuery is generally updated on the second Tuesday of every
 
 In the list below, we've curated some release notes for each monthly dataset. Subscribe to our [CrUX Announce](https://groups.google.com/a/chromium.org/forum/#!forum/chrome-ux-report-announce) mailing list or follow [@ChromeUXReport](https://twitter.com/ChromeUXReport) on Twitter for release Announcements.
 
+## 202208
+
+[Announcement](https://groups.google.com/a/chromium.org/g/chrome-ux-report-announce/c/xKHFbog7-9w)
+
+Publication date
+ : September 13, 2022
+
+Notable stats
+ : - 16,754,655 origins
+ : - 40.7% of origins have good [Core Web Vitals](https://web.dev/vitals/#core-web-vitals)
+
 ## 202207
 
 [Announcement](https://groups.google.com/a/chromium.org/g/chrome-ux-report-announce/c/N5B3F9QVOmY)


### PR DESCRIPTION
Changes proposed in this pull request:

- Add a section for the 202208 dataset with link to announcement and origin / cwv stats.