### PR TITLE
[ext-docs] Update Welcome page

### DIFF
--- a/site/en/docs/extensions/mv3/index.md
+++ b/site/en/docs/extensions/mv3/index.md
@@ -1,56 +1,46 @@
 ---
 layout: 'layouts/doc-post.njk'
-
-# The page title. This appears at the top of the doc and as the page name
-# in Google Search.
 title: Welcome
-
-# This appears below the title and is an optional teaser
 subhead: 'Learn about developing extensions for Chrome.'
-
-# This appears in the ToC of the project landing page at
-# /docs/[project-name]/. It also appears in the <meta description> used in 
-# Google Search.
 description: 'Documentation for Chrome extensions developers.'
-
-# The publish date
 date: 2020-11-09
-
-# An optional updated date
-# updated: 2020-10-16
-
-# A list of authors. These usernames correspond to the keys in the
-# _data/authorsData.json file.
-
+updated: 2022-09-20
 ---
 
 These pages contain guides and reference information for developers who want to
-create extensions for the Chrome browser. If you're not sure where to begin,
-have a look at the following starting pages:
+create extensions for the Chrome browser.
 
-* [What are extensions?](/docs/extensions/mv3/overview/) to help you understand just what an extension is.
-* The [Getting started tutorial](/docs/extensions/mv3/getstarted/) if you're ready for hello, world.
+If you're not sure where to begin, have a look at the following starting pages:
+
+- [Extensions 101][doc-ext-101] covers some basic concepts of extension development.
+- [Development Basics][doc-dev-basics] introduces the extension development workflow.
 
 Beyond that, you might find useful entry points in these pages:
 
-* Learn the scope of things in the [Extension development overview](/docs/extensions/mv3/devguide/)
-* Pick something from the [samples page](https://github.com/GoogleChrome/chrome-extensions-samples), install it, and start hacking on it.
-* Look for answers in the [Extensions FAQ page](/docs/extensions/mv3/faq/)
-
-{% Aside %}
-Now that Manifest V3 has launched, we've changed the default documentation to
-be for Manifest V3. If you are maintaining a legacy Manifest V2 extension, see the [Manifest V2
-documentation](/docs/extensions/mv2).
-{% endAside %}
+- Choose one of the step-by-step [getting started tutorials][gs-tuts].
+- Learn the scope of things in the [Extension development overview][doc-dev-overview].
+- Pick something from the [samples page][gh-ext-samples], install it, and start hacking on it.
 
 {% Aside 'warning' %}
+
 As Manifest V3 approaches full feature parity with V2, we will be phasing out
-Manifest V2. See [Manifest V2 support timeline](/docs/extensions/mv3/mv2-sunset) for details.
+Manifest V2 in 2023. See [Manifest V2 support timeline][doc-mv2-sunset] for details.
+
 {% endAside %}
 
 In addition to the documentation here, many developers find helpful community content at:
 
-* The [Chromium extensions](https://groups.google.com/a/chromium.org/g/chromium-extensions) Google Group.
-* The Stack Overflow [google-chrome extension](https://stackoverflow.com/tags/google-chrome-extension/info) tag.
+- The [Chromium extensions][gg-extensions] Google Group.
+- The Stack Overflow [google-chrome extension][so-extension-tag] tag.
 
 Thank you for being a member of the extension developer community. We're glad you are here!
+
+[doc-dev-basics]: /docs/extensions/mv3/getstarted/development-basics
+[doc-dev-overview]: /docs/extensions/mv3/devguide/
+[doc-ext-101]: /docs/extensions/mv3/getstarted/extensions-101
+[doc-mv2-sunset]: /docs/extensions/mv3/mv2-sunset
+[gg-extensions]: https://groups.google.com/a/chromium.org/g/chromium-extensions
+[gh-ext-samples]: https://github.com/GoogleChrome/chrome-extensions-samples
+[github-ext-doc]: https://github.com/GoogleChrome/developer.chrome.com
+[gs-tuts]: /docs/extensions/mv3/getstarted/#tutorials
+[so-extension-tag]: https://stackoverflow.com/questions/tagged/google-chrome-extension


### PR DESCRIPTION
Updated the extensions Welcome page to include the new Getting Started guides.

This should not be merged until the launch of these guides in [PR#3328](https://github.com/GoogleChrome/developer.chrome.com/pull/3328)

## Staged link
[Welcome to Chrome Extensions](https://deploy-preview-3717--developer-chrome-com.netlify.app/docs/extensions/mv3/)