### PR TITLE
Add a note about curl command for Windows-based systems

### DIFF
--- a/site/en/docs/crux/api/index.md
+++ b/site/en/docs/crux/api/index.md
@@ -22,7 +22,7 @@ date: 2022-06-23
 
 # Optional
 # Include an updated date when you update your post
-updated: 2022-10-20
+updated: 2022-11-01
 
 # Optional
 # How to add a new author
@@ -283,6 +283,9 @@ curl -s --request POST 'https://chromeuxreport.googleapis.com/v1/records:queryRe
     --data '{"formFactor":"PHONE","origin":"https://www.example.com","metrics":["largest_contentful_paint", "experimental_time_to_first_byte"]}'
 ```
 
+{% Aside 'note' %}
+The above example is for MacOS or Linux based systems—including the Git BASH shell for Windows. Other systems may require slight modifications. For example, the `cmd.exe` command line does not allow single quotes for parameters, nor the line continuations (`\`), so requires using double quotes (escaping inner quotes as appropriate with `\"`), and also using a single line.
+{% endAside %}
 
 Page-level data is available through the API by passing a `url` property in the query, instead of `origin`:
 


### PR DESCRIPTION
Fixes https://github.com/GoogleChrome/web.dev/issues/6696

Changes proposed in this pull request:

- Add a note about `curl` command and how it might have to be altered for other systems
