### PR TITLE
fix: duplicate `/` in github url

### DIFF
--- a/site/_data/i18n/common.yml
+++ b/site/_data/i18n/common.yml
@@ -190,6 +190,7 @@ featured:
 
 improve_article:
   en: 'Improve article'
+  zh: '改进文章'
   ja: '記事を改善する'
 
 featured_cards:
@@ -198,11 +199,11 @@ featured_cards:
       en: Google Developer Groups
     body:
       en: |
-        Connect with fellow developers and startups in your area, 
+        Connect with fellow developers and startups in your area,
         hear from industry experts, share your skills, and learn.
     cta:
       en: Find your local group
-      
+
 cookie_banner:
   explainer:
     en: |

--- a/site/_data/site.json
+++ b/site/_data/site.json
@@ -4,7 +4,7 @@
   "url": "https://developer.chrome.com",
   "imgixDomain": "wd.imgix.net",
   "bucket": "web-dev-uploads",
-  "repo": "https://github.com/GoogleChrome/developer.chrome.com/",
+  "repo": "https://github.com/GoogleChrome/developer.chrome.com",
   "locales": [
     "en",
     "es",

--- a/site/_filters/github-link.js
+++ b/site/_filters/github-link.js
@@ -32,6 +32,7 @@ const githubLink = inputPath => {
     );
   }
   const branch = 'main';
+  // fix: duplicate `/` in github url
   return `${repo}/${path.join('blob', branch, inputPath)}`;
 };
 


### PR DESCRIPTION
Fixes #4136

https://github.com/GoogleChrome/developer.chrome.com/issues/4136

Changes proposed in this pull request:

- site/_data/i18n/common.yml
- site/_data/site.json
- site/_filters/github-link.js