### PR TITLE
Let findByUrl fallback to default locale if no results

### DIFF
--- a/site/_data/lib/find.js
+++ b/site/_data/lib/find.js
@@ -66,7 +66,16 @@ const findByUrl = (collection, url, locale = '') => {
     locale = path.join('/', locale);
   }
 
-  const urlToFind = path.join(locale, url);
+  let urlToFind = path.join(locale, url);
+  const result = internalFind(collection, urlCacheKey, 'url', urlToFind);
+  // If something has been found or nothing has been found while
+  // not specifying a locale, end here. If a locale has been defined
+  // we want to try searching again with the default locale
+  if (result || !locale) {
+    return result;
+  }
+
+  urlToFind = path.join('/', defaultLocale, url);
   return internalFind(collection, urlCacheKey, 'url', urlToFind);
 };
 


### PR DESCRIPTION
Follow-up to https://github.com/GoogleChrome/developer.chrome.com/pull/4267. 

Some templates use `findByUrl` which did not yet fallback to `defaultLocale` like `findByFilePath` does or other templates which fallback to defaultLocale on their own.

Making it so ensures pages defined in site/_data/docs/**/toc.yaml are not skipped during template rendering if they are not localized like currently on https://developer.chrome.com/ja/docs/privacy-sandbox/, which misses https://developer.chrome.com/docs/privacy-sandbox/unified-origin-trial/.