### PR TITLE
DevTools 107 > Elements > Disable search as you type

### DIFF
--- a/site/en/docs/devtools/dom/index.md
+++ b/site/en/docs/devtools/dom/index.md
@@ -2,7 +2,7 @@
 layout: "layouts/doc-post.njk"
 title: "Get started with viewing and changing the DOM"
 date: 2019-03-01
-updated: 2022-06-09
+updated: 2022-10-25
 description: "How to view nodes, search for nodes, edit nodes, reference nodes in the Console, break on node changes, and more."
 authors:
   - kaycebasques
@@ -116,6 +116,12 @@ You can search the DOM Tree by string, CSS selector, or XPath selector.
    {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/qigo04bdlo2evHazfIAp.png", alt="Highlighting the query in the Search bar", width="800", height="545" %}
 
 As mentioned above, the Search bar also supports CSS and XPath selectors.
+
+The **Elements** panel selects the first matching result in the DOM tree and rolls it into view in the viewport. By default, this happens as you type. If you are, for example, a software tester who is always working with long search queries, you can make DevTools start search only when you press <kbd>Enter</kbd>.
+
+To avoid unnecessary jumps between nodes, clear the {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/9gzXiTYY0nZzBxGI6KrV.svg", alt="Settings.", width="24", height="24" %} **Settings** > **Preferences** > **Global** > **Search as you type** checkbox.
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/BKcshLBj0EI1OahoEXbS.png", alt="Cleared Search as you type checkbox in Settings.", width="800", height="425" %}
 
 ## Edit the DOM {: #edit }
 

--- a/site/en/docs/devtools/dom/index.md
+++ b/site/en/docs/devtools/dom/index.md
@@ -117,7 +117,7 @@ You can search the DOM Tree by string, CSS selector, or XPath selector.
 
 As mentioned above, the Search bar also supports CSS and XPath selectors.
 
-The **Elements** panel selects the first matching result in the DOM tree and rolls it into view in the viewport. By default, this happens as you type. If you are, for example, a software tester who is always working with long search queries, you can make DevTools start search only when you press <kbd>Enter</kbd>.
+The **Elements** panel selects the first matching result in the DOM tree and rolls it into view in the viewport. By default, this happens as you type. If you always work with long search queries, you can make DevTools run search only when you press <kbd>Enter</kbd>.
 
 To avoid unnecessary jumps between nodes, clear the {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/9gzXiTYY0nZzBxGI6KrV.svg", alt="Settings.", width="24", height="24" %} **Settings** > **Preferences** > **Global** > **Search as you type** checkbox.
 


### PR DESCRIPTION
Documented https://developer.chrome.com/en/blog/new-in-devtools-107/#search-type

Publish on Oct 25