### PR TITLE
fix typo in chrome extension documentation

### DIFF
--- a/site/en/docs/extensions/mv3/content_scripts/index.md
+++ b/site/en/docs/extensions/mv3/content_scripts/index.md
@@ -266,7 +266,7 @@ function injectedFunction() {
 chrome.action.onClicked.addListener((tab) => {
   chrome.scripting.executeScript({
     target: { tabId: tab.id },
-    function: injectedFunction
+    func: injectedFunction
   });
 });
 ```


### PR DESCRIPTION
the prop name of ScriptInjection object should be `func` instead of `function`

Fixes #3792