### PR TITLE
Updated Private Network Access Preflights timeline and add author

### DIFF
--- a/site/_data/authorsData.json
+++ b/site/_data/authorsData.json
@@ -350,6 +350,9 @@
     "github": "ivanlish",
     "image": "image/DLKYfvmcBoO4o7kmxoNBYhucroy1/S9Tz7VYL3vENKp9VXE7W.jpeg"
   },
+  "phao": {
+    "image": "image/rBdfHcznoAg2EYwDmhXr1iDTKxg2/gSQk1JDCAZq9COWj6Nog.JPG"
+  },
   "jecelynyeen": {
     "country": "DE",
     "twitter": "jecfish",

--- a/site/_data/i18n/authors.yaml
+++ b/site/_data/i18n/authors.yaml
@@ -433,7 +433,7 @@ phao:
   title:
     en: 'Jonathan Hao'
   description:
-    en: 'Software Engineer at Google working on the Web Platform Security.'
+    en: 'Software Engineer at Google working on Web Platform Security.'
 jecelynyeen:
   title:
     en: 'Jecelyn Yeen'

--- a/site/_data/i18n/authors.yaml
+++ b/site/_data/i18n/authors.yaml
@@ -429,6 +429,11 @@ lyf:
     zh: '罗一凡'
   description:
     en: 'Yifan is a Software Engineer working on the Web Platform.'
+phao:
+  title:
+    en: 'Jonathan Hao'
+  description:
+    en: 'Software Engineer at Google working on the Web Platform Security.'
 jecelynyeen:
   title:
     en: 'Jecelyn Yeen'

--- a/site/en/blog/private-network-access-preflight/index.md
+++ b/site/en/blog/private-network-access-preflight/index.md
@@ -8,18 +8,20 @@ authors:
   - phao
 description: Chrome is deprecating access to private network endpoints from non-secure public websites as part of the Private Network Access specification. Read on for recommended actions.
 date: 2022-01-06
-updated: 2022-07-26
+updated: 2022-10-10
 hero: image/VbsHyyQopiec0718rMq2kTE1hke2/iqanYAE91Ab6BsgwhBjq.jpg
 alt: An airplane in the sky
 tags:
   - chrome-98
   - chrome-102
   - chrome-104
+  - chrome-109
   - security
 ---
 
 **Updates**
 
+- **Oct 10, 2022**: Updated deprecation trial timeline.
 - **July 7, 2022**: Updated current status and add IP address space defination.
 - **April 27, 2022**: Updated timeline announcement.
 - **March 7, 2022**: Announced rollback after issues were discovered in
@@ -68,9 +70,7 @@ the change and adjust accordingly.
     seconds.
     {% endAside %}
 
-2. In ~~Chrome 107 at the earliest~~ Chrome 109:
-    * This will begin _only_ if and when compatibility data indicates that the
-      change is safe enough and we've outreached directly when necessary.
+2. In Chrome 109:
     * Chrome enforces that preflight requests must succeed, otherwise failing
       the requests.
     * [A deprecation trial](/blog/origin-trials/#deprecation-trials) starts at

--- a/site/en/blog/private-network-access-preflight/index.md
+++ b/site/en/blog/private-network-access-preflight/index.md
@@ -5,6 +5,7 @@ authors:
   - titouan
   - agektmr
   - lyf
+  - phao
 description: Chrome is deprecating access to private network endpoints from non-secure public websites as part of the Private Network Access specification. Read on for recommended actions.
 date: 2022-01-06
 updated: 2022-07-26
@@ -67,7 +68,7 @@ the change and adjust accordingly.
     seconds.
     {% endAside %}
 
-2. In Chrome 107 at the earliest:
+2. In ~~Chrome 107 at the earliest~~ Chrome 109:
     * This will begin _only_ if and when compatibility data indicates that the
       change is safe enough and we've outreached directly when necessary.
     * Chrome enforces that preflight requests must succeed, otherwise failing


### PR DESCRIPTION
cc @letitz @iVanlIsh 

Changes proposed in this pull request:

- Updated the Private Network Access Preflights timeline. The deprecation trial will start on M109.
- Added myself to the authors