### PR TITLE
Events - content updates

### DIFF
--- a/site/en/meet-the-team/events/link-rel-preload/index.md
+++ b/site/en/meet-the-team/events/link-rel-preload/index.md
@@ -1,0 +1,29 @@
+---
+title: Link Rel Preload | Perf.Now() pre-event
+summary: >-
+  The night before Perf.now(), the community is getting together for
+  a night of lightning talks, games and finger foods, on us.
+image: image/fuiz5I8Iv7bV8YbrK2PKiY3Vask2/hZOjTuTVO19BpM7X1YTm.png
+location: Amsterdam, Netherlands
+date: 2022-10-26
+externalUrl: https://www.meetup.com/front-end-forward/events/288132310/
+sessions:
+  - speaker: egsweeny
+    title: Core Web Vitals
+    description: Coming soon
+    topics:
+      - Performance
+    time: null
+    type: speaker
+    slidesUrl: null
+    videoUrl: null
+  - speaker: mmocny
+    title: Interaction to Next Paint (INP)
+    description: Coming soon
+    topics:
+      - Performance
+    time: null
+    type: speaker
+    slidesUrl: null
+    videoUrl: null
+---

--- a/site/en/meet-the-team/events/performance-now/index.md
+++ b/site/en/meet-the-team/events/performance-now/index.md
@@ -23,26 +23,26 @@ sessions:
   - topics:
       - Performance
     description: >-
-        The Chrome team will be available at the event at the "Performance Help
-        Desk" at the event.
+      The Chrome team will be available at the event at the "Performance Help
+      Desk" at the event.
     participants:
-        - rviscomi
-        - tunetheweb
-        - jeremywagner
-        - egsweeny
-        - paulirish
-        - patmeenan
-        - anniesullie
-        - yoavweiss
-        - mmocny
-        - ianclelland
-        - roydeepanjan
-        - karaerickson
-        - katiehempenius
-        - diklla
-        - gilberto_cocchi
-        - harrytheodoulou
-        - milutinkristofic
+      - rviscomi
+      - tunetheweb
+      - jeremywagner
+      - egsweeny
+      - paulirish
+      - patmeenan
+      - anniesullie
+      - yoavweiss
+      - mmocny
+      - ianclelland
+      - roydeepanjan
+      - karaerickson
+      - katiehempenius
+      - diklla
+      - gilberto_cocchi
+      - harrytheodoulou
+      - milutinkristofic
     type: participant
     slidesUrl: null
     videoUrl: null

--- a/site/en/meet-the-team/events/performance-now/index.md
+++ b/site/en/meet-the-team/events/performance-now/index.md
@@ -8,31 +8,42 @@ location: 'Amsterdam, Netherlands'
 date: '2022-10-27'
 externalUrl: 'https://perfnow.nl/'
 sessions:
+  - speaker: katiehempenius
+    title: >-
+      What's new in performance?
+    description: >-
+      This talk will discuss new APIs, tools, and metrics and how you can
+      apply them to your site.
+    topics:
+      - Performance
+    time: null
+    type: speaker
+    slidesUrl: null
+    videoUrl: null
   - topics:
       - Performance
     description: >-
-      The Chrome team will be available at the event at the "Performance Help
-      Desk" at the event.
+        The Chrome team will be available at the event at the "Performance Help
+        Desk" at the event.
     participants:
-      - rviscomi
-      - tunetheweb
-      - jeremywagner
-      - egsweeny
-      - paulirish
-      - patmeenan
-      - anniesullie
-      - yoavweiss
-      - mmocny
-      - ianclelland
-      - roydeepanjan
-      - karaerickson
-      - katiehempenius
-      - diklla
-      - gilberto_cocchi
-      - harrytheodoulou
-      - milutinkristofic
+        - rviscomi
+        - tunetheweb
+        - jeremywagner
+        - egsweeny
+        - paulirish
+        - patmeenan
+        - anniesullie
+        - yoavweiss
+        - mmocny
+        - ianclelland
+        - roydeepanjan
+        - karaerickson
+        - katiehempenius
+        - diklla
+        - gilberto_cocchi
+        - harrytheodoulou
+        - milutinkristofic
     type: participant
     slidesUrl: null
     videoUrl: null
-
 ---


### PR DESCRIPTION
Adds the 'link rel preload' event and updates 'performance.now'.