### PR TITLE
Correction to examples in $() and $$()

### DIFF
--- a/site/en/docs/devtools/console/utilities/index.md
+++ b/site/en/docs/devtools/console/utilities/index.md
@@ -75,7 +75,7 @@ property:
 This function also supports a second parameter, `startNode`, that specifies an 'element' or Node from
 which to search for elements. The default value of this parameter is `document`.
 
-The following example returns a reference to the first element after the currently selected Node and
+The following example returns a reference to the first `img` element that is a descendant of `devsite-header-background`, and
 displays its `src` property:
 
 {% Img src="image/admin/Q5XlmeIMaHQkpP1QryBd.png", alt="Example of $('img', div).src.", width="800", height="234" %}
@@ -90,7 +90,7 @@ overwritten, and `$` will correspond to that library's implementation.
 ## \$\$(selector \[, startNode\]) {: #querySelectorAll-function }
 
 `$$(selector)` returns an array of elements that match the given CSS selector. This command is
-equivalent to calling [document.querySelectorAll()][3].
+equivalent to calling <code>Array.from([document.querySelectorAll()][3])</code>.
 
 The following example uses `$$()` to create an array of all `<img>` elements in the current document
 and displays the value of each element's `src` property:


### PR DESCRIPTION
Fixes #4344
CLA signed as Shane Burgess.

Addresses two minor mistakes in the Console Utilities API reference:

1. Example text for $(selector, startNode) didn't match the screenshot. The "currently selected node" would have been represented as $0.
2. Clarified that $$(selector) returns an array, whereas document.querySelectorAll() returns a NodeList.
_Note that an inline `<code>` block was used instead of backticks in order to maintain the hyperlink within._
