### PR TITLE
Update API reference intro.

### DIFF
--- a/site/en/docs/extensions/reference/index.md
+++ b/site/en/docs/extensions/reference/index.md
@@ -4,7 +4,7 @@ description: 'The complete reference to all APIs made available to Chrome Extens
 layout: 'layouts/reference-landing.njk'
 ---
 
-Chrome provides extensions with many special-purpose interfaces such as `chrome.runtime` and `chrome.alarms`.
+Chrome provides extensions with many special-purpose APIs such as `chrome.alarms` and `chrome.action`. Many APIs consist of a namespace and its related manifest fields. These fields are frequently permissions, but not always. For example, `chrome.alarms` requires only the `alarms` permission, while `chrome.action` requires an action object in the `manifest.json` file.
 
 ## API conventions
 

--- a/site/en/docs/extensions/reference/index.md
+++ b/site/en/docs/extensions/reference/index.md
@@ -1,13 +1,11 @@
 ---
-title: 'API Reference'
+title: 'API reference'
 description: 'The complete reference to all APIs made available to Chrome Extensions. This includes APIs for the deprecated Chrome Apps platform as well as APIs still in beta and dev.'
 layout: 'layouts/reference-landing.njk'
 ---
 
-Chrome provides extensions with many special-purpose APIs like `chrome.runtime` and `chrome.alarms`.
+Chrome provides extensions with many special-purpose interfaces such as `chrome.runtime` and `chrome.alarms`.
 
 ## API conventions
 
-Unless the doc says otherwise, methods in the `chrome.*` APIs are **asynchronous**: they return immediately, without waiting for the operation to finish.
-If you need to know the outcome of an operation, then you pass a callback function into the method.
-For more information, [watch this video](https://www.youtube.com/watch?v=bmxr75CV36A).
+Unless stated otherwise, methods in the `chrome.*` APIs are **asynchronous**: they return immediately, without waiting for the operation to finish. If you need to know the result of calling such methods, use the returned promise or pass a callback function into the method. For more information, see [Asynchronous methods](/docs/extensions/mv3/architecture-overview/#async-sync).


### PR DESCRIPTION
Does the following:

* Updates a claim that callbacks exclusively are returned by asynchronous methods.
* Adds a link to current guidances on asynchronous calls.
* Changes the title to match capitalization rules for dcc.

**Staged links**
[Chrome API reference](https://deploy-preview-4228--developer-chrome-com.netlify.app/docs/extensions/reference/)