### PR TITLE
Nested PS docs landing

### DIFF
--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -44,13 +44,22 @@
     - url: /docs/privacy-sandbox/fledge-best-practices
 - title: i18n.docs.privacy-sandbox.measure
   sections:
-    - url: /docs/privacy-sandbox/attribution-reporting
-    - url: /docs/privacy-sandbox/attribution-reporting/system-overview
-    - url: /docs/privacy-sandbox/attribution-reporting-experiment
-    - url: /docs/privacy-sandbox/attribution-reporting-updates
-    - url: /docs/privacy-sandbox/attribution-reporting/summary-reports
-    - url: /docs/privacy-sandbox/private-aggregation
-    - url: /docs/privacy-sandbox/private-aggregation-fundamentals
+    - title: i18n.docs.privacy-sandbox.attribution-reporting
+      sections:
+        - url: /docs/privacy-sandbox/attribution-reporting
+          title: i18n.docs.privacy-sandbox.attribution-reporting-overview
+        - url: /docs/privacy-sandbox/attribution-reporting/system-overview
+          title: i18n.docs.privacy-sandbox.attribution-reporting-system
+        - url: /docs/privacy-sandbox/attribution-reporting-experiment
+          title: i18n.docs.privacy-sandbox.attribution-reporting-experiment
+        - url: /docs/privacy-sandbox/attribution-reporting-updates
+          title: i18n.docs.privacy-sandbox.attribution-reporting-changing
+        - url: /docs/privacy-sandbox/attribution-reporting/summary-reports
+          title: i18n.docs.privacy-sandbox.attribution-reporting-summary
+    - title: i18n.docs.privacy-sandbox.private-aggregation
+      sections:
+        - url: /docs/privacy-sandbox/private-aggregation
+        - url: /docs/privacy-sandbox/private-aggregation-fundamentals
 - title: i18n.docs.privacy-sandbox.fight-spam
   sections:
     - url: /docs/privacy-sandbox/trust-tokens

--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -44,7 +44,7 @@
     - url: /docs/privacy-sandbox/fledge-best-practices
 - title: i18n.docs.privacy-sandbox.measure
   sections:
-    - title: i18n.docs.privacy-sandbox.attribution-reporting
+    - title: i18n.docs.privacy-sandbox.measure-ads
       sections:
         - url: /docs/privacy-sandbox/attribution-reporting
           title: i18n.docs.privacy-sandbox.attribution-reporting-overview
@@ -56,7 +56,7 @@
           title: i18n.docs.privacy-sandbox.attribution-reporting-changing
         - url: /docs/privacy-sandbox/attribution-reporting/summary-reports
           title: i18n.docs.privacy-sandbox.attribution-reporting-summary
-    - title: i18n.docs.privacy-sandbox.private-aggregation
+    - title: i18n.docs.privacy-sandbox.measure-cross-site
       sections:
         - url: /docs/privacy-sandbox/private-aggregation
         - url: /docs/privacy-sandbox/private-aggregation-fundamentals

--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -22,7 +22,10 @@
     - url: /docs/privacy-sandbox/chips
     - url: /docs/privacy-sandbox/fenced-frame
     - url: /docs/privacy-sandbox/fedcm
-    - url: /docs/privacy-sandbox/permissions-policy
+    - title: i18n.docs.privacy-sandbox.control-browser-features
+      sections:
+        - url: /docs/privacy-sandbox/permissions-policy
+          title: i18n.docs.privacy-sandbox.permissions-policy
     - title: i18n.docs.privacy-sandbox.cross-site-storage
       sections:
         - url: /docs/privacy-sandbox/shared-storage
@@ -32,11 +35,13 @@
         - url: /docs/privacy-sandbox/shared-storage/known-customer
 - title: i18n.docs.privacy-sandbox.tracking-prevention
   sections:
-    - url: /docs/privacy-sandbox/user-agent
-    - url: /docs/privacy-sandbox/user-agent/snippets
     - url: /docs/privacy-sandbox/gnatcatcher
     - url: /docs/privacy-sandbox/privacy-budget
     - url: /docs/privacy-sandbox/bounce-tracking-mitigations
+    - title: i18n.docs.privacy-sandbox.limit-passive-fingerprint
+      sections:
+        - url: /docs/privacy-sandbox/user-agent
+        - url: /docs/privacy-sandbox/user-agent/snippets
 - title: i18n.docs.privacy-sandbox.relevant
   sections:
     - title: i18n.docs.privacy-sandbox.interest-ads

