### PR TITLE
Update browser support for touch-action

### DIFF
--- a/site/en/blog/300ms-tap-delay-gone-away/index.md
+++ b/site/en/blog/300ms-tap-delay-gone-away/index.md
@@ -37,7 +37,7 @@ html {
 }
 ```
 
-This technique isn't supported in Firefox, so the viewport tag is much preferred.
+This technique [isn't supported in Safari](https://caniuse.com/?search=touch-action), so the viewport tag is much preferred.
 
 ## Is losing double-tap-to-zoom an accessibility concern?
 

--- a/site/en/blog/300ms-tap-delay-gone-away/index.md
+++ b/site/en/blog/300ms-tap-delay-gone-away/index.md
@@ -6,7 +6,7 @@ description: >
 authors:
   - jakearchibald
 date: 2013-12-12
-updated: 2019-01-16 
+updated: 2022-10-21
 ---
 
 {% YouTube id="AjUpiwvIa5A" %}


### PR DESCRIPTION
Since the [300ms tap delay, gone away](https://developer.chrome.com/blog/300ms-tap-delay-gone-away/) post was written, Firefox now supports the `touch-action` property according to [caniuse](https://caniuse.com/?search=touch-action):

<img width="1148" alt="image" src="https://user-images.githubusercontent.com/1120896/197288739-a97aa35a-0e34-4da4-9bc6-6c397d9905d8.png">

However, Safari still does not support it, so this PR updates the post to clarify that.

For context, this post gets referenced a lot in discussions about FID and INP responsiveness.