### PR TITLE
doc(workbox): missing 'process' keyword

### DIFF
--- a/site/en/docs/workbox/using-workbox-without-precaching/index.md
+++ b/site/en/docs/workbox/using-workbox-without-precaching/index.md
@@ -54,7 +54,7 @@ To satisfy the above conditions, a function can be passed to [`output.filename`]
 // webpack.config.js
 import process from 'process';
 
-const isProd = env.NODE_ENV === 'production';
+const isProd = process.env.NODE_ENV === 'production';
 
 export default {
   mode: isProd ? 'production' : 'development',


### PR DESCRIPTION
Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- workbox (chapter "Using Workbox without precaching") => missing 'process' keyword