### PR TITLE
fix: chrome 107 beta screen capture link broken

### DIFF
--- a/site/en/blog/chrome-107-beta/index.md
+++ b/site/en/blog/chrome-107-beta/index.md
@@ -22,7 +22,7 @@ In CSS Grid, the `grid-template-columns` and `grid-template-rows` properties all
 
 ## Privacy preserving screen sharing controls
 
-The [Screen Capture API]([https://w3c.github.io/mediacapture-screen-share/](https://w3c.github.io/mediacapture-screen-share/)) introduces additions to the existing Media Capture and Streams API to let the user select a screen or portion of a screen (such as a window) to capture as a media stream. This stream can then be recorded or shared with others over the network. In this beta some new features are added to this API.
+The [Screen Capture API](https://w3c.github.io/mediacapture-screen-share/) introduces additions to the existing Media Capture and Streams API to let the user select a screen or portion of a screen (such as a window) to capture as a media stream. This stream can then be recorded or shared with others over the network. In this beta some new features are added to this API.
 
 {% Aside %}  
 Learn more about the Screen Capture API in the MDN guide to [Using the Screen Capture API](https://developer.mozilla.org/docs/Web/API/Screen_Capture_API/Using_Screen_Capture).   


### PR DESCRIPTION
Changes proposed in this pull request:

- Reading the new Chrome 107 Beta blog post, I noticed the link to the Screen Capture API was broken. Seems to be due to mistaken use of unsupported nested link syntax.

Test it now: https://deploy-preview-3884--developer-chrome-com.netlify.app/blog/chrome-107-beta/#privacy-preserving-screen-sharing-controls 

Perhaps we would consider a Markdown validator of some kind to run on CI on each PR to prevent this in the future!