### PR TITLE
Fix typo in spc-on-android article's example code

### DIFF
--- a/site/en/blog/spc-on-android/index.md
+++ b/site/en/blog/spc-on-android/index.md
@@ -107,7 +107,7 @@ navigator.credentials.create({
       ...,  
     },
     extensions: {
-      payments: {  
+      payment: {  
         isPayment: true,  
       } 
     },


### PR DESCRIPTION
Changes proposed in this pull request:

- Replace 'payments' with 'payment' in the example registration code