### PR TITLE
Add timezone info for CrUX

### DIFF
--- a/site/en/docs/crux/api/index.md
+++ b/site/en/docs/crux/api/index.md
@@ -256,7 +256,7 @@ As of October 2022, the CrUX API contains a `collectionPeriod` object with `firs
 
 This allows better understanding of the data and whether it's been updated yet for that day or is returning the same data as yesterday.
 
-Note that the CrUX API is approximately two days behind today's date since it waits for completed data for the day, and there is some processing time involved before it is available in the API.
+Note that the CrUX API is approximately two days behind today's date since it waits for completed data for the day, and there is some processing time involved before it is available in the API. The timezone used is Pacific Standard Time (PST) with no changes for daylight savings.
 
 ## Example queries
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Adds a note as to the timezone used for CrUX and what constitutes a "day"
