### PR TITLE
Adding pwa summit registration banner

### DIFF
--- a/site/_data/banner.yml
+++ b/site/_data/banner.yml
@@ -1,0 +1,6 @@
+type: info
+text: 'PWA Summit 22 is ready for you, with talks from the community and organizers along with workshops and more.'
+actions:
+  - text: Get your ticket today
+    href: https://pwasummit.com/register
+  - text: Dismiss

--- a/site/_data/banner.yml
+++ b/site/_data/banner.yml
@@ -2,5 +2,5 @@ type: info
 text: 'PWA Summit 22 is ready for you, with talks from the community and organizers along with workshops and more.'
 actions:
   - text: Get your ticket today
-    href: https://pwasummit.com/register
+    href: https://pwasummit.org/register
   - text: Dismiss


### PR DESCRIPTION
PWA Summit banner. Will be live until Oct 4th, on Oct 5th will be replaced with one with a link to the livestream.

I checked the copy and dates with @harleenkbatra08