### PR TITLE
Use njk comment syntax in partials instead of raw HTML comments

### DIFF
--- a/site/en/_partials/devtools/whats-new.md
+++ b/site/en/_partials/devtools/whats-new.md
@@ -2,7 +2,7 @@
 
 A list of everything that has been covered in the [What's New In DevTools](/tags/new-in-devtools/) series.
 
-<!-- $content -->
+{# $content #}
 
 ### Chrome 108 {: #chrome108 }
 

--- a/site/es/_partials/devtools/whats-new.md
+++ b/site/es/_partials/devtools/whats-new.md
@@ -2,16 +2,16 @@
 
 Por favor, revisa la versión en inglés de <a href="/tags/new-in-devtools/" translate="no">What's New In DevTools</a> para una lista completa de las características lanzadas. Debajo tienes más contenido que ha sido traducido al castellano.
 
-<!-- $content -->
+{# $content #}
 
-<!-- ### Chrome 108 {: #chrome108 }
+{# ### Chrome 108 {: #chrome108 }
 
 * [Hints for inactive CSS properties](/es/blog/new-in-devtools-108/#css-hint)
 * [Auto-detect XPath and text selectors in the Recorder panel](/es/blog/new-in-devtools-108/#recorder)
 * [Step through comma-separated expressions](/es/blog/new-in-devtools-108/#debugging)
 * [Improved Ignore list setting](/es/blog/new-in-devtools-108/#ignore-list)
 * [Miscellaneous highlights](/es/blog/new-in-devtools-108/#misc)
- -->
+ #}
 
 ### Chrome 107 {: #chrome107 }
 
@@ -78,7 +78,7 @@ Por favor, revisa la versión en inglés de <a href="/tags/new-in-devtools/" tra
 * [Mejorada previsualización de valor en línea durante la depuración](/es/blog/new-in-devtools-103/#inline-preview)
 * [Soporte para grandes bloques para autenticadores virtuales](/es/blog/new-in-devtools-103/#webauthn)
 * [Nuevos atajos de teclado en el panel Fuentes](/es/blog/new-in-devtools-103/#shortcuts)
-* [Mejoras en los sourcemaps](/es/blog/new-in-devtools-103/#sourcemaps) -->
+* [Mejoras en los sourcemaps](/es/blog/new-in-devtools-103/#sourcemaps)
 
 
 ### Chrome 102 {: #chrome102 }
@@ -125,7 +125,7 @@ Por favor, revisa la versión en inglés de <a href="/tags/new-in-devtools/" tra
 * [Muestra los archivos de fuente de Worker en el panel de Fuentes](/es/blog/new-in-devtools-99/#worker-sourcemap)
 * [Actualizaciones del modo oscuro automático de Chrome](/es/blog/new-in-devtools-99/#auto-dark-mode)
 * [Selector de color y panel de división en modo táctil](/es/blog/new-in-devtools-99/#touch-friendly)
-* [Destacados varios](/es/blog/new-in-devtools-99/#misc) -->
+* [Destacados varios](/es/blog/new-in-devtools-99/#misc)
 
 
 ### Chrome 98 {: #chrome98 }
@@ -157,7 +157,7 @@ Por favor, revisa la versión en inglés de <a href="/tags/new-in-devtools/" tra
 ### Chrome 96 {: #chrome96 }
 
 * [Función de vista previa: Nuevo panel de Descripción General de CSS](/es/blog/new-in-devtools-96/#css-overview)
-<!-- * [Restored and improved CSS length edit and copy experince](/es/blog/new-in-devtools-966/#length) -->
+{# * [Restored and improved CSS length edit and copy experince](/es/blog/new-in-devtools-966/#length) #}
 * [Emule la función multimedia CSS de contraste](/es/blog/new-in-devtools-96/#prefers-contrast)
 * [Emula la función de tema oscuro automático de Chrome](/es/blog/new-in-devtools-96/#auto-dark-mode)
 * [Copiar declaraciones como JavaScript en el panel Estilos](/es/blog/new-in-devtools-96/#copy-as-js)

--- a/site/ja/_partials/devtools/whats-new.md
+++ b/site/ja/_partials/devtools/whats-new.md
@@ -2,7 +2,7 @@
 
 関連する機能の完全なリストは、<a href="/tags/new-in-devtools/" translate="no">What's New In DevTools</a> の英語版を参照してください。以下は、日本語に翻訳された内容の一部です。
 
-<!-- $content -->
+{# $content #}
 
 ### Chrome 108 {: #chrome108 }
 
@@ -157,7 +157,7 @@
 ### Chrome 96 {: #chrome96 }
 
 * [プレビュー機能: 新しい CSS Overview パネル](/ja/blog/new-in-devtools-96/#css-overview)
-<!-- * [Restored and improved CSS length edit and copy experince](/ja/blog/new-in-devtools-966/#length) -->
+{# * [Restored and improved CSS length edit and copy experince](/ja/blog/new-in-devtools-966/#length) #}
 * [CSS の prefers-contrast メディア機能のエミュレート](/ja/blog/new-in-devtools-96/#prefers-contrast)
 * [Chrome の Auto Dark Theme 機能のエミュレート](/ja/blog/new-in-devtools-96/#auto-dark-mode)
 * [Styles ペインで JavaScript として宣言をコピー](/ja/blog/new-in-devtools-96/#copy-as-js)

--- a/site/ja/_partials/devtools/whats-new.md
+++ b/site/ja/_partials/devtools/whats-new.md
@@ -157,7 +157,7 @@
 ### Chrome 96 {: #chrome96 }
 
 * [プレビュー機能: 新しい CSS Overview パネル](/ja/blog/new-in-devtools-96/#css-overview)
-{# * [Restored and improved CSS length edit and copy experince](/ja/blog/new-in-devtools-966/#length) #}
+* [CSS の length の編集とコピーの挙動の復旧と改善](/ja/blog/new-in-devtools-966/#length)
 * [CSS の prefers-contrast メディア機能のエミュレート](/ja/blog/new-in-devtools-96/#prefers-contrast)
 * [Chrome の Auto Dark Theme 機能のエミュレート](/ja/blog/new-in-devtools-96/#auto-dark-mode)
 * [Styles ペインで JavaScript として宣言をコピー](/ja/blog/new-in-devtools-96/#copy-as-js)

--- a/site/ko/_partials/devtools/whats-new.md
+++ b/site/ko/_partials/devtools/whats-new.md
@@ -2,16 +2,16 @@
 
 <a href="/tags/new-in-devtools/" translate="no">What's New In DevTools</a> 영어 버전을 참고하여 관련 기능의 전체 목록을 볼 수 있습니다. 아래 콘텐츠들은 한국어로 번역된 콘텐츠들입니다.
 
-<!-- $content -->
+{# $content #}
 
-<!-- ### Chrome 108 {: #chrome108 }
+{# ### Chrome 108 {: #chrome108 }
 
 * [Hints for inactive CSS properties](/ko/blog/new-in-devtools-108/#css-hint)
 * [Auto-detect XPath and text selectors in the Recorder panel](/ko/blog/new-in-devtools-108/#recorder)
 * [Step through comma-separated expressions](/ko/blog/new-in-devtools-108/#debugging)
 * [Improved Ignore list setting](/ko/blog/new-in-devtools-108/#ignore-list)
 * [Miscellaneous highlights](/ko/blog/new-in-devtools-108/#misc)
- -->
+ #}
 
 ### Chrome 107 {: #chrome107 }
 

--- a/site/pt/_partials/devtools/whats-new.md
+++ b/site/pt/_partials/devtools/whats-new.md
@@ -2,7 +2,7 @@
 
 Consulte a versão em inglês do <a href="/tags/new-in-devtools/" translate="no">What's New In DevTools</a> para uma lista completa dos recursos lançados. Abaixo estão alguns conteúdos que foram traduzidos para o português.
 
-<!-- $content -->
+{# $content #}
 
 ### Chrome 108 {: #chrome108 }
 

--- a/site/ru/_partials/devtools/whats-new.md
+++ b/site/ru/_partials/devtools/whats-new.md
@@ -3,16 +3,16 @@
 Чтобы увидеть полный список обновлений,  перейдите на английскую версию по ссылке 
 <a href="/tags/new-in-devtools/" translate="no">What's New In DevTools</a>. Ниже перечислены материалы, переведенные на русский язык.
 
-<!-- $content -->
+{# $content #}
 
-<!-- ### Chrome 108 {: #chrome108 }
+{# ### Chrome 108 {: #chrome108 }
 
 * [Hints for inactive CSS properties](/ru/blog/new-in-devtools-108/#css-hint)
 * [Auto-detect XPath and text selectors in the Recorder panel](/ru/blog/new-in-devtools-108/#recorder)
 * [Step through comma-separated expressions](/ru/blog/new-in-devtools-108/#debugging)
 * [Improved Ignore list setting](/ru/blog/new-in-devtools-108/#ignore-list)
 * [Miscellaneous highlights](/ru/blog/new-in-devtools-108/#misc)
- -->
+ #}
 
 ### Chrome 107 {: #chrome107 }
 
@@ -67,7 +67,7 @@
 * [Определение блокирующего фрейма на панели Возвратного кэша (Back/forward cache)](/ru/blog/new-in-devtools-104/#bfcache)
 * [Улучшены подсказки автодополнения для объектов JavaScript](/ru/blog/new-in-devtools-104/#autocomplete)
 * [Улучшение карт источников](/ru/blog/new-in-devtools-104/#sourcemaps)
-* [Другие важные моменты](/ru/blog/new-in-devtools-104/#misc) -->
+* [Другие важные моменты](/ru/blog/new-in-devtools-104/#misc)
 
 ### Chrome 103 {: #chrome103 }
 

--- a/site/zh/_partials/devtools/whats-new.md
+++ b/site/zh/_partials/devtools/whats-new.md
@@ -2,16 +2,16 @@
 
 欲查询完整的 DevTools 已发布的功能，请参考 <a href="/tags/new-in-devtools/" translate="no">What's New In DevTools</a> 英文系列。以下是部分已翻译成中文的内容。
 
-<!-- $content -->
+{# $content #}
 
-<!-- ### Chrome 108 {: #chrome108 }
+{# ### Chrome 108 {: #chrome108 }
 
 * [Hints for inactive CSS properties](/zh/blog/new-in-devtools-108/#css-hint)
 * [Auto-detect XPath and text selectors in the Recorder panel](/zh/blog/new-in-devtools-108/#recorder)
 * [Step through comma-separated expressions](/zh/blog/new-in-devtools-108/#debugging)
 * [Improved Ignore list setting](/zh/blog/new-in-devtools-108/#ignore-list)
 * [Miscellaneous highlights](/zh/blog/new-in-devtools-108/#misc)
- -->
+ #}
 
 ### Chrome 107 {: #chrome107 }
 


### PR DESCRIPTION
There's a bunch of stuff I tried and I know this isn't ideal as we loose proper code highlighting, but only this allows us to keep all other nunjucks features including macros and other shortcodes. Fixes #4249.

@jecfish, let me know if that would work for you.