### PR TITLE
Origin trial extended through to Chrome 106

### DIFF
--- a/site/en/blog/chips-origin-trial-extended/index.md
+++ b/site/en/blog/chips-origin-trial-extended/index.md
@@ -2,13 +2,15 @@
 layout: 'layouts/blog-post.njk'
 title: Cookies Having Independent State (CHIPS) origin trial extended
 description: >
-  CHIPS is a Privacy Sandbox proposal that introduces a mechanism to opt-in
-  to having third-party cookies partitioned by top-level site. The origin trial
-  that started in Chrome 100, will now be available until the release of Chrome 105,
-  scheduled for August 30, 2022.
+  CHIPS is a Privacy Sandbox proposal that introduces a mechanism to opt-in to
+  having third-party cookies partitioned by top-level site. The origin trial
+  that started in Chrome 100, will now be available until the release of Chrome
+  107, scheduled for October 25, 2022.
 subhead: >
-  The origin trial will now be available until the release of Chrome 105, scheduled for August 30, 2022.
+  The origin trial will now be available until the release of Chrome 107,
+  scheduled for October 25, 2022.
 date: 2022-05-26
+updated: 2022-09-23
 authors:
   - mihajlija
 tags:
@@ -17,26 +19,31 @@ tags:
   - cookies
 ---
 
-[CHIPS](/docs/privacy-sandbox/chips/) is a Privacy
-Sandbox proposal that introduces a mechanism to opt-in to having third-party
-cookies partitioned by top-level site using a new cookie attribute,
-`Partitioned`.
+[CHIPS](/docs/privacy-sandbox/chips/) is a Privacy Sandbox proposal that
+introduces a mechanism to opt-in to having third-party cookies partitioned by
+top-level site using a new cookie attribute, `Partitioned`.
+
+{% Aside %}
+
+**Update:** To give developers more time to test the feature and gather more
+feedback, an [extension to the experiment will run through Chrome
+106](https://groups.google.com/a/chromium.org/g/blink-dev/c/MKQODOL0Fso/m/S3ss7A8jCAAJ)
+until the release of Chrome 107, on October 25, 2022.
+
+{% endAside %}
 
 The experiment started in Chrome 100 on March 29, 2022 and was scheduled to run
 until June 14, 2022.
 
-To give developers more time to test the feature and gather more feedback, an
-[extension to the experiment will run through Chrome 104](https://groups.google.com/a/chromium.org/g/blink-dev/c/kZRtetS8jsY) until the release of Chrome 105, on August 30, 2022.
-
-Starting in version 103, Chrome will include an alternative CHIPS origin trial design for HTTP
-cookies, which should enable an opt-in mechanism that will make deployment
-easier for large organizations.
+Starting in version 103, Chrome will include an alternative CHIPS origin trial
+design for HTTP cookies, which should enable an opt-in mechanism that will make
+deployment easier for large organizations.
 
 In the new design, sending `Accept-CH: Sec-CH-Partitioned-Cookies` header will
 no longer be required to enroll in the origin trial. Sites will only need to
-send the `Origin-Trial` header with their CHIPS origin trial token when they are sending
-responses that include the `Set-Cookie` header with the `Partitioned`
+send the `Origin-Trial` header with their CHIPS origin trial token when they are
+sending responses that include the `Set-Cookie` header with the `Partitioned`
 attribute.
 
-To enroll in the origin trial and start experimenting, head over to
-[CHIPS origin trial instructions](/blog/chips-origin-trial/).
+To enroll in the origin trial and start experimenting, head over to [CHIPS
+origin trial instructions](/blog/chips-origin-trial/).

--- a/site/en/blog/chips-origin-trial/index.md
+++ b/site/en/blog/chips-origin-trial/index.md
@@ -6,17 +6,18 @@ subhead: >
 description: >
   Starting in Chrome 100, CHIPS origin trial allows opting cookies in to "partitioned" storage, with a separate cookie jar per top-level site. Partitioned cookies can be set by a third-party service, but only read within the context of the top-level site where they were initially set.
 date: 2022-03-17
-updated: 2022-06-10
+updated: 2022-09-23
 authors:
   - mihajlija  
 tags:
  - origin-trials
  - cookies
- - privacy  
+ - privacy
 ---
 
 ## Changes
 
+- **September 2022**:  See the [updated information on extending the origin trial through Chrome 106](/blog/chips-origin-trial-extended).
 - **June 2022**:  As of Chrome 104, setting cookies with the `Partitioned` attribute no longer requires omitting the `Domain` attribute.
 - **May 2022**: As of Chrome 103, sending `Accept-CH: Sec-CH-Partitioned-Cookies` header is no longer required for opting into the origin trial.
 

--- a/site/en/docs/privacy-sandbox/chips/index.md
+++ b/site/en/docs/privacy-sandbox/chips/index.md
@@ -7,7 +7,7 @@ description: >
   Allow developers to opt-in a cookie to "partitioned" storage, with a separate cookie jar per top-level site.
   Partitioned cookies can be set by a third-party service, but only read within the context of the top-level site where they were initially set.
 date: 2022-02-15
-updated: 2022-06-10
+updated: 2022-09-23
 authors:
   - mihajlija
 tags:
@@ -21,7 +21,7 @@ tags:
 
 ## Implementation status
 
-- [Origin trial](/origintrials/#/view_trial/1239615797433729025) available from Chrome 100 to 105
+- [Origin trial](/origintrials/#/view_trial/1239615797433729025) available from Chrome 100 to 106
 - [Intent to Experiment](https://groups.google.com/a/chromium.org/g/blink-dev/c/_dJFNJpf91U) 
 - [Chrome Platform Status](https://chromestatus.com/feature/5179189105786880)
 
@@ -160,7 +160,7 @@ Set-Cookie: __Host-example=34d8g; SameSite=None; Secure; Path=/; Partitioned;
 
 ## Try it out
 
-[CHIPS origin trial](/blog/chips-origin-trial) is available from Chrome 100 to 105. 
+[CHIPS origin trial](/blog/chips-origin-trial) is available from Chrome 100 to 106.
 
 CHIPS is also available behind flags from Chrome 99. Check out the testing instructions and demo on [chromium.org](https://www.chromium.org/updates/chips/). 
 


### PR DESCRIPTION
Updates CHIPS documentation to show extension through to 106 (previously 105).
Not really a new announcement, hence no new post—more of a clarification.