### PR TITLE
Summary report and aggregation service landings

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -42,6 +42,9 @@ redirects:
 - from: /blog/fedcm-origin-trial
   to: /docs/privacy-sandbox/fedcm
 
+- from: /docs/privacy-sandbox/attribution-reporting/summary-reports/
+  to: /docs/privacy-sandbox/summary-reports/
+
 - from: /android
   to: /docs/android
 

--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -71,6 +71,8 @@
           title: i18n.docs.privacy-sandbox.attribution-reporting-system
         - url: /docs/privacy-sandbox/attribution-reporting-experiment
           title: i18n.docs.privacy-sandbox.attribution-reporting-experiment
+        - url: https://docs.google.com/document/d/1BXchEk-UMgcr2fpjfXrQ3D8VhTR-COGYS1cwK_nyLfg/view?usp=sharing
+          title: i18n.docs.privacy-sandbox.attribution-reporting-handbook
         - url: /docs/privacy-sandbox/attribution-reporting-updates
           title: i18n.docs.privacy-sandbox.attribution-reporting-changing
     - title: i18n.docs.privacy-sandbox.measure-cross-site

--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -73,12 +73,12 @@
           title: i18n.docs.privacy-sandbox.attribution-reporting-experiment
         - url: /docs/privacy-sandbox/attribution-reporting-updates
           title: i18n.docs.privacy-sandbox.attribution-reporting-changing
-        - url: /docs/privacy-sandbox/attribution-reporting/summary-reports
-          title: i18n.docs.privacy-sandbox.attribution-reporting-summary
     - title: i18n.docs.privacy-sandbox.measure-cross-site
       sections:
         - url: /docs/privacy-sandbox/private-aggregation
         - url: /docs/privacy-sandbox/private-aggregation-fundamentals
+    - url: /docs/privacy-sandbox/aggregation-service
+    - url: /docs/privacy-sandbox/summary-reports
 - title: i18n.docs.privacy-sandbox.fight-spam
   sections:
     - url: /docs/privacy-sandbox/trust-tokens

--- a/site/_data/i18n/docs/privacy-sandbox.yml
+++ b/site/_data/i18n/docs/privacy-sandbox.yml
@@ -53,7 +53,7 @@ blog:
 measure-ads:
   en: 'Measure ad conversions with Attribution Reporting'
 measure-cross-site:
-  en: 'Measure cross-site data with Private Aggregation'
+  en: 'Measure cross-site events with Private Aggregation'
 attribution-reporting-overview:
   en: 'Attribution Reporting overview'
 attribution-reporting-experiment:

--- a/site/_data/i18n/docs/privacy-sandbox.yml
+++ b/site/_data/i18n/docs/privacy-sandbox.yml
@@ -60,6 +60,8 @@ attribution-reporting-experiment:
   en: 'Experiment and participate'
 attribution-reporting-changing:
   en: 'API updates'
+attribution-reporting-handbook:
+  en: 'Developer handbook'
 attribution-reporting_description:
   en: 'Measure when user action leads to a conversion, without cross-site identifiers.'
 attribution-reporting-system:

