### PR TITLE
Separate shared storage use cases

### DIFF
--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -26,7 +26,7 @@
 - title: i18n.docs.privacy-sandbox.storage
   sections:
     - url: /docs/privacy-sandbox/shared-storage
-    - url: /docs/privacy-sandbox/shared-storage/url-selection
+    - url: /docs/privacy-sandbox/shared-storage/frequency-control
     - url: /docs/privacy-sandbox/shared-storage/ab-testing
     - url: /docs/privacy-sandbox/shared-storage/creative-rotation
     - url: /docs/privacy-sandbox/shared-storage/known-customer

--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -23,8 +23,6 @@
     - url: /docs/privacy-sandbox/fenced-frame
     - url: /docs/privacy-sandbox/fedcm
     - url: /docs/privacy-sandbox/permissions-policy
-- title: i18n.docs.privacy-sandbox.storage
-  sections:
     - url: /docs/privacy-sandbox/shared-storage
     - url: /docs/privacy-sandbox/shared-storage/frequency-control
     - url: /docs/privacy-sandbox/shared-storage/ab-testing

--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -23,8 +23,13 @@
     - url: /docs/privacy-sandbox/fenced-frame
     - url: /docs/privacy-sandbox/fedcm
     - url: /docs/privacy-sandbox/permissions-policy
+- title: i18n.docs.privacy-sandbox.storage
+  sections:
     - url: /docs/privacy-sandbox/shared-storage
-    - url: /docs/privacy-sandbox/use-shared-storage
+    - url: /docs/privacy-sandbox/shared-storage/url-selection
+    - url: /docs/privacy-sandbox/shared-storage/ab-testing
+    - url: /docs/privacy-sandbox/shared-storage/creative-rotation
+    - url: /docs/privacy-sandbox/shared-storage/known-customer
 - title: i18n.docs.privacy-sandbox.tracking-prevention
   sections:
     - url: /docs/privacy-sandbox/user-agent

--- a/site/_data/i18n/docs/privacy-sandbox.yml
+++ b/site/_data/i18n/docs/privacy-sandbox.yml
@@ -20,6 +20,8 @@ overview-article:
   en: 'Introduction'
 status:
   en: 'Is it ready yet?'
+storage:
+  en: 'Secure cross-site storage'
 trust-tokens:
   en: 'Trust Tokens'
 start:

