### PR TITLE
Replace 'homepage' with 'home page'.

### DIFF
--- a/site/en/docs/extensions/mv2/settings_override/index.md
+++ b/site/en/docs/extensions/mv2/settings_override/index.md
@@ -12,9 +12,9 @@ Settings overrides are a way for extensions to override selected Chrome settings
 available on Windows in all current versions of Chrome and is available on Mac in Chrome 56 and
 later.
 
-## Homepage, search provider, and startup pages {: #others }
+## Home page, search provider, and startup pages {: #others }
 
-Here is an example how [homepage][1], [search provider][2] and [startup pages][3] can be modified in
+Here is an example how [home page][1], [search provider][2] and [startup pages][3] can be modified in
 the [extension manifest][4]. Web sites used in the settings API must be [verified][5] (via Webmaster
 Tools) as being associated with that item in the Chrome Web Store. Note that if you verify ownership
 for a domain (for example, http://example.com) you can use any subdomain or page (for example,

--- a/site/en/docs/extensions/mv3/single_purpose/index.md
+++ b/site/en/docs/extensions/mv3/single_purpose/index.md
@@ -81,15 +81,15 @@ before it can be restored.
 In order to minimize disruption for users, we recommend that you take a moment to carefully review
 your extensions and make necessary updates as soon as possible.
 
-## 6) Can my extension make changes to the start page, homepage, and new tab settings? {: #six }
+## 6) Can my extension make changes to the start page, home page, and new tab settings? {: #six }
 
 Yes. If the purpose of your extension is to modify one narrow function of the browser (either the
-start page, homepage or new tab page, for example), and it does only that, then it would be
+start page, home page or new tab page, for example), and it does only that, then it would be
 compliant with the single-purpose policy. Additionally, if the purpose of your extension is limited
 to one focus area or subject matter, then you can have various functions related to that one area or
-subject matter, including changes to the start page, homepage and new tab page.
+subject matter, including changes to the start page, home page and new tab page.
 
-As of July 1, 2017, however, the only way to programmatically change the startup page, the homepage,
+As of July 1, 2017, however, the only way to programmatically change the startup page, the home page,
 or the search provider settings in Chrome on Windows and Mac is via the Settings Overrides API. If
 your extension modifies one of these functions, it must use the Settings Overrides API.
 
@@ -101,7 +101,7 @@ before.
 In addition, if you want to publish an extension that modifies Chrome settings, you must either
 control any domains you wish to set in any changed browser settings or redistribute an extension
 created by the entity that controls those domains. For example, you could distribute an extension
-that changes the homepage to wikipedia.org if the Wikimedia Foundation originally created and
+that changes the home page to wikipedia.org if the Wikimedia Foundation originally created and
 published the extension in the Chrome Web Store, and gave you the right to distribute it.
 
 ## 7) Can my extension make changes to the default search settings? {: #seven }
@@ -134,9 +134,9 @@ extension.
 
 All Chrome settings changed by an extension will be reverted when that extension is disabled.
 
-## 11) Will users' existing homepage, search provider or startup pages be affected by the introduction of the Settings Override API? {: #eleven }
+## 11) Will users' existing home page, search provider or startup pages be affected by the introduction of the Settings Override API? {: #eleven }
 
-No. A user's existing homepage, search provider or startup settings will remain unchanged by the
+No. A user's existing home page, search provider or startup settings will remain unchanged by the
 introduction of Settings Override API. Following the launch of the Settings Override API, only
 extensions can programmatically change these settings and only through the Settings Override API.
 


### PR DESCRIPTION
Partially addresses #2469.

Other occurrences of 'homepage' are:

* Documents being worked on by @IanStanion-google, so they will be fixed there.
* Documents under [Chrome Web Store](https://developer.chrome.com/docs/webstore/) which will need to be updated as future policy updates are reviewed.