### PR TITLE
Specify only one service_worker key is allowed.

### DIFF
--- a/site/en/docs/extensions/mv3/mv3-migration/index.md
+++ b/site/en/docs/extensions/mv3/mv3-migration/index.md
@@ -108,9 +108,10 @@ In Manifest V3, background pages are now [*extension service workers*][mdn-servi
 
 {% endColumns %}
 
-Even though Manifest V3, does not support multiple background scripts, you can optionally declare
-the service worker as an [ES Module][webdev-esm] by specifying `"type": "module"`, which allows you
-to import further code.
+Even through Manifest V3, multiple background scripts are not supported and only 
+one `service_worker` can be specified.  You can optionally declare the service 
+worker as an [ES Module][webdev-esm] by specifying `"type": "module"`, which 
+allows you to import further code.
 
 ### Host permissions  {: #host-permissions }
 


### PR DESCRIPTION
Fixes ambiguity of how many `service_worker` fields can be specified https://developer.chrome.com/docs/extensions/mv3/mv3-migration/#man-sw.  

Changes proposed in this pull request: Add description to specify only one `service_worker` field can be defined in the `background` field. 

-
-
-