### PR TITLE
Add reference docs for The Pop-Up API, and my own author details

### DIFF
--- a/site/_data/authorsData.json
+++ b/site/_data/authorsData.json
@@ -944,5 +944,11 @@
   "rouslan": {
     "github": "rsolomakhin",
     "image": "image/YLflGBAPWecgtKJLqCJHSzHqe2J2/dZOnFhReaU2NKpk1Rr9f.jpg"
+  },
+  "chrisdavidmills": {
+    "github": "chrisdavidmills",
+    "twitter": "chrisdavidmills",
+    "linkedin": "https://www.linkedin.com/in/chris-mills-4471711/",
+    "image": "image/nkovDlvelCQoTyX9N57xf85AR9T2/jlh9RMlHQcyL1oQ7tP7z.jpg"
   }
 }

--- a/site/_data/docs/web-platform/toc.yml
+++ b/site/_data/docs/web-platform/toc.yml
@@ -15,6 +15,7 @@
   sections:
     - url: /docs/web-platform/launch-handler
     - url: /docs/web-platform/webgpu
+    - url: /docs/web-platform/popup-api
 
 - title: i18n.docs.web-platform.developer-trials
   sections:

--- a/site/_data/i18n/authors.yaml
+++ b/site/_data/i18n/authors.yaml
@@ -1137,3 +1137,8 @@ rouslan:
     en: 'Rouslan Solomakhin'
   description:
     en: 'Software Engineer on the Chrome team.'
+chrisdavidmills:
+  title:
+    en: 'Chris Mills'
+  description:
+    en: 'Independent tech writer specializing in web platform docs'

--- a/site/_data/i18n/authors.yaml
+++ b/site/_data/i18n/authors.yaml
@@ -1141,4 +1141,4 @@ chrisdavidmills:
   title:
     en: 'Chris Mills'
   description:
-    en: 'Independent tech writer specializing in web platform docs'
+    en: 'Independent tech writer specializing in web platform docs.'

