### PR TITLE
Update artwork in mv2 transition article

### DIFF
--- a/site/en/blog/crx-scripting-api/index.md
+++ b/site/en/blog/crx-scripting-api/index.md
@@ -7,7 +7,7 @@ layout: "layouts/blog-post.njk"
 authors:
   - dotproto
 date: 2021-06-08
-hero: 'image/WlD8wC6g8khYWPJUsQceQkhXSlv1/7SI8nw8jvSCspg2q71ya.png'
+hero: 'image/sQ51XsLqKMgSQMCZjIN0B7hlBO02/i5pqKwKHgLHAt7ZwaP0E.png'
 alt: ''
 tags:
   - extensions

--- a/site/en/blog/more-mv2-transition/index.md
+++ b/site/en/blog/more-mv2-transition/index.md
@@ -6,7 +6,7 @@ layout: "layouts/blog-post.njk"
 authors:
   - dsli
 date: 2022-09-28
-hero: image/WlD8wC6g8khYWPJUsQceQkhXSlv1/GoUHyuctM1Zs9wdy5a2s.png
+hero: image/sQ51XsLqKMgSQMCZjIN0B7hlBO02/fjebBemTd8DpKrEe3ya3.png
 alt: Image with extensions logo and text saying Manifest V3 transition timeline
 tags:
   - extensions

--- a/site/en/blog/mv2-transition/index.md
+++ b/site/en/blog/mv2-transition/index.md
@@ -7,7 +7,7 @@ authors:
   - dsli
 date: 2021-09-23
 updated: 2022-10-03
-hero: image/WlD8wC6g8khYWPJUsQceQkhXSlv1/GoUHyuctM1Zs9wdy5a2s.png
+hero: image/sQ51XsLqKMgSQMCZjIN0B7hlBO02/fjebBemTd8DpKrEe3ya3.png
 alt: Image with extensions logo and text saying Manifest V3 transition timeline
 tags:
   - extensions

--- a/site/en/blog/mv3-actions/index.md
+++ b/site/en/blog/mv3-actions/index.md
@@ -8,7 +8,7 @@ layout: "layouts/blog-post.njk"
 authors:
   - dotproto
 date: 2021-06-23
-hero: 'image/WlD8wC6g8khYWPJUsQceQkhXSlv1/95SnF7CbCqSWiV03WjVF.png'
+hero: 'image/sQ51XsLqKMgSQMCZjIN0B7hlBO02/cAjp0aky7GBuS3ZK9sXB.png'
 alt: ''
 tags:
   - extensions


### PR DESCRIPTION
Remove the words 'Chrome Extensions blog' since we don't have one.


-
-
-