### PR TITLE
Revert "Fix grammar in PNA deprecation trial post"

### DIFF
--- a/site/en/blog/private-network-access-update/index.md
+++ b/site/en/blog/private-network-access-update/index.md
@@ -164,15 +164,20 @@ the circumstances of each affected website.
 
 ### Register for the deprecation trial {: #register-deprecation-trial}
 
-First, register for the "Private Network Access from non-secure contexts" trial
-using [the web developers
-console](/origintrials/#/view_trial/4081387162304512001),
-and obtain a trial token for each affected origin. Then configure your web
-servers to attach the origin-specific `Origin-Trial: $token` header on
-responses. Note that this header need only be set on main resource and
-navigation responses when the resulting document will make use of
-the deprecated feature. It is useless (though harmless) to attach this header to
-subresource responses.
+{% Aside %}
+To participate with multiple origins (such as `examplepetstore.com` and
+`example-pet-store.com`), repeat these steps for each origin.
+{% endAside %}
+
+1. Click [**Register**](/origintrials/#/view_trial/4081387162304512001) for the
+   Private Network Access from non-secure contexts origin trial to obtain a
+   trial token for the participating origin.
+2. Add the origin-specific `Origin-Trial: $token` to your
+   [response header](https://developer.mozilla.org/docs/Glossary/Response_header).
+   This header response header need only be set on main resource and navigation
+   responses when the resulting document makes use of the deprecated feature.
+   It is useless (though harmless) to attach this header to subresource
+   responses.
 
 Since this trial must be enabled or disabled before a document is allowed to
 make any requests, it *cannot* be enabled through a `<meta>` tag. Such tags are

--- a/site/en/blog/private-network-access-update/index.md
+++ b/site/en/blog/private-network-access-update/index.md
@@ -174,7 +174,7 @@ To participate with multiple origins (such as `examplepetstore.com` and
    trial token for the participating origin.
 2. Add the origin-specific `Origin-Trial: $token` to your
    [response header](https://developer.mozilla.org/docs/Glossary/Response_header).
-   This header response header need only be set on main resource and navigation
+   This response header need only be set on main resource and navigation
    responses when the resulting document makes use of the deprecated feature.
    It is useless (though harmless) to attach this header to subresource
    responses.

--- a/site/en/blog/private-network-access-update/index.md
+++ b/site/en/blog/private-network-access-update/index.md
@@ -170,7 +170,7 @@ console](/origintrials/#/view_trial/4081387162304512001),
 and obtain a trial token for each affected origin. Then configure your web
 servers to attach the origin-specific `Origin-Trial: $token` header on
 responses. Note that this header need only be set on main resource and
-navigation responses, and then only when the resulting document will make use of
+navigation responses when the resulting document will make use of
 the deprecated feature. It is useless (though harmless) to attach this header to
 subresource responses.
 

--- a/site/en/blog/private-network-access-update/index.md
+++ b/site/en/blog/private-network-access-update/index.md
@@ -170,7 +170,7 @@ console](/origintrials/#/view_trial/4081387162304512001),
 and obtain a trial token for each affected origin. Then configure your web
 servers to attach the origin-specific `Origin-Trial: $token` header on
 responses. Note that this header need only be set on main resource and
-navigation responses, and only then will the resulting document make use of
+navigation responses, and then only when the resulting document will make use of
 the deprecated feature. It is useless (though harmless) to attach this header to
 subresource responses.
 


### PR DESCRIPTION
Reverts GoogleChrome/developer.chrome.com#3968. @letitz says the original commit changed the meaning of the sentence.

cc @letitz