--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -23,11 +23,13 @@
     - url: /docs/privacy-sandbox/fenced-frame
     - url: /docs/privacy-sandbox/fedcm
     - url: /docs/privacy-sandbox/permissions-policy
-    - url: /docs/privacy-sandbox/shared-storage
-    - url: /docs/privacy-sandbox/shared-storage/frequency-control
-    - url: /docs/privacy-sandbox/shared-storage/ab-testing
-    - url: /docs/privacy-sandbox/shared-storage/creative-rotation
-    - url: /docs/privacy-sandbox/shared-storage/known-customer
+    - title: i18n.docs.privacy-sandbox.cross-site-storage
+      sections:
+        - url: /docs/privacy-sandbox/shared-storage
+        - url: /docs/privacy-sandbox/shared-storage/frequency-control
+        - url: /docs/privacy-sandbox/shared-storage/ab-testing
+        - url: /docs/privacy-sandbox/shared-storage/creative-rotation
+        - url: /docs/privacy-sandbox/shared-storage/known-customer
 - title: i18n.docs.privacy-sandbox.tracking-prevention
   sections:
     - url: /docs/privacy-sandbox/user-agent
@@ -37,11 +39,15 @@
     - url: /docs/privacy-sandbox/bounce-tracking-mitigations
 - title: i18n.docs.privacy-sandbox.relevant
   sections:
-    - url: /docs/privacy-sandbox/topics
-    - url: /docs/privacy-sandbox/topics-experiment
-    - url: /docs/privacy-sandbox/fledge
-    - url: /docs/privacy-sandbox/fledge-experiment
-    - url: /docs/privacy-sandbox/fledge-best-practices
+    - title: i18n.docs.privacy-sandbox.interest-ads
+      sections:
+        - url: /docs/privacy-sandbox/topics
+        - url: /docs/privacy-sandbox/topics-experiment
+    - title: i18n.docs.privacy-sandbox.ondevice-auctions
+      sections:
+        - url: /docs/privacy-sandbox/fledge
+        - url: /docs/privacy-sandbox/fledge-experiment
+        - url: /docs/privacy-sandbox/fledge-best-practices
 - title: i18n.docs.privacy-sandbox.measure
   sections:
     - title: i18n.docs.privacy-sandbox.measure-ads

--- a/site/_data/i18n/docs/privacy-sandbox.yml
+++ b/site/_data/i18n/docs/privacy-sandbox.yml
@@ -36,6 +36,8 @@ events:
 blog:
   en: 'Blog'
   ja: 'ブログ'
+attribution-reporting-overview:
+  en: 'Measure digital ads with Attribution Reporting'
 attribution-reporting-experiment:
   en: 'Experiment and participate'
 attribution-reporting-changing:
@@ -46,6 +48,8 @@ attribution-reporting-system:
   en: 'End-to-end system overview'
 attribution-reporting-summary:
   en: 'Summary reports'
+private-aggregation:
+  en: 'Private Aggregation API'
 tracking-prevention:
   en: 'Prevent covert tracking'
   ja: '隠されたトラッキングを防ぐ'

--- a/site/_data/i18n/docs/privacy-sandbox.yml
+++ b/site/_data/i18n/docs/privacy-sandbox.yml
@@ -36,8 +36,12 @@ events:
 blog:
   en: 'Blog'
   ja: 'ブログ'
+measure-ads:
+  en: 'Measure ad conversions'
+measure-cross-site:
+  en: 'Measure cross-site data'
 attribution-reporting-overview:
-  en: 'Measure digital ads with Attribution Reporting'
+  en: 'Attribution Reporting overview'
 attribution-reporting-experiment:
   en: 'Experiment and participate'
 attribution-reporting-changing:

--- a/site/_data/i18n/docs/privacy-sandbox.yml
+++ b/site/_data/i18n/docs/privacy-sandbox.yml
@@ -1,5 +1,9 @@
 attribution-reporting:
   en: 'Attribution Reporting'
+interest-ads:
+  en: 'Interest-based ads'
+ondevice-auctions:
+  en: 'On-device auctions'
 fledge:
   en: 'FLEDGE'
 fledge-best-practices:
@@ -37,9 +41,9 @@ blog:
   en: 'Blog'
   ja: 'ブログ'
 measure-ads:
-  en: 'Measure ad conversions'
+  en: 'Measure ad conversions with Attribution Reporting'
 measure-cross-site:
-  en: 'Measure cross-site data'
+  en: 'Measure cross-site data with Private Aggregation'
 attribution-reporting-overview:
   en: 'Attribution Reporting overview'
 attribution-reporting-experiment:
