### PR TITLE
DevTools 107 > Settings > Shortcuts

### DIFF
--- a/site/en/docs/devtools/customize/index.md
+++ b/site/en/docs/devtools/customize/index.md
@@ -93,20 +93,43 @@ You can sync your DevTools settings across devices. To enable that, you need to:
 2. The DevTools sync settings can be updated via **Settings** > **Sync** > **Enable settings sync** checkbox.
     {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/LUwFNTDyP22L1euSGg73.png", alt="DevTools sync settings", width="800", height="654" %}
 3. Most of the settings are synced, except for the **Workspace**, **Experiments**, and **Devices** tabs and a few other general settings. The state of the **Enable settings sync** checkbox is synced across devices as well.
-  For example, the following **appearance** settings are synced so you have a consistent experience across devices and don’t need to re-define the same settings again.
+  For example, the following **appearance** settings are synced so you have a consistent experience across devices and don't need to re-define the same settings again.
     {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/t8SQuZ4mE2xiLVxaZz11.png", alt="appearance settings", width="800", height="584" %}
-  However, the **dock** settings isn’t sync because developers have different dock preferences when debugging on different sites.
+  However, the **dock** settings isn't sync because developers have different dock preferences when debugging on different sites.
     {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/jWv8rwkF4q6SwTQbSNpp.png", alt="dock", width="426", height="134" %}
 
 
 ## Customize keyboard shortcuts {: #keyboard-shortcuts }
 
-See [Customize chords keyboard shortcuts](/blog/new-in-devtools-88/#keyboard-shortcuts).
+To edit keyboard shortcuts:
 
-{% Img src="image/admin/tF18281gSqF69MENLGuk.png", alt="Chords keyboard shortcuts", width="800", height="508" %}
+1. [In DevTools](/docs/devtools/open/), click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/9gzXiTYY0nZzBxGI6KrV.svg", alt="Settings", width="24", height="24" %} **Settings**.
 
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/LwoUTAEghXYMyYV5EfIy.png", alt="Settings.", width="800", height="445" %}
 
-## Experiments {: #experiments }
+1. In the **Settings** > **Shortcuts** tab, hover over any shortcut and click the {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/JJEyylF1sToNKTtoFm4Q.svg", alt="Edit.", width="24", height="24" %} **Edit** button.
+
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/BuceMKLqXmgLxRZPXTfg.png", alt="Edit shortcut.", width="800", height="596" %}
+
+1. Put the cursor in the text bar and press any convenient combination of keys (chord). DevTools notifies you if the combination is already in use.
+
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/lsqH7u5rnAcaE3dQdqWH.png", alt="A chord shortcut that is already in use.", width="800", height="565" %}
+
+1. Record a new combination and click the {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/7l4ffLtFrht87gVnT0IZ.svg", alt="Check.", width="24", height="24" %} **Check** button.
+
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/3VBJ5QKkUCG1H2FX8f78.png", alt="Save the new shortcut.", width="800", height="565" %}
+
+To revert or delete changes, click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/tby5LrQzKTKzHia2fEBO.svg", alt="Back.", width="24", height="24" %} **Back** or {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/w9Vbnqf9cVz7YeqMkAi0.svg", alt="Delete.", width="24", height="24" %} **Delete**.
+
+By default, DevTools doesn't assign shortcuts to all available actions. For example, to toggle [light and dark theme preference](/docs/devtools/rendering/emulate-css/#emulate-css-media-feature-prefers-color-scheme) with a keystroke, set your own shortcut in the **Shortcuts** > **Rendering** section as described above.
+
+{% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/7oGdE2eRsgwokWXW9XvA.png", alt="Toggle light and dark themes with keyboard shortcut.", width="800", height="576" %}
+
+To bring back defaults, click **Restore default shortcuts** in the bottom-right corner of the **Settings** > **Shortcuts** tab.
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/nQK0bSoeOzjAzWnmC3AY.png", alt="Restore default shortcuts.", width="800", height="463" %}
+
+## Enable experiments {: #experiments }
 
 To enable DevTools experiments:
 

--- a/site/en/docs/devtools/customize/index.md
+++ b/site/en/docs/devtools/customize/index.md
@@ -103,7 +103,7 @@ You can sync your DevTools settings across devices. To enable that, you need to:
 
 To edit keyboard shortcuts:
 
-1. [In DevTools](/docs/devtools/open/), click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/9gzXiTYY0nZzBxGI6KrV.svg", alt="Settings", width="24", height="24" %} **Settings**.
+1. [In DevTools](/docs/devtools/open/), click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/9gzXiTYY0nZzBxGI6KrV.svg", alt="Settings.", width="24", height="24" %} **Settings**.
 
    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/LwoUTAEghXYMyYV5EfIy.png", alt="Settings.", width="800", height="445" %}
 

--- a/site/en/docs/devtools/customize/index.md
+++ b/site/en/docs/devtools/customize/index.md
@@ -94,7 +94,7 @@ You can sync your DevTools settings across devices. To enable that, you need to:
     {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/LUwFNTDyP22L1euSGg73.png", alt="DevTools sync settings", width="800", height="654" %}
 3. Most of the settings are synced, except for the **Workspace**, **Experiments**, and **Devices** tabs and a few other general settings. The state of the **Enable settings sync** checkbox is synced across devices as well.
   For example, the following **appearance** settings are synced so you have a consistent experience across devices and don't need to re-define the same settings again.
-    {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/t8SQuZ4mE2xiLVxaZz11.png", alt="appearance settings", width="800", height="584" %}
+    {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/t8SQuZ4mE2xiLVxaZz11.png", alt="The appearance settings.", width="800", height="584" %}
   However, the **dock** settings isn't sync because developers have different dock preferences when debugging on different sites.
     {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/jWv8rwkF4q6SwTQbSNpp.png", alt="dock", width="426", height="134" %}
 

--- a/site/en/docs/devtools/customize/index.md
+++ b/site/en/docs/devtools/customize/index.md
@@ -96,7 +96,7 @@ You can sync your DevTools settings across devices. To enable that, you need to:
   For example, the following **appearance** settings are synced so you have a consistent experience across devices and don't need to re-define the same settings again.
     {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/t8SQuZ4mE2xiLVxaZz11.png", alt="The appearance settings.", width="800", height="584" %}
   However, the **dock** settings isn't sync because developers have different dock preferences when debugging on different sites.
-    {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/jWv8rwkF4q6SwTQbSNpp.png", alt="dock", width="426", height="134" %}
+    {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/jWv8rwkF4q6SwTQbSNpp.png", alt="The dock.", width="426", height="134" %}
 
 
 ## Customize keyboard shortcuts {: #keyboard-shortcuts }


### PR DESCRIPTION
Documented:
- https://developer.chrome.com/blog/new-in-devtools-107/#shortcuts
- https://developer.chrome.com/blog/new-in-devtools-107/#toggle-themes

Publish on Oct 25.