--- a/site/en/docs/privacy-sandbox/aggregation-service/index.md
+++ b/site/en/docs/privacy-sandbox/aggregation-service/index.md
@@ -1,0 +1,127 @@
+---
+layout: 'layouts/doc-post.njk'
+title: 'Aggregation service'
+subhead: >
+  Deploy and manage this service to produce summary reports for the
+  Attribution Reporting API or the Private Aggregation API.
+description: >
+  Deploy and manage this service to produce summary reports for the
+  Attribution Reporting API or the Private Aggregation API.
+date: 2022-11-30
+authors:
+  - alexandrawhite
+---
+
+Deploy and manage an aggregation service to process aggregatable
+reports from the
+[Attribution Reporting API](/docs/privacy-sandbox/attribution-reporting/) or
+the [Private Aggregation API](/docs/privacy-sandbox/private-aggregation/) to
+create a [summary report](/docs/privacy-sandbox/summary-report/).
+
+{% Aside %}
+At this time, the aggregation service and its local testing tool only process
+aggregatable reports for the Attribution Reporting API. This will be updated to
+support the Private Aggregation API soon.
+{% endAside %}
+
+## Implementation status
+
+* The [Aggregation Service proposal](https://github.com/WICG/attribution-reporting-api/blob/main/AGGREGATION_SERVICE_TEE.md)
+  has entered public discussion.
+* The aggregation service can be tested for the
+  [Attribution Reporting API](/docs/privacy-sandbox/attribution-reporting-experiment/).
+  It is still in development for use with the
+  [Private Aggregation API](/docs/privacy-sandbox/private-aggregation/).
+
+The proposal outlines
+[key terms](https://github.com/WICG/attribution-reporting-api/blob/main/AGGREGATION_SERVICE_TEE.md#key-terms),
+useful for understanding the aggregation service.
+
+## Secure data processing
+
+The aggregation service decrypts and combines the collected data from the aggregatable reports, [adds noise](#noise-scale), and returns the final summary report. This service runs in a trusted execution environment (TEE), which is deployed on a cloud service that supports necessary security measures to protect this data.
+
+{% Aside %}
+A [Trusted Execution Environment](https://en.wikipedia.org/wiki/Trusted_execution_environment)
+is a special configuration of computer hardware and software that allows
+external parties to verify the exact versions of software running on the
+computer. TEEs allow external parties to verify that the software does exactly
+what the software manufacturer claims it does—nothing more or less.
+{% endAside %}
+
+The TEE's code is the only place in the aggregation service which has access to
+raw reports&mdash;this code will be auditable by security researchers, privacy
+advocates, and adtechs. To confirm that the TEE is running the exact approved
+software and that data remains secured, a coordinator performs attestation.
+
+<figure>
+{% Img
+  src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/b1avI43zUaKT2UAdGOo1.png",
+  alt="Aggregatable reports are collected, batched, and send to the TEE to be transformed into a final summary report.",
+  width="800", height="457"
+%}
+<figcaption>
+  <p>Aggregatable reports are collected, batched, and send to the aggregation service, running on a TEE. The aggregation service environment is owned and operated by the same party collecting the data.</p>
+</figure>
+
+### Coordinator attestation of the TEE
+
+The _coordinator_ is an entity responsible for key management and aggregatable
+report accounting.
+
+A coordinator has several responsibilities: 
+
+* Maintain a list of authorized binary images. These images are
+  [cryptographic hashes](https://en.wikipedia.org/wiki/Cryptographic_hash_function)
+  of the aggregation service software builds, which Google will periodically
+  release. This will be reproducible so that any party can verify the images
+  are identical to the aggregation service builds.
+* Operate a key management system. Encryption keys are required for the Chrome
+  on a user's device to encrypt aggregatable reports. Decryption keys are
+  necessary for proving the aggregation service code matches the binary images.
+* Track the aggregatable reports to prevent reuse in aggregation for summary
+  reports, as reuse may reveal personal identifying information (PII).
+
+## Noise and scaling {: #noise-scale}
+
+To protect user privacy, the aggregation service applies an
+[additive noise mechanism](https://en.wikipedia.org/wiki/Additive_noise_mechanisms)
+to the raw data from aggregatable reports. This means that a certain amount of
+statistical noise is added to each aggregate value before its release in a
+summary report. 
+
+While you are not in direct control of the ways noise is added, you can
+influence the impact of noise on its measurement data.
+
+<figure>
+{% Img
+  src="image/hVf1flv5Jdag8OQKYqOcJgWUvtz1/qJ182Vhszwsgf1PVLEpT.png",
+  alt="Noise is constant, regardless of the aggregated value.",
+  width="600", height="462"
+%}
+</figure>
+
+The noise value is randomly drawn from a
+[Laplace probability distribution](https://en.wikipedia.org/wiki/Laplace_distribution),
+and the distribution is the same regardless of the amount of data collected in
+aggregatable reports. The more data you collect, the less impact the noise will
+have on the summary report results. You can multiply the aggregatable report
+data by a scaling factor to reduce the impact of noise.
+
+To understand how noise is added, your controls, and the impact on your
+reports, refer to the
+[Contribution section of the Attribution Reporting strategy guide](https://docs.google.com/document/d/1bU0a_njpDcRd9vDR0AJjwJjrf3Or8vAzyfuK8JZDEfo/edit#heading=h.683u7t2q1xk2). 
+
+## Generate summary reports
+
+Summary report generation is dependent on your API usage. Learn more about
+generating summary reports for the
+[Private Aggregation API](/docs/privacy-sandbox/summary-reports#private-aggregation) 
+and the [Attribution Reporting API](/docs/privacy-sandbox/summary-reports#attribution-reporting).
+
+## Engage with this API
+
+We want to engage in conversations with you to ensure we build an API that works for everyone. Like other Privacy Sandbox proposals, the aggregation service is [documented and discussed publicly](https://github.com/WICG/attribution-reporting-api/blob/main/AGGREGATION_SERVICE_TEE.md).
+
+* You can [experiment with the Attribution Reporting API](/docs/privacy-sandbox/attribution-reporting-experiment/).
+* The Private Aggregation API is available for testing in Chrome M107+ Canary and Dev, but the aggregation service is still in development.

--- a/site/en/docs/privacy-sandbox/attribution-reporting-data-clearing/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting-data-clearing/index.md
@@ -12,10 +12,10 @@ authors:
 ---
 
 {% Aside %} If you're not familiar with the API, head over to [Introduction to Attribution
-Reporting (Conversion Measurement)](/docs/privacy-sandbox/attribution-reporting-introduction/)
+Reporting (Conversion Measurement)](/docs/privacy-sandbox/attribution-reporting/)
 before reading this post. {% endAside %}
 
-The [Attribution Reporting API](/docs/privacy-sandbox/attribution-reporting-introduction/) makes it
+The [Attribution Reporting API](/docs/privacy-sandbox/attribution-reporting/) makes it
 possible to measure when an ad click leads to a conversion on an advertiser site, such as a sale or
 a sign-up. The API offers a privacy-preserving approach to measuring ad conversions. It doesn't rely
 on third-party cookies or mechanisms that can be used to identify individual users across sites.
@@ -24,7 +24,7 @@ generated and stored on the user's device; later, the browser sends these report
 endpoint.
 
 Sites have experimented with the Attribution Reporting API in Chrome, via an [origin
-trial](/docs/privacy-sandbox/attribution-reporting-introduction/#status).
+trial](/docs/privacy-sandbox/attribution-reporting/#status).
 
 One of the insights
 provided by these early experiments is the impact of **user-initiated data clearing, such as browser history clearing,** on the data advertisers and adtech companies get from the API. [Aggregate Chrome statistics](https://groups.google.com/u/1/a/chromium.org/g/attribution-reporting-api-dev/c/5Ppe0cL-l1Y)
@@ -209,6 +209,6 @@ they were scheduled to be sent soon.
 
 ## Attribution Reporting: all resources
 
-See [Attribution Reporting](/docs/privacy-sandbox/attribution-reporting-introduction).
+See [Attribution Reporting](/docs/privacy-sandbox/attribution-reporting/).
 
 {% Partial 'privacy-sandbox/ar-get-updates.njk' %}

--- a/site/en/docs/privacy-sandbox/attribution-reporting-experiment/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting-experiment/index.md
@@ -10,12 +10,12 @@ authors:
 
 ## Learn the essentials
 
-Read [Attribution Reporting](/docs/privacy-sandbox/attribution-reporting) and
+Read [Attribution Reporting](/docs/privacy-sandbox/attribution-reporting/) and
 check the most recent [updates](/docs/privacy-sandbox/attribution-reporting-updates/).
 
 ## Try the API
 
-1. Try the [demo](https://goo.gle/attribution-reporting-demo).
+1. Try the [demo](https://goo.gle/attribution-reporting-demo/).
 2. Check the [API status](/docs/privacy-sandbox/attribution-reporting/#status) to learn about ways
    you can experiment with the API today.
 3. Experiment with the API.
@@ -28,11 +28,10 @@ check the most recent [updates](/docs/privacy-sandbox/attribution-reporting-upda
      * [Handbook](https://docs.google.com/document/d/1BXchEk-UMgcr2fpjfXrQ3D8VhTR-COGYS1cwK_nyLfg/):
        Demo, detailed code examples and (local) debugging tips.
 4. Experiment with [summary
-   reports](/docs/privacy-sandbox/attribution-reporting/summary-reports).
-   *  Adtechs can generate summary reports with the aggregation service. Learn
-	how to set it up for
-	[local testing](https://github.com/google/trusted-execution-aggregation-service/#set-up-local-testing)
-	or [test in production with Amazon Web Services](https://github.com/google/trusted-execution-aggregation-service/#test-on-aws-with-support-for-encrypted-reports) (AWS) :
+   reports](/docs/privacy-sandbox/summary-reports).
+   *  Adtechs can generate summary reports with the [aggregation service](/docs/privacy-sandbox/aggregation-service). Set up
+      [local testing](https://github.com/google/trusted-execution-aggregation-service/#set-up-local-testing)
+      or [test in production with Amazon Web Services](https://github.com/google/trusted-execution-aggregation-service/#test-on-aws-with-support-for-encrypted-reports) (AWS) :
         *  Create or have an [AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) available.
         *  [Register](/origintrials/#/view_trial/771241436187197441) for the
 	      Privacy Sandbox Relevance and Measurement origin trial (OT).

--- a/site/en/docs/privacy-sandbox/attribution-reporting/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/index.md
@@ -29,7 +29,8 @@ underlying concepts, but doesn't go into much technical detail.
   deployment.
 
 {% Aside %}
-🧐 There is a [glossary](#glossary) at the end of this post.
+If you're unfamiliar with some of these terms, consult the
+[Privacy Sandbox glossary](/docs/privacy-sandbox/glossary/).
 {% endAside %}
 
 ## Changes
@@ -58,41 +59,34 @@ This API enables advertisers and adtech providers to measure conversions in the 
 ## Who needs to know about this API?
 
 - **Adtech platforms** such as [demand-side
-  platforms](https://en.wikipedia.org/wiki/Demand-side_platform) (DSP) or [data management
-  platforms](https://en.wikipedia.org/wiki/Data_management_platform) (DMP) may use this API to
+  platforms](/docs/privacy-sandbox/glossary/#dsp) (DSP) or [data management
+  platforms](/docs/privacy-sandbox/glossary/#dmp) (DMP) may use this API to
   support functionality that currently relies on third-party cookies.
-- **Advertisers and publishers relying on custom code** for advertising or conversion measurement
-  may use this API to replace existing techniques.
-- **Advertisers and publishers relying on adtech platforms** for conversion measurement don't need
+- **Advertisers and publishers relying on custom code** for advertising or
+  conversion measurement may use this API to replace existing techniques.
+- **Advertisers and publishers relying on adtech platforms** for conversion
+  measurement don't need
   to use the API directly, but may be interested in understanding it if they're working with adtech
   platforms that may integrate the API.
 
-{% Aside %} The Attribution Reporting API may also serve use cases that are not related to advertising. {% endAside %}
+{% Aside %}
 
-## Status
-
-**🕙 [Last updated](/docs/privacy-sandbox/attribution-reporting-updates/): June 2022**
-
-### How can I try Attribution Reporting?
-
-At the time of this writing, you can try Attribution Reporting:
-
-- This API is available for experiments in the ads relevance and measurement origin trial.
-- You can test locally in your browser with a _flag_.
-
-**If you're interested in experimenting with the API, head over to [Attribution Reporting: experiment and participate](/docs/privacy-sandbox/attribution-reporting-experiment/).**
-
-{% Aside 'key-term' %}
-
-- A _flag_ is a toggle that tells the Chrome browser to enable specific
-  experimental functionalities.
-- An _origin trial_ is a way to test a new or experimental web platform feature
-  with end users, and give feedback to the web standards
-  community on the feature. Learn more in [Getting started with Chrome's origin trials](/blog/origin-trials/).
-  Multiple rounds of origin trials are run, to improve and adjust the API
-  based on ecosystem feedback.
+In the future, the Attribution Reporting API may serve use cases that are not related to advertising.
 
 {% endAside %}
+
+
+## Try the API
+
+- The Attribution Reporting API is available for experiments in the
+  [ads relevance and measurement origin trial](/docs/privacy-sandbox/unified-origin-trial/).
+   - Multiple rounds of origin trials are run to improve and adjust APIs based on ecosystem feedback.
+- You can test locally in your browser. [Set a _flag_](/blog/browser-flags/),
+  which tells the Chrome browser to enable specific experimental
+  functionalities.
+
+If you're interested in experimenting with the API, head over to
+[Attribution Reporting: experiment and participate](/docs/privacy-sandbox/attribution-reporting-experiment/).
 
 ### Status details
 
@@ -118,7 +112,7 @@ At the time of this writing, you can try Attribution Reporting:
     <tr>
     <tr>
     <td>Conversion journey: cross-device<br><a href="https://github.com/WICG/attribution-reporting-api/blob/main/archive/cross_device.md">Explainer</a></td>
-    <td>Not planned for the first version of the API.</td>
+    <td>Proposal, not implemented yet.</td>
     </tr>
 </tbody>
 </table>
@@ -133,12 +127,12 @@ The Attribution Reporting API gives access to different types of insights via tw
 advertiser or a third-party adtech provider. These two types of reports can be used simultaneously
 and are complementary.
 
-- **Event-level reports** associate a particular ad click or view (on the ad side) with data on the
+- [**Event-level reports**](#event-level-reports) associate a particular ad click or view (on the ad side) with data on the
   conversion side. To preserve user privacy by preventing the joining of user identity across sites,
   conversion-side data is very limited, and the data is noised (meaning that for a small
   percentage of cases, random data is sent instead of real reports). As an extra privacy protection, reports are not sent
   immediately.
-- **Summary reports** are not tied to a specific event on the ad side. These reports provide
+- [**Summary reports**](#summary-reports) are not tied to a specific event on the ad side. These reports provide
   richer, higher-fidelity conversion data than event-level reports. A combination of privacy
   techniques help reduce the risk of identity joining across sites.
 
@@ -148,16 +142,16 @@ Both report types can be used simultaneously. They're complementary.
 
 Event-level reports associate an ad click or view with coarse conversion data.
 
-<figure>
+<figure class="screenshot">
  {% Img src="image/O2RNUyVSLubjvENAT3e7JSdqSOx1/8PZhfv4UXYxt2vTKRNI2.png",
- alt="event-level report", width="400", height="180" %}
+ alt="Event-level report", width="400", height="180" %}
  <figcaption>Example event-level report: Click ID 200400600 on <code>news.example</code> (attached to user ID Bob_Doe on <code>news.example</code>) has led to a purchase on <code>shop.example</code>.</figcaption>
 </figure>
 
 Event-level reports are suited for:
 
-- **Optimization**. Event-level reports help answer questions like _"How can I improve my return on
-  investment?"_. In particular, these reports can be used to optimize for ad placement, since a
+- **Optimization**. Event-level reports help answer questions like "How can I improve my return on
+  investment?". In particular, these reports can be used to optimize for ad placement, since a
   unique ID for the ad side can be made available in the reports. Event-level reports can provide
   training data for machine learning models.
 - **Coarse reporting**, where very little information is needed about the conversion. The current
@@ -173,12 +167,12 @@ Event-level reports are suited for:
 Summary reports (formerly known as aggregate reports) offer more detailed
 conversion data and more flexibility for joining click/view data and conversion data.
 
-Learn more about in [Attribution Reporting: summary reports](/docs/privacy-sandbox/attribution-reporting/summary-reports/).
+Learn more about [summary reports](/docs/privacy-sandbox/summary-reports/).
 
 <figure>
- {% Img src="image/O2RNUyVSLubjvENAT3e7JSdqSOx1/TxgT3W5pNEZhWgDSYIY3.png", alt="summary
- report", width="400", height="180"%}
- <figcaption>Example of insights from summary reports: CampaignID 1234567 on <code>news.example</code> has led to 518 conversions on <code>shoes.example</code>, and to a total spend of $38174. Half of the conversions were from users in NYC, USA.</figcaption>
+ {% Img
+   src="image/O2RNUyVSLubjvENAT3e7JSdqSOx1/TxgT3W5pNEZhWgDSYIY3.png", alt="Example of insights from summary reports.", width="400", height="180"%}
+ <figcaption>Here's an example of insights from summary reports: CampaignID 1234567 on <code>news.example</code> has led to 518 conversions on <code>shoes.example</code>, and to a total spend of $38174. Half of the conversions were from users in NYC, USA.</figcaption>
 </figure>
 
 Summary reports are best suited for reporting use cases. These reports help
@@ -190,8 +184,12 @@ conversion data is too coarse)—is an area of active research.
 
 ### Other features
 
-Other features proposed include [app-to-web attribution](https://github.com/WICG/conversion-measurement-api/blob/main/app_to_web.md):
-see or click an ad in an app and convert on the web.
+Other features proposed in this API include:
+
+- [App-to-web attribution](https://github.com/WICG/conversion-measurement-api/blob/main/app_to_web.md):
+  see or click an ad in an app and convert on the web.
+- [Cross-device attribution](https://github.com/WICG/attribution-reporting-api/blob/main/archive/cross_device.md):
+  see or click an ad on mobile and convert on desktop.
 
 {% Aside %}
 In a future without third-party cookies, this API would be combined with other privacy-preserving
@@ -257,7 +255,7 @@ policy](https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy) as w
 
 {% Aside %}
 
-### What's the security benefit?
+### Security benefits
 
 By doing this, a script with top-level access allows the frames it adds itself
 to use Attribution Reporting. Only a third-party script that is trusted by the
@@ -293,7 +291,9 @@ conversion on an advertiser site.
 ### Summary reports
 
 <figure>
-{% Img src="image/O2RNUyVSLubjvENAT3e7JSdqSOx1/un70ZcJVrWepdWWsnMIY.png", alt="ALT_TEXT_HERE", width="800", height="1024" %}
+{% Img
+  src="image/O2RNUyVSLubjvENAT3e7JSdqSOx1/un70ZcJVrWepdWWsnMIY.png", alt="", width="800", height="1024"
+%}
  <figcaption style="text-align:left;">Summary reports are generated as follows:<br>
 *  When the user clicks or sees a specially configured ad, the browser—on the user's local device—records this event, alongside the attribution configuration data that was specified.<br>
 *  Later on, when the user converts, the browser matches this detailed clicks or views event ("attribution source event") with detailed conversion data ("attribution trigger data") defined by an adtech company, following a specific logic that is defined by the adtech. The output of this process is an aggregatable report.<br>
@@ -353,84 +353,69 @@ enough to track Bob's activity across sites in detail. Bob's
 activity on `news.example` and on `shoes.example` remains
 separate.
 
-{% Img src="image/O2RNUyVSLubjvENAT3e7JSdqSOx1/aurePszyAGz9Osu3G0XN.jpg", alt="Diagram: side-by-side
-view of today's web (joined identity) and tomorrow's web (partitioned identity)", width="800",
-height="314" %}
+{% Img
+  src="image/O2RNUyVSLubjvENAT3e7JSdqSOx1/aurePszyAGz9Osu3G0XN.jpg",
+  alt="Side-by-side view of today's web (joined identity) and tomorrow's web (partitioned identity)",
+  width="800", height="314"
+%}
 
 ### In detail
 
-**Event-level reports** link an ad-side identifier with only a small amount of conversion-side data.
-While they do provide cross-site information about a conversion, but the conversion-side information is
-too coarse to join user identity across sites.
+**Event-level reports** link an ad-side identifier with a small amount of
+conversion-side data. While they do provide cross-site information about a
+conversion, but the conversion-side information is too coarse to join user
+identity across sites.
 
 **Summary reports** provide detailed insights, but only at an aggregated level; because the contents
 of these aggregatable reports are encrypted when they are sent to the adtech, the adtech cannot get
 any information from the reports without using an aggregation service. The aggregation service only
 provides access to noisy aggregates.
 
-Additional privacy protections such as rate limitations are imposed on both event-level and
-aggregate reports.
+Additional privacy protections such as rate limitations are imposed on both
+event-level and aggregate reports.
 
 <figure>
-{% Img src="image/O2RNUyVSLubjvENAT3e7JSdqSOx1/mDdo2XLyGLBCAlgH7MPZ.png", alt="ALT_TEXT_HERE", width="800", height="1237" %}
+{% Img src="image/O2RNUyVSLubjvENAT3e7JSdqSOx1/mDdo2XLyGLBCAlgH7MPZ.png", alt="", width="800", height="1237" %}
 </figure>
 {% Details %}
 {% DetailsSummary 'h3' %}
-In detail: event-level reports and privacy {% endDetailsSummary %}
+In detail: event-level reports and privacy
+{% endDetailsSummary %}
+
 Event-level reports provide conversion insights without tracking users across
 sites, by following the following privacy mechanisms:
-- No cross-site identifier is used and no detailed cross-site browsing activity leaves the device.
-Event-level reports associate 64 bits of information on the ad side (`news.example`) with only 1
-bit or 3 bits on the conversion side (`shop.example`). 64 bits **are enough information to be
-mapped to an individual user identifier, but these 64 bits can only be linked with very little
-cross-site information:** 1 bit or 3 bits, which are not enough to hold an identifier. Note: the
-ad-side 64 bits are not new information. A user ID can already be available on the ad side today.
-`news.example` or `adtech.example` already knows about a certain user's activity on
-`news.example`.
+
+- No cross-site identifier is used and no detailed cross-site browsing activity
+  leaves the device.
+- Event-level reports associate 64 bits of information on the ad side (`news.example`) with only 1 bit or 3 bits on the conversion side (`shop.example`). 64 bits are enough information to be mapped to an individual user identifier, but these 64 bits can only be linked with very little cross-site information: 1 bit or 3 bits, which are not enough to hold an identifier.
+  - The ad-side 64 bits are not new information. A user ID can already be available on the ad side today. `news.example` or `adtech.example` already knows about a certain user's activity on `news.example`.
 - Additional protections are applied to prevent abuse and cross-site tracking:
-- The reports are sent with a **delay**.
-- The conversion data is **noised**: a certain percentage of the time, fake reports are generated.
-- The number of attributed conversion reports is limited per click or view.
+  - The reports are sent with a **delay**.
+  - The conversion data is **noised**: a certain percentage of the time, fake reports are generated.
+  - The number of attributed conversion reports is limited per click or view.
 {% endDetails %}
+
 {% Details %}
 {% DetailsSummary 'h3' %}
-In detail: summary reports and privacy {% endDetailsSummary %}
+In detail: summary reports and privacy
+{% endDetailsSummary %}
  
-Summary reports associate a detailed click or view event with detailed conversion data. However,
-they provide conversion insights without tracking users across sites, by following the following
-privacy mechanisms:
+Summary reports associate a click or view event with detailed conversion data.
+They provide conversion insights without tracking users across sites, by using the following privacy mechanisms:
  
 - No cross-site identifier is used.
-- Each attribution can make multiple contributions to a resulting summary report. Any given user can
- trigger multiple attributions for a particular click (or view) and conversion.
-- Data is aggregated up to the level of many events (many users) and no individual events can be
- observed precisely. When drilling down into the aggregated data, as the level of detail increases,
- the relative noise on that data increases as well. Slices of data that aggregate a lot of events
- and users are more accurate to preserve usefulness.
-- The raw reports that associate a detailed click or view event with detailed conversion data are
- encrypted and not readable by the adtech company. Aggregate data is then computed from these
- reports via a trusted server.
- 
+- Each attribution can make multiple contributions to a resulting summary
+  report. Any given user can trigger multiple attributions for a particular
+  click (or view) and conversion.
+- Data is aggregated up to the level of many events (many users) and no
+  individual events can be observed precisely. When looking at the
+  aggregated data, as the level of detail increases so does the relative noise
+  on that data increases as well. Slices of data that aggregate a lot of events
+  and users are more accurate to preserve usefulness.
+- The raw reports that associate a detailed click or view event with detailed conversion data are encrypted and not readable by the adtech company.
+  This data can only be read by the [aggregation service](/docs/privacy-sandbox/aggregation-service).
 - Additional protections are applied to prevent abuse and cross-site tracking:
- 
-- Reports are sent with random delays.
-- Queries on different slices of the data are rate-limited.
+  - Reports are sent with random delays.
+  - Queries on different slices of the data are rate-limited.
  
 {% endDetails %}
-
-## Glossary
-
-- **Adtech platforms**: companies that provide software and tools to enable brands or agencies to
-  target, deliver, and analyze their digital advertising.
-- **Advertisers**: companies paying for advertising.
-- **Publishers**: companies that display ads on their websites.
-- **Click-through conversion**: conversion that is attributed to an ad click.
-- **View-through conversion**: conversion that is attributed to an ad impression (if the user
-  doesn't interact with the ad, then later converts).
-
-{% Aside %}
-
-You may also want to consult the complete [Privacy Sandbox
-glossary](/docs/privacy-sandbox/glossary/).
-
-{% endAside %}

--- a/site/en/docs/privacy-sandbox/attribution-reporting/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/index.md
@@ -387,8 +387,15 @@ sites, by following the following privacy mechanisms:
 
 - No cross-site identifier is used and no detailed cross-site browsing activity
   leaves the device.
-- Event-level reports associate 64 bits of information on the ad side (`news.example`) with only 1 bit or 3 bits on the conversion side (`shop.example`). 64 bits are enough information to be mapped to an individual user identifier, but these 64 bits can only be linked with very little cross-site information: 1 bit or 3 bits, which are not enough to hold an identifier.
-  - The ad-side 64 bits are not new information. A user ID can already be available on the ad side today. `news.example` or `adtech.example` already knows about a certain user's activity on `news.example`.
+- Event-level reports associate 64 bits of information on the ad side
+  (`news.example`) with only 1 bit or 3 bits on the conversion side
+  (`shop.example`). 64 bits are enough information to be mapped to an
+  individual user identifier, but these 64 bits can only be linked with very
+  little cross-site information: 1 bit or 3 bits, which are not enough to hold
+  an identifier.
+  - The ad-side 64 bits are not new information. A user ID can already be
+    available on the ad side today. `news.example` or `adtech.example` 
+    already knows about a certain user's activity on `news.example`.
 - Additional protections are applied to prevent abuse and cross-site tracking:
   - The reports are sent with a **delay**.
   - The conversion data is **noised**: a certain percentage of the time, fake reports are generated.

--- a/site/en/docs/privacy-sandbox/attribution-reporting/system-overview/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/system-overview/index.md
@@ -25,7 +25,7 @@ Before continuing, make sure to read the
 [Attribution Reporting overview](/docs/privacy-sandbox/attribution-reporting).
 This will help you understand the API's purpose and the flow of the different output reports
 ([event-level report](/docs/privacy-sandbox/attribution-reporting/#event-level-reports)
-and [summary reports](/docs/privacy-sandbox/attribution-reporting/summary-reports/)).
+and [summary reports](/docs/privacy-sandbox/summary-reports/)).
 If you come across unfamiliar terms, refer to the
 [Privacy Sandbox glossary](/docs/privacy-sandbox/glossary/).
 
@@ -92,7 +92,7 @@ data. The output reports provide insights on your campaigns or business.
 The output report can be:
 
 *  _Event-level reports_ associate a particular ad click or view (on the ad side) with data on the conversion side. To preserve user privacy by limiting the joining of user identity across sites, conversion-side data is very limited, and the data is noisy (meaning that for a small percentage of cases, random data is sent instead of real reports).
-*  _[Summary reports](/docs/privacy-sandbox/attribution-reporting/summary-reports/)_ are not tied to a specific event on the ad side. These reports offer more detailed conversion data and flexibility for joining click and view data with conversion data. 
+*  _[Summary reports](/docs/privacy-sandbox/summary-reports/)_ are not tied to a specific event on the ad side. These reports offer more detailed conversion data and flexibility for joining click and view data with conversion data. 
 
 Your report selection determines what data you'll need to collect.
 
@@ -235,18 +235,17 @@ can be changed without needing to change attribution sources or triggers.
 
 ### Aggregation Service
 
-The Aggregation Service is responsible for processing aggregatable reports to
+The [Aggregation Service](/docs/privacy-sandbox/aggregation-service/) is responsible for processing aggregatable reports to
 generate a summary report. Aggregatable reports are encrypted and can only be
 read by the Aggregation Service, which runs on a trusted execution environment
 (TEE).
 
-The Aggregation Service
-[requests decryption keys from the coordinator](https://github.com/WICG/attribution-reporting-api/blob/main/AGGREGATION_SERVICE_TEE.md#attestation-and-the-coordinator)
+The Aggregation Service requests decryption keys from the [coordinator](/docs/privacy-sandbox/aggregation-service/#coordinator )
 to decrypt and aggregate the data. Once decrypted and aggregated, the results
 are noised to preserve privacy and returned as a summary report. 
 
-Practitioners can generate aggregatable cleartext reports to [test the
-Aggregation Service locally](https://github.com/google/trusted-execution-aggregation-service#set-up-local-testing).
+Practitioners can generate aggregatable cleartext reports to
+[test the Aggregation Service locally](https://github.com/google/trusted-execution-aggregation-service#set-up-local-testing).
 Or, you can [test with encrypted reports on AWS with Nitro Enclaves](https://github.com/google/trusted-execution-aggregation-service/#test-on-aws-with-support-for-encrypted-reports).
 
 ## What's next?

--- a/site/en/docs/privacy-sandbox/glossary/index.md
+++ b/site/en/docs/privacy-sandbox/glossary/index.md
@@ -129,15 +129,13 @@ site. See [First-party cookie](#first-party-cookie) and
 
 An entity responsible for key management and aggregatable report accounting. The coordinator maintains a list of hashes of approved aggregation service configurations and configures access to decryption keys.
 
-## Differential privacy  {: #differential-privacy }
+## Data management platform (DMP) {: #dmp }
 
-Techniques to allow sharing of information about a dataset to reveal patterns
-of behaviour without revealing private information about individuals or whether
-they belong to the dataset.
+A software used to collect and manage data relevant for advertisers. These
+platforms help advertisers and publishers identify audience segments, which can
+then be used for campaign targeting.
 
-## Domain
-
-See [Top-Level Domain](#tld) and [eTLD](#etld).
+Learn more about [DMPs](https://en.wikipedia.org/wiki/Data_management_platform).
 
 ## Demand-side platform (DSP) {: #dsp }
 
@@ -147,6 +145,16 @@ across a range of publisher sites. Publishers put their
 [ad inventory](#ad-inventory) up for sale through marketplaces called ad
 exchanges, and DSPs decide programmatically which available ad impression makes
 most sense for an advertiser to buy.
+
+## Differential privacy {: #differential-privacy }
+
+Techniques to allow sharing of information about a dataset to reveal patterns
+of behaviour without revealing private information about individuals or whether
+they belong to the dataset.
+
+## Domain
+
+See [Top-Level Domain](#tld) and [eTLD](#etld).
 
 ## eTLD, eTLD+1 {: #etld }
 

--- a/site/en/docs/privacy-sandbox/private-aggregation/index.md
+++ b/site/en/docs/privacy-sandbox/private-aggregation/index.md
@@ -33,7 +33,9 @@ For example, if you have previously recorded demographic and geographic data in 
 
 ### Key concepts
 
-When you call the [Private Aggregation API](https://github.com/patcg-individual-drafts/private-aggregation-api) with an aggregation key and an aggregatable value, the browser generates an aggregatable report. The reports are sent to your server that batches the reports. The batched reports are processed later by the [Aggregation Service](https://github.com/WICG/attribution-reporting-api/blob/main/AGGREGATION_SERVICE_TEE.md), and a summary report is generated. 
+When you call the Private Aggregation API with an aggregation key and an aggregatable value, the browser generates an aggregatable report. 
+
+Aggregatable reports are sent to your server for collection and batching. The batched reports are processed later by the [Aggregation Service](/docs/privacy-sandbox/aggregation-service/), and a [summary report](/docs/privacy-sandbox/summary-reports/) is generated. 
 
 See the [Private Aggregation API fundamentals](/docs/privacy-sandbox/private-aggregation-fundamentals) document to learn more about the key concepts involved with the Private Aggregation API.
 
@@ -75,17 +77,21 @@ Private Aggregation is a general purpose API for cross-site measurement, and it�
 
 #### Unique reach measurement
 
-You may want to measure how many unique users have seen their content. Private Aggregation API can provide an answer such as “Approximately 317 unique users have seen the Content ID 861”. 
+You may want to measure how many unique users have seen their content. Private Aggregation API can provide an answer such as "Approximately 317 unique users have seen the Content ID 861." 
 
 You can set a flag in Shared Storage to signify whether the user has already seen the content or not. On the first visit where the flag does not exist, a call to Private Aggregation is made and then the flag is set. On subsequent visits by the user, including cross-site visits, you can check Shared Storage and skip submitting a report to Private Aggregation if the flag is set. 
 
 #### Demographics measurement
 
-You may want to measure the demographics of the users who have seen your content across different sites. Private Aggregation can provide an answer, such as “Approximately 317 unique users are from the age of 18-45 and are from Germany.” Use Shared Storage to access demographics data from a third-party context. At a later point in time, you can generate a report with Private Aggregation by encoding the age group and country dimensions in the aggregation key. 
+You may want to measure the demographics of the users who have seen your content across different sites.
+
+Private Aggregation can provide an answer, such as "Approximately 317 unique users are from the age of 18-45 and are from Germany." Use Shared Storage to access demographics data from a third-party context. At a later point in time, you can generate a report with Private Aggregation by encoding the age group and country dimensions in the aggregation key. 
 
 #### K+ frequency measurement
 
-You may want to measure the number of users who have seen a piece of content or an ad at least K times on a given browser, for a pre-chosen value of K. Private Aggregation can provide an answer such as “Approximately 89 users have seen the Content ID 581 at least 3 times.” A counter can be incremented in Shared Storage from different sites and can be read within a worklet. When the count has reached K, a report can be submitted via Private Aggregation. 
+You may want to measure the number of users who have seen a piece of content or an ad at least K times on a given browser, for a pre-chosen value of K.
+
+Private Aggregation can provide an answer such as "Approximately 89 users have seen the Content ID 581 at least 3 times." A counter can be incremented in Shared Storage from different sites and can be read within a worklet. When the count has reached K, a report can be submitted via Private Aggregation. 
 
 ### With FLEDGE
 
@@ -97,10 +103,9 @@ The following functions are available in the `privateAggregation` object availab
 
 ### sendHistogramReport()
 
-You can call `privateAggregation.sendHistogramReport({ bucket: <bucket>, value: <value> })` with the _aggregation key_ as `bucket` and the _aggregatable value_ as `value`. For the `bucket` parameter, a `BigInt` is required. For the `value` parameter, an integer Number is required.
+You can call `privateAggregation.sendHistogramReport({ bucket: <bucket>, value: <value> })`, where the aggregation key is `bucket` and the aggregatable value as `value`. For the `bucket` parameter, a `BigInt` is required. For the `value` parameter, an integer Number is required.
 
 Here is an example of how it may be called in Shared Storage for reach measurement: 
-
 
 #### `iframe.js`
 
@@ -166,7 +171,7 @@ The above code example will call Private Aggregation whenever the cross-site ifr
 
 ### enableDebugMode()
 
-While third-party cookies are still available, we will provide a temporary mechanism that allows easier debugging and testing by enabling the debug mode. A debug report is useful in comparing your cookie-based measurements with your Private Aggregation measurements, and also allows you to quickly validate your API integration. 
+While third-party cookies are still available, we'll provide a temporary mechanism that allows easier debugging and testing by enabling the debug mode. A debug report is useful in comparing your cookie-based measurements with your Private Aggregation measurements, and also allows you to quickly validate your API integration. 
 
 Calling `privateAggregation.enableDebugMode()` in the worklet enables the debug mode which causes aggregatable reports to include the unencrypted (cleartext) payload. You can then process these payloads with the Aggregation Service [local testing tool](https://github.com/google/trusted-execution-aggregation-service#set-up-local-testing). 
 

--- a/site/en/docs/privacy-sandbox/summary-reports/index.md
+++ b/site/en/docs/privacy-sandbox/summary-reports/index.md
@@ -1,0 +1,179 @@
+---
+layout: 'layouts/doc-post.njk'
+title: 'Summary reports'
+subhead: >
+  Measure data aggregated across users with the Attribution Reporting API
+  and the Private Aggregation API.
+description: >
+  Measure data aggregated across users with the Attribution Reporting API
+  and the Private Aggregation API.
+date: 2022-11-30
+authors:
+  - alexandrawhite
+---
+
+## Implementation status
+
+*  Participate and experiment with [Attribution Reporting summary reports](/docs/privacy-sandbox/attribution-reporting-experiment/).
+   *  This API is available in the [ads relevance and measurement origin trial](/blog/privacy-sandbox-unified-origin-trial/).
+
+## What is a summary report?
+
+A _summary report_ is compiled for a group of users so that it cannot be tied
+to any individual. Summary reports offer detailed conversion data with
+flexibility for click and view data. Summary reports do not rely on third-party
+cookies or mechanisms that can be used to identify individual users across
+sites.
+
+Summary reports are created in two contexts:
+
+* **Ads measurement**: adtechs can generate summary reports with
+  [Attribution Reporting](/docs/privacy-sandbox/attribution-reporting-introduction/), to
+  measure when an ad click or view leads to a conversion on an advertiser site,
+  such as a sale or a sign-up. Adtechs can also generate summary reports for
+  [FLEDGE auctions with Private Aggregation](/docs/privacy-sandbox/private-aggregation/#with-fledge).
+* **General cross-site reporting**: developers capture cross-site data in
+  Shared Storage, and can report on that data with
+  [Private Aggregation](/docs/privacy-sandbox/private-aggregation/#with-shared-storage).
+  This has many uses, such as gaining insight into user demographics and
+  capturing unique reaches for content.
+
+Summary reports are requested differently for Attribution Reporting and Private
+Aggregation. Before you can learn how to generate reports, you must first
+understand what aggregation is and how summary reports may be used to address
+your measurement needs.
+
+## Key concepts
+
+### Design your data collection {: #design-data-collection}
+
+A key principle of summary reports is early design decisions. You decide what data to collect in what categories. The output reports provide insights on your campaigns or business. 
+
+The output report offers detailed cross-site conversion data and flexibility for joining click and view data with conversion data. You can also think of the final output as an input for the tools you use to make decisions.
+
+Ask yourself: what do I want to learn about user engagement with my content?
+
+{% Details %}
+
+{% DetailsSummary %}
+#### Ad conversions
+{% endDetailsSummary %}
+
+For example, if you generate summary reports to determine how many conversions led to some total spend value, that may help your team decide what your next ad campaign should target to generate a higher total spend.
+
+{% endDetails %}
+
+{% Details %}
+
+{% DetailsSummary %}
+#### Cross-site engagement
+{% endDetailsSummary %}
+
+For example, if you generate summary reports to determine how many people read your content on a third-party's website, that may help your team decide on how to partner with that third-party to generate higher engagement and encourage readers to visit your site directly.
+
+{% endDetails %}
+
+### What information is captured in the browser?
+
+An _aggregatable report_ is the raw data captured from a user's browser, which
+includes a predetermined set of buckets (or _aggregation keys_). How you
+determine this criteria is dependent on your [design decisions](#design-data-collection).
+
+Summary reports offer a combination of aggregated data alongside detailed conversion data.
+
+{% Details %}
+
+{% DetailsSummary %}
+#### Ad conversions
+{% endDetailsSummary %}
+
+Conversions are defined by the advertiser or adtech company, and may be different for different ad campaigns. One campaign could measure the number of ad clicks that were followed by a user purchasing the advertised item. Another campaign could measure how many ad views led to advertiser site visits. 
+
+For example, an adtech provider runs an ad campaign on news.example, where a conversion represents a user clicking an ad for shoes and completing a purchase of shoes on shoes.example.
+
+The adtech receives a summary report for this ad campaign with ID `1234567`, which states there were <strong>518</strong> conversions on shoes.example on <strong>January 12, 2022</strong>, with a total spend of <strong>$38,174</strong>. <strong>60%</strong> of conversions were from users buying blue sneakers with product SKU `9872` and <strong>40%</strong> were users who bought yellow sandals with product SKU `2643`. The campaign ID is detailed ad-side data, while the product SKUs are detailed conversion data. The number of conversions and total spend are aggregated data.
+
+{% endDetails %}
+
+{% Details %}
+
+{% DetailsSummary %}
+#### Cross-site engagement
+{% endDetailsSummary %}
+
+Before you can capture data, you must define what information you want to collect, identify what conversions you expect from any given cross-site integration, and determine which report type to collect.
+
+There are a number of possible use cases, detailed in the Private Aggregation documentation. Let's explore one example:
+
+You may want to measure the demographics of the users who have seen your content across different sites. Private Aggregation can provide an answer, such as “Approximately 317 unique users are from the age of 18-45 and are from Germany.” First, decide specifically what information you want to collect (such as age and location). Then, use [Shared Storage](/docs/privacy-sandbox/shared-storage/) to collect that specific demographics data from a third-party site. At a later point in time, you can submit a report via Private Aggregation with the age group and country dimensions encoded in the aggregation key. 
+
+{% endDetails %}
+
+### How is data captured before aggregation?
+
+As summary reports are made up of the data from a group of individuals, let's start with one individual's browser actions.
+
+1. A user visits a publisher site and sees or clicks an ad, otherwise known as an attribution source event.
+2. A few minutes or days later the user converts, otherwise known as an attribution trigger event. For example, a conversion can be defined as a product purchase.
+3. The browser software matches the ad click or view with the conversion event. Based on this match, the browser creates an aggregatable report with specific logic created by an adtech provider.
+4. The browser encrypts this data and, after a small delay, sends it to an adtech server for collection. The adtech server must rely on an aggregation service to access the noised insights.
+
+### Batching aggregatable reports
+
+Before aggregatable reports can be processed and aggregated into a summary report, they must first be collected and batched. A _batch_ is a strategic group of aggregatable reports.
+
+Aggregatable reports have a small amount of unencrypted data, included as `shared_info`, which can be used to create batches. This includes the timestamp and reporting origin. You cannot batch based on encrypted information within the report.
+
+Ideally, batches will contain many reports (in other words, more than 100 reports in a batch). You may decide to batch on a daily, weekly, or monthly basis. This strategy can change for specific events where a higher traffic is expected. 
+
+For example, if batching aggregatable reports for the Attribution Reporting API, you may decide to update your batching strategy for the day of a large sale, where you expect a larger volume of ad conversions.
+
+With the Private Aggregation API, you may expect to change your strategy on the day of a large press release about a specific piece of content, embedded on third-party websites.
+
+###  Processing data with the aggregation service
+
+The _[aggregation service](/docs/privacy-sandbox/aggregation-service/)_ decrypts and combines the batched data from the aggregatable reports, [adds noise](/docs/privacy-sandbox/aggregation-service#noise), and returns the final summary report. This service runs in a trusted execution environment (TEE), which is deployed on a cloud service that supports necessary security measures to protect this data.
+
+## Summary reports with Attribution Reporting
+
+For adtech providers to retrieve a summary report, the following steps must be taken:
+
+1. The adtech provider collects aggregatable reports from individual users'
+   browsers.
+   {% Aside %}
+   The adtech provider can only decrypt these reports in the aggregation service.
+   {% endAside %}
+1. The adtech provider batches the aggregatable reports and sends the batches
+   to the aggregation service.
+1. The aggregation service schedules a
+   [worker](https://developer.mozilla.org/docs/Web/API/Service_Worker_API) to aggregate the data.
+   {% Aside %}
+   Before the worker can aggregate, attestation is required from the ​​coordinator. If the worker passes attestation, the decryption keys will be provided.
+   {% endAside %}
+1. The aggregation worker decrypts and aggregates data from the aggregatable
+   reports, along with noised data.
+1. The aggregation service returns the summary report to the adtech provider.
+
+The adtech can use the summary report to inform bidding and to offer reporting to its own customers. A [JSON-encoded scheme](https://github.com/WICG/conversion-measurement-api/blob/main/AGGREGATE.md#aggregate-attribution-reports) is the proposed format for summary reports.
+
+## Summary reports with Private Aggregation
+
+1. Call your shared storage worklet to generate a histogram report using
+   Private Aggregation. In this call, define what buckets should be aggregated.
+1. The aggregation service schedules a worker to aggregate the data.
+   {% Aside %}
+   Before the worker can aggregate, attestation is required from the
+   ​​coordinator. If the worker passes attestation, the decryption keys will be
+   provided.
+   {% endAside %}
+1. The aggregation worker decrypts and aggregates data from the aggregatable
+   reports, along with noised data.
+1. The aggregation service returns the summary report to the requester.
+
+## Engage and share feedback
+
+Summary reports are a key piece of the Privacy Sandbox measurement offerings.
+
+* Discuss the [Attribution Reporting API](/docs/privacy-sandbox/attribution-reporting-experiment/#discuss-the-api).
+* Discuss the [Private Aggregation API](/docs/privacy-sandbox/private-aggregation/#engage-and-share-feedback).
+* **Developer support**: Ask questions and join discussions on the [Privacy Sandbox Developer Support repo](https://github.com/GoogleChromeLabs/privacy-sandbox-dev-support).

--- a/site/en/privacy-sandbox/index.njk
+++ b/site/en/privacy-sandbox/index.njk
@@ -55,8 +55,10 @@ sections:
       title: API updates
       description: A quick reference to how the proposal has changed to address community feedback.
   related_measurement:
-    - url: /docs/privacy-sandbox/attribution-reporting/summary-reports
+    - url: /docs/privacy-sandbox/summary-reports
       title: Summary reports overview
+    - url: /docs/privacy-sandbox/aggregation-service
+      title: Aggregation service
     - url: /docs/privacy-sandbox/attribution-reporting-data-clearing
       title: Impact of user-initiated data clearing
   strengthen_privacy_boundaries:


### PR DESCRIPTION
New pages for summary reports and the aggregation service for ARA/PAA, plus redirects and URL updates.

- [Aggregation service](https://deploy-preview-4421--developer-chrome-com.netlify.app/docs/privacy-sandbox/aggregation-service/)
- [Summary reports](https://deploy-preview-4421--developer-chrome-com.netlify.app/docs/privacy-sandbox/summary-reports/)

Larger updates:
- [ARA overview](https://deploy-preview-4421--developer-chrome-com.netlify.app/docs/privacy-sandbox/attribution-reporting/)
