### PR TITLE
Update webdev-infra to 1.0.33

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -69,7 +69,6 @@ jobs:
         run: npm run lint:scss
 
       - name: Build External
-        if: ${{ steps.filter.outputs._external == 'true' }}
         run: npm run build-external
 
       - name: Build Eleventy

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "unistore": "^3.5.2",
         "uslug": "^1.0.4",
         "web-vitals": "^3.0.0",
-        "webdev-infra": "^1.0.32",
+        "webdev-infra": "^1.0.33",
         "xss": "^1.0.14"
       },
       "devDependencies": {
@@ -26842,9 +26842,9 @@
       "integrity": "sha512-3Gh6rH5aetFYqfkl9V59KCvjj9vp9U2Tkaep9MO+xpAVg+JULmQfi5zEkcPLkE6iU8pNYVwdjHvIU8RFAchYyQ=="
     },
     "node_modules/webdev-infra": {
-      "version": "1.0.32",
-      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.32.tgz",
-      "integrity": "sha512-lGxr9z+5FdTmzVvo/YkOCeOvv8wuPdz/pz+fuZbmN4rhlvC1XkzJoKf50Tis7vSH2cXoOLULTqAoR3ip2zOBDg==",
+      "version": "1.0.33",
+      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.33.tgz",
+      "integrity": "sha512-yUHRoZw4QZvSLCe6y/RLqla9z8WGqxJ8AO1rvI2UCDhtRZpSZJo1WUdZ7VIIiuijqOiTrGQlzmbzLfnSArIbHw==",
       "dependencies": {
         "@imgix/js-core": "^3.1.3",
         "@justinribeiro/lite-youtube": "^0.9.1",
@@ -48352,9 +48352,9 @@
       "integrity": "sha512-3Gh6rH5aetFYqfkl9V59KCvjj9vp9U2Tkaep9MO+xpAVg+JULmQfi5zEkcPLkE6iU8pNYVwdjHvIU8RFAchYyQ=="
     },
     "webdev-infra": {
-      "version": "1.0.32",
-      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.32.tgz",
-      "integrity": "sha512-lGxr9z+5FdTmzVvo/YkOCeOvv8wuPdz/pz+fuZbmN4rhlvC1XkzJoKf50Tis7vSH2cXoOLULTqAoR3ip2zOBDg==",
+      "version": "1.0.33",
+      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.33.tgz",
+      "integrity": "sha512-yUHRoZw4QZvSLCe6y/RLqla9z8WGqxJ8AO1rvI2UCDhtRZpSZJo1WUdZ7VIIiuijqOiTrGQlzmbzLfnSArIbHw==",
       "requires": {
         "@imgix/js-core": "^3.1.3",
         "@justinribeiro/lite-youtube": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "unistore": "^3.5.2",
     "uslug": "^1.0.4",
     "web-vitals": "^3.0.0",
-    "webdev-infra": "^1.0.32",
+    "webdev-infra": "^1.0.33",
     "xss": "^1.0.14"
   },
   "devDependencies": {


### PR DESCRIPTION
This updates webdev-infra to 1.0.33, which includes https://github.com/GoogleChrome/webdev-infra/pull/35.

With this change Cloud Build's deploy step should be significantly faster as inlined SVGs in pages do no change with every build and by this requiring a smaller subset of files to update/upload.