### PR TITLE
Add scripting

### DIFF
--- a/site/en/docs/extensions/mv3/manifest/activeTab/index.md
+++ b/site/en/docs/extensions/mv3/manifest/activeTab/index.md
@@ -38,6 +38,7 @@ See the [Page Redder][2] sample extension:
   "version": "2.0",
   "permissions": [
     "activeTab"
+    "scripting"
   ],
   "background": {
     "service_worker": "background.js"


### PR DESCRIPTION
Fixes the documentation. The `"scripting"` is necessary to run the script (in Manifest V3). That was not mentioned in the Google Chrome documentation.
https://developer.chrome.com/docs/extensions/mv3/manifest/activeTab/