### PR TITLE
DevTool 95 > Issues > Hide issues + Issues guide refresh

### DIFF
--- a/site/en/docs/devtools/issues/index.md
+++ b/site/en/docs/devtools/issues/index.md
@@ -49,7 +49,7 @@ Future versions of Chrome will support more issue types.
 
     {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/flsQZhbMxK2nCosFjvPC.png", alt="The Issues tab with one more issues found after reloading the page.", width="800", height="443" %}
 
-The Console might also show you [issues reported by the browser](/docs/devtools/console/log/#browser). However, you'll notice that such issues (like the cookie warning in the screenshot below) are hard to understand. It's not clear what you need to do to fix it.
+The **Console** might also show you [issues reported by the browser](/docs/devtools/console/log/#browser). However, you'll notice that such issues (like the cookie warning in the screenshot below) are hard to understand. It's not clear what you need to do to fix it.
 
 {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/VIYVuoLscTkbIZ8Nko7o.png", alt="The Console with an obscure cookie warning.", width="800", height="443" %}
 
@@ -72,7 +72,7 @@ way.
       context, such as the **Network**, **Sources**, **Elements**, and other panels.
     - Links to further guidance.
 
-1.  Click on the items in **AFFECTED RESOURCES**to [view issues in context](#issues-devtools).
+1.  Click on the items in **AFFECTED RESOURCES** to [view issues in context](#issues-devtools).
 
 ### Group issues by kind {: #group-by-kind }
 
@@ -94,7 +94,7 @@ To group issues, check {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/hmp8j3HiLM
 
 Third-party cookie issues are hidden by default.
 
-To view such issues, check {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/hmp8j3HiLMCcqPArD9yt.svg", alt="Checkbox.", width="22", height="22" %} **Include third-party cookie issues** in the action bar at the top of the **Issues** tab. You can find them in the **AFFECTED RESOURCES** section without a link.
+To view such issues, check {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/hmp8j3HiLMCcqPArD9yt.svg", alt="Checkbox.", width="22", height="22" %} **Include third-party cookie issues** in the action bar at the top of the **Issues** tab. You can find third-party cookie issues in the **AFFECTED RESOURCES** section missing a link.
 
 {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/hPAEUH4LTwDFyPoQoPQ0.png", alt="Third-party cookie without a linked resource in the Affected Resources section.", width="800", height="654" %}
 

--- a/site/en/docs/devtools/issues/index.md
+++ b/site/en/docs/devtools/issues/index.md
@@ -25,6 +25,9 @@ Starting from Chrome 92, the **Issues** tab supports the following types of issu
 - [Mixed content][2]
 - [COEP issues][3]
 - [CORS errors][6]
+- [Quirks mode issues][7]
+- (Preview) [Low-contrast issues][8]
+- [Trusted Web Activity issues][9]
 
 Future versions of Chrome will support more issue types.
 
@@ -131,4 +134,6 @@ To investigate an issue:
 [4]: https://samesite-sandbox.glitch.me/
 [5]: /docs/devtools/open
 [6]: https://developer.mozilla.org/docs/Web/HTTP/CORS/Errors
-
+[7]: https://quirks.spec.whatwg.org/
+[8]: /blog/new-in-devtools-90/#low-contrast
+[9]: /docs/android/trusted-web-activity/

--- a/site/en/docs/devtools/issues/index.md
+++ b/site/en/docs/devtools/issues/index.md
@@ -88,7 +88,7 @@ The **Issues** tab counts the number of affected resources for each issue and sh
 
 To group issues, check {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/hmp8j3HiLMCcqPArD9yt.svg", alt="Checkbox.", width="22", height="22" %} **Group by kind** in the action bar at the top of the **Issues** tab.
 
-{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/OOGt5WUOjWFpfkdwA40J.png", alt="Issues grouped in three kinds: Page errors, Braking changes, and Improvements.", width="800", height="543" %}
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/OOGt5WUOjWFpfkdwA40J.png", alt="Issues grouped in three kinds: Page errors, Breaking changes, and Improvements.", width="800", height="543" %}
 
 ### Include third-party issues {: #include-third-party }
 

--- a/site/en/docs/devtools/issues/index.md
+++ b/site/en/docs/devtools/issues/index.md
@@ -5,13 +5,13 @@ authors:
   - samdutton
   - sofiayem
 date: 2020-05-14
-updated: 2022-08-31
+updated: 2022-10-18
 description: "Use the Issues Tab to find and fix problems with your website."
 tags:
   - find-issues
 ---
 
-The **Issues** tab in Chrome DevTools reduces the notification fatigue and clutter of the Console.
+The **Issues** tab in Chrome DevTools reduces the notification fatigue and clutter of the **Console**.
 Use it to find solutions to problems detected by the browser, such as cookie issues and mixed
 content.
 
@@ -33,58 +33,97 @@ Future versions of Chrome will support more issue types.
 ## Open the Issues tab {: #open }
 
 1.  Visit a page with issues to fix, such as [samesite-sandbox.glitch.me][4].
-2.  [Open DevTools][5].
-3.  Click the **Go to Issues** button in the yellow warning bar.
+1.  [Open DevTools][5].
+1.  Click the **Open Issues** button next to {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/9gzXiTYY0nZzBxGI6KrV.svg", alt="Settings.", width="24", height="24" %} **Settings** in the right corner of the action bar at the top. Depending on issue severity, the button can have a red {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/OBuCXn9tp80NwQhjgW1A.png", alt="Error.", width="20", height="20" %}, yellow {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/p5xfRZVMMOJdRLcntKn4.png", alt="Warning.", width="20", height="20" %}, or blue {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Qv8hM734naJTUchdUN1P.png", alt="Information.", width="20", height="20" %} icon.
 
-    {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/gCmzHUEJiNXOrvIB0fZg.png", alt="Chrome DevTools screenshot showing yellow warning bar for Issues detected.", width="800", height="350" %}
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/LNXwL7mNrQJ6vrWxE7EO.png", alt="The Open Issues button with a red icon.", width="800", height="514" %}
 
-    Alternatively, select **Issues** from the **More tools** menu.
+    Alternatively, select **Issues** from the {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/N5Lkpdwpaz4YqRGFr2Ks.svg", alt="More tools menu.", width="24", height="24" %} **More tools** menu.
 
-    {% Img src="image/admin/I1lYj0JQnddws06dscVU.png", alt="Chrome DevTools screenshot showing Issues tab in More tools menu.", width="800", height="350" %}
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/PPFYdVjZGxOWUliKyewL.png", alt="The Issues tab in More tools menu.", width="800", height="514" %}
 
-4.  Once you're on the Issues tab, click the **Reload page** button if necessary.
+1.  Once you're on the **Issues** tab, you might want to reload the page to catch even more issues, this time occurring during page load.
 
-    {% Img src="image/admin/LeFSmbYEy8cjAmdqNYr9.png", alt="Chrome DevTools screenshot showing Issues tab with 'Reload page' button.", width="800", height="481" %}
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/flsQZhbMxK2nCosFjvPC.png", alt="The Issues tab with one more issues found after reloading the page.", width="800", height="443" %}
 
-    You'll notice that issues reported in the Console (such as the cookie warnings here) are quite
-    hard to understand. It's not clear what needs to be done to fix the issues reported.
+The Console might also show you [issues reported by the browser](/docs/devtools/console/log/#browser). However, you'll notice that such issues (like the cookie warning in the screenshot below) are hard to understand. It's not clear what you need to do to fix it.
 
-    {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/TjbgfCTF4wLnhifvpiRc.png", alt="Chrome DevTools screenshot showing Issues tab with two cookie issues.", width="800", height="529" %}
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/VIYVuoLscTkbIZ8Nko7o.png", alt="The Console with an obscure cookie warning.", width="800", height="443" %}
+
+On the other hand, the **Issues** tab provides you with actionable insights.
 
 ## View items in the Issues tab {: #view-issues }
 
 The **Issues** tab presents warnings from the browser in a structured, aggregated, and actionable
 way.
 
-1.  Click an item in the **Issues** tab to get guidance on how to fix the issue and find affected
-    resources.
+1.  Click an item in the **Issues** tab to expand the issue and get guidance on how to fix the it and find affected resources.
 
-    {% Img src="image/admin/ohxdDJRkjvFGaFHO3i0R.png", alt="Chrome DevTools screenshot showing a cookie issue open in the Issues tab.", width="800", height="657" %}
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/3J588AXoubJbr2llFYmc.png", alt="The Issues tab with a cross-site cookie issue expanded.", width="800", height="747" %}
 
     Each item has four components:
 
     - A headline describing the issue.
     - A description providing the context and the solution.
     - An **AFFECTED RESOURCES** section that links to resources within the appropriate DevTools
-      context, such as the Network panel.
+      context, such as the **Network**, **Sources**, **Elements**, and other panels.
     - Links to further guidance.
 
-2.  Click on **AFFECTED RESOURCES** items to view details. In this example, there is one cookie and
-    one request affected.
+1.  Click on the items in **AFFECTED RESOURCES**to [view issues in context](#issues-devtools).
 
-    {% Img src="image/admin/6AwuuJhT2Uuxzc395J41.png", alt="Chrome DevTools screenshot showing affected resources open in the Issues tab.", width="800", height="657" %}
+### Group issues by kind {: #group-by-kind }
+
+{% Aside %}
+**Note**: This is a preview feature disabled by default. To enable it, check {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/9gzXiTYY0nZzBxGI6KrV.svg", alt="Settings.", width="22", height="22" %} **Settings** > **Experiments** > {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/hmp8j3HiLMCcqPArD9yt.svg", alt="Checkbox.", width="22", height="22" %} **Allow grouping and hiding of issues by issue kind**.
+{% endAside %}
+
+The **Issues** tab counts the number of affected resources for each issue and shows it next to their headlines. Additionally, you can organize the issues by their severity in three group kinds:
+
+- {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/OBuCXn9tp80NwQhjgW1A.png", alt="Error.", width="20", height="20" %} **Page Errors** that Chrome reports.
+- {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/p5xfRZVMMOJdRLcntKn4.png", alt="Warning.", width="20", height="20" %} **Breaking Changes** such as deprecations.
+- {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Qv8hM734naJTUchdUN1P.png", alt="Information.", width="20", height="20" %} **Improvements** that DevTools suggests.
+
+To group issues, check {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/hmp8j3HiLMCcqPArD9yt.svg", alt="Checkbox.", width="22", height="22" %} **Group by kind** in the action bar at the top of the **Issues** tab.
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/OOGt5WUOjWFpfkdwA40J.png", alt="Issues grouped in three kinds: Page errors, Braking changes, and Improvements.", width="800", height="543" %}
+
+### Include third-party issues {: #include-third-party }
+
+Third-party cookie issues are hidden by default.
+
+To view such issues, check {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/hmp8j3HiLMCcqPArD9yt.svg", alt="Checkbox.", width="22", height="22" %} **Include third-party cookie issues** in the action bar at the top of the **Issues** tab. You can find them in the **AFFECTED RESOURCES** section without a link.
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/hPAEUH4LTwDFyPoQoPQ0.png", alt="Third-party cookie without a linked resource in the Affected Resources section.", width="800", height="654" %}
+
+### Hide issues {: #hide-issues }
+
+To hide an issue, select **Hide issues like this** from the {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/N5Lkpdwpaz4YqRGFr2Ks.svg", alt="Three-dot menu.", width="24", height="24" %} three-dot menu next to the issue.
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/H8aKDRUmwCw6mqCUi7xD.png", alt="The Hide issues like this option in the three-dot menu next to an issue.", width="800", height="543" %}
+
+To see the list of hidden issues, scroll down to the **Hidden issues** section and expand it.
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/5DbdsJGfwLLMGdyjvFCb.png", alt="The Hidden issues section.", width="800", height="537" %}
+
+To reveal all issues, click **Unhide all**. To reveal a specific issue, select **Unhide issues like this** from the {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/N5Lkpdwpaz4YqRGFr2Ks.svg", alt="Three-dot menu.", width="24", height="24" %} three-dot menu next to the issue.
+
+Additionally, with [grouping enabled](#group-by-kind), you can hide entire groups of issues using the same three-dot menu next to a group.
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/6mgixqWs0Q45Wd6C8bo0.png", alt="The three-dot menu with an option to hide the Improvements group.", width="800", height="537" %}
 
 ## View issues in context {: #issues-devtools }
 
-1.  Click on a resource link to view the item in the appropriate context within DevTools. In this
-    example, click `samesite-sandbox.glitch.me` to show the cookies attached to that request.
+To investigate an issue:
 
-    {% Img src="image/admin/REHyxZ4gkbfzZgRCp3OG.png", alt="Chrome DevTools screenshot showing affected resources open in the Issues tab.", width="800", height="657" %}
+1.  In the **AFFECTED RESOURCES** section, click on a resource link to view the item in the appropriate context within DevTools. In this
+    example, click `samesite-sandbox.glitch.me` to show the cookies attached to that request. The link takes you to the **Network** panel.
 
-2.  Scroll to view the item with a problem: in this case, the cookie `ck02`. Hover over the
-    information icon on the right to see the problem and how to fix it.
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/IMSsZiOfHVBumJ6JSGIr.png", alt="The Affected Resources section with a link to the affected request.", width="800", height="709" %}
 
-    {% Img src="image/admin/CQlNNpB5ISFRD5lCYkKw.png", alt="Chrome DevTools screenshot showing issue with a resource opened from the Issues tab.", width="800", height="679" %}
+1.  Scroll to view the item with a problem: in this case, the cookie `ck02`. Hover over the
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/2OyGRodvgk9neTIEAH4g.svg", alt="Information.", width="24", height="24" %} information icon on the right to see the problem and how to fix it.
+
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Lsz9HyD4YSKs23rdGmMC.png", alt="The Network panel shows a tooltip when you hover over the information icon.", width="800", height="548" %}
 
 [1]: https://web.dev/samesite-cookies-explained
 [2]: https://developers.google.com/web/fundamentals/security/prevent-mixed-content/what-is-mixed-content


### PR DESCRIPTION
Refreshed the Issues guide. Reshot outdated screenshots.
Documented:
- https://developer.chrome.com/blog/new-in-devtools-86/#issues-tab
- https://developer.chrome.com/en/blog/new-in-devtools-95/#hide-issues

Still TODO: update list of reported issues (need to go through WDNT for that).