### PR TITLE
Move glossary from FLEDGE overview

### DIFF
--- a/site/en/docs/privacy-sandbox/fledge/index.md
+++ b/site/en/docs/privacy-sandbox/fledge/index.md
@@ -34,8 +34,8 @@ At the end of this post, learn how to [engage and share feedback](#engage).
 ## What is FLEDGE? {: #what}
 
 FLEDGE is a [Privacy Sandbox](/docs/privacy-sandbox/overview) proposal to serve
-[remarketing](#remarketing) and custom audience use cases, designed so that it cannot be used by
-third parties to track user browsing behavior across sites.
+[remarketing](/docs/privacy-sandbox/glossary/#remarketing) and custom audience
+use cases, designed so that it cannot be used by third parties to track user browsing behavior across sites.
 
 The API enables on-device auctions by the browser, to choose relevant ads from
 websites the user has previously visited.
@@ -46,9 +46,7 @@ FLEDGE is the first experiment to be implemented in Chromium within the
 information for FLEDGE and other Privacy Sandbox proposals.
 
 
-## FLEDGE in one minute {: #overview}
-
-<br>
+### FLEDGE in one minute {: #overview}
 
 <figure class="w-figure">
   {% Img src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/zXKEk8OymLJp6KpOwwbk.png", alt="Illustration providing
@@ -87,8 +85,7 @@ Later, when the user visits a site that sells ad space, the ad space seller
 (most likely the site's 
 [SSP](/docs/privacy-sandbox/glossary/#ssp), or the site itself) can use
 FLEDGE to run an ad auction to select the most appropriate ads to display to the user. The seller
-calls the `navigator.runAdAuction() `function, providing a list of interest group owners who are
-invited to bid.
+calls the `navigator.runAdAuction() `function, which provides a list of interest group owners who are invited to bid.
 
 Bidding code is only run for interest groups that the browser is a member of, and
 whose owners have been invited to bid.
@@ -96,7 +93,7 @@ whose owners have been invited to bid.
 Bidding code is retrieved from the URL provided in the configuration information for the interest
 group. This code must include a `generateBid()` function, which is passed data about the interest
 group, and information from the seller, along with contextual data about the page and from the
-browser. Each bidder is called a [buyer](#buyer).
+browser. Each bidder is called a buyer.
 
 When calling the `navigator.runAdAuction()` function, the seller provides code that includes a
 `scoreAd()` function. This function is run for each bidder in the auction: to score each of the bids
@@ -104,8 +101,10 @@ returned by `generateBid()`. During the ad auction, the bidding code run for eac
 (`generateBid()`) and the ad scoring code run for the seller (`scoreAd()`) can receive realtime data
 from the [FLEDGE Key/Value service](#key-value-service-detail).
 
-The bid with the highest score wins the auction. The ad associated with the bid is displayed in
-a [`<fencedframe>`](#fenced-frame) element, using the ad URL specified by the bid (which must be one of the ad URLs from the list provided in the interest group's configuration information).
+The bid with the highest score wins the auction. The ad associated with the bid
+is displayed in a `<fencedframe>`, using the ad URL specified by the bid (which
+must be one of the ad URLs from the list provided in the interest group's
+configuration information).
 
 To report the auction outcome, the seller's code can include a `reportResult()` function and each
 buyer's code can include a `reportWin()` function.
@@ -192,57 +191,64 @@ from the bike maker.
 
 ### 1. A user visits an advertiser site
 
-{% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/lrC3QOqthGpWyI6Ou9Eb.png", alt="Illustration showing
-  a person visiting the site of a custom bike maker in a browser on their laptop.",
-  width="400", height="190" %}
+<figure>
+{% Img
+  src="image/80mq7dk16vVEg8BBhsVe42n6zn82/lrC3QOqthGpWyI6Ou9Eb.png", alt="A person visits a custom bike maker's site in a browser on their laptop.",
+  width="400", height="190"
+%}
+</figure>
 
-Imagine that a user visits the website of a custom bike maker (the [advertiser](#advertiser) in
-this example) and spends some time on the product page for a handmade steel bike. This provides the
-bike maker with a [remarketing](#remarketing) opportunity.
+Imagine that a user visits the website of a custom bike maker (the advertiser)
+and spends some time on the product page for a handmade steel bike. This provides the bike maker with a remarketing opportunity.
 
 <p style="color: #547fc0; font-size: 4rem; text-align: center;" aria-hidden="true">⬇︎</p>
 
-
 ### 2. The user's browser is asked to add an interest group {: #joinAdInterestGroup}
 
+<figure>
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/vF5beSa9j6VJBTtEcyC1.png",
-  alt="Illustration showing a person viewing a site in a browser on their laptop. JavaScript
-  code joinAdInterestGroup() is running in the browser.", width="400", height="187" %}
+  alt="A person views a site in a browser on their laptop. The JavaScript code joinAdInterestGroup() is running in the browser.", width="400", height="187"
+%}
+</figure>
 
-The advertiser's [DSP](#dsp) (or the advertiser itself) makes a JavaScript call
+The advertiser's [DSP](/docs/privacy-sandbox/glossary/#dsp) (or the advertiser itself) makes a JavaScript call
 `navigator.joinAdInterestGroup()` to ask the browser to add an interest group to the groups it is a
 member of. In this example, the group might be named `custom-bikes`. The interest group owner is
-an ad space buyer in the ad auction described in [step 4](#ad-auction). The owner provides
+an ad space buyer in the ad auction (described in step 4). The owner provides
 configuration information to enable the browser to access bidding code, ad code, and
 realtime data for the group when an ad auction is run.
 
 <p style="color: #547fc0; font-size: 4rem; text-align: center;" aria-hidden="true">⬇︎</p>
 
-### 3. The user visits a site that sells ad space
+### 3. The user visits a site with ad space
 
+<figure>
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/95tUp50coQWLsqzxQhgi.png",
-  alt="Illustration showing a person visiting a news website in a browser on their laptop. The site
-  has an empty ad slot.", width="400", height="182" %}
+  alt="A person visits a news website in a browser on their laptop. The site
+  has an empty ad slot.", width="400", height="182"
+%}
+</figure>
 
-The user visits a news website (a [**publisher**](#publisher)) that uses FLEDGE to select ads.
+The user visits a news website (a [_publisher_](/docs/privacy-sandbox/glossary/#publisher)) that uses FLEDGE to select ads.
 
 <p style="color: #547fc0; font-size: 4rem; text-align: center;" aria-hidden="true">⬇︎</p>
 
-### 4. An ad auction is run in the browser
+### 4. An ad auction runs in the browser
 
-{% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/fP9qHtCjfk8IwrJLtOpo.png",
-  alt="Illustration showing a person viewing a news website in a browser on their laptop. An ad
-  auction using the FLEDGE API is taking place.", width="500", height="228" %}
+<figure>
+{% Img
+  src="image/80mq7dk16vVEg8BBhsVe42n6zn82/fP9qHtCjfk8IwrJLtOpo.png",
+  alt="A person visits a news website in a browser on their laptop. A FLEDGE API adauction is taking place.",
+  width="500", height="228" %}
+</figure>
 
 An ad auction is run on the user's device to select the most appropriate ad for a specific
 available ad space on the publisher site. The code to run the auction is likely to be provided by
-the publisher site's [supply-side platform (SSP)](#ssp) or by the site itself.
+the publisher site's [supply-side platform (SSP)](/docs/privacy-sandbox/glossary/#ssp) or by the site itself.
 
 {% Aside %}
 
-In FLEDGE, the party running an ad auction is called the **seller**.
-
-Parties invited by the seller to bid in the auction are called **buyers**.
+In FLEDGE, the party running an ad auction is called the _seller_. Parties invited by the seller to bid in the auction are called _buyers_.
 
 Each buyer is an interest group owner: each bid in an auction represents an interest group. In
 other words, each bidder is an ad space buyer and also an interest group owner.
@@ -261,28 +267,30 @@ give it a score and choose the most desirable bid.
 
 <p style="color: #547fc0; font-size: 4rem; text-align: center;" aria-hidden="true">⬇︎</p>
 
-### 5. The seller and participating buyers receive realtime data from the Key/Value service
+### 5. The seller and participating buyers receive realtime data
 
+<figure>
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/rn0slzXLZNSzGHMm6w7Y.png",
-  alt="Illustration showing a person viewing a news website in a browser on their laptop. An ad
-  auction using the FLEDGE API is taking place, with a participant getting data from the Key/Value service.", width="600", height="189" %}
+  alt="A person visits a news website in a browser on their laptop. A FLEDGE API ad auction is taking place. Meanwhile, auction participants retrieve data from the Key/Value service.", width="600", height="189" %}
+</figure>
 
-During the ad auction, the ad space [seller](#seller) or bidding ad space [buyers](#buyer) may need
-to access realtime data. For example, the seller may be required to check that [ad creatives](#creative)
-comply with publisher policies, or bidders may need to calculate the remaining budget in an ad
-campaign. To meet the privacy requirements of FLEDGE, this data is supplied using
-[Key/Value service](#key-value-service-detail).
+During the ad auction, the ad space seller or ad space buyers (sometimes referred to as bidders) may need
+to access realtime data. For example, the seller may be required to check that
+[ad creatives](/docs/privacy-sandbox/glossary/#creative)
+comply with publisher policies, or bidders may need to calculate the remaining
+budget in an ad campaign. To meet the privacy requirements of FLEDGE, this data
+is supplied using [Key/Value service](#key-value-service-detail).
 
 <p style="color: #547fc0; font-size: 4rem; text-align: center;" aria-hidden="true">⬇︎</p>
 
 ### 6. The winning ad is displayed
 
+<figure>
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/wlkJ84sb3tRjJXHkCDfE.png",
-  alt="Illustration showing a person viewing a news website in a browser on their laptop. An ad
-  for a bike (20% off) is displayed—with a lock above to show that the ad is displayed in a
-  fenced frame.", width="400", height="192" %}
+  alt="On a news website, an ad for a 20% off a bike is displayed within a fenced frame.", width="400", height="192" %}
+</figure>
 
-The value returned by `navigator.runAdAuction()` in step 5 is passed to a [fenced frame](#fenced-frame)
+The value returned by `navigator.runAdAuction()` in step 5 is passed to a [fenced frame](/docs/privacy-sandbox/fenced-frame)
 for rendering, and the site displays the winning ad. A fenced frame prevents ad code from
 interacting with the surrounding page.
 
@@ -290,27 +298,36 @@ interacting with the surrounding page.
 
 ### 7. The auction result is reported
 
+<figure>
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/OPSYyEPotB8G1CUeDV0Q.png",
-  alt="Illustration representing the result of a FLEDGE ad auction being reported to the ad seller
+  alt="The result of the FLEDGE ad auction is reported to the ad seller
   and ad buyers.", width="600", height="173" %}
+</figure>
 
-The `reportResult()` and `reportWin()` functions are called in auction code provided by the
-[seller](#seller) and the winning buyer respectively, so each has an opportunity to perform logging
-and reporting about the auction result.
+The `reportResult()` and `reportWin()` functions are called in auction code
+provided by the seller and the winning buyer respectively, so each has an
+opportunity to perform logging and reporting about the auction result.
 
 <p style="color: #547fc0; font-size: 4rem; text-align: center;" aria-hidden="true">⬇︎</p>
 
 ### 8. An ad click is reported
 
-{% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/rDAkvTMMDjwc7MuMjzqw.png", alt="Illustration showing
-a person clicking on an ad for a bike, inside a fenced frame, on a news website, with report
-data going to seller and buyers.", width="600", height="220" %}
+<figure>
+{% Img
+  src="image/80mq7dk16vVEg8BBhsVe42n6zn82/rDAkvTMMDjwc7MuMjzqw.png",
+  alt="A person clicks on the ad for a bike (hosted ina fenced frame). A report about this action is sent to seller and buyers.",
+  width="600", height="220"
+%}
+</figure>
 
-A click on an ad rendered in a fenced frame is reported. To learn more about how this might work,
+Once a user clicks on an ad rendered in a fenced frame, the click is reported. To learn more about how this might work,
 see [Fenced Frames Ads Reporting](https://github.com/WICG/turtledove/blob/main/Fenced_Frames_Ads_Reporting.md#reportevent).
 
-<br>
+{: #glossary}
 
+## Key concepts
+
+Looking for more information on FLEDGE terminology? Refer to the [Privacy Sandbox glossary](/docs/privacy-sandbox/glossary/).
 
 {: #interest-group-detail}
 
@@ -321,7 +338,7 @@ see [Fenced Frames Ads Reporting](https://github.com/WICG/turtledove/blob/main/F
 {% endDetailsSummary %}
 
 A FLEDGE interest group represents a group of people with a common interest, corresponding to a
-[remarketing](#remarketing) list.
+[remarketing](/docs/privacy-sandbox/glossary/#remarketing) list.
 
 Every FLEDGE interest group has an owner. Different types of owners will create different types of
 interest groups with different use cases.
@@ -477,7 +494,7 @@ title="Click to view a larger version of image" target="_blank">view a larger ve
 <figure class="w-figure">
   {% Img
     src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/M8lyXt6JbwFncB16mTb0.png",
-    alt="There are six stages in a FLEDGE ad auction",
+    alt="Six stages in a FLEDGE ad auction",
     width="800", height="481"
     %}
 </figure>
@@ -505,7 +522,7 @@ auction result.
 #### 2. The seller starts an auction
 
 The **seller** calls the JavaScript function `navigator.runAdAuction()` to start an auction for an
-available ad slot. The seller is likely to be the site's [SSP](#ssp), or the site itself. In the
+available ad slot. The seller is likely to be the site's [SSP](/docs/privacy-sandbox/glossary/#ssp), or the site itself. In the
 auction configuration value passed to the function, the seller specifies which ad space is for
 sale and who can bid, and provides a URL for code that scores bids.
 
@@ -514,7 +531,7 @@ sale and who can bid, and provides a URL for code that scores bids.
 As explained in [How does FLEDGE work?](#joinAdInterestGroup), each interest group owner provides a
 URL for code that can be used to bid in an ad auction, when the group owner called
 `navigator.joinAdInterestGroup()`. That code must include a `generateBid()` function, which returns
-a numerical bid and a URL for an [ad creative](#creative), along with other data. Each bidding script can receive realtime data from its [Key/Value service](#key-value-service-detail) that was defined in the interest group config. The Key/Value service can be queried for data such as remaining ad campaign budget.
+a numerical bid and a URL for an ad creative, along with other data. Each bidding script can receive realtime data from its [Key/Value service](#key-value-service-detail) that was defined in the interest group config. The Key/Value service can be queried for data such as remaining ad campaign budget.
 
 #### 4. The seller's code evaluates each buyer's bid
 
@@ -532,9 +549,9 @@ contextual winner.
 
 #### 5. The ad is displayed
 
-For the winning ad, the auction code returns an *opaque* value, which can only be passed to a
-[fenced frame](#fenced-frame) to render the ad. Neither the party selling the ad space nor the site
-displaying the ad can inspect this value.
+For the winning ad, the auction code returns an *opaque* value, which can only be passed to a [fenced frame](/docs/privacy-sandbox/fenced-frame/) to render
+the ad. Neither the party selling the ad space nor the site displaying the ad
+can inspect this value.
 
 #### 6. The auction result is reported by the seller and buyers
 
@@ -595,20 +612,7 @@ To ensure that the ecosystem has sufficient time to test, we don’t expect to r
 
 {% endDetails %}
 
-### Glossary
-
-Looking for more information on FLEDGE terminology? Refer to the [Privacy Sandbox glossary](/docs/privacy-sandbox/glossary/)
-
 {: #engage}
-
-## Engage and share feedback
-
--  **GitHub**: Read the [proposal](https://github.com/WICG/turtledove/blob/master/FLEDGE.md),
-   [raise questions and follow discussion](https://github.com/WICG/turtledove/issues).
--  **W3C**: Discuss industry use cases in the [Improving Web Advertising Business
-   Group](https://www.w3.org/community/web-adv/participants).
--  **Developer support**: Ask questions and join discussions on the
-   [Privacy Sandbox Developer Support repo](https://github.com/GoogleChromeLabs/privacy-sandbox-dev-support).
 
 ## Find out more
 
@@ -620,6 +624,11 @@ explains how the demo code works, and shows how to use Chrome DevTools for FLEDG
 -  [Digging into the Privacy Sandbox](https://web.dev/digging-into-the-privacy-sandbox)
 -  [Intent to prototype](https://groups.google.com/a/chromium.org/g/blink-dev/c/w9hm8eQCmNI)
 
-<hr />
+## Engage and share feedback
 
-_Photo by [Ray Hennessy](https://unsplash.com/@rayhennessy) on [Unsplash](https://unsplash.com/)._
+-  **GitHub**: Read the [proposal](https://github.com/WICG/turtledove/blob/master/FLEDGE.md),
+   [raise questions and follow discussion](https://github.com/WICG/turtledove/issues).
+-  **W3C**: Discuss industry use cases in the [Improving Web Advertising Business
+   Group](https://www.w3.org/community/web-adv/participants).
+-  **Developer support**: Ask questions and join discussions on the
+   [Privacy Sandbox Developer Support repo](https://github.com/GoogleChromeLabs/privacy-sandbox-dev-support).

--- a/site/en/docs/privacy-sandbox/fledge/index.md
+++ b/site/en/docs/privacy-sandbox/fledge/index.md
@@ -16,28 +16,20 @@ authors:
   id='HkvmYKqnytw'
 %}
 
-
 ## Who is this article for?
 
-This article covers the basics of FLEDGE, and explains some underlying concepts, but doesn't go into
-much technical detail.
+This article covers the basics of FLEDGE, and explains some underlying
+concepts, but doesn't go into much technical detail.
 
-* If you work in **advertising or adtech**, you might want to skip the parts explaining concepts
-such as [advertiser](#advertiser) and [publisher](#publisher). [How does FLEDGE work?](#how) should
-still be useful.
-
-* If you're a **developer or software engineer**, the [FLEDGE API Developer Guide](/blog/fledge-api)
-provides more in-depth technical detail about the proposal.
-
-* [The FLEDGE demo](https://fledge-demo.glitch.me) provides a walkthrough of a basic FLEDGE
-deployment.
-
+* If you work in **advertising or adtech**, you'll gain an understanding of [how FLEDGE works](#how).
+* If you're a **developer or software engineer**, the [FLEDGE API Developer Guide](/blog/fledge-api) provides more in-depth technical detail about the proposal.
+* [The FLEDGE demo](https://fledge-demo.glitch.me) provides a walkthrough of a basic FLEDGE deployment.
 
 {% Aside %}
-🧐 There is a [glossary](#glossary) of FLEDGE terms at the end of this post, along with information
-about how to [engage and share feedback](#engage).
+<span role="img" aria-label="Thinking face">🧐</span> There is a [glossary](/docs/privacy-sandbox/glossary/) with terms used across FLEDGE documentation.
 {% endAside %}
 
+At the end of this post, learn how to [engage and share feedback](#engage).
 
 ## What is FLEDGE? {: #what}
 
@@ -45,8 +37,8 @@ FLEDGE is a [Privacy Sandbox](/docs/privacy-sandbox/overview) proposal to serve
 [remarketing](#remarketing) and custom audience use cases, designed so that it cannot be used by
 third parties to track user browsing behavior across sites.
 
-The API enables on-device auctions by the browser, to choose relevant ads from websites the user
-has previously visited.
+The API enables on-device auctions by the browser, to choose relevant ads from
+websites the user has previously visited.
 
 FLEDGE is the first experiment to be implemented in Chromium within the
 [TURTLEDOVE](https://github.com/WICG/turtledove) family of proposals. The
@@ -73,15 +65,17 @@ FLEDGE uses [interest groups](#interest-group-detail) to enable sites to display
 relevant to their users.
 
 For example, when a user visits a website that wants to advertise its products, an interest group
-[owner](#interest-group-detail) (such as a [DSP](#dsp) working for the site) can ask the user's
+[owner](#interest-group-detail) (such as a [demand side platform or DSP](/docs/privacy-sandbox/glossary/#dsp) working for the site) can ask the user's
 browser to add membership for the interest group. The group owner (in this example, the DSP) does
 this by calling the JavaScript function `navigator.joinAdInterestGroup()`. If the call is
 successful, the browser records:
+
 * The **name** of the interest group: for example, 'custom-bikes'.
 * The **owner** of the interest group: for example, 'https://dsp.example'.
-* Interest group **configuration information** to enable the browser to access bidding code, ad
-code, and realtime data, if the group's owner is invited to bid in an online ad auction. This
-information can be updated later by the interest group owner.
+* Interest group **configuration information** to enable the browser to access
+  bidding code, ad code, and realtime data, if the group's owner is invited to
+  bid in an online ad auction. This information can be updated later by the
+  interest group owner.
 
 {% Aside %}
 
@@ -89,11 +83,14 @@ There are other use cases for interest groups: see the [examples of owners and t
 
 {% endAside %}
 
-Later, when the user visits a site that sells ad space, the ad space [seller](#seller-detail)
-for the site (most likely the site's [SSP](#ssp), or the site itself) can use
+Later, when the user visits a site that sells ad space, the ad space seller
+(most likely the site's 
+[SSP](/docs/privacy-sandbox/glossary/#ssp), or the site itself) can use
 FLEDGE to run an ad auction to select the most appropriate ads to display to the user. The seller
 calls the `navigator.runAdAuction() `function, providing a list of interest group owners who are
-invited to bid. Bidding code is only run for interest groups that the browser is a member of, and
+invited to bid.
+
+Bidding code is only run for interest groups that the browser is a member of, and
 whose owners have been invited to bid.
 
 Bidding code is retrieved from the URL provided in the configuration information for the interest
@@ -105,7 +102,7 @@ When calling the `navigator.runAdAuction()` function, the seller provides code t
 `scoreAd()` function. This function is run for each bidder in the auction: to score each of the bids
 returned by `generateBid()`. During the ad auction, the bidding code run for each buyer
 (`generateBid()`) and the ad scoring code run for the seller (`scoreAd()`) can receive realtime data
-from the [FLEDGE Key/Value service](#key-value-service).
+from the [FLEDGE Key/Value service](#key-value-service-detail).
 
 The bid with the highest score wins the auction. The ad associated with the bid is displayed in
 a [`<fencedframe>`](#fenced-frame) element, using the ad URL specified by the bid (which must be one of the ad URLs from the list provided in the interest group's configuration information).
@@ -130,11 +127,10 @@ explains how the demo code works, and shows how to use Chrome DevTools for FLEDG
   id='znDD0gkdJyM'
 %}
 
-
-## What browser configuration is available? {: #user-controls}
+### What browser configuration is available? {: #user-controls}
 
 Users can adjust their participation for Privacy Sandbox trials in Chrome by enabling or disabling
-the top-level setting in chrome://settings/privacySandbox.  During initial testing, people will be
+the top-level setting in `chrome://settings/privacySandbox`.  During initial testing, people will be
 able to use this high-level Privacy Sandbox setting to opt out of FLEDGE. Chrome plans to allow
 users to see and manage the list of interest groups that they have been added to across the web
 sites they have visited.  As with the Privacy Sandbox technologies themselves, user settings may
@@ -149,7 +145,7 @@ removed when users clear their site data.
 
 {: #opt-out-site}
 
-## How can I opt out of FLEDGE? {: #opt-out}
+### How can I opt out of FLEDGE? {: #opt-out}
 
 The FLEDGE API developer guide explains how you can [block access to the FLEDGE API](/blog/fledge-api#opt-out) 
 either as a site owner, or as an individual user.
@@ -216,7 +212,7 @@ bike maker with a [remarketing](#remarketing) opportunity.
 The advertiser's [DSP](#dsp) (or the advertiser itself) makes a JavaScript call
 `navigator.joinAdInterestGroup()` to ask the browser to add an interest group to the groups it is a
 member of. In this example, the group might be named `custom-bikes`. The interest group owner is
-an ad-space buyer in the ad auction described in [step 4](#ad-auction). The owner provides
+an ad space buyer in the ad auction described in [step 4](#ad-auction). The owner provides
 configuration information to enable the browser to access bidding code, ad code, and
 realtime data for the group when an ad auction is run.
 
@@ -249,7 +245,7 @@ In FLEDGE, the party running an ad auction is called the **seller**.
 Parties invited by the seller to bid in the auction are called **buyers**.
 
 Each buyer is an interest group owner: each bid in an auction represents an interest group. In
-other words, each bidder is an ad-space buyer and also an interest group owner.
+other words, each bidder is an ad space buyer and also an interest group owner.
 
 {% endAside %}
 
@@ -271,11 +267,11 @@ give it a score and choose the most desirable bid.
   alt="Illustration showing a person viewing a news website in a browser on their laptop. An ad
   auction using the FLEDGE API is taking place, with a participant getting data from the Key/Value service.", width="600", height="189" %}
 
-During the ad auction, the ad-space [seller](#seller) or bidding ad-space [buyers](#buyer) may need
+During the ad auction, the ad space [seller](#seller) or bidding ad space [buyers](#buyer) may need
 to access realtime data. For example, the seller may be required to check that [ad creatives](#creative)
 comply with publisher policies, or bidders may need to calculate the remaining budget in an ad
 campaign. To meet the privacy requirements of FLEDGE, this data is supplied using
-[Key/Value service](#key-value-service).
+[Key/Value service](#key-value-service-detail).
 
 <p style="color: #547fc0; font-size: 4rem; text-align: center;" aria-hidden="true">⬇︎</p>
 
@@ -321,8 +317,7 @@ see [Fenced Frames Ads Reporting](https://github.com/WICG/turtledove/blob/main/F
 {% Details %}
 
 {% DetailsSummary %}
-## What is an interest group?
-
+### What is an interest group?
 {% endDetailsSummary %}
 
 A FLEDGE interest group represents a group of people with a common interest, corresponding to a
@@ -403,17 +398,16 @@ The table below provides examples of different types of FLEDGE interest group an
 {% Details %}
 
 {% DetailsSummary %}
-## What is a buyer?
-
+### What is a buyer?
 {% endDetailsSummary %}
 
-In FLEDGE, a party that owns an [interest group](#interest-group) and bids in an ad [auction](#).
+In FLEDGE, a party that owns an [interest group](#interest-group-detail) and bids in an ad auction.
 
 For example:
 
-* **[Advertiser](#advertiser)**: acting for itself.
-* **[Demand-Side Platform](#dsp)** (DSP): acting for advertisers.
-* **[Interest group owner](#interest-group-detail)**: working for multiple advertisers.
+* **[Advertiser](/docs/privacy-sandbox/glossary/#advertiser)**: acting for itself.
+* **[Demand-Side Platform](/docs/privacy-sandbox/glossary/#dsp)** (DSP): acting for advertisers.
+* **Interest group owner**: working for multiple advertisers.
 
 Buyers have three jobs:
 
@@ -426,10 +420,10 @@ auction.
 
 When a buyer asks a user's browser to add an interest group to the groups it is a member of (by calling the
 JavaScript function `navigator.joinAdInterestGroup()`) the buyer provides the browser with:
-* A URL for bidding code, that will be used when the [seller](#seller) runs an [ad auction](#ad-auction).
-* Potentially, URLs for [ad creatives](#creative) for the interest group. (Ad URLs may be added
+* A URL for bidding code, that will be used when the [seller](/docs/privacy-sandbox/glossary/#seller) runs an [ad auction](/docs/privacy-sandbox/glossary/#ad-auction).
+* Potentially, URLs for [ad creatives](/docs/privacy-sandbox/glossary/#creative) for the interest group. (Ad URLs may be added
 later via an update.)
-* A list of data [keys](#key-value) to be queried, and the URL of the buyer's [Key/Value service](#key-value-service),
+* A list of data [keys](#key-value) to be queried, and the URL of the buyer's [Key/Value service](#key-value-service-detail),
 to enable bidding code to get realtime data during an auction.
 
 The buyer's code can also include a `reportWin()` function to report the auction outcome.
@@ -442,8 +436,7 @@ The buyer's code can also include a `reportWin()` function to report the auction
 {% Details %}
 
 {% DetailsSummary %}
-## Who runs an ad auction?
-
+### Who runs an ad auction?
 {% endDetailsSummary %}
 
 There are multiple parties that might run an auction to sell ad space.
@@ -451,13 +444,15 @@ There are multiple parties that might run an auction to sell ad space.
 For example:
 
 * **Content publisher**: acting for itself to host ad content on its website.
-* **[Supply-side platform](#ssp)** (SSP): working with the publisher and providing other services.
+* **[Supply-side platform](/docs/privacy-sandbox/glossary/#ssp)** (SSP): working with the publisher and providing other services.
 * **Third-party script**: acting for a publisher, to enable participation in ad auctions.
 
-With FLEDGE, an ad-space [seller](#seller) has three jobs:
+With FLEDGE, an ad space [seller](/docs/privacy-sandbox/glossary/#seller) has three jobs:
 
 * Enforce publisher rules: which buyers and which bids are eligible.
-* Run auction logic: JavaScript run in [worklets](#worklet) to calculate a desirability score for each bid.
+* Run auction logic: JavaScript run in
+  [worklets](/docs/privacy-sandbox/glossary/#worklet) to calculate a
+  desirability score for each bid.
 * Report the auction outcome.
 
 These jobs are done programmatically, in code provided by the seller when it instigates an ad
@@ -471,11 +466,8 @@ auction by calling the JavaScript function `navigator.runAdAuction()`.
 {% Details %}
 
 {% DetailsSummary %}
-## How does a FLEDGE ad auction work?
-
+### How does a FLEDGE ad auction work?
 {% endDetailsSummary %}
-
-<br>
 
 {: #auction-diagram}
 
@@ -483,67 +475,68 @@ The diagram below outlines each stage of a FLEDGE ad auction: <a href="https://w
 title="Click to view a larger version of image" target="_blank">view a larger version</a>.
 
 <figure class="w-figure">
-  {% Img src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/M8lyXt6JbwFncB16mTb0.png", alt="Illustration providing
-  an overview of each stage of a FLEDGE ad auction",
-  width="800", height="481" %}
+  {% Img
+    src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/M8lyXt6JbwFncB16mTb0.png",
+    alt="There are six stages in a FLEDGE ad auction",
+    width="800", height="481"
+    %}
 </figure>
 
 <br>
 
 In FLEDGE, an ad auction is a collection of small JavaScript programs the browser runs on the user's
 device to choose an ad. To preserve privacy, all ad auction code from the seller and buyers is run
-in isolated JavaScript [worklets](#worklet) that can't talk to the outside world.
+in isolated JavaScript [worklets](/docs/privacy-sandbox/glossary/#worklet) that can't talk to the outside world.
 
-An ad-space seller (such as a [supply-side platform](#ssp)) initiates a FLEDGE ad auction on a site
+An ad space seller (such as a [supply-side platform](/docs/privacy-sandbox/glossary/#ssp)) initiates a FLEDGE ad auction on a site
 that sells ad space (such as a news site). The seller chooses buyers to participate in the auction,
 indicates what space is for sale, and provides additional criteria for the ad. Each buyer is the
 owner of an interest group.
 
 The seller provides the browser with code to score bids, which includes each bid's value, the
-[ad creative](#creative) URL, and other data returned from each buyer. During the auction, bidding
+[ad creative](/docs/privacy-sandbox/glossary/#creative) URL, and other data returned from each buyer. During the auction, bidding
 code from buyers and bid-scoring code from the seller can receive data from their
-[Key/Value services](#key-value-service). Once an ad is chosen and displayed (in a
-[fenced frame](#fenced-frame) to preserve privacy) the seller and the winning bidder can report the
+[Key/Value services](#key-value-service-detail). Once an ad is chosen and displayed (in a
+[fenced frame](/docs/privacy-sandbox/fenced-frame/) to preserve privacy) the seller and the winning bidder can report the
 auction result.
 
-### 1. A user visits a site that displays ads
+#### 1. A user visits a site that displays ads
 
-### 2. The seller starts an auction
+#### 2. The seller starts an auction
 
 The **seller** calls the JavaScript function `navigator.runAdAuction()` to start an auction for an
 available ad slot. The seller is likely to be the site's [SSP](#ssp), or the site itself. In the
 auction configuration value passed to the function, the seller specifies which ad space is for
 sale and who can bid, and provides a URL for code that scores bids.
 
-
-### 3. Bidding code is run for each invited bidder
+#### 3. Bidding code is run for each invited bidder
 
 As explained in [How does FLEDGE work?](#joinAdInterestGroup), each interest group owner provides a
 URL for code that can be used to bid in an ad auction, when the group owner called
 `navigator.joinAdInterestGroup()`. That code must include a `generateBid()` function, which returns
-a numerical bid and a URL for an [ad creative](#creative), along with other data. Each bidding script can receive realtime data from its [Key/Value service](#key-value-service) that was defined in the interest group config. The Key/Value service can be queried for data such as remaining ad campaign budget.
+a numerical bid and a URL for an [ad creative](#creative), along with other data. Each bidding script can receive realtime data from its [Key/Value service](#key-value-service-detail) that was defined in the interest group config. The Key/Value service can be queried for data such as remaining ad campaign budget.
 
-### 4. The seller's code evaluates each buyer's bid
+#### 4. The seller's code evaluates each buyer's bid
 
 The `navigator.runAdAuction()` code (from step 2) must include a `scoreAd()` function, which is run
 once for each ad and accompanying bid, to determine its desirability. The `scoreAd()` function is
 run for every candidate ad, in the auction logic JavaScript code provided by the seller. This
 function uses the bid value and other data returned by the `generateBid()` function in each buyer's
 code (in the previous step). The seller may also receive realtime data from its
-[Key/Value service](#key-value-service).
+[Key/Value service](#key-value-service-detail).
 
 For each ad, the `scoreAd()` function returns a number indicating its desirability. The most
 desirable ad is the winner. Before an auction starts, the seller finds the best contextual ad for
 the available ad slot. Part of its `scoreAd()` logic is to reject any ad that can't beat the
 contextual winner.
 
-### 5. The ad is displayed
+#### 5. The ad is displayed
 
 For the winning ad, the auction code returns an *opaque* value, which can only be passed to a
 [fenced frame](#fenced-frame) to render the ad. Neither the party selling the ad space nor the site
 displaying the ad can inspect this value.
 
-### 6. The auction result is reported by the seller and buyers
+#### 6. The auction result is reported by the seller and buyers
 
 The seller's code from step 4 can include a definition of the function `reportResult()`. Each
 buyer's code from step 3 can include a definition of `reportWin()`. The code within
@@ -564,13 +557,12 @@ A reporting mechanism for losing bidders is [under discussion](https://github.co
 {% Details %}
 
 {% DetailsSummary %}
-## What is a FLEDGE Key/Value service?
-
+### What is a FLEDGE Key/Value service?
 {% endDetailsSummary %}
 
 FLEDGE Key/Value service allows adtechs to query for realtime data when a bid is made by the buyer, and for sellers to score ads while preserving privacy. FLEDGE Key/Value service is one of the [FLEDGE services](/blog/fledge-service-overview/). 
 
-The Key/Value service is deployed to the adtech's own cloud infrastructure, and the service runs on a [trusted execution environment](#trusted-execution-environment). A request to a Key/Value service cannot result in event-level logging or have other side effects. The Key/Value service will also support [user-defined functions (UDFs)](https://github.com/WICG/turtledove/blob/main/FLEDGE_Key_Value_Server_trust_model.md#support-for-user-defined-functions-udfs) that allow adtechs to execute their own custom logic within the Key/Value service. 
+The Key/Value service is deployed to the adtech's own cloud infrastructure, and the service runs on a [trusted execution environment](/docs/privacy-sandbox/glossary/#trusted-execution-environment). A request to a Key/Value service cannot result in event-level logging or have other side effects. The Key/Value service will also support [user-defined functions (UDFs)](https://github.com/WICG/turtledove/blob/main/FLEDGE_Key_Value_Server_trust_model.md#support-for-user-defined-functions-udfs) that allow adtechs to execute their own custom logic within the Key/Value service. 
 
 {: #key-value}
 
@@ -578,9 +570,9 @@ A buyer or seller provides a list of 'keys' to specify the data they require fro
 
 The FLEDGE Key/Value service code is now available in a [Privacy Sandbox GitHub repository](https://github.com/privacysandbox/fledge-key-value-service). This service can be used by Chrome and Android developers. 
 
-Check out the [announcement blog post](/blog/open-sourcing-fledge-key-value-service/) for the status update. Learn more about the FLEDGE Key/Value service from the [API explainer](https://github.com/WICG/turtledove/blob/main/FLEDGE_Key_Value_Server_API.md) and the [trust model explainer](https://github.com/privacysandbox/fledge-docs/blob/main/key_value_service_trust_model.md).  
-
-
+Learn more about the FLEDGE Key/Value service from the
+[API explainer](https://github.com/WICG/turtledove/blob/main/FLEDGE_Key_Value_Server_API.md)
+and the [trust model explainer](https://github.com/privacysandbox/fledge-docs/blob/main/key_value_service_trust_model.md).
 
 {% endDetails %}
 
@@ -588,8 +580,7 @@ Check out the [announcement blog post](/blog/open-sourcing-fledge-key-value-serv
 {% Details %}
 
 {% DetailsSummary %}
-## How is realtime data incorporated into auctions?
-
+### How is realtime data incorporated into auctions?
 {% endDetailsSummary %}
 
 The [buyers](#buyer-detail) or [seller](#seller-detail) in an ad auction may need access to realtime
@@ -601,158 +592,12 @@ To meet the privacy requirements of FLEDGE, realtime data required during an ad 
 For initial testing, ["Bring Your Own Server"](https://github.com/WICG/turtledove/blob/main/FLEDGE.md#3-buyers-provide-ads-and-bidding-functions-byos-for-now) model is used. In the long-term, adtechs will need to use the open-source FLEDGE Key/Value services running in [trusted execution environments](https://github.com/privacysandbox/fledge-docs/blob/main/trusted_services_overview.md#trusted-execution-environment) for retrieving real-time data.
 
 To ensure that the ecosystem has sufficient time to test, we don’t expect to require the use of the open-source Key/Value services or TEEs until sometime after third-party cookie deprecation. We will provide substantial notice for developers to begin testing and adoption before this transition takes place.
-{% endDetails %}
-
-
-
-<br>
-
-{: #glossary}
-
-{% Details %}
-
-{% DetailsSummary %}
-## Glossary
-
-{% endDetailsSummary %}
-
-{: #ad-auction}
-
-### Ad auction
-
-In FLEDGE, an auction run by a [seller](#seller), in JavaScript code in the browser on
-the user's device, to sell ad space on a site that displays ads.
-
-{: #ad-creative}
-
-### Ad creative
-
-See [creative](#creative).
-
-{: #ad-exchange}
-
-### Ad exchange
-
-A platform to automate buying and selling of ad inventory from multiple ad
-networks.
-
-{: #ad-inventory }
-
-### Ad inventory
-
-The spaces for ads that are available from a site that sells ad space.
-
-{: #advertiser}
-
-### Advertiser
-
-A site that pays to advertise its products. In the example in this post, a custom bike maker.
-
-{: #buyer }
-
-### Buyer
-
-A party bidding for ad space in an [ad auction](#ad-auction), likely to be a DSP, or maybe the
-advertiser itself. Ad-space buyers own and manage interest groups. See
-[What is an ad-space buyer?](#buyer-detail) for more detail.
-
-{: #creative}
-
-### Creative
-
-Ad content: graphics, text, and/or video and audio.
-
-{: #dsp }
-
-### Demand-side platform (DSP)
-
-An adtech service used to automate ad purchasing. DSPs are used by advertisers to buy
-[ad impressions](https://en.wikipedia.org/wiki/Impression_(online_media)) across a range of
-publisher sites. Publishers put their [ad inventory](#ad-inventory) up for sale through marketplaces
-called ad exchanges, and DSPs decide programmatically which available ad impression makes most sense
-for an advertiser to buy.
-
-{: #fenced-frame}
-
-### Fenced frame
-
-A type of [frame](https://developer.mozilla.org/docs/Web/HTML/Element/iframe)
-which can be used to display an ad, but can't interact with the page around it. The
-[fenced frame proposal](https://github.com/shivanigithub/fenced-frame) is under discussion.
-
-{: #interest-group}
-
-### Interest group
-
-A group of people with a common interest, such as a
-[remarketing list](https://www.thinkwithgoogle.com/marketing-strategies/search/remarketing-lists-for-search-ads/).
-Each FLEDGE interest group has an owner: an advertiser, publisher or adtech platform. The owner asks
-the user's browser to join their interest group.
-
-{: #publisher}
-
-{: #key-value-service}
-
-### Key/Value service
-
-The Key/Value service allows the buyers and sellers to receive realtime data when a bid is made or an ad is scored. See [FLEDGE Key/Value service](#key-value-service-detail) for details.
-
-### Publisher
-
-In the context of [the FLEDGE explainer](https://github.com/WICG/turtledove/blob/main/FLEDGE.md#:~:text=publisher),
-a site that is paid to display ads. In the examples here, a news website.
-
-{: #rtb}
-
-### Real-time bidding (RTB)
-
-An automated auction for buying and selling ad impressions on websites,
-completed during page load.
-
-{: #remarketing}
-
-### Remarketing
-
-Advertising to people who've already visited your site. For example, ads for a custom bike maker
-could be shown to people who had previously viewed product pages on their site.
-
-{: #seller }
-
-### Seller
-
-In FLEDGE, the party running an ad auction, likely to be an [SSP](#ssp) or maybe the publisher
-itself.
-
-{: #ssp }
-
-### Supply-side platform, Sell-side platform (SSP)
-
-An adtech service used to automate selling ad inventory. SSPs allow publishers to offer their
-inventory (empty rectangles where ads will go) to multiple ad exchanges, DSPs, and networks. This
-enables a wide range of potential buyers to bid for ad space.
-
-{: #trusted-execution-environment}
-
-### Trusted execution environment
-
-A [trusted execution environment (TEE)](https://confidentialcomputing.io/wp-content/uploads/sites/85/2021/03/confidentialcomputing_outreach_whitepaper-8-5x11-1.pdf) provides a level of assurance for data integrity, data confidentiality, and code integrity. Services for FLEDGE, including the Key/Value service, runs on a TEE.
-
-To learn more about TEE, see the [FLEDGE services explainer](https://github.com/privacysandbox/fledge-docs/blob/main/trusted_services_overview.md#trusted-execution-environment).
-
-{: #worklet}
-
-### Worklet
-
-A small chunk of JavaScript, loaded from a single URL and run with restrictions. In particular, a
-worklet cannot access the network, storage, cookies, or the web page on which it runs. Bidding
-logic from ad-space [buyers](#buyer-detail), and ad desirability calculation by the ad-space
-[seller](#seller-detail), is run in worklets when the seller calls the `navigator.runAdAuction()`
-JavaScript function.
 
 {% endDetails %}
 
+### Glossary
 
-<br>
+Looking for more information on FLEDGE terminology? Refer to the [Privacy Sandbox glossary](/docs/privacy-sandbox/glossary/)
 
 {: #engage}
 

--- a/site/en/docs/privacy-sandbox/fledge/index.md
+++ b/site/en/docs/privacy-sandbox/fledge/index.md
@@ -2,7 +2,7 @@
 layout: 'layouts/doc-post.njk'
 title: 'FLEDGE API'
 subhead: >
-  A proposal for on-device ad auctions to serve remarketing and custom audiences, without the need for cross-site third-party tracking.
+  A proposal for on-device ad auctions to serve remarketing and custom audiences, without cross-site third-party tracking.
 description: >
   A Privacy Sandbox proposal to serve remarketing and custom audience use cases, designed so it cannot be used by third-parties to track user browsing behavior across sites. The API enables on-device auctions by the browser, to choose relevant ads from websites the user has previously visited.
 date: 2022-01-27
@@ -242,9 +242,10 @@ The user visits a news website (a [_publisher_](/docs/privacy-sandbox/glossary/#
   width="500", height="228" %}
 </figure>
 
-An ad auction is run on the user's device to select the most appropriate ad for a specific
-available ad space on the publisher site. The code to run the auction is likely to be provided by
-the publisher site's [supply-side platform (SSP)](/docs/privacy-sandbox/glossary/#ssp) or by the site itself.
+An ad auction is run in the browser on the user's device to select the most
+appropriate ad for a specific available ad space. The auction code is likely 
+provided by the publisher's
+[supply-side platform (SSP)](/docs/privacy-sandbox/glossary/#ssp) or by the site itself.
 
 {% Aside %}
 
@@ -255,15 +256,18 @@ other words, each bidder is an ad space buyer and also an interest group owner.
 
 {% endAside %}
 
-Bidding code is run for all of the browser's interest groups—as long as the owner of that group is
-on the list of invited bidders passed to `navigator.runAdAuction()`.
+Bidding code is run for all of the browser's interest groups—as long as the
+owner of that group is on the list of invited bidders passed to
+`navigator.runAdAuction()`.
 
-The auction is initiated when the seller calls the JavaScript function `navigator.runAdAuction()`.
-This function uses code from the seller and each invited bidder. Each bidder's code (from the
-URL provided in step 2) must include a `generateBid()` function to submit a bid. This function uses
-data about the ad space available in order to choose whether to bid and to calculate a bid amount.
-The seller's auction code must include a `scoreAd()` function, which is run once for each bid to
-give it a score and choose the most desirable bid.
+The auction is initiated when the seller calls `navigator.runAdAuction()`. This
+JavaScript function includes data from the seller and each invited buyer. Each
+buyer's code (from the URL provided in step 2) must include a `generateBid()`
+function to submit a bid. This function uses data about the ad space available
+to inform the buyer what creative to bid and calculate a bid value.
+
+The seller's auction includes a `scoreAd()` function, which is run
+once for each bid, to score and select the most desirable bid.
 
 <p style="color: #547fc0; font-size: 4rem; text-align: center;" aria-hidden="true">⬇︎</p>
 
@@ -271,15 +275,18 @@ give it a score and choose the most desirable bid.
 
 <figure>
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/rn0slzXLZNSzGHMm6w7Y.png",
-  alt="A person visits a news website in a browser on their laptop. A FLEDGE API ad auction is taking place. Meanwhile, auction participants retrieve data from the Key/Value service.", width="600", height="189" %}
+  alt="A person visits a news website in a browser on their laptop. A FLEDGE API ad auction is taking place. Meanwhile, auction participants retrieve data from the Key/Value service.", width="600", height="189"
+  %}
 </figure>
 
-During the ad auction, the ad space seller or ad space buyers (sometimes referred to as bidders) may need
-to access realtime data. For example, the seller may be required to check that
+During the ad auction, the ad space seller or ad space buyers may need
+to access real-time data. For example, the seller may be required to check that
 [ad creatives](/docs/privacy-sandbox/glossary/#creative)
 comply with publisher policies, or bidders may need to calculate the remaining
-budget in an ad campaign. To meet the privacy requirements of FLEDGE, this data
-is supplied using [Key/Value service](#key-value-service-detail).
+budget in an ad campaign.
+
+To meet the privacy requirements of FLEDGE, this data is supplied by a 
+[Key/Value service](#key-value-service-detail).
 
 <p style="color: #547fc0; font-size: 4rem; text-align: center;" aria-hidden="true">⬇︎</p>
 

--- a/site/en/docs/privacy-sandbox/glossary/index.md
+++ b/site/en/docs/privacy-sandbox/glossary/index.md
@@ -76,7 +76,7 @@ For example, a correlation of ad clicks or views with [conversions](#conversion)
 The [rendering engine](https://en.wikipedia.org/wiki/Browser_engine) used by
 Chrome, developed as part of the [Chromium](#chromium) project.
 
-### Buyer
+## Buyer
 
 A party bidding for ad space in an [ad auction](#ad-auction), likely to be a
 [DSP](#DSP), or maybe the advertiser itself. Ad space buyers own and manage
@@ -139,7 +139,7 @@ they belong to the dataset.
 
 See [Top-Level Domain](#tld) and [eTLD](#etld).
 
-### Demand-side platform (DSP) {: #dsp }
+## Demand-side platform (DSP) {: #dsp }
 
 An adtech service used to automate ad purchasing. DSPs are used by advertisers
 to buy [ad impressions](https://en.wikipedia.org/wiki/Impression_(online_media))
@@ -334,7 +334,7 @@ ads.
 The total number of people who see an ad or who visit a web page that displays
 the ad.
 
-### Real-time bidding (RTB) {: #rtb}
+## Real-time bidding (RTB) {: #rtb}
 
 An automated auction for buying and selling ad impressions on websites,
 completed during page load.

--- a/site/en/docs/privacy-sandbox/glossary/index.md
+++ b/site/en/docs/privacy-sandbox/glossary/index.md
@@ -17,6 +17,30 @@ authors:
 if something is missing!
 {% endAside %}
 
+## Ad auction (FLEDGE)
+
+In FLEDGE, an ad auction is run by a seller (ikely to be an [SSP](#SSP) or maybe the publisher itself), in JavaScript code in the browser on the
+user's device, to sell ad space on a site that displays ads.
+
+{: #creative}
+
+## Ad creative, creative {: #ad-creative}
+
+The contents of the ad served to users. Creatives can be images, videos, audio,
+and other formats. Creatives live within an ad space, and are served by adtech
+within line items.
+
+## Ad exchange
+
+A platform to automate buying and selling of ad inventory from multiple ad
+networks.
+
+{: #ad-space }
+
+## Ad inventory, ad space {: #ad-inventory }
+
+The spaces for ads that are available from a site that sells ad space.
+
 ## Ad platform (Adtech) {: #adtech }
 
 A company that provides services to deliver ads.
@@ -51,6 +75,14 @@ For example, a correlation of ad clicks or views with [conversions](#conversion)
 
 The [rendering engine](https://en.wikipedia.org/wiki/Browser_engine) used by
 Chrome, developed as part of the [Chromium](#chromium) project.
+
+### Buyer
+
+A party bidding for ad space in an [ad auction](#ad-auction), likely to be a
+[DSP](#DSP), or maybe the advertiser itself. Ad space buyers own and manage
+interest groups. 
+
+Learn about [ad space buyers in FLEDGE](/docs/privacy-sandbox/fledge/#buyer-detail).
 
 ## Chromium {: #chromium }
 
@@ -107,6 +139,15 @@ they belong to the dataset.
 
 See [Top-Level Domain](#tld) and [eTLD](#etld).
 
+### Demand-side platform (DSP) {: #dsp }
+
+An adtech service used to automate ad purchasing. DSPs are used by advertisers
+to buy [ad impressions](https://en.wikipedia.org/wiki/Impression_(online_media))
+across a range of publisher sites. Publishers put their
+[ad inventory](#ad-inventory) up for sale through marketplaces called ad
+exchanges, and DSPs decide programmatically which available ad impression makes
+most sense for an advertiser to buy.
+
 ## eTLD, eTLD+1 {: #etld }
 
 Stands for effective top-level domains (TLD), which are defined by the
@@ -151,6 +192,18 @@ the site.
 
 FedCM was previously known as WebID, and is still
 [in development in the W3C](https://github.com/wicg/fedcm).
+
+## Fenced frame
+
+A (`<fencedframe>`) is a proposed HTML element for embedded content, similar to
+an [iframe](https://developer.mozilla.org/docs/Web/HTML/Element/iframe). Unlike
+iframes, a fenced frame restricts communication with its embedding context to
+allow the frame access to cross-site data without sharing it with the embedding
+context.
+
+Some Privacy Sandbox APIs may require select documents to render within a
+fenced frame. Learn more about the
+[Fenced Frames proposal](/docs/privacy-sandbox/fenced-frame/).
 
 ## Fingerprinting {: #fingerprinting }
 
@@ -273,16 +326,22 @@ every response to every server.
 
 ## Publisher
 
-In the Privacy Sandbox context, a site that displays ads. 
+In the Privacy Sandbox context, a site with ad space that is paid to display
+ads.
 
 ## Reach
 
 The total number of people who see an ad or who visit a web page that displays
 the ad.
 
+### Real-time bidding (RTB) {: #rtb}
+
+An automated auction for buying and selling ad impressions on websites,
+completed during page load.
+
 ## Remarketing
 
-Reaching people on other sites who have previously visited your site.
+Advertising to people who've already visited your site on other sites.
 
 For example, an online store could show ads for a toy sale to people who
 previously viewed toys on their site.
@@ -293,6 +352,11 @@ The entity that receives aggregatable reports&mdash;in other words, the adtech
 that called the Attribution Reporting API. Aggregatable reports are sent from
 user devices to a [well-known](#well-known) URL associated with the reporting
 origin.
+
+## Seller
+
+The party running an ad auction, likely to be an [SSP](#ssp) or maybe the
+publisher itself.
 
 ## Site
 
@@ -307,6 +371,13 @@ aggregation applied to aggregatable reports. The summary
 includes aggregated user data and detailed conversion data.
 
 Summary reports were formerly known as aggregate reports.
+
+## Supply-side platform, Sell-side platform {: #SSP}
+
+An adtech service used to automate selling ad inventory. SSPs allow publishers
+to offer their inventory (empty rectangles where ads will go) to multiple ad
+exchanges, [DSPs](#DSP), and networks. This enables a wide range of potential
+buyers to bid for ad space.
 
 ## Surface
 
@@ -348,6 +419,11 @@ parties to verify the exact versions of software running on the computer. TEEs
 allow external parties to verify that the software does exactly what the
 software manufacturer claims it does—nothing more or less.
 
+To learn more about TEEs used for the Privacy Sandbox proposals, read the
+[FLEDGE services explainer](https://github.com/privacysandbox/fledge-docs/blob/main/trusted_services_overview.md#trusted-execution-environment)
+and the
+[Aggregation Service explainer](https://github.com/WICG/attribution-reporting-api/blob/main/AGGREGATION_SERVICE_TEE.md).
+
 ## User-Agent string {: #user-agent }
 
 An HTTP header used by servers and network peers to request indentifying
@@ -381,3 +457,10 @@ to make site-wide metadata accessible in standard locations in a `/.well-known/`
 
 See a list of recommendations for `.well-known` at
 [iana.org/assignments/well-known-uris/well-known-uris.xhtml](https://www.iana.org/assignments/well-known-uris/well-known-uris.xhtml).
+
+## Worklet
+
+A [worklet](https://developer.mozilla.org/docs/Web/API/Worklet) allows
+you to run specific JavaScript functions and return information back to the
+requester. Within a worklet, you can execute JavaScript but you cannot interact
+or communicate with the outside page.


### PR DESCRIPTION
The FLEDGE overview document contains glossary items which should live in the Privacy Sandbox glossary.

Additional updates include:

- More accessible-friendly alt text
- Light restructuring of heading sizes
- Redirecting glossary definitions to the glossary itself