@@ -49,7 +53,7 @@ attribution-reporting-changing:
 attribution-reporting_description:
   en: 'Measure when user action leads to a conversion, without cross-site identifiers.'
 attribution-reporting-system:
-  en: 'End-to-end system overview'
+  en: 'Attribution Reporting end-to-end'
 attribution-reporting-summary:
   en: 'Summary reports'
 private-aggregation:

--- a/site/_data/i18n/docs/privacy-sandbox.yml
+++ b/site/_data/i18n/docs/privacy-sandbox.yml
@@ -4,6 +4,8 @@ interest-ads:
   en: 'Interest-based ads'
 ondevice-auctions:
   en: 'On-device auctions'
+cross-site-storage:
+  en: 'Secure cross-site storage'
 fledge:
   en: 'FLEDGE'
 fledge-best-practices:

--- a/site/_data/i18n/docs/privacy-sandbox.yml
+++ b/site/_data/i18n/docs/privacy-sandbox.yml
@@ -29,7 +29,11 @@ status:
 storage:
   en: 'Secure cross-site storage'
 trust-tokens:
-  en: 'Trust Tokens'
+  en: 'Private State Tokens'
+limit-passive-fingerprint:
+  en: 'Limit passive fingerprinting'
+control-browser-features:
+  en: 'Control access to browser features'
 start:
   en: 'Get started'
   ja: 'はじめに'
@@ -83,8 +87,6 @@ proposals:
   en: 'Proposal lifecycle'
 permissions-policy:
   en: 'Permissions Policy'
-permissions-policy-description:
-  en: 'Manage browser access to your page and embedded third-party iframes.'
 feedback:
   en: 'Feedback'
 faq:

--- a/site/_data/i18n/docs/privacy-sandbox.yml
+++ b/site/_data/i18n/docs/privacy-sandbox.yml
@@ -1,9 +1,9 @@
 attribution-reporting:
   en: 'Attribution Reporting'
 interest-ads:
-  en: 'Interest-based ads'
+  en: 'Interest-based advertising'
 ondevice-auctions:
-  en: 'On-device auctions'
+  en: 'On-device auctions for custom audiences'
 cross-site-storage:
   en: 'Secure cross-site storage'
 fledge:

--- a/site/_includes/macros/navigation-tree-sections.njk
+++ b/site/_includes/macros/navigation-tree-sections.njk
@@ -18,7 +18,7 @@ and marks it as active.
       <div class="navigation-tree__icon">
         {{ icon('arrow-right', {hidden: true}) }}
       </div>
-      <span>{{ item.title | i18n }}</span>
+      <span class="section-title">{{ item.title | i18n }}</span>
     </button>
     <div class="navigation-tree__nested">
       {{ navigationTreeSectionsInternal(item.sections) }}
@@ -48,8 +48,15 @@ and marks it as active.
       {% endif %}
 
       {% if post %}
+      
+        {% if item.title %}
+          {% set articleTitle = item.title | i18n(locale) %}
+        {% else %}
+           {% set articleTitle = post.data.title %}
+        {% endif %}
+        
         <a href="{{ post.url }}" class="navigation-tree__link" {% if item.active %}{{ helpers.getLinkActiveState(post.url, page.url) | safe }}{% endif %}>
-          <span>{{ post.data.title }}</span>
+          <span class="article-title">{{ articleTitle }}</span>
         </a>
       {% endif %}
     {% endif %}

--- a/site/_includes/macros/project-sections.njk
+++ b/site/_includes/macros/project-sections.njk
@@ -22,7 +22,11 @@ have been defined in the _data/docs/*.yml file for this project.
       <li>
         {% set translatedTitle = item.title | i18n(locale) %}
         {% set translatedSlug = translatedTitle | slugify %}
-        <div id="{{ translatedSlug }}">
+        <div id="{{ translatedSlug }}"
+          {% if type === 'column' %}
+            class="project-sections__nested-title"
+          {% endif %}
+           >
           {{ translatedTitle }}
           <a class="heading-link" href="#{{ translatedSlug }}">#</a>
         </div>
@@ -71,13 +75,14 @@ have been defined in the _data/docs/*.yml file for this project.
         {% set inner %}
           {% if type === 'column' %}
             <span class="project-sections__icon"></span>
+            {% else %}
+            <span class="project-sections__icon-optional"></span>
           {% endif %}
           <a
             class="display-inline-flex align-center color-primary-shade decoration-none surface lg:gap-right-600"
             href="{{ postUrl }}"
             {%- if isExternal -%}
-            target="_blank"
-            rel="noopener"
+            target="_blank" rel="noopener"
             {%- endif -%}
             >
               {{ postTitle }}

--- a/site/_scss/blocks/_project-sections.scss
+++ b/site/_scss/blocks/_project-sections.scss
@@ -65,13 +65,14 @@
 
 .project-sections__nested-title {
   @include flex-font((14px 24px), (16px 24px), (16px 24px));
-  padding-bottom:0.5em;
+  padding-bottom: 0.5em;
 }
 
 .project-sections__nested-column > li > .project-sections__icon-optional ~ * { /* stylelint-disable-line selector-max-compound-selectors */
   margin-left: calc(#{get-size(400)} + 28px);
 }
