### PR TITLE
Add 'action' to the manifest

### DIFF
--- a/site/en/docs/extensions/mv3/getstarted/tut-focus-mode/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/tut-focus-mode/index.md
@@ -145,6 +145,7 @@ To use the `activeTab` permission, add it to the manifest's permission array:
 {
   ...
   "permissions": ["activeTab"],
+  "action": {},
   ...
 }
 ```


### PR DESCRIPTION
Without action following error occurs:
chrome extension: Uncaught TypeError: Cannot read properties of undefined (reading 'onClicked')

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

-
-
-