--- a/site/en/docs/web-platform/popup-api/backdrop-pseudo-element/index.md
+++ b/site/en/docs/web-platform/popup-api/backdrop-pseudo-element/index.md
@@ -1,0 +1,44 @@
+---
+layout: 'layouts/doc-post.njk'
+title: ::backdrop
+description: Allows styling of content behind the pop-up while the pop-up is open.
+subhead: Allows styling of content behind the pop-up while the pop-up is open.
+authors:
+  - chrisdavidmills
+date: 2022-10-19
+updated: 2022-10-19
+---
+
+The **`::backdrop`** [CSS](https://developer.mozilla.org/docs/Web/CSS) [pseudo-element](https://developer.mozilla.org/docs/Web/CSS/Pseudo-elements) sits behind an open [pop-up](/docs/web-platform/popup-api/) in the stacking order, but in front of the rest of the document, and spans the entire width and height of the viewport. It allows the rest of the content to be styled while the pop-up is open — for example you might want to blur or darken it.
+
+`::backdrop` neither inherits from nor is inherited by any other elements.
+
+## Syntax
+
+```css
+::backdrop
+```
+
+## Example
+
+Here we are darkening the rest of the content while the pop-up is shown:
+
+```css
+p[popup]::backdrop {
+  background-color: rgba(0,0,0,0.5);
+}
+```
+
+## Browser compatibility
+
+* The Pop-Up API is planned for launch in Chrome 110, available in stable in early February 2023 (check the [Chrome Roadmap](https://chromestatus.com/roadmap) for updates).
+* It is enabled by default in [Chrome Canary](https://www.google.com/chrome/canary/) for local testing.  
+* Register for the [Origin Trial](/origintrials/#/view_trial/4500221927649968129) if you want to test it in a production environment. Read [Getting started with Chrome's origin trials](/docs/web-platform/origin-trials/) for more information.
+* There is a polyfill available at [https://github.com/oddbird/popup-polyfill](https://github.com/oddbird/popup-polyfill).
+
+## See also
+
+* [The Pop-Up API](/docs/web-platform/popup-api/)
+* [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
+* [Chrome Platform Status: The Pop-Up API](https://chromestatus.com/feature/5463833265045504) 
+* [Open UI: Pop Up API Explainer](https://open-ui.org/components/popup.research.explainer)

--- a/site/en/docs/web-platform/popup-api/backdrop-pseudo-element/index.md
+++ b/site/en/docs/web-platform/popup-api/backdrop-pseudo-element/index.md
@@ -9,7 +9,7 @@ date: 2022-10-19
 updated: 2022-10-19
 ---
 
-The **`::backdrop`** [CSS](https://developer.mozilla.org/docs/Web/CSS) [pseudo-element](https://developer.mozilla.org/docs/Web/CSS/Pseudo-elements) sits behind an open [pop-up](/docs/web-platform/popup-api/) in the stacking order, but in front of the rest of the document, and spans the entire width and height of the viewport. It allows the rest of the content to be styled while the pop-up is open — for example you might want to blur or darken it.
+The **`::backdrop`** [CSS](https://developer.mozilla.org/docs/Web/CSS) [pseudo-element](https://developer.mozilla.org/docs/Web/CSS/Pseudo-elements) sits behind an open [pop-up](/docs/web-platform/popup-api/) in the stacking order, but in front of the rest of the document, and spans the entire width and height of the viewport. It allows the rest of the content to be styled while the pop-up is open—for example you might want to blur or darken it.
 
 `::backdrop` neither inherits from nor is inherited by any other elements.
 

--- a/site/en/docs/web-platform/popup-api/backdrop-pseudo-element/index.md
+++ b/site/en/docs/web-platform/popup-api/backdrop-pseudo-element/index.md
@@ -21,7 +21,7 @@ The **`::backdrop`** [CSS](https://developer.mozilla.org/docs/Web/CSS) [pseudo-e
 
 ## Example
 
-Here we are darkening the rest of the content while the pop-up is shown:
+In the following example the rest of the content is darkened while the pop-up is shown:
 
 ```css
 p[popup]::backdrop {

--- a/site/en/docs/web-platform/popup-api/defaultopen-attribute/index.md
+++ b/site/en/docs/web-platform/popup-api/defaultopen-attribute/index.md
@@ -1,0 +1,48 @@
+---
+layout: 'layouts/doc-post.njk'
+title: defaultopen
+description: Causes a pop-up to automatically open on page load.
+subhead: Causes a pop-up to automatically open on page load.
+authors:
+  - chrisdavidmills
+date: 2022-10-19
+updated: 2022-10-19
+---
+
+The **`defaultopen`** [global attribute](https://developer.mozilla.org/docs/Web/HTML/Global_attributes) is a [boolean](https://developer.mozilla.org/docs/Glossary/Boolean) attribute that causes a [pop-up](/docs/web-platform/popup-api/) to automatically open on page load.
+
+It can be used on any HTML element that has been turned into a popup using the [`popup`](/docs/web-platform/popup-api/popup-attribute) attribute.
+
+{% Aside 'caution' %}
+`defaultopen` does not work with pop-ups of type `hint`.
+{% endAside %}
+
+## Values
+
+The attribute can have any of the following values:
+
+`false` (default value)
+: The pop-up does not open on page load.
+    
+none or `true`
+: The pop-up opens on page load.
+
+## Example
+
+```html
+<p id="my-popup" popup="auto" defaultopen>Hello!</p>
+```
+
+## Browser compatibility
+
+* The Pop-Up API is planned for launch in Chrome 110, available in stable in early February 2023 (check the [Chrome Roadmap](https://chromestatus.com/roadmap) for updates).
+* It is enabled by default in [Chrome Canary](https://www.google.com/chrome/canary/) for local testing.  
+* Register for the [Origin Trial](/origintrials/#/view_trial/4500221927649968129) if you want to test it in a production environment. Read [Getting started with Chrome's origin trials](/docs/web-platform/origin-trials/) for more information.
+* There is a polyfill available at [https://github.com/oddbird/popup-polyfill](https://github.com/oddbird/popup-polyfill).
+
+## See also
+
+* [The Pop-Up API](/docs/web-platform/popup-api/)
+* [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
+* [Chrome Platform Status: The Pop-Up API](https://chromestatus.com/feature/5463833265045504) 
+* [Open UI: Pop Up API Explainer](https://open-ui.org/components/popup.research.explainer)

--- a/site/en/docs/web-platform/popup-api/defaultopen-property/index.md
+++ b/site/en/docs/web-platform/popup-api/defaultopen-property/index.md
@@ -1,0 +1,46 @@
+---
+layout: 'layouts/doc-post.njk'
+title: defaultOpen
+description: Causes a pop-up to automatically open on page load.
+subhead: Causes a pop-up to automatically open on page load.
+authors:
+  - chrisdavidmills
+date: 2022-10-19
+updated: 2022-10-19
+---
+
+The `defaultOpen` property of the [`Element`](https://developer.mozilla.org/docs/Web/API/Element) interface causes a [pop-up](/docs/web-platform/popup-api/) to automatically open on page load. It is the DOM definition of the HTML [`defaultopen`](/docs/web-platform/popup-api/defaultopen-attribute) attribute.
+
+{% Aside 'caution' %}
+`defaultopen` does not work with pop-ups of type `hint`.
+{% endAside %}
+
+## Value
+
+A boolean. `false` is the default value; A value of `true` causes the pop-up to open on page load.
+
+## Example
+
+```js
+const popup = document.getElementById('my-popup');
+
+// get
+popup.defaultopen;
+
+// set
+popup.defaultopen = 'false';
+```
+
+## Browser compatibility
+
+* The Pop-Up API is planned for launch in Chrome 110, available in stable in early February 2023 (check the [Chrome Roadmap](https://chromestatus.com/roadmap) for updates).
+* It is enabled by default in [Chrome Canary](https://www.google.com/chrome/canary/) for local testing.  
+* Register for the [Origin Trial](/origintrials/#/view_trial/4500221927649968129) if you want to test it in a production environment. Read [Getting started with Chrome's origin trials](/docs/web-platform/origin-trials/) for more information.
+* There is a polyfill available at [https://github.com/oddbird/popup-polyfill](https://github.com/oddbird/popup-polyfill).
+
+## See also
+
+* [The Pop-Up API](/docs/web-platform/popup-api/)
+* [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
+* [Chrome Platform Status: The Pop-Up API](https://chromestatus.com/feature/5463833265045504) 
+* [Open UI: Pop Up API Explainer](https://open-ui.org/components/popup.research.explainer)

--- a/site/en/docs/web-platform/popup-api/hidepopup-method/index.md
+++ b/site/en/docs/web-platform/popup-api/hidepopup-method/index.md
@@ -1,0 +1,59 @@
+---
+layout: 'layouts/doc-post.njk'
+title: hidePopUp()
+description: Dismisses a pop-up.
+subhead: Dismisses a pop-up.
+authors:
+  - chrisdavidmills
+date: 2022-10-19
+updated: 2022-10-19
+---
+
+The **`hidePopUp()`** instance method of the [`Element`](https://developer.mozilla.org/docs/Web/API/Element) interface dismisses a [pop-up](/docs/web-platform/popup-api/) element.
+
+## Syntax
+
+```js
+hidePopUp()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+Void.
+
+### Exceptions
+
+`NotSupportedError` [`DOMException`](https://developer.mozilla.org/docs/Web/API/DOMException)
+: Thrown if `hidePopUp()` is called on an element that does not have a valid value of the [`popup`](/docs/web-platform/popup-api/popup-attribute) attribute set on it.
+
+`InvalidStateError` [`DOMException`](https://developer.mozilla.org/docs/Web/API/DOMException)
+: Thrown if `hidePopUp()` is called on a valid pop-up that is not currently showing.
+
+## Example
+
+```js
+const popup = document.getElementById('my-popup');
+popup.showPopUp(); // needs to be shown first
+
+  ...
+
+popup.hidePopUp();
+```
+
+## Browser compatibility
+
+* The Pop-Up API is planned for launch in Chrome 110, available in stable in early February 2023 (check the [Chrome Roadmap](https://chromestatus.com/roadmap) for updates).
+* It is enabled by default in [Chrome Canary](https://www.google.com/chrome/canary/) for local testing.  
+* Register for the [Origin Trial](/origintrials/#/view_trial/4500221927649968129) if you want to test it in a production environment. Read [Getting started with Chrome's origin trials](/docs/web-platform/origin-trials/) for more information.
+* There is a polyfill available at [https://github.com/oddbird/popup-polyfill](https://github.com/oddbird/popup-polyfill).
+
+## See also
+
+* [The Pop-Up API](/docs/web-platform/popup-api/)
+* [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
+* [Chrome Platform Status: The Pop-Up API](https://chromestatus.com/feature/5463833265045504) 
+* [Open UI: Pop Up API Explainer](https://open-ui.org/components/popup.research.explainer)

--- a/site/en/docs/web-platform/popup-api/index.md
+++ b/site/en/docs/web-platform/popup-api/index.md
@@ -171,7 +171,7 @@ p[popup]:open {
 }
 ```
 
-Use the [`::backdrop`](/docs/web-platform/popup-api/backdrop-pseudo-element) pseudo-element to style the document behind the pop-up while it is being shown — here we are darkening the rest of the content:
+Use the [`::backdrop`](/docs/web-platform/popup-api/backdrop-pseudo-element) pseudo-element to style the document behind the pop-up while it is being shown. The following example darkens the rest of the content:
 
 ```css
 p[popup]::backdrop {

--- a/site/en/docs/web-platform/popup-api/index.md
+++ b/site/en/docs/web-platform/popup-api/index.md
@@ -46,7 +46,7 @@ You can show and dismiss pop-ups in two different ways:
 * Declaratively, using HTML attributes. Add the [`popuptoggletarget`](/docs/web-platform/popup-api/popuptoggletarget-attribute), [`popupshowtarget`](/docs/web-platform/popup-api/popupshowtarget-attribute), or [`popuphidetarget`](/docs/web-platform/popup-api/popuphidetarget-attribute) to an `<input>` or `<button>` element to turn it into a pop-up trigger element. In each case, the attribute value must be the `id` of the pop-up, to associate the two.
 * Programmatically, using JavaScript. The [`showPopUp()`](/docs/web-platform/popup-api/showpopup-method) and [`hidePopUp()`](/docs/web-platform/popup-api/hidepopup-method) methods are used to show and dismiss pop-ups, respectively, and the [`popupshow`](/docs/web-platform/popup-api/popupshow-event) and [`popuphide`](/docs/web-platform/popup-api/popuphide-event) events can be used to react to pop-ups being shown or hidden.
 
-The Pop-Up API also comes with a couple of handy CSS features, a [`::backdrop`](/docs/web-platform/popup-api/backdrop-pseudo-element) pseudo-element to style the document behind the pop-up when it is shown (e.g. you might want to blur or fade the page while showing pop-ups), and an [`:open`](/docs/web-platform/popup-api/open-pseudo-class) pseudo-class to style the pop-up only when it is open.
+The Pop-Up API also comes with a couple of handy CSS features, a [`::backdrop`](/docs/web-platform/popup-api/backdrop-pseudo-element) pseudo-element to style the document behind the pop-up when it is shown (for example, you might want to blur or fade the page while showing pop-ups), and an [`:open`](/docs/web-platform/popup-api/open-pseudo-class) pseudo-class to style the pop-up only when it is open.
 
 ## HTML attributes
 

--- a/site/en/docs/web-platform/popup-api/index.md
+++ b/site/en/docs/web-platform/popup-api/index.md
@@ -158,7 +158,7 @@ Declaratively create a single button to toggle the pop-up between shown and hidd
 <button popuptoggletarget="my-popup">Show pop-up</button>
 ```
 
-Use the [`:open`](/docs/web-platform/popup-api/open-pseudo-class) pseudo-class to style the pop-up when it has been shown. In this case we are transitioning the pop-up in from the bottom of the viewport, rather than just having it appear in the center:
+Use the [`:open`](/docs/web-platform/popup-api/open-pseudo-class) pseudo-class to style the pop-up when it has been shown. The following example transitions the pop-up in from the bottom of the viewport, rather than have it appear in the center:
 
 ```css
 p[popup] {

--- a/site/en/docs/web-platform/popup-api/index.md
+++ b/site/en/docs/web-platform/popup-api/index.md
@@ -1,0 +1,209 @@
+---
+layout: 'layouts/doc-post.njk'
+title: The Pop-Up API
+description: The Pop-Up API provides a standard mechanism for displaying pop-ups on the Web.
+subhead: The Pop-Up API provides a standard mechanism for displaying pop-ups on the Web.
+authors:
+  - chrisdavidmills
+date: 2022-10-19
+updated: 2022-10-19
+---
+
+The Pop-Up API provides developers with a standard, consistent, flexible mechanism for displaying pop-up content on top of other page content. Pop-ups can be closed by clicking out of the pop-up or pressing <kbd>Esc</kbd>, and opening another pop-up should close the previous one. Typical use cases include user-interactive elements like action menus, form element suggestions, content pickers, teaching UI, and the Listbox portion of a `<select>` control.
+
+## Current status
+
+* The Pop-Up API is planned for launch in Chrome 110, available in stable in early February 2023 (check the [Chrome Roadmap](https://chromestatus.com/roadmap) for updates).
+* It is enabled by default in [Chrome Canary](https://www.google.com/chrome/canary/) for local testing.  
+* Register for the [Origin Trial](/origintrials/#/view_trial/4500221927649968129) if you want to test it in a production environment. Read [Getting started with Chrome's origin trials](/docs/web-platform/origin-trials/) for more information.
+* There is a polyfill available at [https://github.com/oddbird/popup-polyfill](https://github.com/oddbird/popup-polyfill).
+
+## Concepts and usage
+
+Pop-ups are used constantly, all over the web. Developers keep having to reimplement pop-up styling, positioning and z-index stacking, focus management, keyboard interactions, and accessibility semantics for each new project. As well as duplication of work, this has also resulted in an inconsistent end-user experience across different apps. In answer to this, the [Open UI group](https://open-ui.org/) published a [proposal for the Pop-Up API](https://open-ui.org/components/popup.research.explainer).
+
+Any HTML element can be turned into a pop-up using the [`popup`](/docs/web-platform/popup-api/popup-attribute) attribute. The Pop-Up API provides the following default behavior:
+
+* Pop-ups are hidden by default (using `display: none`). To display a pop-up by default on page load, you can give it the [`defaultopen`](/docs/web-platform/popup-api/defaultopen-attribute) attribute.
+* Pop-ups are also given a default fixed position in the center of the viewport, padding, and a border.
+* When shown, pop-ups are promoted to the top layer of the DOM (above `document`).
+* You can hide a visible pop-up by pressing <kbd>Esc</kbd>, navigating to another element via the keyboard, or clicking outside the pop-up. This is referred to as **light dismissing**.
+* When a new pop-up is shown, previously-shown pop-ups are dismissed automatically.
+* Popups are designed to be accessible, with an element defined as a pop-up trigger automatically getting [`aria-haspopup`](https://developer.mozilla.org/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup) semantics. In addition, focus into the pop-up can be controlled using `autofocus` and, when the pop-up is light dismissed, a heuristic determines where focus should go next. For example, focus could go back to the previously-focused element, or an element clicked outside of the pop-up. See [Focus Management](https://open-ui.org/components/popup.research.explainer#focus-management) for more details.
+
+{% Aside 'key-term' %}
+A _pop-up trigger_ is an element that causes a change in the state of the pop-up it is associated with, for example a `<button>` that shows and dismisses the pop-up.
+{% endAside %}
+
+The [`popup`](/docs/web-platform/popup-api/popup-attribute) attribute can take one of the following values:
+
+* `auto`: The pop-up exhibits the standard behavior explained above.
+* `hint`: You can only show a single `hint` type pop-up at a time. They can be light dismissed, but they can't be shown by default using [`defaultopen`](/docs/web-platform/popup-api/defaultopen-attribute).
+* `manual`: Manual pop-ups cannot be light dismissed (they can only be dismissed by an explicit trigger element or by JavaScript), and they don't automatically dismiss previously-shown pop-ups.
+
+You can show and dismiss pop-ups in two different ways:
+
+* Declaratively, using HTML attributes. Add the [`popuptoggletarget`](/docs/web-platform/popup-api/popuptoggletarget-attribute), [`popupshowtarget`](/docs/web-platform/popup-api/popupshowtarget-attribute), or [`popuphidetarget`](/docs/web-platform/popup-api/popuphidetarget-attribute) to an `<input>` or `<button>` element to turn it into a pop-up trigger element. In each case, the attribute value must be the `id` of the pop-up, to associate the two.
+* Programmatically, using JavaScript. The [`showPopUp()`](/docs/web-platform/popup-api/showpopup-method) and [`hidePopUp()`](/docs/web-platform/popup-api/hidepopup-method) methods are used to show and dismiss pop-ups, respectively, and the [`popupshow`](/docs/web-platform/popup-api/popupshow-event) and [`popuphide`](/docs/web-platform/popup-api/popuphide-event) events can be used to react to pop-ups being shown or hidden.
+
+The Pop-Up API also comes with a couple of handy CSS features, a [`::backdrop`](/docs/web-platform/popup-api/backdrop-pseudo-element) pseudo-element to style the document behind the pop-up when it is shown (e.g. you might want to blur or fade the page while showing pop-ups), and an [`:open`](/docs/web-platform/popup-api/open-pseudo-class) pseudo-class to style the pop-up only when it is open.
+
+## HTML attributes
+
+[`defaultopen`](/docs/web-platform/popup-api/defaultopen-attribute)
+: Causes a pop-up to automatically open on page load.
+
+[`popup`](/docs/web-platform/popup-api/popup-attribute)
+: Turns an element into a pop-up.
+
+[`popuptoggletarget`](/docs/web-platform/popup-api/popuptoggletarget-attribute)
+: Creates a trigger element that toggles an associated pop-up between shown and hidden states.
+
+[`popupshowtarget`](/docs/web-platform/popup-api/popupshowtarget-attribute)
+: Creates a trigger element that shows an associated hidden pop-up.
+
+[`popuphidetarget`](/docs/web-platform/popup-api/popuphidetarget-attribute)
+: Creates a trigger element that dismisses an associated shown pop-up.
+
+## CSS features
+
+[`::backdrop`](/docs/web-platform/popup-api/backdrop-pseudo-element)
+: Pseudo-element that sits behind an open pop-up in the stacking order, but in front of the rest of the document, and spans the entire width and height of the viewport. Allows the rest of the content to be styled while the pop-up is open — for example you might want to blur or darken it.
+
+[`:open`](/docs/web-platform/popup-api/open-pseudo-class)
+: Pseudo-class allowing a pop-up to be styled, but only when it is being shown.
+
+## Interfaces
+
+### Extensions to `Element`
+
+Properties:
+
+[`defaultOpen`](/docs/web-platform/popup-api/defaultopen-property)
+: Causes a pop-up to automatically open on page load. DOM definition of the HTML [`defaultopen`](/docs/web-platform/popup-api/defaultopen-attribute) attribute.
+
+[`popUp`](/docs/web-platform/popup-api/popup-property)
+: Turns an element into a pop-up. DOM definition of the HTML [`popup`](/docs/web-platform/popup-api/popup-attribute) attribute.
+
+`onpopupshow`
+: Event handler property for the [`popupshow`](/docs/web-platform/popup-api/popupshow-event) event, fired on the pop-up when it is shown.
+
+`onpopuphide`
+: Event handler property for the [`popuphide`](/docs/web-platform/popup-api/popuphide-event) event, fired on the pop-up when it is dismissed.
+
+Instance methods:
+
+[`showPopUp()`](/docs/web-platform/popup-api/showpopup-method)
+: Shows a pop-up element.
+
+[`hidePopUp()`](/docs/web-platform/popup-api/hidepopup-method)
+: Dismisses a pop-up element.
+
+Events:
+
+[`popupshow`](/docs/web-platform/popup-api/popupshow-event)
+: Fired on the pop-up when it is shown.
+
+[`popuphide`](/docs/web-platform/popup-api/popuphide-event)
+: Fired on the pop-up when it is dismissed.
+
+### Extensions to `HTMLButtonElement` and `HTMLInputElement`
+
+Properties:
+
+[`popUpToggleTarget`](/docs/web-platform/popup-api/popuptoggletarget-property)
+: Creates a trigger element that toggles an associated pop-up between shown and hidden states. DOM definition of the HTML [`popuptoggletarget`](/docs/web-platform/popup-api/popuptoggletarget-attribute) attribute.
+
+[`popUpShowTarget`](/docs/web-platform/popup-api/popupshowtarget-property)
+: Creates a trigger element that shows an associated hidden pop-up. DOM definition of the HTML [`popupshowtarget`](/docs/web-platform/popup-api/popupshowtarget-attribute) attribute.
+
+[`popUpHideTarget`](/docs/web-platform/popup-api/popuphidetarget-property)
+: Creates a trigger element that dismisses an associated shown pop-up. DOM definition of the HTML [`popuphidetarget`](/docs/web-platform/popup-api/popuphidetarget-attribute) attribute.
+
+## Examples
+
+{% Aside %}
+This section shows basic usage of the API; for more substantial code including numerous complete examples, check out [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/) by Jhey Tompkins.
+{% endAside %}
+
+Declaratively create different types of pop-up. The first two are equivalent:
+
+```html
+<p id="my-popup" popup>Hello!</p>
+<p id="my-popup" popup="auto">Hello!</p>
+<p id="my-popup" popup="hint">Hello!</p>
+<p id="my-popup" popup="manual">Hello!</p>
+```
+
+Specify that a pop-up should open automatically on page load with [`defaultopen`](/docs/web-platform/popup-api/defaultopen-attribute):
+
+```html
+<p id="my-popup" popup="auto" defaultopen>Hello!</p>
+```
+
+{% Aside 'caution' %}
+[`defaultopen`](/docs/web-platform/popup-api/defaultopen-attribute) does not work with pop-ups of type `hint`.
+{% endAside %}
+
+Declaratively create buttons to show and hide the pop-up:
+
+```html
+<button popupshowtarget="my-popup">Show pop-up</button>
+<button popuphidetarget="my-popup">Dismiss pop-up</button>
+```
+
+Declaratively create a single button to toggle the pop-up between shown and hidden states:
+
+```html
+<button popuptoggletarget="my-popup">Show pop-up</button>
+```
+
+Use the [`:open`](/docs/web-platform/popup-api/open-pseudo-class) pseudo-class to style the pop-up when it has been shown. In this case we are transitioning the pop-up in from the bottom of the viewport, rather than just having it appear in the center:
+
+```css
+p[popup] {
+  transform: translateY(60vh);
+}
+
+p[popup]:open {
+  transition: transform 0.6s;
+  transform: translateY(0vh);
+}
+```
+
+Use the [`::backdrop`](/docs/web-platform/popup-api/backdrop-pseudo-element) pseudo-element to style the document behind the pop-up while it is being shown — here we are darkening the rest of the content:
+
+```css
+p[popup]::backdrop {
+  background-color: rgba(0,0,0,0.5);
+}
+```
+
+Use JavaScript to programmatically show and hide pop-ups:
+
+```js
+  popup.showPopUp();
+  popup.hidePopUp();
+```
+
+Use event listeners to respond to pop-ups being shown and hidden. Here we are switching the `textContent` of the pop-up trigger button so that it makes sense when the pop-up is in its shown and hidden states:
+
+```js
+  popup.addEventListener('popupshow', () => {
+    popupToggleBtn.textContent = 'Dismiss pop-up';
+  })
+
+  popup.addEventListener('popuphide', () => {
+    popupToggleBtn.textContent = 'Show pop-up';
+  })
+```
+
+## Feedback
+
+Your feedback on the API is welcome. [Send an email](mailto:public-open-ui@w3.org) to the Open UI group, or go to their [Getting Involved](https://open-ui.org/get-involved) page to learn about other ways to ask questions and contribute. 
+
+## See also
+
+* [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
+* [Chrome Platform Status: The Pop-Up API](https://chromestatus.com/feature/5463833265045504) 
+* [Open UI: Pop-Up API Explainer](https://open-ui.org/components/popup.research.explainer)

--- a/site/en/docs/web-platform/popup-api/index.md
+++ b/site/en/docs/web-platform/popup-api/index.md
@@ -68,7 +68,7 @@ The Pop-Up API also comes with a couple of handy CSS features, a [`::backdrop`](
 ## CSS features
 
 [`::backdrop`](/docs/web-platform/popup-api/backdrop-pseudo-element)
-: Pseudo-element that sits behind an open pop-up in the stacking order, but in front of the rest of the document, and spans the entire width and height of the viewport. Allows the rest of the content to be styled while the pop-up is open — for example you might want to blur or darken it.
+: Pseudo-element that sits behind an open pop-up in the stacking order, but in front of the rest of the document, and spans the entire width and height of the viewport. Allows the rest of the content to be styled while the pop-up is open—for example you might want to blur or darken it.
 
 [`:open`](/docs/web-platform/popup-api/open-pseudo-class)
 : Pseudo-class allowing a pop-up to be styled, but only when it is being shown.

--- a/site/en/docs/web-platform/popup-api/index.md
+++ b/site/en/docs/web-platform/popup-api/index.md
@@ -186,7 +186,7 @@ Use JavaScript to programmatically show and hide pop-ups:
   popup.hidePopUp();
 ```
 
-Use event listeners to respond to pop-ups being shown and hidden. Here we are switching the `textContent` of the pop-up trigger button so that it makes sense when the pop-up is in its shown and hidden states:
+Use event listeners to respond to pop-ups being shown and hidden. The following example switches the `textContent` of the pop-up trigger button so that it makes sense when the pop-up is in its shown and hidden states:
 
 ```js
   popup.addEventListener('popupshow', () => {

--- a/site/en/docs/web-platform/popup-api/open-pseudo-class/index.md
+++ b/site/en/docs/web-platform/popup-api/open-pseudo-class/index.md
@@ -19,7 +19,7 @@ The **`:open`** [CSS](https://developer.mozilla.org/docs/Web/CSS) [pseudo-class]
 
 ## Example
 
-In this case we are transitioning the pop-up in from the bottom of the viewport, rather than just having it appear in the center:
+The following example transitions the pop-up in from the bottom of the viewport, rather than have it appear in the center:
 
 ```css
 p[popup] {

--- a/site/en/docs/web-platform/popup-api/open-pseudo-class/index.md
+++ b/site/en/docs/web-platform/popup-api/open-pseudo-class/index.md
@@ -1,0 +1,47 @@
+---
+layout: 'layouts/doc-post.njk'
+title: :open
+description: Allows a pop-up to be styled, but only when it is being shown.
+subhead: Allows a pop-up to be styled, but only when it is being shown.
+authors:
+  - chrisdavidmills
+date: 2022-10-19
+updated: 2022-10-19
+---
+
+The **`:open`** [CSS](https://developer.mozilla.org/docs/Web/CSS) [pseudo-class](https://developer.mozilla.org/docs/Web/CSS/Pseudo-classes) allows a [pop-up](/docs/web-platform/popup-api/) to be styled, but only when it is being shown.
+
+## Syntax
+
+```css
+:open
+```
+
+## Example
+
+In this case we are transitioning the pop-up in from the bottom of the viewport, rather than just having it appear in the center:
+
+```css
+p[popup] {
+  transform: translateY(60vh);
+}
+
+p[popup]:open {
+  transition: transform 0.6s;
+  transform: translateY(0vh);
+}
+```
+
+## Browser compatibility
+
+* The Pop-Up API is planned for launch in Chrome 110, available in stable in early February 2023 (check the [Chrome Roadmap](https://chromestatus.com/roadmap) for updates).
+* It is enabled by default in [Chrome Canary](https://www.google.com/chrome/canary/) for local testing.  
+* Register for the [Origin Trial](/origintrials/#/view_trial/4500221927649968129) if you want to test it in a production environment. Read [Getting started with Chrome's origin trials](/docs/web-platform/origin-trials/) for more information.
+* There is a polyfill available at [https://github.com/oddbird/popup-polyfill](https://github.com/oddbird/popup-polyfill).
+
+## See also
+
+* [The Pop-Up API](/docs/web-platform/popup-api/)
+* [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
+* [Chrome Platform Status: The Pop-Up API](https://chromestatus.com/feature/5463833265045504) 
+* [Open UI: Pop Up API Explainer](https://open-ui.org/components/popup.research.explainer)

--- a/site/en/docs/web-platform/popup-api/popup-attribute/index.md
+++ b/site/en/docs/web-platform/popup-api/popup-attribute/index.md
@@ -1,0 +1,50 @@
+---
+layout: 'layouts/doc-post.njk'
+title: popup
+description: Turns an element into a pop-up.
+subhead: Turns an element into a pop-up.
+authors:
+  - chrisdavidmills
+date: 2022-10-19
+updated: 2022-10-19
+---
+
+The **`popup`** [global attribute](https://developer.mozilla.org/docs/Web/HTML/Global_attributes) is an [emumerated](https://developer.mozilla.org/docs/Glossary/Enumerated) attribute that turns an element into a [pop-up](/docs/web-platform/popup-api/).
+
+It can be used on any HTML element that makes sense as a pop-up.
+
+## Values
+
+The attribute can have any of the following values:
+
+`auto` (default value)
+: The pop-up exhibits the standard behavior explained at [The Pop-up API: concepts and usage](/docs/web-platform/popup-api/#concepts-and-usage).
+    
+`hint`
+: You can only show a single `hint` type popup at a time. They can be light dismissed, but they can't be shown by default using [`defaultopen`](/docs/web-platform/popup-api/defaultopen-attribute).
+
+`manual`
+: Manual pop-ups cannot be light dismissed, they can only be dismissed by an explicit trigger element (created for example using [`popuptoggletarget`](/docs/web-platform/popup-api/popuptoggletarget-attribute)) or by JavaScript (using [`hidePopUp()`](/docs/web-platform/popup-api/hidepopup-method)), and they don't automatically dismiss previously-shown pop-ups.
+
+## Example
+
+```html
+<p id="my-popup" popup>Hello!</p>
+<p id="my-popup" popup="auto">Hello!</p>
+<p id="my-popup" popup="hint">Hello!</p>
+<p id="my-popup" popup="manual">Hello!</p>
+```
+
+## Browser compatibility
+
+* The Pop-Up API is planned for launch in Chrome 110, available in stable in early February 2023 (check the [Chrome Roadmap](https://chromestatus.com/roadmap) for updates).
+* It is enabled by default in [Chrome Canary](https://www.google.com/chrome/canary/) for local testing.  
+* Register for the [Origin Trial](/origintrials/#/view_trial/4500221927649968129) if you want to test it in a production environment. Read [Getting started with Chrome's origin trials](/docs/web-platform/origin-trials/) for more information.
+* There is a polyfill available at [https://github.com/oddbird/popup-polyfill](https://github.com/oddbird/popup-polyfill).
+
+## See also
+
+* [The Pop-Up API](/docs/web-platform/popup-api/)
+* [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
+* [Chrome Platform Status: The Pop-Up API](https://chromestatus.com/feature/5463833265045504) 
+* [Open UI: Pop Up API Explainer](https://open-ui.org/components/popup.research.explainer)

--- a/site/en/docs/web-platform/popup-api/popup-property/index.md
+++ b/site/en/docs/web-platform/popup-api/popup-property/index.md
@@ -1,0 +1,51 @@
+---
+layout: 'layouts/doc-post.njk'
+title: popUp
+description: Turns an element into a pop-up.
+subhead: Turns an element into a pop-up.
+authors:
+  - chrisdavidmills
+date: 2022-10-19
+updated: 2022-10-19
+---
+
+The `popUp` property of the [`Element`](https://developer.mozilla.org/docs/Web/API/Element) interface turns an element into a [pop-up](/docs/web-platform/popup-api/). It is the DOM definition of the HTML [`popup`](/docs/web-platform/popup-api/popup-attribute) attribute.
+
+## Value
+
+A string that can take one of the following values:
+
+`auto`
+: The pop-up exhibits the standard behavior explained at [The Pop-up API: concepts and usage](/docs/web-platform/popup-api/#concepts-and-usage).
+    
+`hint`
+: You can only show a single `hint` type popup at a time. They can be light dismissed, but they can't be shown by default using [`defaultopen`](/docs/web-platform/popup-api/defaultopen-attribute).
+
+`manual`
+: Manual pop-ups cannot be light dismissed, they can only be dismissed by an explicit trigger element (created for example using [`popuptoggletarget`](/docs/web-platform/popup-api/popuptoggletarget-attribute)) or by JavaScript (using [`hidePopUp()`](/docs/web-platform/popup-api/hidepopup-method)), and they don't automatically dismiss previously-shown pop-ups.
+
+## Example
+
+```js
+const popup = document.getElementById('my-popup');
+
+// get
+popup.popUp;
+
+// set
+popup.popUp = 'hint';
+```
+
+## Browser compatibility
+
+* The Pop-Up API is planned for launch in Chrome 110, available in stable in early February 2023 (check the [Chrome Roadmap](https://chromestatus.com/roadmap) for updates).
+* It is enabled by default in [Chrome Canary](https://www.google.com/chrome/canary/) for local testing.  
+* Register for the [Origin Trial](/origintrials/#/view_trial/4500221927649968129) if you want to test it in a production environment. Read [Getting started with Chrome's origin trials](/docs/web-platform/origin-trials/) for more information.
+* There is a polyfill available at [https://github.com/oddbird/popup-polyfill](https://github.com/oddbird/popup-polyfill).
+
+## See also
+
+* [The Pop-Up API](/docs/web-platform/popup-api/)
+* [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
+* [Chrome Platform Status: The Pop-Up API](https://chromestatus.com/feature/5463833265045504) 
+* [Open UI: Pop Up API Explainer](https://open-ui.org/components/popup.research.explainer)

--- a/site/en/docs/web-platform/popup-api/popuphide-event/index.md
+++ b/site/en/docs/web-platform/popup-api/popuphide-event/index.md
@@ -1,0 +1,52 @@
+---
+layout: 'layouts/doc-post.njk'
+title: "Element: popuphide event"
+description: Fired on the pop-up when it is dismissed.
+subhead: Fired on the pop-up when it is dismissed.
+authors:
+  - chrisdavidmills
+date: 2022-10-19
+updated: 2022-10-19
+---
+
+The `popuphide` event of the [`Element`](https://developer.mozilla.org/docs/Web/API/Element) interface fires on a [pop-up](/docs/web-platform/popup-api/) element when it is dismissed.
+
+## Syntax
+
+Use the event name in methods like [`addEventListener()`](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener), or set the equivalent event handler property.
+
+```js
+addEventListener("popuphide", (event) => {});
+onpopuphide = (event) => {};
+```
+
+## Example
+
+```js
+const popup = document.getElementById('my-popup');
+const popupToggleBtn = document.getElementById('my-popup-btn');
+
+// Event listener version
+popup.addEventListener('popuphide', () => {
+  popupToggleBtn.textContent = 'Show pop-up';
+})
+
+// Event handler property version
+popup.onpopuphide = () => {
+  popupToggleBtn.textContent = 'Show pop-up';
+}
+```
+
+## Browser compatibility
+
+* The Pop-Up API is planned for launch in Chrome 110, available in stable in early February 2023 (check the [Chrome Roadmap](https://chromestatus.com/roadmap) for updates).
+* It is enabled by default in [Chrome Canary](https://www.google.com/chrome/canary/) for local testing.  
+* Register for the [Origin Trial](/origintrials/#/view_trial/4500221927649968129) if you want to test it in a production environment. Read [Getting started with Chrome's origin trials](/docs/web-platform/origin-trials/) for more information.
+* There is a polyfill available at [https://github.com/oddbird/popup-polyfill](https://github.com/oddbird/popup-polyfill).
+
+## See also
+
+* [The Pop-Up API](/docs/web-platform/popup-api/)
+* [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
+* [Chrome Platform Status: The Pop-Up API](https://chromestatus.com/feature/5463833265045504) 
+* [Open UI: Pop Up API Explainer](https://open-ui.org/components/popup.research.explainer)

--- a/site/en/docs/web-platform/popup-api/popuphidetarget-attribute/index.md
+++ b/site/en/docs/web-platform/popup-api/popuphidetarget-attribute/index.md
@@ -1,0 +1,38 @@
+---
+layout: 'layouts/doc-post.njk'
+title: popuphidetarget
+description: Creates a trigger element that dismisses an associated shown pop-up.
+subhead: Creates a trigger element that dismisses an associated shown pop-up.
+authors:
+  - chrisdavidmills
+date: 2022-10-19
+updated: 2022-10-19
+---
+
+The **`popuphidetarget`** attribute creates a trigger element that dismisses an associated shown [pop-up](/docs/web-platform/popup-api/).
+
+It can be used on the [`<button>`](https://developer.mozilla.org/docs/Web/HTML/Element/button) and [`<input>`](https://developer.mozilla.org/docs/Web/HTML/Element/input) elements.
+
+## Values
+
+The attribute takes a string value equal to the ID of the pop-up element that you want to dismiss, to associate the two.
+
+## Example
+
+```html
+<button popuphidetarget="my-popup">Dismiss pop-up</button>
+```
+
+## Browser compatibility
+
+* The Pop-Up API is planned for launch in Chrome 110, available in stable in early February 2023 (check the [Chrome Roadmap](https://chromestatus.com/roadmap) for updates).
+* It is enabled by default in [Chrome Canary](https://www.google.com/chrome/canary/) for local testing.  
+* Register for the [Origin Trial](/origintrials/#/view_trial/4500221927649968129) if you want to test it in a production environment. Read [Getting started with Chrome's origin trials](/docs/web-platform/origin-trials/) for more information.
+* There is a polyfill available at [https://github.com/oddbird/popup-polyfill](https://github.com/oddbird/popup-polyfill).
+
+## See also
+
+* [The Pop-Up API](/docs/web-platform/popup-api/)
+* [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
+* [Chrome Platform Status: The Pop-Up API](https://chromestatus.com/feature/5463833265045504) 
+* [Open UI: Pop Up API Explainer](https://open-ui.org/components/popup.research.explainer)

--- a/site/en/docs/web-platform/popup-api/popuphidetarget-property/index.md
+++ b/site/en/docs/web-platform/popup-api/popuphidetarget-property/index.md
@@ -1,0 +1,42 @@
+---
+layout: 'layouts/doc-post.njk'
+title: popUpHideTarget
+description: Creates a trigger element that dismisses an associated shown pop-up.
+subhead: Creates a trigger element that dismisses an associated shown pop-up.
+authors:
+  - chrisdavidmills
+date: 2022-10-19
+updated: 2022-10-19
+---
+
+The `popUpHideTarget` property of the [`HTMLInputElement`](https://developer.mozilla.org/docs/Web/API/HTMLInputElement) and [`HTMLButtonElement`](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement) interfaces creates a trigger element that dismisses an associated shown [pop-up](/docs/web-platform/popup-api/). It is the DOM definition of the HTML [`popuphidetarget`](/docs/web-platform/popup-api/popuphidetarget-attribute) attribute.
+
+## Value
+
+A string value equal to the ID of the pop-up element that you want to show, to associate the two.
+
+## Example
+
+```js
+const popup = document.getElementById('my-popup-btn');
+
+// get
+popup.popUpHideTarget;
+
+// set
+popup.popUpHideTarget = 'my-popup';
+```
+
+## Browser compatibility
+
+* The Pop-Up API is planned for launch in Chrome 110, available in stable in early February 2023 (check the [Chrome Roadmap](https://chromestatus.com/roadmap) for updates).
+* It is enabled by default in [Chrome Canary](https://www.google.com/chrome/canary/) for local testing.  
+* Register for the [Origin Trial](/origintrials/#/view_trial/4500221927649968129) if you want to test it in a production environment. Read [Getting started with Chrome's origin trials](/docs/web-platform/origin-trials/) for more information.
+* There is a polyfill available at [https://github.com/oddbird/popup-polyfill](https://github.com/oddbird/popup-polyfill).
+
+## See also
+
+* [The Pop-Up API](/docs/web-platform/popup-api/)
+* [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
+* [Chrome Platform Status: The Pop-Up API](https://chromestatus.com/feature/5463833265045504) 
+* [Open UI: Pop Up API Explainer](https://open-ui.org/components/popup.research.explainer)

--- a/site/en/docs/web-platform/popup-api/popupshow-event/index.md
+++ b/site/en/docs/web-platform/popup-api/popupshow-event/index.md
@@ -1,0 +1,52 @@
+---
+layout: 'layouts/doc-post.njk'
+title: "Element: popupshow event"
+description: Fired on the pop-up when it is shown.
+subhead: Fired on the pop-up when it is shown.
+authors:
+  - chrisdavidmills
+date: 2022-10-19
+updated: 2022-10-19
+---
+
+The `popupshow` event of the [`Element`](https://developer.mozilla.org/docs/Web/API/Element) interface fires on a [pop-up](/docs/web-platform/popup-api/) element when it is shown.
+
+## Syntax
+
+Use the event name in methods like [`addEventListener()`](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener), or set the equivalent event handler property.
+
+```js
+addEventListener("popupshow", (event) => {});
+onpopupshow = (event) => {};
+```
+
+## Example
+
+```js
+const popup = document.getElementById('my-popup');
+const popupToggleBtn = document.getElementById('my-popup-btn');
+
+// Event listener version
+popup.addEventListener('popupshow', () => {
+  popupToggleBtn.textContent = 'Dismiss pop-up';
+})
+
+// Event handler property version
+popup.onpopupshow = () => {
+  popupToggleBtn.textContent = 'Dismiss pop-up';
+}
+```
+
+## Browser compatibility
+
+* The Pop-Up API is planned for launch in Chrome 110, available in stable in early February 2023 (check the [Chrome Roadmap](https://chromestatus.com/roadmap) for updates).
+* It is enabled by default in [Chrome Canary](https://www.google.com/chrome/canary/) for local testing.  
+* Register for the [Origin Trial](/origintrials/#/view_trial/4500221927649968129) if you want to test it in a production environment. Read [Getting started with Chrome's origin trials](/docs/web-platform/origin-trials/) for more information.
+* There is a polyfill available at [https://github.com/oddbird/popup-polyfill](https://github.com/oddbird/popup-polyfill).
+
+## See also
+
+* [The Pop-Up API](/docs/web-platform/popup-api/)
+* [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
+* [Chrome Platform Status: The Pop-Up API](https://chromestatus.com/feature/5463833265045504) 
+* [Open UI: Pop Up API Explainer](https://open-ui.org/components/popup.research.explainer)

--- a/site/en/docs/web-platform/popup-api/popupshowtarget-attribute/index.md
+++ b/site/en/docs/web-platform/popup-api/popupshowtarget-attribute/index.md
@@ -1,0 +1,38 @@
+---
+layout: 'layouts/doc-post.njk'
+title: popupshowtarget
+description: Creates a trigger element that shows an associated hidden pop-up.
+subhead: Creates a trigger element that shows an associated hidden pop-up.
+authors:
+  - chrisdavidmills
+date: 2022-10-19
+updated: 2022-10-19
+---
+
+The **`popupshowtarget`** attribute creates a trigger element that shows an associated hidden [pop-up](/docs/web-platform/popup-api/).
+
+It can be used on the [`<button>`](https://developer.mozilla.org/docs/Web/HTML/Element/button) and [`<input>`](https://developer.mozilla.org/docs/Web/HTML/Element/input) elements.
+
+## Values
+
+The attribute takes a string value equal to the ID of the pop-up element that you want to show, to associate the two.
+
+## Example
+
+```html
+<button popupshowtarget="my-popup">Show pop-up</button>
+```
+
+## Browser compatibility
+
+* The Pop-Up API is planned for launch in Chrome 110, available in stable in early February 2023 (check the [Chrome Roadmap](https://chromestatus.com/roadmap) for updates).
+* It is enabled by default in [Chrome Canary](https://www.google.com/chrome/canary/) for local testing.  
+* Register for the [Origin Trial](/origintrials/#/view_trial/4500221927649968129) if you want to test it in a production environment. Read [Getting started with Chrome's origin trials](/docs/web-platform/origin-trials/) for more information.
+* There is a polyfill available at [https://github.com/oddbird/popup-polyfill](https://github.com/oddbird/popup-polyfill).
+
+## See also
+
+* [The Pop-Up API](/docs/web-platform/popup-api/)
+* [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
+* [Chrome Platform Status: The Pop-Up API](https://chromestatus.com/feature/5463833265045504) 
+* [Open UI: Pop Up API Explainer](https://open-ui.org/components/popup.research.explainer)

--- a/site/en/docs/web-platform/popup-api/popupshowtarget-property/index.md
+++ b/site/en/docs/web-platform/popup-api/popupshowtarget-property/index.md
@@ -1,0 +1,42 @@
+---
+layout: 'layouts/doc-post.njk'
+title: popUpShowTarget
+description: Creates a trigger element that shows an associated hidden pop-up.
+subhead: Creates a trigger element that shows an associated hidden pop-up.
+authors:
+  - chrisdavidmills
+date: 2022-10-19
+updated: 2022-10-19
+---
+
+The `popUpShowTarget` property of the [`HTMLInputElement`](https://developer.mozilla.org/docs/Web/API/HTMLInputElement) and [`HTMLButtonElement`](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement) interfaces creates a trigger element that shows an associated hidden [pop-up](/docs/web-platform/popup-api/). It is the DOM definition of the HTML [`popupshowtarget`](/docs/web-platform/popup-api/popupshowtarget-attribute) attribute.
+
+## Value
+
+A string value equal to the ID of the pop-up element that you want to show, to associate the two.
+
+## Example
+
+```js
+const popup = document.getElementById('my-popup-btn');
+
+// get
+popup.popUpShowTarget;
+
+// set
+popup.popUpShowTarget = 'my-popup';
+```
+
+## Browser compatibility
+
+* The Pop-Up API is planned for launch in Chrome 110, available in stable in early February 2023 (check the [Chrome Roadmap](https://chromestatus.com/roadmap) for updates).
+* It is enabled by default in [Chrome Canary](https://www.google.com/chrome/canary/) for local testing.  
+* Register for the [Origin Trial](/origintrials/#/view_trial/4500221927649968129) if you want to test it in a production environment. Read [Getting started with Chrome's origin trials](/docs/web-platform/origin-trials/) for more information.
+* There is a polyfill available at [https://github.com/oddbird/popup-polyfill](https://github.com/oddbird/popup-polyfill).
+
+## See also
+
+* [The Pop-Up API](/docs/web-platform/popup-api/)
+* [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
+* [Chrome Platform Status: The Pop-Up API](https://chromestatus.com/feature/5463833265045504) 
+* [Open UI: Pop Up API Explainer](https://open-ui.org/components/popup.research.explainer)

--- a/site/en/docs/web-platform/popup-api/popuptoggletarget-attribute/index.md
+++ b/site/en/docs/web-platform/popup-api/popuptoggletarget-attribute/index.md
@@ -1,0 +1,38 @@
+---
+layout: 'layouts/doc-post.njk'
+title: popuptoggletarget
+description: Creates a trigger element that toggles an associated pop-up between shown and hidden states.
+subhead: Creates a trigger element that toggles an associated pop-up between shown and hidden states.
+authors:
+  - chrisdavidmills
+date: 2022-10-19
+updated: 2022-10-19
+---
+
+The **`popuptoggletarget`** attribute creates a trigger element that toggles an associated [pop-up](/docs/web-platform/popup-api/) between shown and hidden states.
+
+It can be used on the [`<button>`](https://developer.mozilla.org/docs/Web/HTML/Element/button) and [`<input>`](https://developer.mozilla.org/docs/Web/HTML/Element/input) elements.
+
+## Values
+
+The attribute takes a string value equal to the ID of the pop-up element that you want to toggle, to associate the two.
+
+## Example
+
+```html
+<button popuptoggletarget="my-popup">Show pop-up</button>
+```
+
+## Browser compatibility
+
+* The Pop-Up API is planned for launch in Chrome 110, available in stable in early February 2023 (check the [Chrome Roadmap](https://chromestatus.com/roadmap) for updates).
+* It is enabled by default in [Chrome Canary](https://www.google.com/chrome/canary/) for local testing.  
+* Register for the [Origin Trial](/origintrials/#/view_trial/4500221927649968129) if you want to test it in a production environment. Read [Getting started with Chrome's origin trials](/docs/web-platform/origin-trials/) for more information.
+* There is a polyfill available at [https://github.com/oddbird/popup-polyfill](https://github.com/oddbird/popup-polyfill).
+
+## See also
+
+* [The Pop-Up API](/docs/web-platform/popup-api/)
+* [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
+* [Chrome Platform Status: The Pop-Up API](https://chromestatus.com/feature/5463833265045504) 
+* [Open UI: Pop Up API Explainer](https://open-ui.org/components/popup.research.explainer)

--- a/site/en/docs/web-platform/popup-api/popuptoggletarget-property/index.md
+++ b/site/en/docs/web-platform/popup-api/popuptoggletarget-property/index.md
@@ -1,0 +1,42 @@
+---
+layout: 'layouts/doc-post.njk'
+title: popUpToggleTarget
+description: Creates a trigger element that toggles an associated pop-up between shown and hidden states.
+subhead: Creates a trigger element that toggles an associated pop-up between shown and hidden states.
+authors:
+  - chrisdavidmills
+date: 2022-10-19
+updated: 2022-10-19
+---
+
+The `popUpToggleTarget` property of the [`HTMLInputElement`](https://developer.mozilla.org/docs/Web/API/HTMLInputElement) and [`HTMLButtonElement`](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement) interfaces creates a trigger element that toggles an associated [pop-up](/docs/web-platform/popup-api/) between shown and hidden states. It is the DOM definition of the HTML [`popuptoggletarget`](/docs/web-platform/popup-api/popuptoggletarget-attribute) attribute.
+
+## Value
+
+A string value equal to the ID of the pop-up element that you want to toggle, to associate the two.
+
+## Example
+
+```js
+const popup = document.getElementById('my-popup-btn');
+
+// get
+popup.popUpToggleTarget;
+
+// set
+popup.popUpToggleTarget = 'my-popup';
+```
+
+## Browser compatibility
+
+* The Pop-Up API is planned for launch in Chrome 110, available in stable in early February 2023 (check the [Chrome Roadmap](https://chromestatus.com/roadmap) for updates).
+* It is enabled by default in [Chrome Canary](https://www.google.com/chrome/canary/) for local testing.  
+* Register for the [Origin Trial](/origintrials/#/view_trial/4500221927649968129) if you want to test it in a production environment. Read [Getting started with Chrome's origin trials](/docs/web-platform/origin-trials/) for more information.
+* There is a polyfill available at [https://github.com/oddbird/popup-polyfill](https://github.com/oddbird/popup-polyfill).
+
+## See also
+
+* [The Pop-Up API](/docs/web-platform/popup-api/)
+* [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
+* [Chrome Platform Status: The Pop-Up API](https://chromestatus.com/feature/5463833265045504) 
+* [Open UI: Pop Up API Explainer](https://open-ui.org/components/popup.research.explainer)

--- a/site/en/docs/web-platform/popup-api/showpopup-method/index.md
+++ b/site/en/docs/web-platform/popup-api/showpopup-method/index.md
@@ -1,0 +1,58 @@
+---
+layout: 'layouts/doc-post.njk'
+title: showPopUp()
+description: Shows a pop-up.
+subhead: Shows a pop-up.
+authors:
+  - chrisdavidmills
+date: 2022-10-19
+updated: 2022-10-19
+---
+
+The **`showPopUp()`** instance method of the [`Element`](https://developer.mozilla.org/docs/Web/API/Element) interface shows a [pop-up](/docs/web-platform/popup-api/) element.
+
+## Syntax
+
+```js
+showPopUp()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+Void.
+
+### Exceptions
+
+`NotSupportedError` [`DOMException`](https://developer.mozilla.org/docs/Web/API/DOMException)
+: Thrown if `showPopUp()` is called on an element that does not have a valid value of the [`popup`](/docs/web-platform/popup-api/popup-attribute) attribute set on it.
+
+`InvalidStateError` [`DOMException`](https://developer.mozilla.org/docs/Web/API/DOMException)
+: Thrown if `showPopUp()` is called on a valid pop-up that is already shown.
+
+`InvalidStateError` [`DOMException`](https://developer.mozilla.org/docs/Web/API/DOMException)
+: Thrown if `showPopUp()` is called on a valid pop-up that is not connected to a document.
+
+## Example
+
+```js
+const popup = document.getElementById('my-popup');
+popup.showPopUp();
+```
+
+## Browser compatibility
+
+* The Pop-Up API is planned for launch in Chrome 110, available in stable in early February 2023 (check the [Chrome Roadmap](https://chromestatus.com/roadmap) for updates).
+* It is enabled by default in [Chrome Canary](https://www.google.com/chrome/canary/) for local testing.  
+* Register for the [Origin Trial](/origintrials/#/view_trial/4500221927649968129) if you want to test it in a production environment. Read [Getting started with Chrome's origin trials](/docs/web-platform/origin-trials/) for more information.
+* There is a polyfill available at [https://github.com/oddbird/popup-polyfill](https://github.com/oddbird/popup-polyfill).
+
+## See also
+
+* [The Pop-Up API](/docs/web-platform/popup-api/)
+* [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
+* [Chrome Platform Status: The Pop-Up API](https://chromestatus.com/feature/5463833265045504) 
+* [Open UI: Pop Up API Explainer](https://open-ui.org/components/popup.research.explainer)


### PR DESCRIPTION
Changes proposed in this pull request:

* I've added full reference docs for the [Pop-Up API](https://chromestatus.com/feature/5463833265045504).
* I've added my author details to the site

Some notes about my work:

* I went for the approach of following the MDN reference docs style as closely as possible, while still trying to make it work for d.c.c.

* I had a play with the navigation menu but could find a way to successfully show submenus below the Pop-Up API menu item, for HTML attributes, JS features, etc. The reference pages are all just linked to from the main page. Does that work for you? I could see the nav menu getting really messy if we included all that stuff in it, anyway…

* I didn't create separate pages for the event handler properties because they are dealt with on the event pages, and I felt like that would be too repetitious. Even though MDN tends to have both pages available in each case.

* I am not sure if we need the “subhead” included in the reference pages for each individual attribute, etc., but I’ve put them in for now, to see what you think
