### PR TITLE
Get `locale` from context for `{% aside %}` shortcode.

### DIFF
--- a/site/_shortcodes/Aside.js
+++ b/site/_shortcodes/Aside.js
@@ -1,6 +1,8 @@
 const fs = require('fs');
 const {i18n} = require('../_filters/i18n');
 
+const defaultLocale = 'en';
+
 /**
  * Load SVG icons to be injected into the page.
  * @param {string} name The filename (without extension) of the svg icon to
@@ -27,19 +29,8 @@ const icons = {
  * @param {string} [type='note'] An aside style type
  */
 function Aside(content, type = 'note') {
-  // Infer the page locale using this.page.
-  // The locale is used to display localized text next to the icon
-  // e.g. 'Caution' -> 'Precaución'
-  let locale;
-  // @ts-ignore
-  if (this.page && this.page.filePathStem) {
-    // filePath stem looks like '/en/docs/webstore/hosted_apps/index'
-    // @ts-ignore
-    locale = this.page.filePathStem.split('/')[1];
-  } else {
-    locale = 'en';
-  }
-
+  // @ts-ignore: `this` has type of `any`
+  const locale = this.ctx.locale || defaultLocale;
   let text;
   if (type !== 'note') {
     text = i18n(`i18n.common.${type}`, locale);

--- a/tests/site/_shortcodes/Aside.js
+++ b/tests/site/_shortcodes/Aside.js
@@ -3,14 +3,14 @@ const cheerio = require('cheerio');
 const {Aside} = require('../../../site/_shortcodes/Aside');
 
 test('creates a default aside', t => {
-  const thisToBind = {page: {filePathStem: '/en/foo/index'}};
+  const thisToBind = {ctx: {locale: 'en'}};
   const $ = cheerio.load(Aside.bind(thisToBind)('hello world'));
   t.assert($('.aside').length === 1);
   t.assert($('.aside').text().trim() === 'hello world');
 });
 
 test('adds an aside__label', t => {
-  const thisToBind = {page: {filePathStem: '/en/foo/index'}};
+  const thisToBind = {ctx: {locale: 'en'}};
   const $ = cheerio.load(Aside.bind(thisToBind)('hello world', 'caution'));
   t.assert($('.aside__label').length === 1);
   t.assert($('.aside__label > svg').length === 1);
@@ -18,7 +18,7 @@ test('adds an aside__label', t => {
 });
 
 test('adds a localized aside__label', t => {
-  const thisToBind = {page: {filePathStem: '/es/foo/index'}};
+  const thisToBind = {ctx: {locale: 'es'}};
   const $ = cheerio.load(Aside.bind(thisToBind)('hello world', 'caution'));
   t.assert($('.aside__label > span').text().trim() === 'Precaución');
 });


### PR DESCRIPTION
Stumbled over this while working on #2007. Shortcode functions get the render context passed with `this` since 11ty 1.0 making the complex locale extraction from the path superfluous.