### PR TITLE
Add example Curl command to CrUX API docs

### DIFF
--- a/site/_scss/blocks/_event-card.scss
+++ b/site/_scss/blocks/_event-card.scss
@@ -48,7 +48,9 @@
 
   &__image,
   &__desktop-image {
+    /* stylelint-disable property-no-unknown */
     aspect-ratio: 1/1;
+    /* stylelint-enable property-no-unknown */
     position: relative;
 
     img {

--- a/site/_scss/blocks/_event-card.scss
+++ b/site/_scss/blocks/_event-card.scss
@@ -48,9 +48,7 @@
 
   &__image,
   &__desktop-image {
-    /* stylelint-disable property-no-unknown */
     aspect-ratio: 1/1;
-    /* stylelint-enable property-no-unknown */
     position: relative;
 
     img {

--- a/site/en/docs/crux/api/index.md
+++ b/site/en/docs/crux/api/index.md
@@ -239,6 +239,7 @@ Note: The values for each percentile are synthetically derived, it does not impl
 
 Queries are submitted as JSON objects via a POST request to `https://chromeuxreport.googleapis.com/v1/records:queryRecord?key=[YOUR_API_KEY]"` with query data as a JSON object in the POST body, e.g.
 
+
 ```json
 {
   "origin": "https://example.com",
@@ -250,7 +251,17 @@ Queries are submitted as JSON objects via a POST request to `https://chromeuxrep
 }
 ```
 
-Page-level data is available through the API by passing a `url` property in the query:
+For example, this can be called from `curl` with the following command line (replacing API_KEY with your key):
+
+```
+curl -s --request POST 'https://chromeuxreport.googleapis.com/v1/records:queryRecord?key=API_KEY' \
+    --header 'Accept: application/json' \
+    --header 'Content-Type: application/json' \
+    --data '{"formFactor":"PHONE","origin":"https://www.example.com","metrics",["largest_contentful_paint", "experimental_time_to_first_byte"]}'
+```
+
+
+Page-level data is available through the API by passing a `url` property in the query, instead of `origin`:
 
 ```json
 {

--- a/site/en/docs/crux/api/index.md
+++ b/site/en/docs/crux/api/index.md
@@ -253,7 +253,7 @@ Queries are submitted as JSON objects via a POST request to `https://chromeuxrep
 
 For example, this can be called from `curl` with the following command line (replacing API_KEY with your key):
 
-```
+```bash
 curl -s --request POST 'https://chromeuxreport.googleapis.com/v1/records:queryRecord?key=API_KEY' \
     --header 'Accept: application/json' \
     --header 'Content-Type: application/json' \

--- a/site/en/docs/crux/api/index.md
+++ b/site/en/docs/crux/api/index.md
@@ -251,7 +251,7 @@ Queries are submitted as JSON objects via a POST request to `https://chromeuxrep
 }
 ```
 
-For example, this can be called from `curl` with the following command line (replacing API_KEY with your key):
+For example, this can be called from `curl` with the following command line (replacing `API_KEY` with your key):
 
 ```bash
 curl -s --request POST 'https://chromeuxreport.googleapis.com/v1/records:queryRecord?key=API_KEY' \


### PR DESCRIPTION
Changes proposed in this pull request:

- Adds example Curl command line as discussed on CrUX chat.

CC: @powdercloud @paulirish 

