### PR TITLE
[doc-ext] Remove no longer relevant aside in service worker article

### DIFF
--- a/site/en/docs/extensions/mv3/service_workers/index.md
+++ b/site/en/docs/extensions/mv3/service_workers/index.md
@@ -3,7 +3,7 @@ layout: "layouts/doc-post.njk"
 title: "Manage events with service workers"
 date: 2012-09-17
 updated: 2018-05-01
-description: How to respond to browser triggers (events) from a Chrome Extension background script.
+description: How to respond to browser triggers (events) from a Chrome Extension service worker.
 ---
 
 Extensions are event-based programs used to modify or enhance the Chrome browsing experience. Events
@@ -32,9 +32,9 @@ loaded.
 Effective background scripts stay dormant until an event they are listening for fires, react with
 specified instructions, then unload.
 
-## Register background scripts {: #manifest }
+## Register the service worker {: #manifest }
 
-Extensions register their background service workers in the [manifest][3] under the `"background"`
+Extensions register their service worker in the [manifest][3] under the `"background"`
 field. This field uses the `"service_worker"` key, which specifies a single JavaScript file.
 
 ```json/3-6
@@ -47,12 +47,6 @@ field. This field uses the `"service_worker"` key, which specifies a single Java
   ...
 }
 ```
-
-{% Aside %}
-
-The script used for `"service_worker"` must be located in your extension's root directory.
-
-{% endAside %}
 
 You can optionally specify an extra field of `"type": "module"` to include the service worker as an
 ES Module, which allows you to `import` further code. See [ES modules in service workers][sw-module]


### PR DESCRIPTION
This PR removes an aside that warned developers to place the service worker file in the root. This was true during the first releases of MV3, but it is no longer the case.

**Staged link**
[Service worker](https://deploy-preview-4208--developer-chrome-com.netlify.app/docs/extensions/mv3/service_workers/)
