### PR TITLE
Add missing new sections to JA Privacy Sandbox landing page

### DIFF
--- a/site/ja/privacy-sandbox/index.njk
+++ b/site/ja/privacy-sandbox/index.njk
@@ -18,6 +18,7 @@ sections:
   prevent_covert_tracking:
     - url: /docs/privacy-sandbox/gnatcatcher
     - url: /docs/privacy-sandbox/privacy-budget
+    - url: /docs/privacy-sandbox/bounce-tracking-mitigations	
   show_relevant_content_topics:
     - url: /docs/privacy-sandbox/topics
     - url: /docs/privacy-sandbox/topics-experiment
@@ -39,8 +40,16 @@ sections:
     - url: /docs/privacy-sandbox/fedcm
     - url: /docs/privacy-sandbox/first-party-sets
     - url: /docs/privacy-sandbox/fenced-frame
+    - url: /docs/privacy-sandbox/storage-partitioning
+  storage_cross_site:
+    - url: /docs/privacy-sandbox/storage-partitioning
     - url: /docs/privacy-sandbox/shared-storage
-    - url: /docs/privacy-sandbox/use-shared-storage
+    - url: /docs/privacy-sandbox/private-aggregation
+  related_storage_usecases:
+    - url: /docs/privacy-sandbox/shared-storage/frequency-control
+    - url: /docs/privacy-sandbox/shared-storage/creative-rotation
+    - url: /docs/privacy-sandbox/shared-storage/known-customer
+    - url: /docs/privacy-sandbox/shared-storage/ab-testing
   fight_spam:
     - url: /docs/privacy-sandbox/trust-tokens
 ---
@@ -150,6 +159,23 @@ sections:
   250,
   124,
   "image/VbsHyyQopiec0718rMq2kTE1hke2/tCE6xv0QdnKWNSEJQUbA.svg"
+  )
+}}
+
+{{ landingSectionExpanded(
+  "Secure cross-site storage",
+  "Prevent fraud, run A/B testing, rotate creatives, and support other use cases, while protecting user privacy.",
+  sections.storage_cross_site,
+  "green",
+  "top-3",
+  true,
+  "image/VbsHyyQopiec0718rMq2kTE1hke2/g0sHuyvPENgBaLhY6uJA.svg",
+  "Analytics icon.",
+  250,
+  124,
+  "image/VbsHyyQopiec0718rMq2kTE1hke2/g0sHuyvPENgBaLhY6uJA.svg",
+  "Explore use cases",
+  sections.related_storage_usecases
   )
 }}
 


### PR DESCRIPTION
This syncs the new sections for the Privacy Landing page over the the Japanese version.

@agektmr, up to you if we should merge this now and provide translations for the new section later or do it in one go 🙂 