### PR TITLE
Update Speculation Rules links

### DIFF
--- a/site/en/blog/prerender-pages/index.md
+++ b/site/en/blog/prerender-pages/index.md
@@ -349,7 +349,6 @@ Prerendering is in active development by the Chrome team, and there are plenty o
 
 ## Related links
 
-- [Bringing instant page-loads to the browser through speculative prerendering](https://web.dev/speculative-prerendering/)
 - [Introducing NoState Prefetch](/blog/nostate-prefetch/)
 - [Speculation Rules API](https://github.com/jeremyroman/alternate-loading-modes/blob/main/triggers.md#speculation-rules)
 - [The Navigational speculation GitHub repo](https://github.com/WICG/nav-speculation/)

--- a/site/en/blog/private-prefetch-proxy/index.md
+++ b/site/en/blog/private-prefetch-proxy/index.md
@@ -7,7 +7,7 @@ description: >
 subhead: >
   Speeding up Largest Contentful Paint (LCP) with cross-site prefetching.
 date: 2022-05-11
-updated: 2022-06-14
+updated: 2022-12-02
 authors:
   - katiehempenius
   - kenjibaheux
@@ -22,8 +22,8 @@ alt: >
 
 Starting with Chrome 103 for Android, Chrome will gradually roll out a private prefetch proxy feature to speed up out-going navigations from Google Search and other participating websites by 30% at the median. This private prefetch proxy feature allows the prefetching of cross-origin content without exposing user information to the destination website until the user navigates.
 
-Read on to learn about [how this feature works](#how), 
-[how it can help significantly improve your sites' Largest Contentful Paint (LCP)](#owners), 
+Read on to learn about [how this feature works](#how),
+[how it can help significantly improve your sites' Largest Contentful Paint (LCP)](#owners),
 or [how referrer websites can help their users](#referrers) achieve their goals by speeding up cross-site navigations.
 
 ## How Private Prefetch Proxy works {: #how }
@@ -44,7 +44,7 @@ In addition, because the secure communication channel is encrypted end-to-end, i
 Beyond the network aspects detailed earlier, we also need to prevent servers from identifying a user at prefetch time, via information previously stored on their device. To that end, Chrome currently restricts the usage of Private Prefetch Proxy to websites for which the user has no cookies or other local state. Here are the restrictions for prefetch requests made via Private Prefetch Proxy:
 
 - **Cookies:** Prefetch requests are not allowed to carry cookies.
-  - If there is a cookie for a resource, Chrome will make an uncredentialed fetch but will not use the response (see later [Caching](#caching) section). 
+  - If there is a cookie for a resource, Chrome will make an uncredentialed fetch but will not use the response (see later [Caching](#caching) section).
   - Although responses to a prefetch request can include cookies, these cookies will only be saved if the user navigates to the prefetched page.
 - **Fingerprinting:** Other surfaces which could be used for fingerprinting are also adjusted. For example, the `User-Agent` header sent by prefetch proxy only carries limited information.
 
@@ -91,7 +91,7 @@ For more flexibility (for example, a sudden peak of heavy access), you may want 
 
 ## For referrer website owners {: #referrers }
 
-If you operate a website with lots of links to other websites, you may be interested in using the Private Prefetch Proxy feature to speed up these cross-origin navigations. You will need to add [speculation rules](https://web.dev/speculative-prerendering/#in-browser-speculation-rules-for-prefetch-and-prerender) to your pages for Chrome to know which page you believe it should prefetch via Private Prefetch Proxy. Here is a simple example:
+If you operate a website with lots of links to other websites, you may be interested in using the Private Prefetch Proxy feature to speed up these cross-origin navigations. You will need to add [speculation rules](/blog/prerender-pages/#using-the-speculation-rules-api-to-prerender-pages) to your pages for Chrome to know which page you believe it should prefetch via Private Prefetch Proxy. Here is a simple example:
 
 ```html
 <script type="speculationrules">


### PR DESCRIPTION
We removed the old Speculation Rules article in https://github.com/GoogleChrome/web.dev/pull/9158 so this PR removes/updates those links here in dcc.
