### PR TITLE
Set default bodyparser option for express app

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -83,7 +83,7 @@ if (isGAEProd) {
 }
 
 app.use(express.json());
-app.use(express.urlencoded());
+app.use(express.urlencoded({extended: true}));
 
 app.post('/_render', renderHandler);
 


### PR DESCRIPTION
This gets rid of the following error that is logged during server startup:

```
body-parser deprecated undefined extended: provide extended option server/index.js:86:17
```

`{extended: true}` has been the default (see https://github.com/expressjs/body-parser#extended), but relying on the default has been deprecated.

