### PR TITLE
Fix navigation tracking on pageviews

### DIFF
--- a/site/_data/analytics.json
+++ b/site/_data/analytics.json
@@ -5,5 +5,5 @@
     "NAVIGATION_TYPE": "dimension2",
     "WEB_VITALS_DEBUG": "dimension3"
   },
-  "TRACKING_VERSION": "3.0"
+  "version": 4
 }

--- a/site/_includes/partials/script.js
+++ b/site/_includes/partials/script.js
@@ -39,7 +39,11 @@
     '{{ analytics.TRACKING_VERSION }}'
   );
   try {
-    ga('set', '{{ analytics.dimensions.NAVIGATION_TYPE }}', performance.getEntriesByType('navigation')[0].type);
+    ga(
+      'set',
+      '{{ analytics.dimensions.NAVIGATION_TYPE }}',
+      performance.getEntriesByType('navigation')[0].type
+    );
   } catch (error) {
     ga('set', '{{ analytics.dimensions.NAVIGATION_TYPE }}', '(not set)');
   }

--- a/site/_includes/partials/script.js
+++ b/site/_includes/partials/script.js
@@ -36,7 +36,7 @@
   ga(
     'set',
     '{{ analytics.dimensions.TRACKING_VERSION }}',
-    '{{ analytics.TRACKING_VERSION }}'
+    '{{ analytics.version }}'
   );
   try {
     ga(

--- a/site/_includes/partials/script.js
+++ b/site/_includes/partials/script.js
@@ -38,6 +38,11 @@
     '{{ analytics.dimensions.TRACKING_VERSION }}',
     '{{ analytics.TRACKING_VERSION }}'
   );
+  try {
+    ga('set', '{{ analytics.dimensions.NAVIGATION_TYPE }}', performance.getEntriesByType('navigation')[0].type);
+  } catch (error) {
+    ga('set', '{{ analytics.dimensions.NAVIGATION_TYPE }}', '(not set)');
+  }
 
   ga('send', 'pageview');
 

--- a/site/_includes/partials/script.js
+++ b/site/_includes/partials/script.js
@@ -42,7 +42,7 @@
     ga(
       'set',
       '{{ analytics.dimensions.NAVIGATION_TYPE }}',
-      performance.getEntriesByType('navigation')[0].type
+      performance.getEntriesByType('navigation')[0].type.replace(/_/g, '-')
     );
   } catch (error) {
     ga('set', '{{ analytics.dimensions.NAVIGATION_TYPE }}', '(not set)');


### PR DESCRIPTION
Noticed we're not tracking page navigation types except back_forward_cache (which has special handling).

This PR implements same stuff we have on web.dev: https://github.com/GoogleChrome/web.dev/blob/main/src/site/_includes/partials/analytics.njk