### PR TITLE
Gracefully render dev tools related articles if blog is ignored

### DIFF
--- a/site/en/_partials/devtools/engineering-blog.md
+++ b/site/en/_partials/devtools/engineering-blog.md
@@ -6,6 +6,7 @@
 {% set colln = collections.tags['new-in-devtools'].posts[locale] %}
 
 <!-- Get 3 random engineering posts and 2 latest what's new in DevTools posts -->
+{% if colld.length and colln.length %}
 {% set sliced = (colld.length / 3) | round(0, "floor") %}
 {% set list1 = colld | slice(sliced) | random %}
 {% set list2 = [ colln[0], colln[1] ] %}
@@ -17,5 +18,6 @@
 {% for item in list %}
 - [{{ item.data.title }}]({{ item.url | url }})
 {% endfor %}
+{% endif %}
 
 Subscribe to [Chrome DevTools blog](/tags/devtools) to stay up to date with the DevTools news.


### PR DESCRIPTION
Fixes #4159. Bugs like this drive me nuts...

11ty tries to render the partial on start-up, even if it's never used. But when the blog is ignored, the lists are empty and working on them fails.