### PR TITLE
Update V2 deprecation blurb and add it to remaining V2 documents.

### DIFF
--- a/site/en/_partials/extensions/mv2-legacy-page.md
+++ b/site/en/_partials/extensions/mv2-legacy-page.md
@@ -1,9 +1,4 @@
 {% Aside 'warning' %}
-
-The page you're viewing describes the Manifest V2 extension platform.
-
-As of [January 17, 2022](/docs/extensions/mv3/mv2-sunset/) Chrome Web Store has stopped accepting
-new Manifest V2 extensions. Use [Manifest
-V3](/docs/extensions/mv3/intro) when building new extensions.
-
+The Chrome Web Store no longer acceppts Manifest V2 extensions. Please use [Manifest
+V3](/docs/extensions/mv3/intro) when building new extensions. You will find a section on upgrading in the navigation tree at left, including the [Manifest V2 support timeline](/docs/extensions/mv3/mv2-sunset/).
 {% endAside %}

--- a/site/en/docs/extensions/migrate-to-mv3/upgrading-web-requests/index.md
+++ b/site/en/docs/extensions/migrate-to-mv3/upgrading-web-requests/index.md
@@ -8,7 +8,7 @@ description: TBD
 
 Blocking web requests in Manifest V2 could significantly degrade both the performance of extensions and the performance of pages they worked with. Code that used the [`Chrome.webRequest` interface](/docs/extensions/reference/webRequest) could implement up to nine potentially blocking events for each network request and each web page was potentially blocked by multiple extensions. 
 
