### PR TITLE
Make 'updated' labels localizable, add JA translations

### DIFF
--- a/site/_data/i18n/common.yml
+++ b/site/_data/i18n/common.yml
@@ -97,6 +97,7 @@ follow:
 toc:
   en: 'Table of contents'
   es: 'Tabla de contenido'
+  ja: '目次'
 
 tags:
   en: 'Tags'
@@ -161,12 +162,15 @@ release_beta:
 
 translated_to:
   en: 'Translated to:'
+  ja: '翻訳先言語：'
 
 published_on:
   en: 'Published on'
+  ja: '公開日'
 
 updated_on:
   en: 'Updated on'
+  ja: '更新日'
 
 authors:
   en: 'Authors'
@@ -177,3 +181,11 @@ website:
 
 featured:
   en: Featured
+
+last_updated:
+  en: 'Last updated:'
+  ja: '最終更新日：'
+
+improve_article:
+  en: 'Improve article'
+  ja: '記事を改善する'

--- a/site/_includes/partials/updated.njk
+++ b/site/_includes/partials/updated.njk
@@ -1,11 +1,11 @@
 <p class="color-secondary-text type--caption">
   {% if updated %}
-    Last updated: <time>{{ helpers.formatDateLong(updated, locale) }}</time>
+    {{ 'i18n.common.last_updated' | i18n(locale) }} <time>{{ helpers.formatDateLong(updated, locale) }}</time>
   {% elif date %}
-    Last updated: <time>{{ helpers.formatDateLong(date, locale) }}</time>
+    {{ 'i18n.common.last_updated' | i18n(locale) }} <time>{{ helpers.formatDateLong(date, locale) }}</time>
     <span>•</span>
   {% endif %}
   <a href="{{ page.inputPath | githubLink }}">
-    Improve article
+    {{ 'i18n.common.improve_article' | i18n(locale) }}
   </a>
 </p>


### PR DESCRIPTION
1) Makes labels in the Updated section of the articles localizable: 
![CleanShot 2022-09-14 at 10 10 39@2x](https://user-images.githubusercontent.com/8548803/190120870-48e98638-e5f7-45b6-bb26-6a9e0c8d3498.png)

2) Adds Japanese translations to i18n labels used for rendering articles: 
![CleanShot 2022-09-14 at 09 56 01@2x](https://user-images.githubusercontent.com/8548803/190120944-e1cdeda4-c1f2-4937-b67c-a8af173715ee.png)
