### PR TITLE
Correct location of TOC file in web platform handbook

### DIFF
--- a/site/en/docs/handbook/web-platform/index.md
+++ b/site/en/docs/handbook/web-platform/index.md
@@ -8,7 +8,7 @@ date: 2022-05-06
 
 Web Platform documentation should follow the conventions outlined in the [Add a Doc][add-a-doc] guide. 
 
-The `toc.yml` file is located at `site/_collections/_data/docs/web-platform/toc.yml`. 
+The `toc.yml` file that defines the table of contents structure is located at `site/_data/docs/web-platform/toc.yml`. 
 Link your new doc in this file in the appropriate category. If your doc moves between Origin and Developer Trials, 
 and when it ships, make a PR to update this file to move it in the list.
 


### PR DESCRIPTION
Changes proposed in this pull request:

- I noticed that the location of the `toc.yml` file listed at https://developer.chrome.com/docs/handbook/web-platform/ was wrong, so I decided to fix it as a test case, just to make sure I've got all the basic machinery working properly before I make any more substantial changes.
-
-