### PR TITLE
Added note about NodeJS support for early hints

### DIFF
--- a/site/en/blog/early-hints/index.md
+++ b/site/en/blog/early-hints/index.md
@@ -134,7 +134,7 @@ Here is a quick summary of the level of support for Early Hints among popular OS
 -  **Apache:** [supported](https://httpd.apache.org/docs/2.4/howto/http2.html#earlyhints) via mod_http2.
 -  **H2O:** [supported](https://github.com/h2o/h2o/pull/1767).
 -  **NGINX:** [experimental module](https://github.com/nginx-modules/ngx_http_early_hints).
--  **Node:** not yet supported by core. Available as a [draft plugin for Fastify](https://www.npmjs.com/package/fastify-early-hints).
+-  **Node:** not yet supported by 16.x (LTS). Implemented in NodeJS 18.x (https://nodejs.org/docs/latest-v18.x/api/http.html#responsewriteearlyhintshints-callback)
 
 ## Enabling Early Hints, the easy way
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Added note about NodeJS support for early hints. It appears as though support landed in NodeJS 18.x on [Aug 17, 2022](https://github.com/nodejs/node/pull/44180)