### PR TITLE
Fix view-transitions article’s updated field

### DIFF
--- a/site/en/docs/web-platform/view-transitions/index.md
+++ b/site/en/docs/web-platform/view-transitions/index.md
@@ -6,7 +6,7 @@ authors:
 description: >
   The View Transition API allows page transitions within single-page apps, and will later include multi-page apps.
 date: 2021-08-17
-updated: 2022-08-02
+updated: 2022-11-22
 ---
 
 {% Aside %}


### PR DESCRIPTION
The view-transitions article says that the last update was in August, yet it was committed/merged earlier this week. Small oversight I guess?