### PR TITLE
[doc-cws] Removes mention of large tile

### DIFF
--- a/site/en/docs/webstore/best_listing/index.md
+++ b/site/en/docs/webstore/best_listing/index.md
@@ -140,13 +140,12 @@ Promotional images are your chance to capture users' attention and entice them t
 just use a screenshot; your images should communicate the brand and appear professional. Here are
 specifics about each promotional image:
 
-**Small promo tile: 440x280 pixels** &emsp; Appears on the homepage, category pages, and in search
+Small promo tile: 440x280 pixels
+: Appears on the homepage, category pages, and in search
 results.
 
-**Large promo tile: 920x680 pixels** &emsp; Not currently used. You do not need to provide a large
-promo tile at this time.
-
-**Marquee image: 1400x560 pixels** &emsp; This image is used if your item is chosen for the marquee
+Marquee image: 1400x560 pixels
+: This image is used if your item is chosen for the marquee
 feature (the rotating carousel on the top of the Chrome Web Store homepage). To increase your
 chances of being featured, ensure your marquee image is uncluttered, high-resolution, and has
 consistent branding elements to your other assets so users can immediately associate it with your

--- a/site/en/docs/webstore/best_listing/index.md
+++ b/site/en/docs/webstore/best_listing/index.md
@@ -145,7 +145,7 @@ Small promo tile: 440x280 pixels
 results.
 
 Marquee image: 1400x560 pixels
-: This image is used if your item is chosen for the marquee
+: Used if your item is chosen for the marquee
 feature (the rotating carousel on the top of the Chrome Web Store homepage). To increase your
 chances of being featured, ensure your marquee image is uncluttered, high-resolution, and has
 consistent branding elements to your other assets so users can immediately associate it with your

--- a/site/en/docs/webstore/images/index.md
+++ b/site/en/docs/webstore/images/index.md
@@ -216,7 +216,6 @@ if you'd like your extension to be featured more prominently in the Chrome Web S
 of each of the following:
 
 - Small: 440x280 pixels **(required)**
-- Large: 920x680 pixels
 - Marquee: 1400x560 pixels
 
 {% Aside 'note' %}
@@ -239,31 +238,20 @@ thumb for designing your images:
 
 The following graphics are examples of the promotional images for an extension:
 
-<table>
-  <thead>
-    <tr>
-      <th>Small promo image (440x280)</th>
-      <th>Large promo image (920x680)</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        {% Img src="image/nPi5hOhvGtatFrSN6ugwlPVHcs43/9KruJ8pLUNTrzXIXP6JN.png", 
-               alt="Small promo image", height="140", width="220" %}
-      </td>
-      <td>
-        {% Img src="image/nPi5hOhvGtatFrSN6ugwlPVHcs43/uvSRznxKJngidMKDIeqN.png", 
-               alt="Large promo image", height="340", width="460" %}
-      </td>
-    </tr>
-  </tbody>
-</table>
+<figure>
+{% Img src="image/nPi5hOhvGtatFrSN6ugwlPVHcs43/9KruJ8pLUNTrzXIXP6JN.png", alt="Small promo image", height="140", width="220" %}
+  <figcaption>
+Small promo image (440x280)
+  </figcaption>
+</figure>
 
-Marquee image (1400x560):
+<figure>
+{% Img src="image/nPi5hOhvGtatFrSN6ugwlPVHcs43/tn6IOh8ZCrflIOcu8isV.png", alt="Marquee", height="280", width="700" %}
+  <figcaption>
+Marquee image (1400x560)
+  </figcaption>
+</figure>
 
-{% Img src="image/nPi5hOhvGtatFrSN6ugwlPVHcs43/tn6IOh8ZCrflIOcu8isV.png", 
-        alt="Marquee", height="280", width="700" %}
 
 {% Aside 'note' %}
 


### PR DESCRIPTION
Updating docs to match [CWS announcement](https://developer.chrome.com/docs/extensions/whatsnew/#cws-large-promo-tile) regarding the large tile.