--- a/site/_includes/content/privacysandbox-partials/sharedstorage-engage.njk
+++ b/site/_includes/content/privacysandbox-partials/sharedstorage-engage.njk
@@ -1,0 +1,9 @@
+## Engage and share feedback
+
+The Shared Storage proposal is under active discussion and subject to change
+in the future. If you try this API and have feedback, we'd love to hear it.
+
+*  **GitHub**: Read the
+   [proposal](https://github.com/pythagoraskitty/shared-storage), [raise questions and participate in discussion](https://github.com/pythagoraskitty/shared-storage/issues).
+*  **Developer support**: Ask questions and join discussions on the
+   [Privacy Sandbox Developer Support repo](https://github.com/GoogleChromeLabs/privacy-sandbox-dev-support).

--- a/site/_scss/blocks/_landing-section-expanded.scss
+++ b/site/_scss/blocks/_landing-section-expanded.scss
@@ -66,6 +66,12 @@
     ul {
       list-style: none;
       padding: 0;
+      -moz-column-count: 2;
+      -moz-column-gap: 20px;
+      -webkit-column-count: 2;
+      -webkit-column-gap: 20px;
+      column-count: 2;
+      column-gap: 20px
     }
   }
   

--- a/site/_scss/blocks/_landing-section-expanded.scss
+++ b/site/_scss/blocks/_landing-section-expanded.scss
@@ -65,7 +65,7 @@
   .related-articles {
     ul {
       column-count: 2;
-      column-gap: 20px
+      column-gap: 20px;
       list-style: none;
       padding: 0;
     }

--- a/site/_scss/blocks/_landing-section-expanded.scss
+++ b/site/_scss/blocks/_landing-section-expanded.scss
@@ -66,10 +66,6 @@
     ul {
       list-style: none;
       padding: 0;
-      -moz-column-count: 2;
-      -moz-column-gap: 20px;
-      -webkit-column-count: 2;
-      -webkit-column-gap: 20px;
       column-count: 2;
       column-gap: 20px
     }

--- a/site/_scss/blocks/_landing-section-expanded.scss
+++ b/site/_scss/blocks/_landing-section-expanded.scss
@@ -64,10 +64,10 @@
 
   .related-articles {
     ul {
-      list-style: none;
-      padding: 0;
       column-count: 2;
       column-gap: 20px
+      list-style: none;
+      padding: 0;
     }
   }
   

--- a/site/en/docs/privacy-sandbox/shared-storage/ab-testing/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/ab-testing/index.md
@@ -127,8 +127,8 @@ Explore other Shared Storage use cases and code samples:
    You can store the creative rotation mode, and other metadata, to rotate the
    creatives across different sites. 
 *  [**Known customer for payment provider**](/docs/privacy-sandbox/shared-storage/known-customer):
-   You can store whether the user has registered on your site into Shared
-   Storage, then render a different element based on that stored status.
+   You can store whether the user has registered on your site into shared
+   storage, then render a different element based on that stored status.
 
 These are only some of the possible use cases for Shared Storage. We'll
 continue to add examples as we

--- a/site/en/docs/privacy-sandbox/shared-storage/ab-testing/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/ab-testing/index.md
@@ -11,9 +11,10 @@ authors:
   - kevinkiklee
 ---
 
-The Shared Storage proposal intends to create a general purpose cross-site
-storage API which supports many possible use cases. One such example is A/B
-testing, which is available to test in Chrome 104.0.5086.0 and later.
+The [Shared Storage API](/docs/privacy-sandbox/shared-storage/) is a Privacy
+Sandbox proposal for general purpose, cross-site storage, which supports many
+possible use cases. One such example is A/B testing, which is available to test
+in Chrome 104.0.5086.0 and later.
 
 With URL selection, you can assign a user to an experiment group, then store
 that group in Shared Storage to be accessed in a cross-site environment. 

--- a/site/en/docs/privacy-sandbox/shared-storage/ab-testing/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/ab-testing/index.md
@@ -1,0 +1,138 @@
+---
+layout: 'layouts/doc-post.njk'
+title: 'A/B Testing'
+subhead: >
+  Use a Shared Storage worklet to run A/B testing.
+description: >
+  Use a Shared Storage worklet to run A/B testing.
+date: 2022-10-15
+authors:
+  - alexandrawhite
+  - kevinkiklee
+---
+
+The Shared Storage proposal intends to create a general purpose cross-site
+storage API which supports many possible use cases. One such example is A/B
+testing, which is available to test in Chrome 104.0.5086.0 and later.
+
+With URL selection, you can assign a user to an experiment group, then store
+that group in Shared Storage to be accessed in a cross-site environment. 
+
+## Try A/B testing
+
+To experiment with A/B testing with Shared Storage, confirm you're using Chrome 104.0.5086.0 or later. Then enable the **Privacy Sandbox Ads APIs experiment** flag at `chrome://flags/#privacy-sandbox-ads-apis`.
+
+{% Img
+	src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/CWfgCMJQ5cYPOfjttF3k.png",
+	alt="Set Privacy Sandbox Ads APIs experiment to enabled to use these APIs",
+	width="744", height="124"
+%}
+
+You can also enable Shared Storage with the `--enable-features=PrivacySandboxAdsAPIsOverride,OverridePrivacySandboxSettingsLocalTesting,SharedStorageAPI,FencedFrames` flag in the command line. 
+
+## Experiment with code samples
+
+{% Aside %}
+
+The following code samples were created to demonstrate how the API may be used
+for the given use cases. These are not meant to be used in production.
+
+{% endAside %}
+
+
+To see if an experiment has the desired effect, you can run A/B testing across
+multiple sites. As an advertiser, you can choose to render a different ad based
+on what group the user is assigned to. The group assignment is saved in shared
+storage.
+
+In this example:
+
+*  `ab-testing.js` should be embedded in an ad iframe, which maps a control and
+   two experiment ads. The script calls the shared storage worklet for the experiment.
+*  `ab-testing-worklet.js`  is the shared storage worklet that returns which
+   group the user is assigned to, determining which ad is shown.
+
+**[ab-testing.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/advertiser/ab-testing.js)**
+
+```javascript
+// Map the experiment groups to the URLs
+const EXPERIMENT_MAP = [
+  {
+    group: 'control',
+    url: `https://advertiser.example/ads/default-ad.html`,
+  },
+  {
+    group: 'experiment-a',
+    url: `https://advertiser.example/ads/experiment-ad-a.html`,
+  },
+  {
+    group: 'experiment-b',
+    url: `https://advertiser.example/ads/experiment-ad-b.html`,
+  },
+];
+
+// Choose a random group for the initial experiment
+function getRandomExperiment() {
+  const randomIndex = Math.floor(Math.random() * EXPERIMENT_MAP.length);
+  return EXPERIMENT_MAP[randomIndex].group;
+}
+
+async function injectAd() {
+  // Load the worklet module
+  await window.sharedStorage.worklet.addModule('ab-testing-worklet.js');
+
+  // Set the initial value in the storage to a random experiment group
+  window.sharedStorage.set('ab-testing-group', getRandomExperiment(), {
+    ignoreIfPresent: true,
+  });
+
+  const urls = EXPERIMENT_MAP.map(({ url }) => ({ url }));
+  const groups = EXPERIMENT_MAP.map(({ group }) => group);
+
+  // Run the URL selection operation to select an ad based on the experiment group in shared storage
+  const opaqueURL = await window.sharedStorage.selectURL('ab-testing', urls, { data: groups });
+
+  // Render the opaque URL into a fenced frame
+  document.getElementById('ad-slot').src = opaqueURL;
+}
+
+injectAd();
+```
+
+**[ab-testing-worklet.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/advertiser/ab-testing-worklet.js)**
+
+```javascript
+class SelectURLOperation {
+  async run(urls, data) {
+    // Read the user's group from shared storage
+    const experimentGroup = await this.sharedStorage.get('ab-testing-group');
+
+    // Return the index of the group
+    return data.indexOf(experimentGroup);
+  }
+}
+
+register('ab-testing', SelectURLOperation);
+```
+
+## Other use cases
+
+Explore other Shared Storage use cases and code samples:
+
+*  [**URL selection**](/docs/privacy-sandbox/shared-storage/url-selection): run
+   a worklet script to select a URL from a provided list, based on the stored
+   data, and then render that URL in a fenced frame. This has many possible
+   uses, such as selecting new  ads when a frequency cap is reached.
+*  [**Creative rotation**](/docs/privacy-sandbox/shared-storage/creative-rotation):
+   You can store the creative rotation mode, and other metadata, to rotate the
+   creatives across different sites. 
+*  [**Known customer for payment provider**](/docs/privacy-sandbox/shared-storage/known-customer):
+   You can store whether the user has registered on your site into Shared
+   Storage, then render a different element based on that stored status.
+
+These are only some of the possible use cases for Shared Storage. We'll
+continue to add examples as we
+[receive feedback](/docs/privacy-sandbox/shared-storage/#engage-and-share-feedback)
+and discover new use cases.
+
+{% include 'content/privacysandbox-partials/sharedstorage-engage.njk' %}

--- a/site/en/docs/privacy-sandbox/shared-storage/ab-testing/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/ab-testing/index.md
@@ -119,10 +119,10 @@ register('ab-testing', SelectURLOperation);
 
 Explore other Shared Storage use cases and code samples:
 
-*  [**URL selection**](/docs/privacy-sandbox/shared-storage/url-selection): run
-   a worklet script to select a URL from a provided list, based on the stored
-   data, and then render that URL in a fenced frame. This has many possible
-   uses, such as selecting new  ads when a frequency cap is reached.
+*  [**Frequency control**](/docs/privacy-sandbox/shared-storage/frequency-control):
+   run a worklet script to select a URL from a provided list, based on the
+   stored data, and then render that URL in a fenced frame. This has many
+   possible uses, such as selecting new content when a frequency cap is reached.
 *  [**Creative rotation**](/docs/privacy-sandbox/shared-storage/creative-rotation):
    You can store the creative rotation mode, and other metadata, to rotate the
    creatives across different sites. 

--- a/site/en/docs/privacy-sandbox/shared-storage/ab-testing/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/ab-testing/index.md
@@ -5,7 +5,7 @@ subhead: >
   Use a Shared Storage worklet to run A/B testing.
 description: >
   Use a Shared Storage worklet to run A/B testing.
-date: 2022-10-15
+date: 2022-10-14
 authors:
   - alexandrawhite
   - kevinkiklee

--- a/site/en/docs/privacy-sandbox/shared-storage/creative-rotation/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/creative-rotation/index.md
@@ -15,7 +15,8 @@ The Shared Storage proposal intends to create a general purpose cross-site
 storage API which supports many possible use cases. One such example is
 creative rotation, which is available to test in Chrome 104.0.5086.0 and later.
 
-With creative rotation, you can store the creative rotation mode and other metadata to rotate a creative seen by users across different sites. 
+With creative rotation, you can store the creative rotation mode and other
+metadata to rotate a creative seen by users across different sites. 
 
 ## Try creative rotation
 
@@ -37,7 +38,6 @@ The following code samples were created to demonstrate how the API may be used
 for the given use cases. These are not meant to be used in production.
 
 {% endAside %}
-
 
 An advertiser may want to apply different strategies to an ad campaign, and
 rotate the creatives to increase effectiveness of the ads. Shared storage can
@@ -169,10 +169,10 @@ Explore other Shared Storage use cases and code samples:
    uses, such as selecting new  ads when a frequency cap is reached.
 *  [**A/B testing**](/docs/privacy-sandbox/shared-storage/ab-testing): You can
    assign a user to an experiment group, then store that group in Shared
-   Storage to be accessed cross-site. 
-*  [**Creative rotation**](/docs/privacy-sandbox/shared-storage/creative-rotation):
-   You can store the creative rotation mode, and other metadata, to rotate the
-   creatives across different sites. 
+   Storage to be accessed cross-site.
+*  [**Known customer for payment provider**](/docs/privacy-sandbox/shared-storage/known-customer):
+   You can store whether the user has registered on your site into shared
+   storage, then render a different element based on that stored status.
 
 These are only some of the possible use cases for Shared Storage. We'll
 continue to add examples as we

--- a/site/en/docs/privacy-sandbox/shared-storage/creative-rotation/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/creative-rotation/index.md
@@ -11,9 +11,10 @@ authors:
   - kevinkiklee
 ---
 
-The Shared Storage proposal intends to create a general purpose cross-site
-storage API which supports many possible use cases. One such example is
-creative rotation, which is available to test in Chrome 104.0.5086.0 and later.
+The [Shared Storage API](/docs/privacy-sandbox/shared-storage/) is a Privacy
+Sandbox proposal for general purpose, cross-site storage, which supports many
+possible use cases. One such example is creative rotation, which is available
+to test in Chrome 104.0.5086.0 and later.
 
 With creative rotation, you can store the creative rotation mode and other
 metadata to rotate a creative seen by users across different sites. 

--- a/site/en/docs/privacy-sandbox/shared-storage/creative-rotation/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/creative-rotation/index.md
@@ -5,7 +5,7 @@ subhead: >
   Use a Shared Storage worklet to rotate creatives across sites.
 description: >
   Use a Shared Storage worklet to rotate creatives across sites.
-date: 2022-10-15
+date: 2022-10-14
 authors:
   - alexandrawhite
   - kevinkiklee

--- a/site/en/docs/privacy-sandbox/shared-storage/creative-rotation/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/creative-rotation/index.md
@@ -163,10 +163,10 @@ register('creative-rotation', SelectURLOperation);
 
 Explore other Shared Storage use cases and code samples:
 
-*  [**URL selection**](/docs/privacy-sandbox/shared-storage/url-selection): run
-   a worklet script to select a URL from a provided list, based on the stored
-   data, and then render that URL in a fenced frame. This has many possible
-   uses, such as selecting new  ads when a frequency cap is reached.
+*  [**Frequency control**](/docs/privacy-sandbox/shared-storage/frequency-control):
+   run a worklet script to select a URL from a provided list, based on the
+   stored data, and then render that URL in a fenced frame. This has many
+   possible uses, such as selecting new content when a frequency cap is reached.
 *  [**A/B testing**](/docs/privacy-sandbox/shared-storage/ab-testing): You can
    assign a user to an experiment group, then store that group in Shared
    Storage to be accessed cross-site.

--- a/site/en/docs/privacy-sandbox/shared-storage/creative-rotation/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/creative-rotation/index.md
@@ -1,0 +1,182 @@
+---
+layout: 'layouts/doc-post.njk'
+title: 'Creative rotation'
+subhead: >
+  Use a Shared Storage worklet to rotate creatives across sites.
+description: >
+  Use a Shared Storage worklet to rotate creatives across sites.
+date: 2022-10-15
+authors:
+  - alexandrawhite
+  - kevinkiklee
+---
+
+The Shared Storage proposal intends to create a general purpose cross-site
+storage API which supports many possible use cases. One such example is
+creative rotation, which is available to test in Chrome 104.0.5086.0 and later.
+
+With creative rotation, you can store the creative rotation mode and other metadata to rotate a creative seen by users across different sites. 
+
+## Try creative rotation
+
+To experiment with creative rotation with Shared Storage, confirm you're using Chrome 104.0.5086.0 or later. Then enable the **Privacy Sandbox Ads APIs experiment** flag at `chrome://flags/#privacy-sandbox-ads-apis`.
+
+{% Img
+	src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/CWfgCMJQ5cYPOfjttF3k.png",
+	alt="Set Privacy Sandbox Ads APIs experiment to enabled to use these APIs",
+	width="744", height="124"
+%}
+
+You can also enable Shared Storage with the `--enable-features=PrivacySandboxAdsAPIsOverride,OverridePrivacySandboxSettingsLocalTesting,SharedStorageAPI,FencedFrames` flag in the command line. 
+
+## Experiment with code samples
+
+{% Aside %}
+
+The following code samples were created to demonstrate how the API may be used
+for the given use cases. These are not meant to be used in production.
+
+{% endAside %}
+
+
+An advertiser may want to apply different strategies to an ad campaign, and
+rotate the creatives to increase effectiveness of the ads. Shared storage can
+be used to run different rotation strategies, such as sequential rotation and
+evenly-distributed rotation, across different sites.
+
+In this example:
+
+*  `creative-rotation.js` is embedded in an ad iframe. This script sets which
+   ads are the most important (ad weight), and calls to the worklet to
+   determine which ad should be displayed.
+*  `creative-rotation-worklet.js`  is the shared storage worklet that
+   determines the weighted distribution for the ad creatives and returns which
+   should be displayed.
+
+**[creative-rotation.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/advertiser/creative-rotation.js)**
+
+```javascript
+// Ad config with the URL of the ad, a probability weight for rotation, and the clickthrough rate.
+const DEMO_AD_CONFIG = [
+  {
+    url: 'https://advertiser.example/ads/ad-1.html',
+    weight: 0.7,
+  },
+  {
+    url: 'https://advertiser.example/ads/ad-2.html',
+    weight: 0.2,
+  },
+  {
+    url: 'https://advertiser.example/ads/ad-3.html',
+    weight: 0.1,
+  },
+];
+
+// Set the mode to sequential and set the starting index to 0.
+async function seedStorage() {
+  await window.sharedStorage.set('creative-rotation-mode', 'sequential', {
+    ignoreIfPresent: true,
+  });
+
+  await window.sharedStorage.set('creative-rotation-index', 0, {
+    ignoreIfPresent: true,
+  });
+}
+
+async function injectAd() {
+  // Load the worklet module
+  await window.sharedStorage.worklet.addModule('creative-rotation-worklet.js');
+
+  // Initially set the storage to sequential mode for the demo
+  seedStorage();
+
+  // Run the URL selection operation to determine the next ad that should be rendered
+  const urls = DEMO_AD_CONFIG.map(({ url }) => ({ url }));
+  const opaqueURL = await window.sharedStorage.selectURL('creative-rotation', urls, { data: DEMO_AD_CONFIG });
+
+  // Render the opaque URL into a fenced frame
+  document.getElementById('ad-slot').src = opaqueURL;
+}
+
+injectAd();
+```
+
+**[creative-rotation-worklet.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/advertiser/creative-rotation-worklet.js)**
+
+```javascript
+class SelectURLOperation {
+  async run(urls, data) {
+    // Read the rotation mode from Shared Storage
+    const rotationMode = await this.sharedStorage.get('creative-rotation-mode');
+
+    // Generate a random number to be used for rotation
+    const randomNumber = Math.random();
+
+    let index;
+
+    switch (rotationMode) {
+      /**
+       * Sequential rotation
+       * - Rotates the creatives in order
+       * - Example: A -> B -> C -> A ...
+       */
+      case 'sequential':
+        const currentIndex = await this.sharedStorage.get('creative-rotation-index');
+        index = parseInt(currentIndex, 10);
+        const nextIndex = (index + 1) % urls.length;
+
+        await this.sharedStorage.set('creative-rotation-index', nextIndex);
+        break;
+
+      /**
+       * Weighted rotation
+       * - Rotates the creatives with weighted probability
+       * - Example: A=70% / B=20% / C=10%
+       */
+      case 'weighted-distribution':
+        // Find the first URL where the cumulative sum of the weights
+        // exceed the random number. The array is sorted by the weight
+        // in descending order.
+        let weightSum = 0;
+        const { url } = data
+          .sort((a, b) => b.weight - a.weight)
+          .find(({ weight }) => {
+            weightSum += weight;
+            return weightSum > randomNumber;
+          });
+
+        index = urls.indexOf(url);
+        break;
+
+      default:
+        index = 0;
+    }
+
+    return index;
+  }
+}
+
+register('creative-rotation', SelectURLOperation);
+```
+
+## Other use cases
+
+Explore other Shared Storage use cases and code samples:
+
+*  [**URL selection**](/docs/privacy-sandbox/shared-storage/url-selection): run
+   a worklet script to select a URL from a provided list, based on the stored
+   data, and then render that URL in a fenced frame. This has many possible
+   uses, such as selecting new  ads when a frequency cap is reached.
+*  [**A/B testing**](/docs/privacy-sandbox/shared-storage/ab-testing): You can
+   assign a user to an experiment group, then store that group in Shared
+   Storage to be accessed cross-site. 
+*  [**Creative rotation**](/docs/privacy-sandbox/shared-storage/creative-rotation):
+   You can store the creative rotation mode, and other metadata, to rotate the
+   creatives across different sites. 
+
+These are only some of the possible use cases for Shared Storage. We'll
+continue to add examples as we
+[receive feedback](/docs/privacy-sandbox/shared-storage/#engage-and-share-feedback)
+and discover new use cases.
+
+{% include 'content/privacysandbox-partials/sharedstorage-engage.njk' %}

--- a/site/en/docs/privacy-sandbox/shared-storage/frequency-control/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/frequency-control/index.md
@@ -7,7 +7,7 @@ subhead: >
 description: >
   Run a Shared Storage worklet to select a URL and render it
   in a fenced frame.
-date: 2022-10-15
+date: 2022-10-14
 authors:
   - alexandrawhite
   - kevinkiklee

--- a/site/en/docs/privacy-sandbox/shared-storage/frequency-control/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/frequency-control/index.md
@@ -1,6 +1,6 @@
 ---
 layout: 'layouts/doc-post.njk'
-title: 'URL Selection'
+title: 'Frequency control'
 subhead: >
   Run a Shared Storage worklet to select a URL and render it
   in a fenced frame.
@@ -14,17 +14,19 @@ authors:
 ---
 
 The Shared Storage proposal intends to create a general purpose cross-site
-storage API which supports many possible use cases. One such example is URL
-selection, which is available to test in Chrome Beta 104.0.5086.0 and later.
+storage API which supports many possible use cases. One such example is
+frequency control, which is available to test in Chrome Beta 104.0.5086.0 and
+later.
 
-With URL selection, you can run a worklet script to select a URL from a
-provided list, based on the stored data, and then render that
-URL in a fenced frame. This has many possible uses, such as selecting new
-ads when a frequency cap is reached.
+Run a worklet script to select a URL from a provided list, based on the stored
+data, and then render that URL in a fenced frame. This can be used to select
+new ads or other content when the frequency cap has been reached.
 
-## Try URL selection
+## Test frequency control
 
-To test URL selection with Shared Storage and fenced frames, confirm you're using Chrome 104.0.5086.0 or later. Then enable the **Privacy Sandbox Ads APIs experiment** flag at `chrome://flags/#privacy-sandbox-ads-apis`.
+To test frequency control with Shared Storage and Fenced Frames, confirm you're
+using Chrome 104.0.5086.0 or later. Then enable the **Privacy Sandbox Ads APIs experiment**
+flag at `chrome://flags/#privacy-sandbox-ads-apis`.
 
 {% Img
 	src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/CWfgCMJQ5cYPOfjttF3k.png",

--- a/site/en/docs/privacy-sandbox/shared-storage/frequency-control/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/frequency-control/index.md
@@ -13,10 +13,10 @@ authors:
   - kevinkiklee
 ---
 
-The Shared Storage proposal intends to create a general purpose cross-site
-storage API which supports many possible use cases. One such example is
-frequency control, which is available to test in Chrome Beta 104.0.5086.0 and
-later.
+The [Shared Storage API](/docs/privacy-sandbox/shared-storage/) is a Privacy
+Sandbox proposal for general purpose, cross-site storage, which supports many
+possible use cases. One example is frequency control, which is available to
+test in Chrome Beta 104.0.5086.0 and later.
 
 Run a worklet script to select a URL from a provided list, based on the stored
 data, and then render that URL in a fenced frame. This can be used to select

--- a/site/en/docs/privacy-sandbox/shared-storage/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/index.md
@@ -62,16 +62,18 @@ example:
 The Shared Storage API intends to support many use cases, replacing several
 existing uses for third-party cookies. This may include:
 
-*  [URL selection](/docs/privacy-sandbox/shared-storage/url-selection/)
-*  Recording aggregated statistics, such as demographics, reach, frequency
-   measurement, and conversion measurement with the
-   [Private Aggregation API](/docs/privacy-sandbox/private-aggregation/)
-*  Frequency controls
+*  [Frequency control](/docs/privacy-sandbox/shared-storage/frequency-control/)
 *  [A/B or lift experiments](docs/privacy-sandbox/shared-storage/ab-testing/)
 *  [Creative rotation](docs/privacy-sandbox/shared-storage/creative-rotation/)
 *  [Determining known customers](docs/privacy-sandbox/shared-storage/known-customer/)
+*  Recording aggregated statistics, such as demographics, reach, frequency
+   measurement, and conversion measurement with the
+   [Private Aggregation API](/docs/privacy-sandbox/private-aggregation/)
 *  Confirm login for payment provider
-*  User consent status
+
+{% Aside %}
+While it is technically possible to configure and collect user consent status with Shared Storage, we don't recommend this use case.
+{% endAside %}
 
 The proposal intends to create a general purpose API which supports many
 possible future use cases. This allows for further experimentation and change,

--- a/site/en/docs/privacy-sandbox/shared-storage/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/index.md
@@ -6,7 +6,7 @@ subhead: >
 description: >
   Allow access to unpartitioned cross-site data in a secure environment.
 date: 2022-04-25
-updated: 2022-06-28
+updated: 2022-10-17
 authors:
   - alexandrawhite
   - kevinkiklee
@@ -50,8 +50,8 @@ such as [Trust Tokens](/docs/privacy-sandbox/trust-tokens/),
 Many different organizations may benefit from using the Shared Storage API. For
 example:
 
-*  Adtechs to solve many common ads use cases which currently rely on
-   third-party cookies.
+*  Content producers and adtechs to solve many common use cases, which currently
+   rely on third-party cookies.
 *  Payments providers to understand if the user is an existing customer and
    tailor the checkout experience.
 *  Web security companies who use custom on-device logic to flag suspicious or
@@ -62,13 +62,14 @@ example:
 The Shared Storage API intends to support many use cases, replacing several
 existing uses for third-party cookies. This may include:
 
+*  [URL selection](/docs/privacy-sandbox/shared-storage/url-selection/)
 *  Recording aggregated statistics, such as demographics, reach, frequency
    measurement, and conversion measurement with the
-   [Private Aggregation API](https://github.com/alexmturner/private-aggregation-api)
-*  Frequency capping
-*  Lift experiments
-*  A/B experiments
-*  Creative rotation
+   [Private Aggregation API](/docs/privacy-sandbox/private-aggregation/)
+*  Frequency controls
+*  [A/B or lift experiments](docs/privacy-sandbox/shared-storage/ab-testing/)
+*  [Creative rotation](docs/privacy-sandbox/shared-storage/creative-rotation/)
+*  [Determining known customers](docs/privacy-sandbox/shared-storage/known-customer/)
 *  Confirm login for payment provider
 *  User consent status
 
@@ -78,23 +79,25 @@ to grow alongside the web ecosystem.
 
 ## How will shared storage work?
 
-Shared storage will allow you to make informed decisions based on cross-site
+Shared storage allows you to make informed decisions based on cross-site
 data, without sharing user information (such as browser history or other
-personal details) with an embedding site. You can write to  shared storage at
-any time, like other JavaScript storage APIs (like localStorage or indexedDB).
-Unlike the other storage APIs, you can only read the shared storage values in
-a secure environment, known as a shared storage worklet.
+personal details) with an embedding site.
+
+You can write to shared storage at any time, like other JavaScript storage APIs
+(like localStorage or indexedDB). Unlike the other storage APIs, you can only
+read the shared storage values in a secure environment, known as a shared
+storage worklet.
 
 The shared storage data can be used for:
 
-*  [**URL selection**](/docs/privacy-sandbox/use-shared-storage#url-selection): 
+*  [**URL selection**](/docs/privacy-sandbox/shared-storage/url-selection): 
    you can run a worklet script to select a URL from a provided list, based on
    the stored data, and then render that URL in a fenced frame.  The returned
    URL will be an opaque URL, which means the developer and other viewers of
    the code won't know which URL was selected.
-*  [**Noisy aggregation of cross-site data**](/docs/privacy-sandbox/use-shared-storage#aggregated-data):
+*  **Noisy aggregation of cross-site data**:
    you will be able to run a worklet script to send your data through the
-   [Private Aggregation API](https://github.com/alexmturner/private-aggregation-api),
+   [Private Aggregation API](/docs/privacy-sandbox/private-aggregation),
    a Privacy Sandbox proposal, which returns a privacy-preserving report. 
 
 ## Try the Shared Storage API
@@ -113,12 +116,4 @@ You can also enable Shared Storage with the `--enable-features=PrivacySandboxAds
 
 Check out the [example use cases and code samples](/docs/privacy-sandbox/use-shared-storage).
 
-## Engage and share feedback
-
-The shared storage proposal is under active discussion and subject to change
-in the future. If you try this API and have feedback, we'd love to hear it.
-
-*  **GitHub**: Read the
-   [proposal](https://github.com/pythagoraskitty/shared-storage), [raise questions and participate in discussion](https://github.com/pythagoraskitty/shared-storage/issues).
-*  **Developer support**: Ask questions and join discussions on the
-   [Privacy Sandbox Developer Support repo](https://github.com/GoogleChromeLabs/privacy-sandbox-dev-support).
+{% include 'content/privacysandbox-partials/sharedstorage-engage.njk' %}

--- a/site/en/docs/privacy-sandbox/shared-storage/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/index.md
@@ -6,7 +6,7 @@ subhead: >
 description: >
   Allow access to unpartitioned cross-site data in a secure environment.
 date: 2022-04-25
-updated: 2022-10-17
+updated: 2022-10-14
 authors:
   - alexandrawhite
   - kevinkiklee

--- a/site/en/docs/privacy-sandbox/shared-storage/known-customer/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/known-customer/index.md
@@ -5,7 +5,7 @@ subhead: >
   Use a Shared Storage worklet to identify known customers.
 description: >
   Use a Shared Storage worklet to identify known customers.
-date: 2022-10-15
+date: 2022-10-14
 authors:
   - alexandrawhite
   - kevinkiklee

--- a/site/en/docs/privacy-sandbox/shared-storage/known-customer/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/known-customer/index.md
@@ -104,10 +104,10 @@ register('known-customer', SelectURLOperation);
 
 Explore other Shared Storage use cases and code samples:
 
-*  [**URL selection**](/docs/privacy-sandbox/shared-storage/url-selection): run
-   a worklet script to select a URL from a provided list, based on the stored
-   data, and then render that URL in a fenced frame. This has many possible
-   uses, such as selecting new  ads when a frequency cap is reached.
+*  [**Frequency control**](/docs/privacy-sandbox/shared-storage/frequency-control):
+   run a worklet script to select a URL from a provided list, based on the
+   stored data, and then render that URL in a fenced frame. This has many
+   possible uses, such as selecting new content when a frequency cap is reached.
 *  [**A/B testing**](/docs/privacy-sandbox/shared-storage/ab-testing): You can
    assign a user to an experiment group, then store that group in shared
    storage to be accessed cross-site. 

--- a/site/en/docs/privacy-sandbox/shared-storage/known-customer/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/known-customer/index.md
@@ -1,0 +1,123 @@
+---
+layout: 'layouts/doc-post.njk'
+title: 'Known customers'
+subhead: >
+  Use a Shared Storage worklet to identify known customers.
+description: >
+  Use a Shared Storage worklet to identify known customers.
+date: 2022-10-15
+authors:
+  - alexandrawhite
+  - kevinkiklee
+---
+
+The Shared Storage proposal intends to create a general purpose cross-site
+storage API which supports many possible use cases. One such example is
+identifying known customers, which is available to test in Chrome 104.0.5086.0
+and later.
+
+You can store whether the user has registered on your site into Shared Storage,
+then render a seperate element based on whether the user's stored status (is
+the user a "known" customer).
+
+## Try setting known customers
+
+To experiment with identifying known customers in Shared Storage, confirm
+you're using Chrome 104.0.5086.0 or later. Then enable the
+**Privacy Sandbox Ads APIs experiment** flag at `chrome://flags/#privacy-sandbox-ads-apis`.
+
+{% Img
+	src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/CWfgCMJQ5cYPOfjttF3k.png",
+	alt="Set Privacy Sandbox Ads APIs experiment to enabled to use these APIs",
+	width="744", height="124"
+%}
+
+You can also enable Shared Storage with the `--enable-features=PrivacySandboxAdsAPIsOverride,OverridePrivacySandboxSettingsLocalTesting,SharedStorageAPI,FencedFrames` flag in the command line. 
+
+## Experiment with code samples
+
+{% Aside %}
+
+The following code samples were created to demonstrate how the API may be used
+for the given use cases. These are not meant to be used in production.
+
+{% endAside %}
+
+You may want to render a different element based on whether the user was seen
+on a different site. For example, a payment provider may want to render a
+"Register" or "Buy now" button based on whether the user has registered at the
+payment provider's site. Shared storage can be used to set the user's status.
+
+In this example:
+
+*  `known-customer.js` is embedded in an ad iframe. This script sets the
+   options for which button should be displayed on a site, "Register" or "Buy now."
+*  `known-customer-worklet.js`  is the shared storage worklet that determines
+   if the user is known. If the user is known, the information is returned. If
+   the user is unknown, that information is returned to display the "Register"
+   button and the user is marked as known for the future.
+
+**[known-customer.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/advertiser/known-customer.js)**
+
+```javascript
+// The first URL for the "register" button is rendered for unknown users.
+const AD_URLS = [
+  { url: `https://${advertiserUrl}/ads/register-button.html` },
+  { url: `https://${advertiserUrl}/ads/buy-now-button.html` },
+];
+
+async function injectAd() {
+  // Load the worklet module
+  await window.sharedStorage.worklet.addModule('known-customer-worklet.js');
+
+  // Set the initial status to unknown ('0' is unknown and '1' is known)
+  window.sharedStorage.set('known-customer', 0, {
+    ignoreIfPresent: true,
+  });
+
+  // Run the URL selection operation to choose the button based on the user status
+  const opaqueURL = await window.sharedStorage.selectURL('known-customer', AD_URLS);
+
+  // Render the opaque URL into a fenced frame
+  document.getElementById('button-slot').src = opaqueURL;
+}
+
+injectAd();
+```
+
+**[known-customer-worklet.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/advertiser/known-customer-worklet.js)**
+
+```javascript
+class SelectURLOperation {
+  async run(urls) {
+    const knownCustomer = await this.sharedStorage.get('known-customer');
+
+    // '0' is unknown and '1' is known
+    return parseInt(knownCustomer);
+  }
+}
+
+register('known-customer', SelectURLOperation);
+```
+
+## Other use cases
+
+Explore other Shared Storage use cases and code samples:
+
+*  [**URL selection**](/docs/privacy-sandbox/shared-storage/url-selection): run
+   a worklet script to select a URL from a provided list, based on the stored
+   data, and then render that URL in a fenced frame. This has many possible
+   uses, such as selecting new  ads when a frequency cap is reached.
+*  [**A/B testing**](/docs/privacy-sandbox/shared-storage/ab-testing): You can
+   assign a user to an experiment group, then store that group in Shared
+   Storage to be accessed cross-site. 
+*  [**Known customer for payment provider**](/docs/privacy-sandbox/shared-storage/known-customer):
+   You can store whether the user has registered on your site into Shared
+   Storage, then render a different element based on that stored status.
+
+These are only some of the possible use cases for Shared Storage. We'll
+continue to add examples as we
+[receive feedback](/docs/privacy-sandbox/shared-storage/#engage-and-share-feedback)
+and discover new use cases.
+
+{% include 'content/privacysandbox-partials/sharedstorage-engage.njk' %}

--- a/site/en/docs/privacy-sandbox/shared-storage/known-customer/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/known-customer/index.md
@@ -11,10 +11,10 @@ authors:
   - kevinkiklee
 ---
 
-The Shared Storage proposal intends to create a general purpose cross-site
-storage API which supports many possible use cases. One such example is
-identifying known customers, which is available to test in Chrome 104.0.5086.0
-and later.
+The [Shared Storage API](/docs/privacy-sandbox/shared-storage/) is a Privacy
+Sandbox proposal for general purpose, cross-site storage, which supports many
+possible use cases. One example is identifying known customers, which is
+available to test in Chrome 104.0.5086.0 and later.
 
 You can store whether the user has registered on your site into Shared Storage,
 then render a seperate element based on whether the user's stored status (is

--- a/site/en/docs/privacy-sandbox/shared-storage/known-customer/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/known-customer/index.md
@@ -109,11 +109,11 @@ Explore other Shared Storage use cases and code samples:
    data, and then render that URL in a fenced frame. This has many possible
    uses, such as selecting new  ads when a frequency cap is reached.
 *  [**A/B testing**](/docs/privacy-sandbox/shared-storage/ab-testing): You can
-   assign a user to an experiment group, then store that group in Shared
-   Storage to be accessed cross-site. 
-*  [**Known customer for payment provider**](/docs/privacy-sandbox/shared-storage/known-customer):
-   You can store whether the user has registered on your site into Shared
-   Storage, then render a different element based on that stored status.
+   assign a user to an experiment group, then store that group in shared
+   storage to be accessed cross-site. 
+*  [**Creative rotation**](/docs/privacy-sandbox/shared-storage/creative-rotation):
+   You can store the creative rotation mode, and other metadata, to rotate the
+   creatives across different sites. 
 
 These are only some of the possible use cases for Shared Storage. We'll
 continue to add examples as we

--- a/site/en/docs/privacy-sandbox/shared-storage/url-selection/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/url-selection/index.md
@@ -1,0 +1,135 @@
+---
+layout: 'layouts/doc-post.njk'
+title: 'URL Selection'
+subhead: >
+  Run a Shared Storage worklet to select a URL and render it in a fenced frame.
+description: >
+  Run a Shared Storage worklet to select a URL and render it in a fenced frame.
+date: 2022-10-15
+authors:
+  - alexandrawhite
+  - kevinkiklee
+---
+
+The Shared Storage proposal intends to create a general purpose cross-site
+storage API which supports many possible use cases. One such example is URL
+selection, which is available to test in Chrome Beta 104.0.5086.0 and later.
+
+With URL selection, you can run a worklet script to select a URL from a provided list, based on the stored data, and then render that
+URL in a fenced frame. This has many possible uses, such as selecting new
+ads when a frequency cap is reached.
+
+## Try URL selection
+
+To test URL selection with Shared Storage and fenced frames, confirm you're using Chrome 104.0.5086.0 or later. Then enable the **Privacy Sandbox Ads APIs experiment** flag at `chrome://flags/#privacy-sandbox-ads-apis`.
+
+{% Img
+	src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/CWfgCMJQ5cYPOfjttF3k.png",
+	alt="Set Privacy Sandbox Ads APIs experiment to enabled to use these APIs",
+	width="744", height="124"
+%}
+
+You can also enable Shared Storage with the `--enable-features=PrivacySandboxAdsAPIsOverride,OverridePrivacySandboxSettingsLocalTesting,SharedStorageAPI,FencedFrames` flag in the command line. 
+
+## Experiment with code samples
+
+{% Aside %}
+
+The following code samples were created to demonstrate how the API may be used
+for the given use cases. These are not meant to be used in production.
+
+{% endAside %}
+
+To select and create an opaque URL, register a worklet module to read shared
+storage data. The worklet class receives a list of up to eight URLs and then
+returns the index of the chosen URL. 
+
+When the client calls `sharedStorage.runURLSelectionOperation()`, the worklet
+executes and returns an opaque URL to be rendered into a [fenced frame](/docs/privacy-sandbox/fenced-frame/).
+
+Let's say you want to render an ad based on the advertiser's frequency cap (the
+maximum number of impressions for a user on a single ad over a set period of
+time). The frequency cap value is stored in shared storage. The shared storage
+worklet reads the values in shared storage, and decrements the value with each
+additional view. If there are available impressions left (the user has not hit
+their frequency cap), the ad is returned (index `1`). If not, the default URL
+is returned (index `0`).
+
+In this example:
+
+*  `frequency-cap.js` is loaded via the advertiser's iframe, and is responsible
+   for loading the shared storage worklet, and rendering the returned opaque
+   source into a fenced frame.
+*  `frequency-cap-worklet.js` is the shared storage worklet that reads the
+   frequency cap count value to determine which URL is returned for the ad creative.
+
+**[frequency-cap.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/advertiser/frequency-cap.js)**
+
+```javascript
+// The first URL is the default ad to be rendered when the frequency cap is reached
+const AD_URLS = [
+  { url: `https://localhost:4437/ads/default-ad.html` },
+  { url: `https://localhost:4437/ads/example-ad.html` },
+];
+
+async function injectAd() {
+  // Load the worklet module
+  await window.sharedStorage.worklet.addModule('frequency-cap-worklet.js');
+
+  // Set the initial frequency cap to 5
+  window.sharedStorage.set('frequency-cap-count', 5, {
+    ignoreIfPresent: true,
+  });
+
+  // Run the URL selection operation to choose an ad based on the frequency cap in shared storage
+  const opaqueURL = await window.sharedStorage.selectURL('frequency-cap', AD_URLS);
+
+  // Render the opaque URL into a fenced frame
+  document.getElementById('ad-slot').src = opaqueURL;
+}
+
+injectAd();
+```
+
+**[frequency-cap-worklet.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/advertiser/frequency-cap-worklet.js)**
+
+```javascript
+class SelectURLOperation {
+  async run(urls, data) {
+    // Read the current frequency cap in shared storage
+    const count = parseInt(await this.sharedStorage.get('frequency-cap-count'));
+
+    // If the count is 0, the frequency cap has been reached
+    if (count === 0) {
+      console.log('frequency cap has been reached, and the default ad will be rendered');
+      return 0;
+    }
+
+    // Set the new frequency count in shared storage
+    await this.sharedStorage.set('frequency-cap-count', count - 1);
+    return 1;
+  }
+}
+
+// Register the operation as 'frequency-cap'
+register('frequency-cap', SelectURLOperation);
+```
+
+## Other use cases
+
+Explore other Shared Storage use cases and code samples:
+
+*  [**A/B testing**](/docs/privacy-sandbox/shared-storage/ab-testing): You can assign a user to an experiment
+   group, then store that group in Shared Storage to be accessed cross-site. 
+*  [**Creative rotation**](/docs/privacy-sandbox/shared-storage/creative-rotation): You can store the creative
+   rotation mode, and other metadata, to rotate the creatives across different sites. 
+*  [**Known customer for payment provider**](/docs/privacy-sandbox/shared-storage/known-customer): You can store
+   whether the user has registered on your site into Shared Storage, then
+   render a different element based on that stored status.
+
+These are only some of the possible use cases for Shared Storage. We'll
+continue to add examples as we
+[receive feedback](/docs/privacy-sandbox/shared-storage/#engage-and-share-feedback)
+and discover new use cases.
+
+{% include 'content/privacysandbox-partials/sharedstorage-engage.njk' %}

--- a/site/en/docs/privacy-sandbox/shared-storage/url-selection/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/url-selection/index.md
@@ -2,9 +2,11 @@
 layout: 'layouts/doc-post.njk'
 title: 'URL Selection'
 subhead: >
-  Run a Shared Storage worklet to select a URL and render it in a fenced frame.
+  Run a Shared Storage worklet to select a URL and render it
+  in a fenced frame.
 description: >
-  Run a Shared Storage worklet to select a URL and render it in a fenced frame.
+  Run a Shared Storage worklet to select a URL and render it
+  in a fenced frame.
 date: 2022-10-15
 authors:
   - alexandrawhite
@@ -15,7 +17,8 @@ The Shared Storage proposal intends to create a general purpose cross-site
 storage API which supports many possible use cases. One such example is URL
 selection, which is available to test in Chrome Beta 104.0.5086.0 and later.
 
-With URL selection, you can run a worklet script to select a URL from a provided list, based on the stored data, and then render that
+With URL selection, you can run a worklet script to select a URL from a
+provided list, based on the stored data, and then render that
 URL in a fenced frame. This has many possible uses, such as selecting new
 ads when a frequency cap is reached.
 
@@ -49,11 +52,12 @@ executes and returns an opaque URL to be rendered into a [fenced frame](/docs/pr
 
 Let's say you want to render an ad based on the advertiser's frequency cap (the
 maximum number of impressions for a user on a single ad over a set period of
-time). The frequency cap value is stored in shared storage. The shared storage
-worklet reads the values in shared storage, and decrements the value with each
-additional view. If there are available impressions left (the user has not hit
-their frequency cap), the ad is returned (index `1`). If not, the default URL
-is returned (index `0`).
+time). The frequency cap value is stored in shared storage.
+
+The shared storage worklet reads the values in shared storage, and decrements
+the value with each additional view. If there are available impressions left
+(the user has not hit their frequency cap), the ad is returned (index `1`). If
+not, the default URL is returned (index `0`).
 
 In this example:
 
@@ -119,13 +123,15 @@ register('frequency-cap', SelectURLOperation);
 
 Explore other Shared Storage use cases and code samples:
 
-*  [**A/B testing**](/docs/privacy-sandbox/shared-storage/ab-testing): You can assign a user to an experiment
-   group, then store that group in Shared Storage to be accessed cross-site. 
-*  [**Creative rotation**](/docs/privacy-sandbox/shared-storage/creative-rotation): You can store the creative
-   rotation mode, and other metadata, to rotate the creatives across different sites. 
-*  [**Known customer for payment provider**](/docs/privacy-sandbox/shared-storage/known-customer): You can store
-   whether the user has registered on your site into Shared Storage, then
-   render a different element based on that stored status.
+*  [**A/B testing**](/docs/privacy-sandbox/shared-storage/ab-testing): You can
+   assign a user to an experiment group, then store that group in shared
+   storage to be accessed cross-site. 
+*  [**Creative rotation**](/docs/privacy-sandbox/shared-storage/creative-rotation):
+   You can store the creative rotation mode, and other metadata, to rotate the
+   creatives across different sites. 
+*  [**Known customer for payment provider**](/docs/privacy-sandbox/shared-storage/known-customer):
+   You can store whether the user has registered on your site into shared
+   storage, then render a different element based on that stored status.
 
 These are only some of the possible use cases for Shared Storage. We'll
 continue to add examples as we

--- a/site/en/docs/privacy-sandbox/use-shared-storage/index.md
+++ b/site/en/docs/privacy-sandbox/use-shared-storage/index.md
@@ -18,10 +18,10 @@ find code samples to help you get started.
 
 The following features are available to test in Chrome 104:
 
-*  [**URL selection**](/docs/privacy-sandbox/shared-storage/url-selection): you can run a worklet script to select
-   a URL from a provided list, based on the stored data, and then render that
-   URL in a fenced frame. This has many possible uses, such as selecting new
-   ads when a frequency cap is reached.
+*  [**Frequency control**](/docs/privacy-sandbox/shared-storage/frequency-control):
+   run a worklet script to select a URL from a provided list, based on the
+   stored data, and then render that URL in a fenced frame. This has many
+   possible uses, such as selecting new content when a frequency cap is reached.
 *  [**A/B testing**](/docs/privacy-sandbox/shared-storage/ab-testing): You can assign a user to an experiment
    group, then store that group in Shared Storage to be accessed cross-site. 
 *  [**Creative rotation**](/docs/privacy-sandbox/shared-storage/creative-rotation): You can store the creative

--- a/site/en/docs/privacy-sandbox/use-shared-storage/index.md
+++ b/site/en/docs/privacy-sandbox/use-shared-storage/index.md
@@ -6,7 +6,7 @@ subhead: >
 description: >
   Examine use cases and code samples for Shared Storage.
 date: 2022-06-28
-updated: 2022-10-17
+updated: 2022-10-14
 authors:
   - alexandrawhite
   - kevinkiklee

--- a/site/en/docs/privacy-sandbox/use-shared-storage/index.md
+++ b/site/en/docs/privacy-sandbox/use-shared-storage/index.md
@@ -6,7 +6,7 @@ subhead: >
 description: >
   Examine use cases and code samples for Shared Storage.
 date: 2022-06-28
-updated: 2022-07-14
+updated: 2022-10-17
 authors:
   - alexandrawhite
   - kevinkiklee
@@ -18,15 +18,15 @@ find code samples to help you get started.
 
 The following features are available to test in Chrome 104:
 
-*  [**URL selection**](#url-selection): you can run a worklet script to select
+*  [**URL selection**](/docs/privacy-sandbox/shared-storage/url-selection): you can run a worklet script to select
    a URL from a provided list, based on the stored data, and then render that
    URL in a fenced frame. This has many possible uses, such as selecting new
    ads when a frequency cap is reached.
-*  [**A/B testing**](#ab-testing): You can assign a user to an experiment
+*  [**A/B testing**](/docs/privacy-sandbox/shared-storage/ab-testing): You can assign a user to an experiment
    group, then store that group in Shared Storage to be accessed cross-site. 
-*  [**Creative rotation**](#creative-rotation): You can store the creative
+*  [**Creative rotation**](/docs/privacy-sandbox/shared-storage/creative-rotation): You can store the creative
    rotation mode, and other metadata, to rotate the creatives across different sites. 
-*  [**Known customer for payment provider**](#known-customer): You can store
+*  [**Known customer for payment provider**](/docs/privacy-sandbox/shared-storage/known-customer): You can store
    whether the user has registered on your site into Shared Storage, then
    render a different element based on that stored status.
 
@@ -34,10 +34,9 @@ The following use case isn't available for testing in Chrome Beta, but we
 intend to support it in the future:
 
 *  [**Noisy aggregation of cross-site data**](#aggregated-data): you will be
-   able to run a worklet script to send your data through the
-   [Private Aggregation API](https://github.com/alexmturner/private-aggregation-api)
-   (currently a draft proposal), a Privacy Sandbox proposal, which returns a
-   privacy-preserving report. 
+   able to run a worklet script to aggregate your data with the
+   [Private Aggregation API](/docs/privacy-sandbox/private-aggregation)
+   which returns a privacy-preserving report. 
 
 These are only some of the possible use cases for Shared Storage. We'll
 continue to add examples as we
@@ -74,418 +73,14 @@ sites.
 The demo contains frequency capping, creative rotation, known customer, and A/B
 testing use cases.
 
-
-## Experiment with code samples
-
-{% Aside %}
-
-The following code samples were created to demonstrate how the API may be used
-for the given use cases. These are not meant to be used in production.
-
-{% endAside %}
-
-### URL selection {: #url-selection }
-
-To select and create an opaque URL, register a worklet module to read shared
-storage data. The worklet class receives a list of up to eight URLs and then
-returns the index of the chosen URL. 
-
-When the client calls `sharedStorage.runURLSelectionOperation()`, the worklet
-executes and returns an opaque URL to be rendered into a [fenced frame](/docs/privacy-sandbox/fenced-frame/).
-
-Let's say you want to render an ad based on the advertiser's frequency cap (the
-maximum number of impressions for a user on a single ad over a set period of
-time). The frequency cap value is stored in shared storage. The shared storage
-worklet reads the values in shared storage, and decrements the value with each
-additional view. If there are available impressions left (the user has not hit
-their frequency cap), the ad is returned (index `1`). If not, the default URL
-is returned (index `0`).
-
-In this example:
-
-*  `frequency-cap.js` is loaded via the advertiser's iframe, and is responsible
-   for loading the shared storage worklet, and rendering the returned opaque
-   source into a fenced frame.
-*  `frequency-cap-worklet.js` is the shared storage worklet that reads the
-   frequency cap count value to determine which URL is returned for the ad creative.
-
-**[frequency-cap.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/advertiser/frequency-cap.js)**
-
-```javascript
-// The first URL is the default ad to be rendered when the frequency cap is reached
-const AD_URLS = [
-  { url: `https://localhost:4437/ads/default-ad.html` },
-  { url: `https://localhost:4437/ads/example-ad.html` },
-];
-
-async function injectAd() {
-  // Load the worklet module
-  await window.sharedStorage.worklet.addModule('frequency-cap-worklet.js');
-
-  // Set the initial frequency cap to 5
-  window.sharedStorage.set('frequency-cap-count', 5, {
-    ignoreIfPresent: true,
-  });
-
-  // Run the URL selection operation to choose an ad based on the frequency cap in shared storage
-  const opaqueURL = await window.sharedStorage.selectURL('frequency-cap', AD_URLS);
-
-  // Render the opaque URL into a fenced frame
-  document.getElementById('ad-slot').src = opaqueURL;
-}
-
-injectAd();
-```
-
-**[frequency-cap-worklet.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/advertiser/frequency-cap-worklet.js)**
-
-```javascript
-class SelectURLOperation {
-  async run(urls, data) {
-    // Read the current frequency cap in shared storage
-    const count = parseInt(await this.sharedStorage.get('frequency-cap-count'));
-
-    // If the count is 0, the frequency cap has been reached
-    if (count === 0) {
-      console.log('frequency cap has been reached, and the default ad will be rendered');
-      return 0;
-    }
-
-    // Set the new frequency count in shared storage
-    await this.sharedStorage.set('frequency-cap-count', count - 1);
-    return 1;
-  }
-}
-
-// Register the operation as 'frequency-cap'
-register('frequency-cap', SelectURLOperation);
-```
-
-### A/B testing {: #ab-testing }
-
-To see if an experiment has the desired effect, you can run A/B testing across
-multiple sites. As an advertiser, you can choose to render a different ad based
-on what group the user is assigned to. The group assignment is saved in shared
-storage.
-
-In this example:
-
-*  `ab-testing.js` should be embedded in an ad iframe, which maps a control and
-   two experiment ads. The script calls the shared storage worklet for the experiment.
-*  `ab-testing-worklet.js`  is the shared storage worklet that returns which
-   group the user is assigned to, determining which ad is shown.
-
-**[ab-testing.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/advertiser/ab-testing.js)**
-
-```javascript
-// Map the experiment groups to the URLs
-const EXPERIMENT_MAP = [
-  {
-    group: 'control',
-    url: `https://advertiser.example/ads/default-ad.html`,
-  },
-  {
-    group: 'experiment-a',
-    url: `https://advertiser.example/ads/experiment-ad-a.html`,
-  },
-  {
-    group: 'experiment-b',
-    url: `https://advertiser.example/ads/experiment-ad-b.html`,
-  },
-];
-
-// Choose a random group for the initial experiment
-function getRandomExperiment() {
-  const randomIndex = Math.floor(Math.random() * EXPERIMENT_MAP.length);
-  return EXPERIMENT_MAP[randomIndex].group;
-}
-
-async function injectAd() {
-  // Load the worklet module
-  await window.sharedStorage.worklet.addModule('ab-testing-worklet.js');
-
-  // Set the initial value in the storage to a random experiment group
-  window.sharedStorage.set('ab-testing-group', getRandomExperiment(), {
-    ignoreIfPresent: true,
-  });
-
-  const urls = EXPERIMENT_MAP.map(({ url }) => ({ url }));
-  const groups = EXPERIMENT_MAP.map(({ group }) => group);
-
-  // Run the URL selection operation to select an ad based on the experiment group in shared storage
-  const opaqueURL = await window.sharedStorage.selectURL('ab-testing', urls, { data: groups });
-
-  // Render the opaque URL into a fenced frame
-  document.getElementById('ad-slot').src = opaqueURL;
-}
-
-injectAd();
-```
-
-**[ab-testing-worklet.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/advertiser/ab-testing-worklet.js)**
-
-```javascript
-class SelectURLOperation {
-  async run(urls, data) {
-    // Read the user's group from shared storage
-    const experimentGroup = await this.sharedStorage.get('ab-testing-group');
-
-    // Return the index of the group
-    return data.indexOf(experimentGroup);
-  }
-}
-
-register('ab-testing', SelectURLOperation);
-```
-
-### Creative rotation {: #creative-rotation }
-
-An advertiser may want to apply different strategies to an ad campaign, and
-rotate the creatives to increase effectiveness of the ads. Shared storage can
-be used to run different rotation strategies, such as sequential rotation and
-evenly-distributed rotation, across different sites.
-
-In this example:
-
-*  `creative-rotation.js` is embedded in an ad iframe. This script sets which
-   ads are the most important (ad weight), and calls to the worklet to
-   determine which ad should be displayed.
-*  `creative-rotation-worklet.js`  is the shared storage worklet that
-   determines the weighted distribution for the ad creatives and returns which
-   should be displayed.
-
-**[creative-rotation.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/advertiser/creative-rotation.js)**
-
-```javascript
-// Ad config with the URL of the ad, a probability weight for rotation, and the clickthrough rate.
-const DEMO_AD_CONFIG = [
-  {
-    url: 'https://advertiser.example/ads/ad-1.html',
-    weight: 0.7,
-  },
-  {
-    url: 'https://advertiser.example/ads/ad-2.html',
-    weight: 0.2,
-  },
-  {
-    url: 'https://advertiser.example/ads/ad-3.html',
-    weight: 0.1,
-  },
-];
-
-// Set the mode to sequential and set the starting index to 0.
-async function seedStorage() {
-  await window.sharedStorage.set('creative-rotation-mode', 'sequential', {
-    ignoreIfPresent: true,
-  });
-
-  await window.sharedStorage.set('creative-rotation-index', 0, {
-    ignoreIfPresent: true,
-  });
-}
-
-async function injectAd() {
-  // Load the worklet module
-  await window.sharedStorage.worklet.addModule('creative-rotation-worklet.js');
-
-  // Initially set the storage to sequential mode for the demo
-  seedStorage();
-
-  // Run the URL selection operation to determine the next ad that should be rendered
-  const urls = DEMO_AD_CONFIG.map(({ url }) => ({ url }));
-  const opaqueURL = await window.sharedStorage.selectURL('creative-rotation', urls, { data: DEMO_AD_CONFIG });
-
-  // Render the opaque URL into a fenced frame
-  document.getElementById('ad-slot').src = opaqueURL;
-}
-
-injectAd();
-```
-
-**[creative-rotation-worklet.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/advertiser/creative-rotation-worklet.js)**
-
-```javascript
-class SelectURLOperation {
-  async run(urls, data) {
-    // Read the rotation mode from Shared Storage
-    const rotationMode = await this.sharedStorage.get('creative-rotation-mode');
-
-    // Generate a random number to be used for rotation
-    const randomNumber = Math.random();
-
-    let index;
-
-    switch (rotationMode) {
-      /**
-       * Sequential rotation
-       * - Rotates the creatives in order
-       * - Example: A -> B -> C -> A ...
-       */
-      case 'sequential':
-        const currentIndex = await this.sharedStorage.get('creative-rotation-index');
-        index = parseInt(currentIndex, 10);
-        const nextIndex = (index + 1) % urls.length;
-
-        await this.sharedStorage.set('creative-rotation-index', nextIndex);
-        break;
-
-      /**
-       * Weighted rotation
-       * - Rotates the creatives with weighted probability
-       * - Example: A=70% / B=20% / C=10%
-       */
-      case 'weighted-distribution':
-        // Find the first URL where the cumulative sum of the weights
-        // exceed the random number. The array is sorted by the weight
-        // in descending order.
-        let weightSum = 0;
-        const { url } = data
-          .sort((a, b) => b.weight - a.weight)
-          .find(({ weight }) => {
-            weightSum += weight;
-            return weightSum > randomNumber;
-          });
-
-        index = urls.indexOf(url);
-        break;
-
-      default:
-        index = 0;
-    }
-
-    return index;
-  }
-}
-
-register('creative-rotation', SelectURLOperation);
-```
-
-### Known customer {: #known-customer }
-
-You may want to render a different element based on whether the user was seen
-on a different site. For example, a payment provider may want to render a
-"Register" or "Buy now" button based on whether the user has registered at the
-payment provider's site. Shared storage can be used to set the user's status.
-
-In this example:
-
-*  `known-customer.js` is embedded in an ad iframe. This script sets the
-   options for which button should be displayed on a site, "Register" or "Buy now."
-*  `known-customer-worklet.js`  is the shared storage worklet that determines
-   if the user is known. If the user is known, the information is returned. If
-   the user is unknown, that information is returned to display the "Register"
-   button and the user is marked as known for the future.
-
-**[known-customer.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/advertiser/known-customer.js)**
-
-```javascript
-// The first URL for the "register" button is rendered for unknown users.
-const AD_URLS = [
-  { url: `https://${advertiserUrl}/ads/register-button.html` },
-  { url: `https://${advertiserUrl}/ads/buy-now-button.html` },
-];
-
-async function injectAd() {
-  // Load the worklet module
-  await window.sharedStorage.worklet.addModule('known-customer-worklet.js');
-
-  // Set the initial status to unknown ('0' is unknown and '1' is known)
-  window.sharedStorage.set('known-customer', 0, {
-    ignoreIfPresent: true,
-  });
-
-  // Run the URL selection operation to choose the button based on the user status
-  const opaqueURL = await window.sharedStorage.selectURL('known-customer', AD_URLS);
-
-  // Render the opaque URL into a fenced frame
-  document.getElementById('button-slot').src = opaqueURL;
-}
-
-injectAd();
-```
-
-**[known-customer-worklet.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/advertiser/known-customer-worklet.js)**
-
-```javascript
-class SelectURLOperation {
-  async run(urls) {
-    const knownCustomer = await this.sharedStorage.get('known-customer');
-
-    // '0' is unknown and '1' is known
-    return parseInt(knownCustomer);
-  }
-}
-
-register('known-customer', SelectURLOperation);
-```
-
-### Cross-site data aggregation (ad campaign reach) {: #aggregated-data }
-
-{% Aside %}
-
-This proposed use case relies on the aggregation service, which is not yet
-available. Once ready, this documentation will be updated.
-
-{% endAside %}
-
-You can also send that data to an aggregation service that measures the reach
-across sites, while protecting user privacy by aggregating data about users.
-
-For example, a consumer goods company runs an awareness ad campaign across
-multiple sites, to maximize the number of people who see their ad. The company
-wants to know their reach, how many unique users have seen the ad. In this
-example, the publisher creates two files: 
-
-* `ad-iframe.js` should be embedded in the iframe, which calls to the shared storage worklet and sends a report with the ad campaign ID.
-* `reach-worklet.js`  is the shared storage worklet which sends the reach report to be aggregated.
-
-**ad-iframe.js**
-
-```javascript
-await window.sharedStorage.worklet.addModule("reach.js");
-await window.sharedStorage.runOperation("send-reach-report", {
-  data: {
-     "campaign-id": "1234"
-  }
-});
-```
-
-**reach-worklet.js**
-
-```javascript
-class SendReachReportOperation {
-  async function run(data) {
-    const report_sent_for_campaign = "report-sent-" + data["campaign-id"];
-    
-    // Compute reach only for users who haven't previously
-	 // had a report sent for this campaign.
-    // Users who previously triggered a report for this campaign on  
-    // a site other than the current one will be skipped.
-    if (await this.sharedStorage.get(report_sent_for_campaign) === "yes") {
-      return;  // Don't send a report.
-    }
-
-    // The user agent will send the report to a default endpoint after
-	 // a delay.
-    privateAggregation.sendHistogramReport({
-      bucket: data["campaign-id"];
-      value: 128,  // A predetermined fixed value; see Private Aggregation API explainer: Scaling values.
-      });
-      
-    await this.sharedStorage.set(report_sent_for_campaign, "yes");
-  }
-}
-registerOperation("send-reach-report", SendReachReportOperation);
-```
-
-### User consent status {: #user-content-status }
+### Not recommended: user consent status {: #user-content-status }
 
 Adtech companies often have cross-site consent statuses that they need to keep
 track of. For example, an adtech company may want to store if a user consents
 to an adtech's terms or service or policies related to regulations, such as
 GDPR.  
 
-Shared storage is not recommended for this use case for two main reasons: 
+**Shared storage is not recommended for this use case**. This is because:
 
 1. A user might opt-out of using the privacy sandbox apis, which would prevent
    organizations from using shared storage at all.

--- a/site/en/privacy-sandbox/index.njk
+++ b/site/en/privacy-sandbox/index.njk
@@ -65,9 +65,18 @@ sections:
     - url: /docs/privacy-sandbox/fedcm
     - url: /docs/privacy-sandbox/first-party-sets
     - url: /docs/privacy-sandbox/fenced-frame
-    - url: /docs/privacy-sandbox/shared-storage
-    - url: /docs/privacy-sandbox/use-shared-storage
     - url: /docs/privacy-sandbox/storage-partitioning
+  storage_cross_site:
+    - url: /docs/privacy-sandbox/storage-partitioning
+    - url: /docs/privacy-sandbox/shared-storage
+    - url: /docs/privacy-sandbox/private-aggregation
+      title: Private Aggregation API
+      description: Measure Shared Storage data and generate a noisy summary report.
+  related_storage_usecases:
+    - url: /docs/privacy-sandbox/shared-storage/url-selection
+    - url: /docs/privacy-sandbox/shared-storage/creative-rotation
+    - url: /docs/privacy-sandbox/shared-storage/known-customer
+    - url: /docs/privacy-sandbox/shared-storage/ab-testing
   fight_spam:
     - url: /docs/privacy-sandbox/trust-tokens
 ---
@@ -177,6 +186,23 @@ sections:
   250,
   124,
   "image/VbsHyyQopiec0718rMq2kTE1hke2/tCE6xv0QdnKWNSEJQUbA.svg"
+  )
+}}
+
+{{ landingSectionExpanded(
+  "Secure cross-site storage",
+  "Prevent fraud, run A/B testing, rotate creatives, and support other use cases, while protecting user privacy.",
+  sections.storage_cross_site,
+  "green",
+  "top-3",
+  true,
+  "image/VbsHyyQopiec0718rMq2kTE1hke2/g0sHuyvPENgBaLhY6uJA.svg",
+  "Analytics icon.",
+  250,
+  124,
+  "image/VbsHyyQopiec0718rMq2kTE1hke2/g0sHuyvPENgBaLhY6uJA.svg",
+  "Explore use cases",
+  sections.related_storage_usecases
   )
 }}
 

--- a/site/en/privacy-sandbox/index.njk
+++ b/site/en/privacy-sandbox/index.njk
@@ -73,7 +73,7 @@ sections:
       title: Private Aggregation API
       description: Measure Shared Storage data and generate a noisy summary report.
   related_storage_usecases:
-    - url: /docs/privacy-sandbox/shared-storage/url-selection
+    - url: /docs/privacy-sandbox/shared-storage/frequency-control
     - url: /docs/privacy-sandbox/shared-storage/creative-rotation
     - url: /docs/privacy-sandbox/shared-storage/known-customer
     - url: /docs/privacy-sandbox/shared-storage/ab-testing


### PR DESCRIPTION
Move all Shared Storage use cases into separate docs. Update PS landing page and `/doc` navigation

- [Docs landing page](https://deploy-preview-4018--developer-chrome-com.netlify.app/docs/privacy-sandbox/#secure-cross-site-storage)
- New use cases
  - [Frequency control](https://deploy-preview-4018--developer-chrome-com.netlify.app/docs/privacy-sandbox/shared-storage/frequency-control/)
   - [A/B Testing](https://deploy-preview-4018--developer-chrome-com.netlify.app/docs/privacy-sandbox/shared-storage/ab-testing/)
  - [Creative rotation](https://deploy-preview-4018--developer-chrome-com.netlify.app/docs/privacy-sandbox/shared-storage/creative-rotation/)
  - [Known customers](https://deploy-preview-4018--developer-chrome-com.netlify.app/docs/privacy-sandbox/shared-storage/known-customer/)
