### PR TITLE
Replace 4-space tab with 2-space tab

### DIFF
--- a/site/en/docs/extensions/mv3/getstarted/tut-reading-time/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/tut-reading-time/index.md
@@ -117,14 +117,14 @@ Add the following code to the `manifest.json` to register a content script calle
 {
   ...
   "content_scripts": [
-      {
-        "js": ["scripts/content.js"],
-        "matches": [
-          "https://developer.chrome.com/docs/extensions/*",
-          "https://developer.chrome.com/docs/webstore/*"
-        ]
-      }
-    ]
+    {
+      "js": ["scripts/content.js"],
+      "matches": [
+        "https://developer.chrome.com/docs/extensions/*",
+        "https://developer.chrome.com/docs/webstore/*"
+      ]
+    }
+  ]
 }
 ```
 


### PR DESCRIPTION
One tab that used 4 spaces is reduced to be consistent with other tab sizes: 2 spaces

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

-
-
-