### PR TITLE
Fix intents zxing link

### DIFF
--- a/site/en/docs/multidevice/android/intents/index.md
+++ b/site/en/docs/multidevice/android/intents/index.md
@@ -109,7 +109,7 @@ And Chrome doesn't launch an external app for a given Intent URI in the followin
 [2]: http://developer.android.com/guide/components/intents-filters.html#extras
 [3]:
   https://code.google.com/p/android-source-browsing/source/browse/core/java/android/content/Intent.java?repo=platform--frameworks--base#6514
-[4]: https://code.google.com/p/zxing/source/browse/trunk/android/AndroidManifest.xml#97
+[4]: https://github.com/zxing/zxing/blob/fa19d4758f38daa5d0ea6557af9a64721cfcce07/android/AndroidManifest.xml#L97
 [5]: http://developer.android.com/guide/components/intents-filters.html#extras
 [6]: http://developer.android.com/reference/android/content/Intent.html#CATEGORY_BROWSABLE
 [7]: http://developer.android.com/guide/components/intents-filters.html

--- a/site/en/docs/multidevice/android/intents/index.md
+++ b/site/en/docs/multidevice/android/intents/index.md
@@ -1,7 +1,7 @@
 ---
 layout: "layouts/doc-post.njk"
 title: Android Intents with Chrome
-date: 2014-02-28
+date: 2022-09-28
 description: How to launch Android apps directly from a web page.
 ---
 

--- a/site/en/docs/multidevice/android/intents/index.md
+++ b/site/en/docs/multidevice/android/intents/index.md
@@ -1,7 +1,7 @@
 ---
 layout: "layouts/doc-post.njk"
 title: Android Intents with Chrome
-date: 2022-09-28
+date: 2014-02-28
 description: How to launch Android apps directly from a web page.
 ---
 


### PR DESCRIPTION

Changes proposed in this pull request:

- The [previous link](https://code.google.com/p/zxing/source/browse/trunk/android/AndroidManifest.xml#97) is doing an incorrect redirect. You might want to have a custom code.google.com link instead.