-To guard against performance problems, Manifest V3 replaces the blocking version of `Chrome.webRequest` with rules specified uner `"declarative_net_request"`
+To guard against performance problems, Manifest V3 replaces the blocking version of `Chrome.webRequest` with rules specified under `"declarative_net_request"`
 
 Extensions that modify network requests will need to transition from the blocking version of the
 [Web Request API](/docs/extensions/reference/webRequest) to the new [Declarative Net Request

--- a/site/en/docs/extensions/migrate-to-mv3/upgrading-web-requests/index.md
+++ b/site/en/docs/extensions/migrate-to-mv3/upgrading-web-requests/index.md
@@ -1,0 +1,17 @@
+---
+layout: 'layouts/doc-post.njk'
+title: "Migrating Web Requests"
+date: 2019-11-02
+updated: 2022-10-24
+description: TBD
+---
+
+Blocking web requests in Manifest V2 could significantly degrade both the performance of extensions and the performance of pages they worked with. Code that used the [`Chrome.webRequest` interface](/docs/extensions/reference/webRequest) could implement up to nine potentially blocking events for each network request and each web page was potentially blocked by multiple extensions. 
+
+To guard against performance problems, Manifest V3 replaces the blocking version of `Chrome.webRequest` with rules specified uner `"declarative_net_request"`
+
+Extensions that modify network requests will need to transition from the blocking version of the
+[Web Request API](/docs/extensions/reference/webRequest) to the new [Declarative Net Request
+API][api-declarativenetrequest]. This new API was designed to work well with the event-based
+execution model of service workers and to maximize an extension's ability to block network requests
+without requiring the extension to have permissions.

--- a/site/en/docs/extensions/mv2/cross-origin-isolation/index.md
+++ b/site/en/docs/extensions/mv2/cross-origin-isolation/index.md
@@ -6,6 +6,8 @@ updated: 2021-11-10
 description: Overview of cross-origin isolation for extensions
 ---
 
+{% Partial 'extensions/mv2-legacy-page.md' %}
+
 [Cross-origin isolation][web-coi-guide] enables a web page to use powerful features such as
 [`SharedArrayBuffer`][mdn-sharedarraybuffer]. An extension can opt into cross-origin isolation by
 specifying the appropriate values for the [`cross_origin_embedder_policy`][doc-coep] and

--- a/site/en/docs/extensions/mv2/manifest/activeTab/index.md
+++ b/site/en/docs/extensions/mv2/manifest/activeTab/index.md
@@ -6,6 +6,8 @@ updated: 2018-11-01
 description: How to use the activeTab permission in your Chrome Extension.
 ---
 
+{% Partial 'extensions/mv2-legacy-page.md' %}
+
 The `activeTab` permission gives an extension temporary access to the currently active tab when the
 user _invokes_ the extension - for example by clicking its [browser action][1]. Access to the tab
 lasts while the user is on that page, and is revoked when the user navigates away or closes the tab.

--- a/site/en/docs/extensions/mv2/manifest/cross_origin_embedder_policy/index.md
+++ b/site/en/docs/extensions/mv2/manifest/cross_origin_embedder_policy/index.md
@@ -6,6 +6,8 @@ date: 2021-08-03
 description: Reference documentation for the cross_origin_embedder_policy property of manifest.json.
 ---
 
+{% Partial 'extensions/mv2-legacy-page.md' %}
+
 The `cross_origin_embedder_policy` manifest key lets the extension to specify a value for the
 [Cross-Origin-Embedder-Policy][mdn-coep] (COEP) response header for requests to the extension's
 origin.  This includes the extension's background context (service worker or background page),

--- a/site/en/docs/extensions/mv2/manifest/cross_origin_opener_policy/index.md
+++ b/site/en/docs/extensions/mv2/manifest/cross_origin_opener_policy/index.md
@@ -6,6 +6,8 @@ date: 2021-08-03
 description: Reference documentation for the cross_origin_opener_policy property of manifest.json.
 ---
 
+{% Partial 'extensions/mv2-legacy-page.md' %}
+
 The `cross_origin_opener_policy` manifest key lets extensions specify a value for the
 [Cross-Origin-Opener-Policy][mdn-coop] (COOP) response header for requests to the extension's
 origin. This includes the extension's background context (service worker or background page), popup,

--- a/site/en/docs/extensions/mv2/manifest/default_locale/index.md
+++ b/site/en/docs/extensions/mv2/manifest/default_locale/index.md
@@ -6,6 +6,8 @@ updated: 2018-04-26
 description: Reference documentation for the default_locale property of manifest.json.
 ---
 
+{% Partial 'extensions/mv2-legacy-page.md' %}
+
 Specifies the subdirectory of `_locales` that contains the default strings for this extension. This
 field is **required** in extensions that have a `_locales` directory; it **must be absent** in
 extensions that have no `_locales` directory. For details, see [Internationalization][1].

--- a/site/en/docs/extensions/mv2/manifest/description/index.md
+++ b/site/en/docs/extensions/mv2/manifest/description/index.md
@@ -6,6 +6,8 @@ updated: 2018-04-26
 description: Reference documentation for the description property of manifest.json.
 ---
 
+{% Partial 'extensions/mv2-legacy-page.md' %}
+
 A plain text string (no HTML or other formatting; no more than 132 characters) that describes the
 extension. The description should be suitable for both the browser's extension management UI and the
 [Chrome Web Store][1]. You can specify locale-specific strings for this field; see

--- a/site/en/docs/extensions/mv2/manifest/event_rules/index.md
+++ b/site/en/docs/extensions/mv2/manifest/event_rules/index.md
@@ -6,6 +6,8 @@ updated: 2015-06-15
 description: Reference documentation for the event_rules property of manifest.json.
 ---
 
+{% Partial 'extensions/mv2-legacy-page.md' %}
+
 The `event_rules` manifest property provides a mechanism to add rules that intercept, block, or
 modify web requests in-flight using [declarativeWebRequest][1] or take actions depending on the
 content of a page, without requiring permission to read the page's content using

--- a/site/en/docs/extensions/mv2/manifest/externally_connectable/index.md
+++ b/site/en/docs/extensions/mv2/manifest/externally_connectable/index.md
@@ -6,6 +6,8 @@ updated: 2014-10-31
 description: Reference documentation for the externally_connectable property of manifest.json.
 ---
 
+{% Partial 'extensions/mv2-legacy-page.md' %}
+
 The `externally_connectable` manifest property declares which extensions, apps, and web pages can
 connect to your extension via [runtime.connect][1] and [runtime.sendMessage][2].
 

--- a/site/en/docs/extensions/mv2/manifest/homepage_url/index.md
+++ b/site/en/docs/extensions/mv2/manifest/homepage_url/index.md
@@ -6,6 +6,8 @@ updated: 2018-04-26
 description: Reference documentation for the homepage_url property of manifest.json.
 ---
 
+{% Partial 'extensions/mv2-legacy-page.md' %}
+
 The URL of the homepage for this extension. The extensions management page (chrome://extensions)
 will contain a link to this URL. This field is particularly useful if you [host the extension on
 your own site][1]. If you distribute your extension using the [Chrome Web Store][2], the homepage

--- a/site/en/docs/extensions/mv2/manifest/icons/index.md
+++ b/site/en/docs/extensions/mv2/manifest/icons/index.md
@@ -6,6 +6,8 @@ updated: 2018-04-26
 description: Reference documentation for the icons property of manifest.json.
 ---
 
+{% Partial 'extensions/mv2-legacy-page.md' %}
+
 One or more icons that represent the extension, app, or theme. You should always provide a 128x128
 icon; it's used during installation and by the Chrome Web Store. Extensions should also provide a
 48x48 icon, which is used in the extensions management page (chrome://extensions). You can also

--- a/site/en/docs/extensions/mv2/manifest/incognito/index.md
+++ b/site/en/docs/extensions/mv2/manifest/incognito/index.md
@@ -6,6 +6,8 @@ updated: 2015-09-25
 description: Reference documentation for the incognito property of manifest.json.
 ---
 
+{% Partial 'extensions/mv2-legacy-page.md' %}
+
 Use the `"incognito"` manifest key with either `"spanning"` or `"split"` to specify how this
 extension will behave if allowed to run in incognito mode. Using `"not_allowed"` to prevent this
 extension from being enabled in incognito mode.

--- a/site/en/docs/extensions/mv2/manifest/key/index.md
+++ b/site/en/docs/extensions/mv2/manifest/key/index.md
@@ -6,6 +6,8 @@ updated: 2018-04-26
 description: Reference documentation for the key property of manifest.json.
 ---
 
+{% Partial 'extensions/mv2-legacy-page.md' %}
+
 This value can be used to control the unique ID of an extension, app, or theme when it is loaded
 during development.
 

--- a/site/en/docs/extensions/mv2/manifest/minimum_chrome_version/index.md
+++ b/site/en/docs/extensions/mv2/manifest/minimum_chrome_version/index.md
@@ -6,6 +6,8 @@ updated: 2018-04-26
 description: Reference documentation for the minimum_chrome_version property of manifest.json.
 ---
 
+{% Partial 'extensions/mv2-legacy-page.md' %}
+
 The version of Chrome that your extension, app, or theme requires, if any. The format for this
 string is the same as for the [version][1] field.
 

--- a/site/en/docs/extensions/mv2/manifest/nacl_modules/index.md
+++ b/site/en/docs/extensions/mv2/manifest/nacl_modules/index.md
@@ -6,6 +6,8 @@ updated: 2018-04-26
 description: Reference documentation for the nacl_modules property of manifest.json.
 ---
 
+{% Partial 'extensions/mv2-legacy-page.md' %}
+
 One or more mappings from MIME types to the Native Client module that handles each type. For
 example, the bold code in the following snippet registers a Native Client module as the content
 handler for the OpenOffice spreadsheet MIME type.

--- a/site/en/docs/extensions/mv2/manifest/name/index.md
+++ b/site/en/docs/extensions/mv2/manifest/name/index.md
@@ -6,6 +6,8 @@ updated: 2018-04-26
 description: Reference documentation for the name and short_name properties of manifest.json.
 ---
 
+{% Partial 'extensions/mv2-legacy-page.md' %}
+
 The `name` and `short_name` manifest properties are short, plain text strings that identify the
 extension. You can specify locale-specific strings for both fields; see [Internationalization][1]
 for details.

--- a/site/en/docs/extensions/mv2/manifest/offline_enabled/index.md
+++ b/site/en/docs/extensions/mv2/manifest/offline_enabled/index.md
@@ -6,6 +6,8 @@ updated: 2015-01-07
 description: Reference documentation for the offline_enabled property of manifest.json.
 ---
 
+{% Partial 'extensions/mv2-legacy-page.md' %}
+
 Whether the app or extension is expected to work offline. When Chrome detects that it is offline,
 apps with this field set to true will be highlighted on the New Tab page.
 

--- a/site/en/docs/extensions/mv2/manifest/requirements/index.md
+++ b/site/en/docs/extensions/mv2/manifest/requirements/index.md
@@ -6,6 +6,8 @@ updated: 2018-04-26
 description: Reference documentation for the requirements property of manifest.json.
 ---
 
+{% Partial 'extensions/mv2-legacy-page.md' %}
+
 Technologies required by the app or extension. Hosting sites such as the Chrome Web Store may use
 this list to dissuade users from installing apps or extensions that will not work on their computer.
 Supported requirements currently include "3D" and "plugins"; additional requirements checks may be

--- a/site/en/docs/extensions/mv2/manifest/sandbox/index.md
+++ b/site/en/docs/extensions/mv2/manifest/sandbox/index.md
@@ -6,6 +6,8 @@ updated: 2018-04-26
 description: Reference documentation for the sandbox property of manifest.json.
 ---
 
+{% Partial 'extensions/mv2-legacy-page.md' %}
+
 **_Warning:_** Starting in version 57, Chrome will no longer allow external web content (including
 embedded frames and scripts) inside sandboxed pages. Please use a [webview][1] instead.
 

--- a/site/en/docs/extensions/mv2/manifest/storage/index.md
+++ b/site/en/docs/extensions/mv2/manifest/storage/index.md
@@ -6,6 +6,8 @@ updated: 2018-05-14
 description: Reference documentation for the storage property of manifest.json.
 ---
 
+{% Partial 'extensions/mv2-legacy-page.md' %}
+
 Unlike the `local` and `sync` storage areas, the `managed` storage area requires its structure to be
 declared as [JSON Schema][1] and is strictly validated by Chrome. This schema must be stored in a
 file indicated by the `"managed_schema"` property of the `"storage"` manifest key and declares the

--- a/site/en/docs/extensions/mv2/manifest/version/index.md
+++ b/site/en/docs/extensions/mv2/manifest/version/index.md
@@ -6,6 +6,8 @@ updated: 2018-04-26
 description: Reference documentation for the version property of manifest.json.
 ---
 
+{% Partial 'extensions/mv2-legacy-page.md' %}
+
 One to four dot-separated integers identifying the version of this extension. A couple of rules
 apply to the integers: they must be between 0 and 65535, inclusive, and non-zero integers can't
 start with 0. For example, 99999 and 032 are both invalid.

--- a/site/en/docs/extensions/mv2/manifest/web_accessible_resources/index.md
+++ b/site/en/docs/extensions/mv2/manifest/web_accessible_resources/index.md
@@ -6,6 +6,8 @@ updated: 2018-05-14
 description: Reference documentation for the web_accessible_resources property of manifest.json.
 ---
 
+{% Partial 'extensions/mv2-legacy-page.md' %}
+
 An array of strings specifying the paths of packaged resources that are expected to be usable in the
 context of a web page. These paths are relative to the package root, and may contain wildcards. For
 example, an extension that injects a content script with the intention of building up some custom


### PR DESCRIPTION
The text that's changed in this PR is the content of an inclusion. ALL of the other files are just places where the inclusion was missing, but needed to be there.