### PR TITLE
Update redirects-yaml to 2.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "purgecss": "^2.3.0",
         "querystring": "^0.2.0",
         "readdirp": "^3.4.0",
-        "redirects-yaml": "^2.0.3",
+        "redirects-yaml": "2.0.4",
         "rollup": "^2.22.2",
         "striptags": "^3.1.1",
         "terser": "^5.4.0",
@@ -59,7 +59,7 @@
         "typescript": "^4.4.4",
         "unistore": "^3.5.2",
         "uslug": "^1.0.4",
-        "web-vitals": "^3.0.0",
+        "web-vitals": "^3.0.4",
         "webdev-infra": "^1.0.33",
         "xss": "^1.0.14"
       },
@@ -19801,9 +19801,9 @@
       }
     },
     "node_modules/redirects-yaml": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/redirects-yaml/-/redirects-yaml-2.0.3.tgz",
-      "integrity": "sha512-TSsSYr/MdcJ5unXrI+0S/kDTZwhzo0jpM0WxXB0zdVopWG75G2cbdzp1ZJuPYY/FMyaPyXZFhBLqrMKficLouQ=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/redirects-yaml/-/redirects-yaml-2.0.4.tgz",
+      "integrity": "sha512-ReJJbFvP99S62JYjBnxIQYYz2almNW+ISu35ZtZ3D0s/HcReN9zch4Qhy9C9QqH8Xx6TudL9dHs4miSWvWrzkQ=="
     },
     "node_modules/regex-cache": {
       "version": "0.4.4",
@@ -42918,9 +42918,9 @@
       }
     },
     "redirects-yaml": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/redirects-yaml/-/redirects-yaml-2.0.3.tgz",
-      "integrity": "sha512-TSsSYr/MdcJ5unXrI+0S/kDTZwhzo0jpM0WxXB0zdVopWG75G2cbdzp1ZJuPYY/FMyaPyXZFhBLqrMKficLouQ=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/redirects-yaml/-/redirects-yaml-2.0.4.tgz",
+      "integrity": "sha512-ReJJbFvP99S62JYjBnxIQYYz2almNW+ISu35ZtZ3D0s/HcReN9zch4Qhy9C9QqH8Xx6TudL9dHs4miSWvWrzkQ=="
     },
     "regex-cache": {
       "version": "0.4.4",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "purgecss": "^2.3.0",
     "querystring": "^0.2.0",
     "readdirp": "^3.4.0",
-    "redirects-yaml": "^2.0.3",
+    "redirects-yaml": "2.0.4",
     "rollup": "^2.22.2",
     "striptags": "^3.1.1",
     "terser": "^5.4.0",


### PR DESCRIPTION
Related to #4292. This allows redirects in redirects.yaml redirecting to anchors.