-.project-sections__nested-column > li > div  {
+
+.project-sections__nested-column > li > div {
   display: flex;
 }
 

--- a/site/_scss/blocks/_project-sections.scss
+++ b/site/_scss/blocks/_project-sections.scss
@@ -63,9 +63,28 @@
   display: flex;
 }
 
+.project-sections__nested-title {
+  @include flex-font((14px 24px), (16px 24px), (16px 24px));
+  padding-bottom:0.5em;
+}
+
+.project-sections__nested-column > li > .project-sections__icon-optional ~ * { /* stylelint-disable-line selector-max-compound-selectors */
+  margin-left: calc(#{get-size(400)} + 28px);
+}
+.project-sections__nested-column > li > div  {
+  display: flex;
+}
+
 // This renders a base64'ed version of 'document.svg' with fill set to #5f6368. This SVG is used a
 // multitude of times on each docs landing page, so dedup it vs including in the HTML.
 .project-sections__icon {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjgiIGhlaWdodD0iMjgiIHZpZXdCb3g9IjAgMCAyOCAyOCIgZmlsbD0iIzVmNjM2OCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNMjIuMTc4IDMuNUg1Ljg0NWEyLjM0IDIuMzQgMCAwMC0yLjMzMyAyLjMzM3YxNi4zMzRBMi4zNCAyLjM0IDAgMDA1Ljg0NSAyNC41aDE2LjMzM2EyLjM0IDIuMzQgMCAwMDIuMzM0LTIuMzMzVjUuODMzQTIuMzQgMi4zNCAwIDAwMjIuMTc4IDMuNXptMCAxOC42NjdINS44NDVWNS44MzNoMTYuMzMzdjE2LjMzNHoiLz48cGF0aCBkPSJNMTkuODU3IDguMTY3SDguMTc4VjEwLjVoMTEuNjc5VjguMTY3ek0xOS44NTcgMTIuODMzSDguMTc4djIuMzM0aDExLjY3OXYtMi4zMzR6TTE2LjM1NyAxNy41SDguMTc4djIuMzMzaDguMTc5VjE3LjV6Ii8+PC9zdmc+');
+  height: 28px;
+  position: absolute;
+  width: 28px;
+}
+
+.project-sections__nested-column .project-sections__icon-optional {
   background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjgiIGhlaWdodD0iMjgiIHZpZXdCb3g9IjAgMCAyOCAyOCIgZmlsbD0iIzVmNjM2OCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNMjIuMTc4IDMuNUg1Ljg0NWEyLjM0IDIuMzQgMCAwMC0yLjMzMyAyLjMzM3YxNi4zMzRBMi4zNCAyLjM0IDAgMDA1Ljg0NSAyNC41aDE2LjMzM2EyLjM0IDIuMzQgMCAwMDIuMzM0LTIuMzMzVjUuODMzQTIuMzQgMi4zNCAwIDAwMjIuMTc4IDMuNXptMCAxOC42NjdINS44NDVWNS44MzNoMTYuMzMzdjE2LjMzNHoiLz48cGF0aCBkPSJNMTkuODU3IDguMTY3SDguMTc4VjEwLjVoMTEuNjc5VjguMTY3ek0xOS44NTcgMTIuODMzSDguMTc4djIuMzM0aDExLjY3OXYtMi4zMzR6TTE2LjM1NyAxNy41SDguMTc4djIuMzMzaDguMTc5VjE3LjV6Ii8+PC9zdmc+');
   height: 28px;
   position: absolute;


### PR DESCRIPTION
ARA, PAA, Topics, FLEDGE, UAR, and Shared Storage now have 2+ related docs. This update keeps content organized by PS use case at a high-level, with nested groups of content for these docs based on developer-focused use case

https://deploy-preview-4141--developer-chrome-com.netlify.app/docs/privacy-sandbox

Changes:

- Adds brief descriptions of the APIs as titles to group docs
- Updates to style and template of a Docs landing page to allow for stylized nesting.