### PR TITLE
Update "What Is Private Network Access" anchor to link to expected subsection

### DIFF
--- a/site/en/blog/private-network-access-preflight/index.md
+++ b/site/en/blog/private-network-access-preflight/index.md
@@ -32,7 +32,7 @@ websites as part of the
 specification.
 
 Chrome will start sending a CORS preflight request ahead of any [private
-network request](#what-is-private-network-access) for a subresource, which asks
+network request](#what-is-private-network-access-pna) for a subresource, which asks
 for explicit permission from the target server. This preflight request will
 carry a new header, `Access-Control-Request-Private-Network: true`, and the
 response to it must carry a corresponding header,


### PR DESCRIPTION
While reading this [generally great!] post I noticed this anchor in the introductory section doesn't resolve. Based on context it seems like it should link to the ~`#what-is-private-network-access`~ `#what-is-private-network-access-pna` section lower in the document