### PR TITLE
Redirect readers to the latest MV2 transition announcement

### DIFF
--- a/site/en/blog/mv2-transition/index.md
+++ b/site/en/blog/mv2-transition/index.md
@@ -6,13 +6,19 @@ layout: "layouts/blog-post.njk"
 authors:
   - dsli
 date: 2021-09-23
-updated: 2022-09-28
+updated: 2022-10-03
 hero: image/WlD8wC6g8khYWPJUsQceQkhXSlv1/GoUHyuctM1Zs9wdy5a2s.png
 alt: Image with extensions logo and text saying Manifest V3 transition timeline
 tags:
   - extensions
 
 ---
+
+{% Aside %}
+
+The Manifest V2 support timeline has been updated. See our [September 2022 blog post](/blog/more-mv2-transition/) and the [Manifest V2 support timeline](/docs/extensions/mv3/mv2-sunset/) page for more details.
+
+{% endAside %}
 
 Earlier this year, for Chrome 88, we announced [the availability of a new manifest
 version](https://blog.chromium.org/2020/12/manifest-v3-now-available-on-m88-beta.html) for the
@@ -43,7 +49,7 @@ expansions of the extension platform. We introduced additional mechanisms to the
 API](/docs/extensions/reference/scripting/), and we expanded the
 [Declarative Net Request
 API](/docs/extensions/reference/declarativeNetRequest/) with support for
-multiple static rulesets, filtering based on tab ID, and session-scoped rules. 
+multiple static rulesets, filtering based on tab ID, and session-scoped rules.
 
 In the coming months, we'll also be launching support for dynamically configurable content scripts
 and an in-memory storage option, among other new capabilities. These changes were crafted with


### PR DESCRIPTION
When publishing the latest [blog post on the Manifest V2 deprecation](https://developer.chrome.com/blog/more-mv2-transition/), we bumped that blog post's "updated" date but didn't change any other content. We _probably_ should have redirected readers of the old blog post to the latest published information.

This PR addresses this disconnect by again bumping the updated date and adding a callout to direct readers to the latest blog post and static documentation.