### PR TITLE
Add PAA landing page and fundamentals page

### DIFF
--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -46,6 +46,8 @@
     - url: /docs/privacy-sandbox/attribution-reporting-experiment
     - url: /docs/privacy-sandbox/attribution-reporting-updates
     - url: /docs/privacy-sandbox/attribution-reporting/summary-reports
+    - url: /docs/privacy-sandbox/private-aggregation
+    - url: /docs/privacy-sandbox/private-aggregation-fundamentals
 - title: i18n.docs.privacy-sandbox.fight-spam
   sections:
     - url: /docs/privacy-sandbox/trust-tokens

--- a/site/en/docs/privacy-sandbox/glossary/index.md
+++ b/site/en/docs/privacy-sandbox/glossary/index.md
@@ -364,7 +364,7 @@ See [Top-Level Domain](#tld) and [eTLD](#etld).
 
 ## Summary report {: #aggregate-report}
 
-An Attribution Reporting API report type. A [summary
+An Attribution Reporting API and Private Aggregation API report type. A [summary
 report](/docs/privacy-sandbox/attribution-reporting/summary-reports/) includes
 aggregated user data and detailed conversion data, resulting from noisy
 aggregation applied to aggregatable reports. The summary

--- a/site/en/docs/privacy-sandbox/private-aggregation-fundamentals/index.md
+++ b/site/en/docs/privacy-sandbox/private-aggregation-fundamentals/index.md
@@ -1,0 +1,226 @@
+---
+layout: 'layouts/doc-post.njk'
+title: 'Private Aggregation API fundamentals'
+subhead: >
+   Key concepts of the Private Aggregation API
+description: >
+   Key concepts of the Private Aggregation API
+date: 2022-10-11
+authors:
+   - kevinkiklee
+---
+
+## Who is this article for?
+
+The [Private Aggregation API]( /docs/privacy-sandbox/private-aggregation) enables aggregate data collection from worklets with access to cross-site data. The concepts shared here are important for developers building reporting functions within Shared Storage and FLEDGE.
+
+*   If you're a **developer** building a reporting system for cross-site measurement. 
+*   If you're a **marketer**, **data scientist**, or other **summary report consumer**, understanding these mechanisms will help you make design decisions to retrieve an optimized summary report.
+
+## Key terms
+
+Before reading this article, it will be helpful to familiarize yourself with key terms and concepts. Each of these terms will be described in-depth within this article.
+
+*   An [_aggregation key](#aggregation-key) _(also known as a bucket) is a predetermined collection of data points. For example, you may want to collect a bucket of location data where the browser reports the country name. An aggregation key may contain more than one dimension (for example, country and ID of your content widget).
+*   An [_aggregatable value_](#aggregatable-value) is an individual data point collected into an aggregation key. In the example where the key is `country`, the value may be `Morocco`.
+*   _Aggregatable reports_ are generated and encrypted within a browser. For the Private Aggregation API, this contains data about a single event.
+*   The _Aggregation Service_ processes data from aggregatable reports to create a summary report.
+*   A _summary report_ is the final output of the aggregation service, and contains noisy aggregated user data and detailed conversion data.
+*   A _[worklet](https://developer.mozilla.org/docs/Web/API/Worklet) _is a piece of infrastructure which allows you to run specific JavaScript functions and return information back to the requester. Within a worklet, you can execute JavaScript but you cannot interact or communicate with the outside page.
+
+## Private Aggregation workflow
+
+When you call the Private Aggregation API with an aggregation key and an aggregatable value, the browser generates an aggregatable report. The reports are sent to your server that batches the reports.  The batched reports are processed later by the Aggregation Service, and a summary report is generated. 
+
+{% Img src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/NqNZ51sVCASKNyNbYoHv.png", alt="a diagram that shows how the data flows from the client, to the collector, to the aggregation service to generate a summary report", width="800", height="211" %}
+
+1. When you call the Private Aggregation API, the client (browser) generates and sends the aggregatable report to your server to be collected.
+2. Your server collects the reports from the clients and batches them to be sent to the Aggregation Service.
+3. Once you've collected enough reports, you'll batch and send them to the Aggregation Service, running in a trusted execution environment, to generate a summary report.
+
+{% Aside 'key-term' %}
+A _trusted execution environment_ is a special configuration of computer hardware and software that allows external parties to verify the exact versions of software running on the computer. TEEs allow external parties to verify that the software does exactly what the software manufacturer claims it does—nothing more or less.
+{% endAside %}
+
+The workflow described in this section is similar to the [Attribution Reporting API](https://docs.google.com/document/d/1bU0a_njpDcRd9vDR0AJjwJjrf3Or8vAzyfuK8JZDEfo/edit#). However, Attribution Reporting associates data gathered from an impression event and a conversion event, which happen at different times. Private Aggregation measures a single, cross-site event. 
+
+# Aggregation key
+
+An _aggregation key_ (“key” for short) represents the bucket where the aggregatable values will be accumulated. One or more dimensions can be encoded into the key. A dimension represents some aspect that you want to gain more insight on, such as the age group of users or the impression count of an ad campaign. 
+
+For example, you may have a widget that is embedded across multiple sites and want to analyze the country of users who have seen your widget. You are looking to answer questions such as “How many of the users who have seen my widget are from Country X?” To report on this question, you can set up an aggregation key that encodes two dimensions: widget ID and country ID. 
+
+The key supplied to the Private Aggregation API is a [BigInt](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt), which consists of multiple dimensions. In this example, the dimensions are the widget ID and country ID. Let's say that the widget ID can be up to 4 digits long such as `1234`, and each country is mapped to a number in alphabetical order such as Afghanistan is `1`, France is `61`, and Zimbabwe is '195'.  Therefore, the aggregatable key would be 7 digits long, where the first 4 characters are reserved for the `WidgetID` and the last 3 characters are reserved for the `CountryID`. 
+
+Let's say the key represents the count of users from France (country ID `061`) who have seen the widget ID `3276`, The aggregation key is `327061`. 
+
+<table>
+  <tr>
+   <td colspan="2" style="background-color: #efefef">Aggregation key
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #d3f1c8">Widget ID
+   </td>
+   <td style="background-color: #92da78">Country ID
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #d3f1c8">3276
+   </td>
+   <td style="background-color: #92da78">061
+   </td>
+  </tr>
+</table>
+
+{% Aside %}
+If a dimension has available key space for multiple digits, but the value has fewer, add leading zeros. For example, if country ID allows 3 digits, the country ID for Algeria is `003`.
+{% endAside %}
+
+The aggregation key can also be generated with a hashing mechanism, such as SHA-256. For example, the string `“WidgetID=3276;CountryID=67”` can be converted to a hex string `c002f0033c108abf3ae0ec654fe38a1792186bfd582380b24ea93ebdeb6395be` which is equivalent to the BigInt `86849257128445315549261263548129498923703362729078813106545648910309959898558n`. 
+
+Some important web APIs that are required to generate a hash, like `[crypto](https://developer.mozilla.org/docs/Web/API/Web_Crypto_API)`, are not currently available within Shared Storage worklets or FLEDGE worklets. As these worklets cannot communicate outside of itself, if you want to create hashes, you need to pre-generate one or more hashes outside the worklet then pass it in.
+
+{% Aside %}
+Although the concepts are similar, the key is constructed differently for the Private Aggregation API than the Attribution Reporting API.  For Attribution Reporting, the key is generated at separate times, during the impression and conversion.  For Private Aggregation, the complete key is specified at the same time, in the JavaScript call.
+{% endAside %}
+
+## Aggregatable value
+
+Aggregatable values are summed per key across many users to generate aggregated insights in the form of summary values in summary reports. 
+
+Let's return to the example question posed above: “How many of the users who have seen my widget are from France?” The answer to this question will look something like “Approximately 4881 users who have seen my Widget ID 3276 are from France.”  The _aggregatable value_ is 1 for each user, and “4881 users” is the _aggregated_ _value_ that is the sum of all _aggregatable_ _values _for that _aggregation key_. 
+
+<table>
+  <tr>
+   <td colspan="2" style="background-color: #efefef">Aggregation key
+   </td>
+   <td style="background-color: #efefef">Aggregatable value
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #d3f1c8">Widget ID
+   </td>
+   <td style="background-color: #92da78">Country ID
+   </td>
+   <td style="background-color: #d2e9ff">View Count
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #d3f1c8">3276
+   </td>
+   <td style="background-color: #92da78">061
+   </td>
+   <td style="background-color: #d2e9ff">1
+   </td>
+  </tr>
+</table>
+
+For this example, we increment the value by 1 for each user who sees the widget.  In practice, the aggregatable value can be scaled to improve [signal-to-noise ratio](https://docs.google.com/document/d/10p_hqAxFp2LKiMaY9nCG4yrKSAi4E8S_hozJiHC-WHQ/edit?resourcekey=0-WcdCSsE19UDSQUOmXjuITg#heading=h.s9h4edeedak3).
+
+### Contribution budget
+
+Each call to the Private Aggregation API is called a _contribution_. To protect user privacy, the number of contributions which can be collected from an individual are limited.
+
+When you sum all aggregatable values across all aggregation keys, the sum must be less than the contribution budget. The budget is scoped per-worklet [origin](https://web.dev/same-site-same-origin/#origin), per-day, and is separate for FLEDGE and Shared Storage worklets. A rolling window of approximately the last 24 hours is used for the day. If a new aggregatable report would cause the budget to be exceeded, the report is not created.
+
+The _contribution budget_ is represented by the parameter `L<sub>1</sub>`, and for the current Privacy Sandbox Origin Trial, the contribution budget has been set to 2<sup>16</sup> = 65,536.  The value of the contribution budget is arbitrary where noise is scaled to it, and you can use this budget to maximize signal-to-noise ratio on the summary values (discussed more below in the [Noise and scaling](https://docs.google.com/document/d/10p_hqAxFp2LKiMaY9nCG4yrKSAi4E8S_hozJiHC-WHQ/edit?resourcekey=0-WcdCSsE19UDSQUOmXjuITg#bookmark=kix.7cm3k1gmii1w) section below). 
+
+To learn more about contribution budgets, see the [explainer](https://github.com/patcg-individual-drafts/private-aggregation-api#contribution-bounding-and-budgeting). Also, refer to the [Contribution Budget section of the Attribution Reporting strategy guide](https://docs.google.com/document/d/1bU0a_njpDcRd9vDR0AJjwJjrf3Or8vAzyfuK8JZDEfo/edit#) for more guidance. 
+
+## Aggregatable reports
+
+Once the user invokes the Private Aggregation API, the browser generates aggregatable reports to be processed by the Aggregation Service at a later point in time to generate summary reports. An aggregatable report is JSON-formatted and contains an encrypted list of contributions, each one being an `{aggregation key, aggregatable value}` pair. Aggregatable reports are sent with a random delay up to one hour. 
+
+The contributions are encrypted and not readable outside of Aggregation Service. The Aggregation Service decrypts the reports and generates a summary report. The encryption key for the browser and the decryption key for the Aggregation Service are issued by the coordinator, which acts as the key management service. The coordinator keeps a list of binary hashes of the service image to verify that the caller is allowed to receive the decryption key. 
+
+An example aggregatable report with [debug mode](https://docs.google.com/document/d/1Bou-N1iz_WoQ9xJr6CRbpwRMV6TxH2ohE7HSpC67LDI/edit?resourcekey=0-jsroTC4qkmDYFb_d5KtxNA#bookmark=id.a6i86ca76utk) enabled: 
+
+```js
+  "aggregation_service_payloads": [
+    {
+      "debug_cleartext_payload": "omRkYXRhgaJldmFsdWVEAAAAgGZidWNrZXRQAAAAAAAAAAAAAAAAAAAE0mlvcGVyYXRpb25paGlzdG9ncmFt",
+      "key_id": "2cc72b6a-b92f-4b78-b929-e3048294f4d6",
+      "payload": "a9Mk3XxvnfX70FsKrzcLNZPy+00kWYnoXF23ZpNXPz/Htv1KCzl/exzplqVlM/wvXdKUXCCtiGrDEL7BQ6MCbQp1NxbWzdXfdsZHGkZaLS2eF+vXw2UmLFH+BUg/zYMu13CxHtlNSFcZQQTwnCHb"
+    }
+  ],
+  "debug_key": "777",
+  "shared_info": "{\"api\":\"private-aggregation\",\"debug_mode\":\"enabled\",\"report_id\":\"5bc74ea5-7656-43da-9d76-5ea3ebb5fca5\",\"reporting_origin\":\"https://localhost:4437\",\"scheduled_report_time\":\"1664907229\",\"version\":\"0.1\"}"
+```
+
+The aggregatable reports can be inspected from the `chrome://private-aggregation-internals` page: 
+
+{% Img src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/mUpLvkqjpzATYeKtUDrW.png", alt="screenshot of the Private Aggregation API internals page", width="800", height="303" %}
+
+For testing purposes, the “Send Selected Reports” button can be used to send the report to the server immediately. 
+
+### Collecting and batching aggregatable reports
+
+The browser sends the aggregatable reports to the origin of the worklet containing the call to the Private Aggregation API, using the listed well-known path:
+
+*   For Shared Storage: `/.well-known/private-aggregation/report-shared-storage`
+*   For FLEDGE: `/.well-known/private-aggregation/report-fledge`
+
+At these endpoints, you will need to operate a server — acting as a collector — that receives the aggregatable reports sent from the clients.
+
+The server should then batch reports and send the batch to the Aggregation Service.  Create batches based on the information available in the unencrypted payload of the aggregatable report, such as the `shared\_info` field. Ideally, the batches should contain 100 or more reports per batch. 
+
+You may decide to batch on a daily or weekly basis. This strategy is flexible, and you can change your batching strategy for specific events where you expect more volume—for example, days of the year when more impressions are expected. Batches should include reports from the same API version, reporting origin, and schedule report time. 
+
+## Aggregation Service
+
+{% Img src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/b1avI43zUaKT2UAdGOo1.png", alt="how the aggregation service runs in a trusted execution environment", width="800", height="457" %}
+
+The Aggregation Service receives encrypted aggregatable reports from the collector and generates summary reports with noise. To decrypt the report payload, the Aggregation Service fetches a decryption key from the coordinator. The service runs in a trusted execution environment (TEE), which provides a level of assurance for data integrity, data confidentiality, and code integrity. Though you own and operate the service, you will not have visibility into the data being processed inside the TEE.  
+
+For each aggregation key, the aggregatable values from the aggregatable reports are summed, then the result is returned in a summary report with noise added. 
+
+{% Aside %}
+At this time, the Aggregation Service and its local testing tool only process aggregatable reports for the Attribution Reporting API. This will be updated to support the Private Aggregation API soon.
+{% endAside %}
+
+## Summary reports
+
+Summary reports allow you to see the data you have collected with noise added. You can request summary reports for a given set of keys.  
+
+A summary report contains a JSON dictionary-style set of key-value pairs. Each pair contains:
+*   _`bucket`_: the aggregation key as a binary number string.  If the aggregation key used is “123”, then the bucket is “1111011”.
+*   _`value`_: the summary value for a given measurement goal, summed up from all available aggregatable reports with noise added.
+
+Example:
+
+```js
+[
+  {"bucket":` `"111001001",` `"value":` `"2558500"},  
+  {"bucket":` `"111101001",` `"value":` `"3256211"},  
+  {"bucket":` `"111101001",` `"value":` `"6536542"},  
+]
+```
+
+### Noise and scaling
+
+To preserve user privacy, the Aggregation Service adds noise once to each summary value every time a summary report is requested.  The noise values are randomly drawn from a [Laplace probability distribution](https://en.wikipedia.org/wiki/Laplace_distribution).  While you are not in direct control of the ways noise is added, you can influence the impact of noise on its measurement data. 
+
+The noise distribution is the same regardless of the sum of all aggregatable values. Therefore, the higher the aggregatable values, the less impact the noise is likely to have.
+
+For example, let's say the noise distribution has a standard deviation of 100 and is centered at zero. If the collected aggregatable report value (or “aggregatable value”) is only 200, then the noise's standard deviation would be 50% of the aggregated value. But, if the aggregatable value is 20,000, then the noise's standard deviation would only be 0.5% of the aggregated value. So, the aggregatable value of 20,000 would have a much higher signal-to-noise ratio.
+
+Therefore, multiplying your aggregatable value by a scaling factor can help reduce noise. The scaling factor represents how much you want to scale a given aggregatable value.
+
+{% Img src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/qJ182Vhszwsgf1PVLEpT.png", alt="how noise is constant regardless of the aggregated value", width="600", height="462" %}
+
+Scaling the values up by choosing a larger scaling factor reduces the relative noise. However, this also causes the sum of all contributions across all buckets to reach the contribution budget limit faster. Scaling the values down by choosing a smaller scaling factor constant increases relative noise, but reduces the risk of reaching the budget limit.
+
+{% Img src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/qgDt0a7GaMFJ07zibVUw.png", alt="scaling the aggregatable value to the contribution budget", width="400", height="340" %}
+
+To calculate an appropriate scaling factor, divide the contribution budget by the maximum sum of aggregatable values across all keys.  
+
+See the [Contribution section of the Attribution Reporting strategy guide](https://docs.google.com/document/d/1bU0a_njpDcRd9vDR0AJjwJjrf3Or8vAzyfuK8JZDEfo/edit#heading=h.683u7t2q1xk2) to learn more. 
+
+## Engage and share feedback
+
+The Private Aggregation API proposal is under active discussion and subject to change in the future. If you try this API and have feedback, we'd love to hear it.
+
+*   **GitHub**: Read the [proposal](https://github.com/patcg-individual-drafts/private-aggregation-api), [raise questions and participate in discussion](https://github.com/patcg-individual-drafts/private-aggregation-api/issues).
+*   **Developer support**: Ask questions and join discussions on the [Privacy Sandbox Developer Support repo](https://github.com/GoogleChromeLabs/privacy-sandbox-dev-support).
+*   Join the [Shared Storage API group](https://groups.google.com/a/chromium.org/g/shared-storage-api-announcements) and the [FLEDGE API group](https://groups.google.com/a/chromium.org/g/fledge-api-announce/) for the latest announcements related to Private Aggregation. 

--- a/site/en/docs/privacy-sandbox/private-aggregation/index.md
+++ b/site/en/docs/privacy-sandbox/private-aggregation/index.md
@@ -1,0 +1,189 @@
+---
+layout: 'layouts/doc-post.njk'
+title: 'Private Aggregation API'
+subhead: >
+   Generate noisy summary reports with cross-site data in a privacy-preserving manner
+description: >
+   Generate noisy summary reports with cross-site data in a privacy-preserving manner
+date: 2022-10-11
+authors:
+   - kevinkiklee
+---
+
+Privacy Sandbox proposals aim to reduce cross-site tracking while supporting legitimate use cases that respect user’s privacy. It’s important that companies can still measure cross-site data such as reach measurement. To provide critical features that the web relies on, the Private Aggregation API has been proposed for aggregating cross-site data in a privacy-preserving manner. 
+
+## Implementation status
+
+This document outlines a new proposal for cross-site measurement.
+
+* The [Private Aggregation API](https://github.com/patcg-individual-drafts/private-aggregation-api/) has entered [public discussion](https://github.com/patcg-individual-drafts/private-aggregation-api/issues).
+* Private Aggregation API is available for testing in Chrome M107+ Canary and Dev.
+
+## What is the Private Aggregation API
+
+The Private Aggregation API enables aggregate data collection from worklets with access to cross-site data such as [FLEDGE](/docs/privacy-sandbox/fledge/) and [Shared Storage](/docs/privacy-sandbox/shared-storage/). 
+
+This API proposal provides one operation, `sendHistogramReport()`, but more may be supported in the future. The histogram operation allows you to aggregate data across users in each bucket (known in the API as an aggregation key) you define. Your histogram call accumulates values and returns a noised aggregated result in the form of a summary report. For instance, the report might show the number of sites each user has seen your content on, or come across a bug in your third-party script. This operation is performed within another API’s worklet.
+
+{% Aside 'key-term' %}
+A _[worklet](https://developer.mozilla.org/docs/Web/API/Worklet)_ allows you to run specific JavaScript functions and return information back to the requester. Within a worklet, you can execute JavaScript but you cannot interact or communicate with the outside page.
+{% endAside %}
+
+For example, if you have previously recorded demographic and geographic data in Shared Storage, you can use the Private Aggregation API to construct a histogram that tells you approximately how many users in New York City have seen your content cross-site. To aggregate for this measurement, you can encode the geography dimension into the aggregation key and count the users in the aggregatable value.
+
+### Key concepts
+
+When you call the [Private Aggregation API](https://github.com/patcg-individual-drafts/private-aggregation-api) with an aggregation key and an aggregatable value, the browser generates an aggregatable report. The reports are sent to your server that batches the reports. The batched reports are processed later by the [Aggregation Service](https://github.com/WICG/attribution-reporting-api/blob/main/AGGREGATION_SERVICE_TEE.md), and a summary report is generated. 
+
+See the [Private Aggregation API fundamentals](https://docs.google.com/document/d/10p_hqAxFp2LKiMaY9nCG4yrKSAi4E8S_hozJiHC-WHQ/edit) document to learn more about the key concepts involved with the Private Aggregation API.
+
+### Differences from Attribution Reporting
+
+The Private Aggregation API shares many similarities with the [Attribution Reporting API](/docs/privacy-sandbox/attribution-reporting/). Attribution Reporting is a standalone API designed to measure conversions, whereas Private Aggregation is built for cross-site measurements in conjunction with APIs like FLEDGE and Shared Storage. Both APIs produce aggregatable reports that are consumed by the Aggregation Service back-end to generate summary reports. 
+
+Attribution Reporting associates data gathered from an impression event and a conversion event, which happen at different times. Private Aggregation measures a single, cross-site event. 
+
+## Test this API
+
+The API is available in the [Privacy Sandbox unified origin trial](/docs/privacy-sandbox/unified-origin-trial/) on Chrome Canary and Dev M107 or later. Learn how you can register for a [third-party origin trial](/docs/web-platform/third-party-origin-trials/).
+
+The Private Aggregation API can also be locally tested by enabling the Privacy Sandbox Ads APIs experiment flag at ``chrome://flags/#privacy-sandbox-ads-apis``.
+
+{% Img
+	src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/CWfgCMJQ5cYPOfjttF3k.png",
+	alt="Set Privacy Sandbox Ads APIs experiment to enabled to use these APIs",
+	width="744", height="124"
+%}
+
+{% Aside %}
+At this time, the Aggregation Service back-end and its local testing tool only process aggregatable reports for the Attribution Reporting API. This will be updated to support the Private Aggregation API soon.
+{% endAside %}
+
+### Use the demo
+
+The demo of Private Aggregation API for Shared Storage can be accessed at [goo.gle/shared-storage-demo](http://goo.gle/shared-storage-demo), and the code is available on [GitHub](https://github.com/GoogleChromeLabs/shared-storage-demo). The demo implements the client-side operations and produces an aggregatable report that is sent to your server. 
+
+A demo of Private Aggregation API for FLEDGE will be published in the future, once the proposal has been finalized. 
+
+## Use cases
+
+Private Aggregation is a general purpose API for cross-site measurement, and it’s available to be used in [Shared Storage](/docs/privacy-sandbox/shared-storage/) and [FLEDGE](/docs/privacy-sandbox/fledge/) worklets. The first step is to decide specifically what information you want to collect. Those data points are the basis of your aggregation keys.
+
+### With Shared storage
+
+Shared Storage allows you to read and write cross-site data in a secure environment to prevent leakage, and the Private Aggregation API allows you to measure cross-site data stored in Shared Storage. 
+
+#### Unique reach measurement
+
+You may want to measure how many unique users have seen their content. Private Aggregation API can provide an answer such as “Approximately 317 unique users have seen the Content ID 861”. 
+
+You can set a flag in Shared Storage to signify whether the user has already seen the content or not. On the first visit where the flag does not exist, a call to Private Aggregation is made and then the flag is set. On subsequent visits by the user, including cross-site visits, you can check Shared Storage and skip submitting a report to Private Aggregation if the flag is set. 
+
+#### Demographics measurement
+
+You may want to measure the demographics of the users who have seen your content across different sites. Private Aggregation can provide an answer, such as “Approximately 317 unique users are from the age of 18-45 and are from Germany.” Use [Shared Storage](/en/docs/privacy-sandbox/shared-storage/) to access demographics data from a third-party context. At a later point in time, you can generate a report with Private Aggregation by encoding the age group and country dimensions in the aggregation key. 
+
+#### K+ frequency measurement
+
+You may want to measure the number of users who have seen a piece of content or an ad at least K times on a given browser, for a pre-chosen value of K. Private Aggregation can provide an answer such as “Approximately 89 users have seen the Content ID 581 at least 3 times.” A counter can be incremented in Shared Storage from different sites and can be read within a worklet. When the count has reached K, a report can be submitted via Private Aggregation. 
+
+### With FLEDGE
+
+FLEDGE enables retargeting and custom audience use cases, and Private Aggregation will allow you to report events from buyer and seller worklets. The API can be used for tasks such as measuring the distribution of auction bids. The Private Aggregation API design for FLEDGE has not been finalized. We will publish additional content once a more complete design is available in FLEDGE.
+
+## Available operations
+
+The following functions are available in the `privateAggregation` object available in Shared Storage and FLEDGE worklets. To learn how to run your code in a worklet, refer to the [Shared Storage code samples](/docs/privacy-sandbox/use-shared-storage/). 
+
+### sendHistogramReport()
+
+You can call `privateAggregation.sendHistogramReport({ bucket: &lt;bucket>, value: &lt;value> })` with the _aggregation key_ as `bucket` and the _aggregatable value_ as `value`. For the `bucket` parameter, a `BigInt` is required. For the `value` parameter, an integer Number is required.
+
+Here is an example of how it may be called in Shared Storage for reach measurement: 
+
+
+`iframe.js`
+
+```js
+// Cross-site iframe code
+
+async function measureReach() {
+ // Register worklet
+ await window.sharedStorage.worklet.addModule('worklet.js');
+
+ // Run reach measurement operation
+ await window.sharedStorage.run('reach-measurement', { 
+  data: { contentId: '1234' } 
+ });
+}
+
+`measureReach();`
+```
+
+`worklet.js`
+
+```js
+// Shared storage worklet code
+
+function convertContentIdToBucket(camapignId){ 
+  // Generate aggregation key
+}
+
+// The scale factor is multiplied by the aggregatable value to
+// maximize the signal-to-noise ratio. See "Noise and scaling" 
+// section in the Aggregation Fundamentals document to learn more.
+const SCALE_FACTOR = 65536;
+
+class ReachMeasurementOperation {
+  async run(data) {
+    const key = 'has-reported-content';
+    // Read the flag from Shared Storage
+    const hasReportedContent = await this.sharedStorage.get(key) === 'true';
+
+    // Do not send report if the flag is set
+    if (hasReportedContent) {
+      return;
+    }
+
+    // Send histogram report
+    // Set the aggregation key in `bucket`
+    // Bucket examples: 54153254n or BigInt(54153254)
+    // Set the scaled aggregatable value in `value`
+    privateAggregation.sendHistogramReport({
+      bucket: convertContentIdToBucket(data.contentId), 
+      value: 1 * SCALE_FACTOR 
+    });
+
+    // Set the flag in Shared Storage
+    await this.sharedStorage.set(key, true);
+  }
+}
+
+register('reach-measurement', ReachMeasurementOperation);
+```
+
+The above code example will call Private Aggregation whenever the cross-site iframe content is loaded. The iframe code loads the worklet, and the worklet calls the Private Aggregation API with the content ID converted to an aggregation key (bucket). 
+
+### enableDebugMode()
+
+While third-party cookies are still available, we will provide a temporary mechanism that allows easier debugging and testing by enabling the debug mode. A debug report is useful in comparing your cookie-based measurements with your Private Aggregation measurements, and also allows you to quickly validate your API integration. 
+
+Calling `privateAggregation.enableDebugMode()` in the worklet enables the debug mode which causes aggregatable reports to include the unencrypted (cleartext) payload. You can then process these payloads with the Aggregation Service [local testing tool](https://github.com/google/trusted-execution-aggregation-service#set-up-local-testing). 
+
+You can also set the debug key by calling `privateAggregation.enableDebugMode({ debug_key: &lt;debug_key> })` where a BigInt can be used as a debug key. The debug key can be used to associate data from a cookie-based measurement and data from Private Aggregation measurement. These can be called only once per context. Any subsequent calls will be ignored.
+
+```js
+// Enables debug mode
+privateAggregation.enableDebugMode();
+
+// Enables debug mode and sets a debug key
+privateAggregation.enableDebugMode({ debug_key: BigInt(1234) });
+```
+
+## Engage and share feedback
+
+The Private Aggregation API proposal is under active discussion and subject to change in the future. If you try this API and have feedback, we'd love to hear it.
+
+*  **GitHub**: Read the [proposal](https://github.com/patcg-individual-drafts/private-aggregation-api), [raise questions and participate in discussion](https://github.com/patcg-individual-drafts/private-aggregation-api/issues).
+*  **Developer support**: Ask questions and join discussions on the [Privacy Sandbox Developer Support repo](https://github.com/GoogleChromeLabs/privacy-sandbox-dev-support).
+*  Join the [Shared Storage API group](https://groups.google.com/a/chromium.org/g/shared-storage-api-announcements) and the [FLEDGE API group](https://groups.google.com/a/chromium.org/g/fledge-api-announce/) for the latest announcements related to Private Aggregation. 


### PR DESCRIPTION
This PR adds the following documents to DCC:
* Private Aggregation API
* Private Aggregation API fundamentals