### PR TITLE
Add description to Meet the team page

### DIFF
--- a/site/en/meet-the-team/index.md
+++ b/site/en/meet-the-team/index.md
@@ -1,5 +1,5 @@
 ---
 layout: 'layouts/events.njk'
 title: 'Meet the chrome team'
-description: ''
+description: "We're meeting you where you are. Join us at upcoming web conferences in your region."
 ---


### PR DESCRIPTION
The Meet the team page currently has no description, making it fall back to the default one which might be confusing when sharing a link to the page.

"We're meeting you where you are. Join us at upcoming web conferences in your region." is what Harleen agreed on.