### PR TITLE
[Lighthouse] Style and link updates

### DIFF
--- a/site/en/_partials/lighthouse-best-practices/scoring.md
+++ b/site/en/_partials/lighthouse-best-practices/scoring.md
@@ -1,5 +1,5 @@
 {% Aside 'note' %}
   Each Best Practices audit is weighted equally in the Lighthouse Best Practices
   Score. Learn more in [The Best Practices
-  score](https://developers.google.com/web/tools/lighthouse/v3/scoring#best-practices).
+  score](/docs/lighthouse/performance/performance-scoring/#best-practices).
 {% endAside %}

--- a/site/en/_partials/lighthouse-seo/scoring.md
+++ b/site/en/_partials/lighthouse-seo/scoring.md
@@ -2,5 +2,5 @@
   Each SEO audit is weighted equally
   in the Lighthouse SEO Score,
   except for the manual **[Structured data is valid](/docs/lighthouse/seo/structured-data/)** audit.
-  Learn more in the [Lighthouse Scoring Guide](https://developers.google.com/web/tools/lighthouse/v3/scoring).
+  Learn more in the [Lighthouse Scoring Guide](/docs/lighthouse/performance/performance-scoring/).
 {% endAside %}

--- a/site/en/blog/heavy-ad-interventions/index.md
+++ b/site/en/blog/heavy-ad-interventions/index.md
@@ -241,7 +241,7 @@ request:
 ## Diagnosing the cause of an intervention
 
 Ad content is just web content, so make use of tools like
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) to audit the overall performance of your
+[Lighthouse](/docs/lighthouse/overview/) to audit the overall performance of your
 content. The resulting audits provide inline guidance on improvements. You can
 also refer to the [web.dev/fast](https://web.dev/fast/) collection.
 

--- a/site/en/blog/inside-browser-part4/index.md
+++ b/site/en/blog/inside-browser-part4/index.md
@@ -247,7 +247,7 @@ information to provide faster and smoother web experience.
 ### Use Lighthouse
 
 If you want to make your code be nice to the browser but have no idea where to start,
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) is a tool that runs audit of any website and gives you a
+[Lighthouse](/docs/lighthouse/overview/) is a tool that runs audit of any website and gives you a
 report on what's being done right and what needs improvement. Reading through the list of audits
 also gives you an idea of what kind of things a browser cares about.
 

--- a/site/en/blog/lighthouse-dbw/index.md
+++ b/site/en/blog/lighthouse-dbw/index.md
@@ -5,17 +5,17 @@ description: >
     What's new in Lighthouse. Redesign, new best practice audits, and an online report viewer.
 authors:
   - ericbidelman
-date: 2016-12-19 
-updated: 2016-12-19 
+date: 2016-12-19
+updated: 2016-12-19
 ---
 
 {% Aside %}
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) is an
+[Lighthouse](/docs/lighthouse/overview/) is an
 [open-source](https://github.com/GoogleChrome/lighthouse), automated tool for
 improving the quality of your web apps. You can install it as a
 [Chrome Extension][crx] or run it as a Node command line tool. When you
 give Lighthouse a URL, it runs a barrage of tests against the page and then
-generates a report explaining how well the page did and indicating areas for 
+generates a report explaining how well the page did and indicating areas for
 improvement.
 {% endAside %}
 
@@ -51,7 +51,7 @@ and include pointers to recommended workarounds.
 To date, Lighthouse has focused on performance metrics and the quality of PWAs.
 However, an overarching goal of the project is to provide a guidebook for all of
 web development. This includes guidance on general best practices, performance
-and accessibility tips, and end-to-end help on making quality apps. 
+and accessibility tips, and end-to-end help on making quality apps.
 
 "Do Better Web" is an effort within the Lighthouse project to help developers do
 better on the web. In other words, help them modernize and optimize their web
@@ -91,7 +91,7 @@ Lighthouse HTML report.
   </figcaption>
 </figure>
 
-Lighthouse Viewer also lets you share reports with others. Clicking the share 
+Lighthouse Viewer also lets you share reports with others. Clicking the share
 icon will sign you in to GitHub. We stash reports as secret gist in your account
 so you can easily delete a shared report or update it later on. Using GitHub for
 data storage also means you get version control for free!

--- a/site/en/blog/lighthouse-jan/index.md
+++ b/site/en/blog/lighthouse-jan/index.md
@@ -33,7 +33,7 @@ tags:
 ---
 
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) is an
+[Lighthouse](/docs/lighthouse/overview/) is an
 [open-source](https://github.com/GoogleChrome/lighthouse), automated tool for
 improving the quality of your web apps. You can install it as a
 [Chrome Extension](https://chrome.google.com/webstore/detail/lighthouse/blipmdconlkpinefehnmjammfjpmpbjk)

--- a/site/en/blog/lighthouse-load-performance/index.md
+++ b/site/en/blog/lighthouse-load-performance/index.md
@@ -12,7 +12,7 @@ updated: 2018-06-11
 {% YouTube id="Mv-l3-tJgGk" %}
 
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) is an automated tool for improving the
+[Lighthouse](/docs/lighthouse/overview/) is an automated tool for improving the
 quality of your site. You give it a URL, and it provides a list of
 recommendations on how to improve page performance, make pages more accessible,
 adhere to best practices and more. You can run it from within Chrome DevTools,

--- a/site/en/blog/lighthouse-platform-packs/index.md
+++ b/site/en/blog/lighthouse-platform-packs/index.md
@@ -28,7 +28,7 @@ updated: 2019-02-01
 # https://developer.chrome.com/docs/handbook/how-to/add-a-tag/
 tags:
   - lighthouse
-  
+
 
 ---
 
@@ -37,7 +37,7 @@ development, and we would love to hear your feedback!
 
 
 By auditing for performance, accessibility and other best practices,
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) provides developers with important guidance
+[Lighthouse](/docs/lighthouse/overview/) provides developers with important guidance
 that they can use to improve their web pages. Many developers, however, use
 different technologies to build their site (such as a CMS or JavaScript
 framework) and may need more specific advice.
@@ -65,7 +65,7 @@ Viewer](https://houssein.me/lighthouse/viewer-wordpress/?gist=9efc3fc22dc500620c
 
 We are starting with WordPress and plan to expand the list in the future
 to other popular CMS and JavaScript frameworks (React, Angular, etc...).
- 
+
 ## How will this feature show up on my Lighthouse report?
 
 There are two options that are being considered:

--- a/site/en/blog/prerender-pages/index.md
+++ b/site/en/blog/prerender-pages/index.md
@@ -349,7 +349,6 @@ Prerendering is in active development by the Chrome team, and there are plenty o
 
 ## Related links
 
-- [Bringing instant page-loads to the browser through speculative prerendering](https://web.dev/speculative-prerendering/)
 - [Introducing NoState Prefetch](/blog/nostate-prefetch/)
 - [Speculation Rules API](https://github.com/jeremyroman/alternate-loading-modes/blob/main/triggers.md#speculation-rules)
 - [The Navigational speculation GitHub repo](https://github.com/WICG/nav-speculation/)

--- a/site/en/blog/private-prefetch-proxy/index.md
+++ b/site/en/blog/private-prefetch-proxy/index.md
@@ -7,7 +7,7 @@ description: >
 subhead: >
   Speeding up Largest Contentful Paint (LCP) with cross-site prefetching.
 date: 2022-05-11
-updated: 2022-06-14
+updated: 2022-12-02
 authors:
   - katiehempenius
   - kenjibaheux
@@ -22,8 +22,8 @@ alt: >
 
 Starting with Chrome 103 for Android, Chrome will gradually roll out a private prefetch proxy feature to speed up out-going navigations from Google Search and other participating websites by 30% at the median. This private prefetch proxy feature allows the prefetching of cross-origin content without exposing user information to the destination website until the user navigates.
 
-Read on to learn about [how this feature works](#how), 
-[how it can help significantly improve your sites' Largest Contentful Paint (LCP)](#owners), 
+Read on to learn about [how this feature works](#how),
+[how it can help significantly improve your sites' Largest Contentful Paint (LCP)](#owners),
 or [how referrer websites can help their users](#referrers) achieve their goals by speeding up cross-site navigations.
 
 ## How Private Prefetch Proxy works {: #how }
@@ -44,7 +44,7 @@ In addition, because the secure communication channel is encrypted end-to-end, i
 Beyond the network aspects detailed earlier, we also need to prevent servers from identifying a user at prefetch time, via information previously stored on their device. To that end, Chrome currently restricts the usage of Private Prefetch Proxy to websites for which the user has no cookies or other local state. Here are the restrictions for prefetch requests made via Private Prefetch Proxy:
 
 - **Cookies:** Prefetch requests are not allowed to carry cookies.
-  - If there is a cookie for a resource, Chrome will make an uncredentialed fetch but will not use the response (see later [Caching](#caching) section). 
+  - If there is a cookie for a resource, Chrome will make an uncredentialed fetch but will not use the response (see later [Caching](#caching) section).
   - Although responses to a prefetch request can include cookies, these cookies will only be saved if the user navigates to the prefetched page.
 - **Fingerprinting:** Other surfaces which could be used for fingerprinting are also adjusted. For example, the `User-Agent` header sent by prefetch proxy only carries limited information.
 
@@ -91,7 +91,7 @@ For more flexibility (for example, a sudden peak of heavy access), you may want 
 
 ## For referrer website owners {: #referrers }
 
-If you operate a website with lots of links to other websites, you may be interested in using the Private Prefetch Proxy feature to speed up these cross-origin navigations. You will need to add [speculation rules](https://web.dev/speculative-prerendering/#in-browser-speculation-rules-for-prefetch-and-prerender) to your pages for Chrome to know which page you believe it should prefetch via Private Prefetch Proxy. Here is a simple example:
+If you operate a website with lots of links to other websites, you may be interested in using the Private Prefetch Proxy feature to speed up these cross-origin navigations. You will need to add [speculation rules](/blog/prerender-pages/#using-the-speculation-rules-api-to-prerender-pages) to your pages for Chrome to know which page you believe it should prefetch via Private Prefetch Proxy. Here is a simple example:
 
 ```html
 <script type="speculationrules">

--- a/site/en/docs/lighthouse/accessibility/custom-control-roles/index.md
+++ b/site/en/docs/lighthouse/accessibility/custom-control-roles/index.md
@@ -56,7 +56,7 @@ then add `role="button"` and `aria-pressed="false"` to the `<div>`.
   height: 346
 } #}
 
-Now screen readers will announces the role and interactive state for the `<div>`.
+Now screen readers will announce the role and interactive state for the `<div>`.
 
 ## Why this matters
 

--- a/site/en/docs/lighthouse/accessibility/custom-controls-labels/index.md
+++ b/site/en/docs/lighthouse/accessibility/custom-controls-labels/index.md
@@ -45,7 +45,7 @@ For example:
 
 For users who either cannot or choose not to use a mouse,
 keyboard navigation is the primary means of reaching everything on a screen.
-Good keyboarding experiences depend on a logical tab order and easily discernable focus styles.
+Good keyboarding experiences depend on a logical tab order and easily discernible focus styles.
 If a keyboard user can't see what's focused, they have no way of interacting with the page.
 
 Learn more in [How to do an Accessibility Review](https://web.dev/how-to-review/#try-it-with-a-screen-reader).

--- a/site/en/docs/lighthouse/accessibility/focus-traps/index.md
+++ b/site/en/docs/lighthouse/accessibility/focus-traps/index.md
@@ -16,7 +16,7 @@ using only the keyboard.
 
 ## How to manually test
 
-To test users can't accidentally trap their focus,
+To test that your users can't accidentally trap their focus,
 navigate to and from all page elements using only the keyboard.
 Use `TAB` to navigate "forward" and `SHIFT + TAB` to navigate "backward."
 
@@ -27,9 +27,9 @@ where keyboard focus may get stuck.
 
 ## How to fix
 
-Pages that present content in multiple formats, such as modal dialogs,
+Pages that present content in multiple formats, such as modal dialogs and
 widgets, are at risk for focus traps.
-In the case of a displaying a modal,
+In the case of displaying a modal,
 when you don't want the user interacting with the rest of the page,
 it makes sense to temporarily trap the user.
 

--- a/site/en/docs/lighthouse/accessibility/focusable-controls/index.md
+++ b/site/en/docs/lighthouse/accessibility/focusable-controls/index.md
@@ -68,7 +68,7 @@ the button's focus indicator always looks the same
 
 For users who either cannot or choose not to use a mouse,
 keyboard navigation is the primary means of reaching everything on a screen.
-Good keyboarding experiences depend on a logical tab order and easily discernable focus styles.
+Good keyboarding experiences depend on a logical tab order and easily discernible focus styles.
 If a keyboard user can't see what's focused, they have no way of interacting with the page.
 
 Learn more in [How to do an Accessibility Review](https://web.dev/how-to-review/#try-it-with-a-screen-reader).

--- a/site/en/docs/lighthouse/accessibility/logical-tab-order/index.md
+++ b/site/en/docs/lighthouse/accessibility/logical-tab-order/index.md
@@ -30,7 +30,7 @@ Learn more in [Keyboard access fundamentals](https://web.dev/keyboard-access/).
 Are you able to reach all of the interactive controls on the page?
 If not, you may need to use `tabindex` to improve the focusability of those controls.
 The general rule of thumb is that any control a user can interact with or provide input to
-should aim to be focusable and display a focus indicator.
+should be focusable and display a focus indicator.
 If a keyboard user can't see what's focused, they have no way of interacting with the page.
 
 ## How to fix

--- a/site/en/docs/lighthouse/accessibility/managed-focus/index.md
+++ b/site/en/docs/lighthouse/accessibility/managed-focus/index.md
@@ -20,8 +20,8 @@ Single-page apps are important to test,
 especially when it comes to managing a user's focus
 to new content.
 
-Typically in a single-page app,
-clicking on a link won't do a hard refresh.
+Typically, in a single-page app,
+clicking on a link won't cause a hard refresh.
 Instead,
 a route change fetches new data for the `<main>` content area.
 

--- a/site/en/docs/lighthouse/best-practices/appcache-manifest/index.md
+++ b/site/en/docs/lighthouse/best-practices/appcache-manifest/index.md
@@ -37,7 +37,7 @@ To pass this audit,
 remove the manifest from your page,
 and use the
 [Cache API](https://developer.mozilla.org/docs/Web/API/Cache)
-via a [service worker](https://developers.google.com/web/fundamentals/primers/service-workers/)
+via a [service worker](/docs/workbox/service-worker-overview/)
 instead.
 
 To migrate from the Application Cache to service workers,

--- a/site/en/docs/lighthouse/best-practices/appcache-manifest/index.md
+++ b/site/en/docs/lighthouse/best-practices/appcache-manifest/index.md
@@ -13,7 +13,7 @@ is [deprecated](https://html.spec.whatwg.org/multipage/browsers.html#offline).
 
 ## How the Lighthouse Application Cache audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) flags pages that use the Application Cache:
+[Lighthouse](/docs/lighthouse/overview/) flags pages that use the Application Cache:
 
 <figure>
   {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/zOiY51J8avDQU8IkL2XG.png", alt="Lighthouse audit showing that a page uses the Application Cache", width="800", height="74" %}

--- a/site/en/docs/lighthouse/best-practices/charset/index.md
+++ b/site/en/docs/lighthouse/best-practices/charset/index.md
@@ -20,7 +20,7 @@ specification solves this problem.
 
 ## How the Lighthouse `charset` audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/)
+[Lighthouse](/docs/lighthouse/overview/)
 flags pages that do not specify their character encoding:
 
 <figure>

--- a/site/en/docs/lighthouse/best-practices/csp-xss/index.md
+++ b/site/en/docs/lighthouse/best-practices/csp-xss/index.md
@@ -56,7 +56,7 @@ Implement the following practices for added security and compatibility. If the C
 
 ### Configure CSP reporting
 
-[Configuring a reporting destination](https://developers.google.com/web/updates/2018/09/reportingapi) will help monitor for any breakages. You can set the reporting destination by using the `report-uri` or `report-to` directives. `report-to` is not currently supported by all modern browsers so it is recommended to use both or just `report-uri`.
+[Configuring a reporting destination](/articles/reporting-api/) will help monitor for any breakages. You can set the reporting destination by using the `report-uri` or `report-to` directives. `report-to` is not currently supported by all modern browsers so it is recommended to use both or just `report-uri`.
 
 If any content violates the CSP, the browser will send a report to the configured destination. Make sure you have an application configured at this destination handling these reports.
 

--- a/site/en/docs/lighthouse/best-practices/csp-xss/index.md
+++ b/site/en/docs/lighthouse/best-practices/csp-xss/index.md
@@ -7,7 +7,7 @@ date: 2021-06-16
 #updated: 2021-06-02
 ---
 
-A Content Security Policy (CSP) helps to ensure any content loaded in the page is trusted by the site owner. CSPs mitigate cross-site scripting (XSS) attacks because they can block unsafe scripts injected by attackers. However, the CSP can easily be bypassed if it is not strict enough.  Check out [Mitigate cross-site scripting (XSS) with a strict Content Security Policy (CSP)](https://web.dev/strict-csp/) for more information. Lighthouse collects CSPs enforced on the main document, and reports issues from [CSP Evaluator](https://csp-evaluator.withgoogle.com/) if they can be bypassed.
+A Content Security Policy (CSP) helps to ensure any content loaded in the page is trusted by the site owner. CSPs mitigate cross-site scripting (XSS) attacks because they can block unsafe scripts injected by attackers. However, the CSP can easily be bypassed if it is not strict enough. Check out [Mitigate cross-site scripting (XSS) with a strict Content Security Policy (CSP)](https://web.dev/strict-csp/) for more information. Lighthouse collects CSPs enforced on the main document, and reports issues from [CSP Evaluator](https://csp-evaluator.withgoogle.com/) if they can be bypassed.
 
 <figure>
 {% Img src="image/9B7J9oWjgsWbuE84mmxDaY37Wpw2/EFTWlPiCrPOn6ETCRiGr.png",

--- a/site/en/docs/lighthouse/best-practices/deprecations/index.md
+++ b/site/en/docs/lighthouse/best-practices/deprecations/index.md
@@ -13,7 +13,7 @@ after they're removed causes errors on your site.
 
 ## How the Lighthouse deprecated API audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) flags pages that call deprecated APIs:
+[Lighthouse](/docs/lighthouse/overview/) flags pages that call deprecated APIs:
 
 <figure>
   {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/zsb1AOPs5Bua46tKX8Ot.png", alt="Lighthouse audit shows usage of deprecated APIs", width="800", height="247" %}

--- a/site/en/docs/lighthouse/best-practices/doctype/index.md
+++ b/site/en/docs/lighthouse/best-practices/doctype/index.md
@@ -14,7 +14,7 @@ which can cause your page to [render in unexpected ways](https://quirks.spec.wha
 
 ## How the Lighthouse doctype audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) flags pages without the `<!DOCTYPE html>` declaration:
+[Lighthouse](/docs/lighthouse/overview/) flags pages without the `<!DOCTYPE html>` declaration:
 
 <figure>
   {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/l6IEjHdtgCa45QimENjb.png", alt="Lighthouse audit showing missing doctype", width="800", height="76" %}

--- a/site/en/docs/lighthouse/best-practices/errors-in-console/index.md
+++ b/site/en/docs/lighthouse/best-practices/errors-in-console/index.md
@@ -20,7 +20,7 @@ An `Error` message means there's a problem on your page that you need to resolve
 
 ## How the Lighthouse browser error audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) flags all browser errors logged to the console:
+[Lighthouse](/docs/lighthouse/overview/) flags all browser errors logged to the console:
 
 <figure>
   {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/AjfKRZm8E4ZUi2QvQtL3.png", alt="Lighthouse audit showing browser errors in the console", width="800", height="247" %}

--- a/site/en/docs/lighthouse/best-practices/errors-in-console/index.md
+++ b/site/en/docs/lighthouse/best-practices/errors-in-console/index.md
@@ -78,6 +78,6 @@ You can also use the `catch` block to handle the error more gracefully.
 ## Resources
 
 - [Source code for **Browser errors were logged to the console** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/errors-in-console.js)
-- [Console Overview](https://developers.google.com/web/tools/chrome-devtools/console/)
+- [Console Overview](/docs/devtools/console/)
 - [Stack Overflow](https://stackoverflow.com/)
 - [try…catch](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/try...catch)

--- a/site/en/docs/lighthouse/best-practices/errors-in-console/index.md
+++ b/site/en/docs/lighthouse/best-practices/errors-in-console/index.md
@@ -8,7 +8,7 @@ updated: 2019-08-28
 ---
 
 Most browsers ship with built-in developer tools.
-These developer tools usually include a [console](https://developers.google.com/web/tools/chrome-devtools/console/).
+These developer tools usually include a [console](/docs/devtools/console/).
 The console gives you information about the page that's currently running.
 
 Messages logged in the console come from

--- a/site/en/docs/lighthouse/best-practices/external-anchors-use-rel-noopener/index.md
+++ b/site/en/docs/lighthouse/best-practices/external-anchors-use-rel-noopener/index.md
@@ -77,4 +77,4 @@ post for more information.
 
 - [Source code for **Links to cross-origin destinations are unsafe** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js)
 - [Share cross-origin resources safely](https://web.dev/cross-origin-resource-sharing/)
-- [Site isolation for web developers](https://developers.google.com/web/updates/2018/07/site-isolation)
+- [Site isolation for web developers](/blog/site-isolation/)

--- a/site/en/docs/lighthouse/best-practices/external-anchors-use-rel-noopener/index.md
+++ b/site/en/docs/lighthouse/best-practices/external-anchors-use-rel-noopener/index.md
@@ -29,7 +29,7 @@ including Edge Legacy and Internet Explorer.
 
 ## How the Lighthouse cross-origin destination audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) flags unsafe links to cross-origin destinations:
+[Lighthouse](/docs/lighthouse/overview/) flags unsafe links to cross-origin destinations:
 
 <figure>
   {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/ztiQKS8eOfdzONC7bocp.png", alt="Lighthouse audit showing unsafe links to cross-origin destinations", width="800", height="213" %}

--- a/site/en/docs/lighthouse/best-practices/geolocation-on-start/index.md
+++ b/site/en/docs/lighthouse/best-practices/geolocation-on-start/index.md
@@ -13,7 +13,7 @@ that automatically request their location on page load.
 
 ## How the Lighthouse geolocation audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) flags pages that request geolocation permission on load:
+[Lighthouse](/docs/lighthouse/overview/) flags pages that request geolocation permission on load:
 
 <figure>
   {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/EKObTXN3729mGBN5bRyv.png", alt="Lighthouse audit showing geolocation request on page load", width="800", height="213" %}

--- a/site/en/docs/lighthouse/best-practices/image-aspect-ratio/index.md
+++ b/site/en/docs/lighthouse/best-practices/image-aspect-ratio/index.md
@@ -42,7 +42,7 @@ hands-on codelab.
 
 If you're having trouble finding the CSS that's causing the incorrect aspect ratio,
 Chrome DevTools can show you the CSS declarations that affect a given image.
-See Google's [View only the CSS that's actually applied to an element](https://developers.google.com/web/tools/chrome-devtools/css/reference#computed)
+See Google's [View only the CSS that's actually applied to an element](/docs/devtools/css/reference/#computed/)
 page for more information.
 
 

--- a/site/en/docs/lighthouse/best-practices/image-aspect-ratio/index.md
+++ b/site/en/docs/lighthouse/best-practices/image-aspect-ratio/index.md
@@ -8,14 +8,14 @@ updated: 2020-04-29
 ---
 
 If a rendered image has an [aspect ratio][ar] that's significantly different
-from the aspect ratio in its source file (the _natural_ aspect ratio),
+to the aspect ratio in its source file (the _natural_ aspect ratio),
 the rendered image may look distorted,
 possibly creating an unpleasant user experience.
 
 ## How the Lighthouse image aspect ratio audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) flags any
-image with a rendered dimension more than a few pixels different from the expected dimension
+[Lighthouse](/docs/lighthouse/overview/) flags any
+image with a rendered dimension of more than a few pixels difference to the expected dimension
 when rendered at its natural ratio:
 
 <figure>
@@ -24,7 +24,7 @@ when rendered at its natural ratio:
 
 There are two common causes for an incorrect image aspect ratio:
 
-- An image is set to explicit width and height values that differ from the source image's dimensions.
+- An image is set with explicit width and height values that differ from the source image's dimensions.
 - An image is set to a width and height as a percentage of a variably-sized container.
 
 {% Partial 'lighthouse-best-practices/scoring.njk' %}
@@ -39,6 +39,7 @@ for an overview and [How to install the Thumbor image CDN](https://web.dev/insta
 hands-on codelab.
 
 ### Check the CSS that affects the image's aspect ratio
+
 If you're having trouble finding the CSS that's causing the incorrect aspect ratio,
 Chrome DevTools can show you the CSS declarations that affect a given image.
 See Google's [View only the CSS that's actually applied to an element](https://developers.google.com/web/tools/chrome-devtools/css/reference#computed)

--- a/site/en/docs/lighthouse/best-practices/image-aspect-ratio/index.md
+++ b/site/en/docs/lighthouse/best-practices/image-aspect-ratio/index.md
@@ -42,7 +42,7 @@ hands-on codelab.
 
 If you're having trouble finding the CSS that's causing the incorrect aspect ratio,
 Chrome DevTools can show you the CSS declarations that affect a given image.
-See Google's [View only the CSS that's actually applied to an element](/docs/devtools/css/reference/#computed/)
+See Google's [View only the CSS that's actually applied to an element](/docs/devtools/css/reference/#computed)
 page for more information.
 
 

--- a/site/en/docs/lighthouse/best-practices/js-libraries/index.md
+++ b/site/en/docs/lighthouse/best-practices/js-libraries/index.md
@@ -7,7 +7,7 @@ date: 2019-05-02
 updated: 2019-08-28
 ---
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) lists all front-end JavaScript libraries detected on the page:
+[Lighthouse](/docs/lighthouse/overview/) lists all front-end JavaScript libraries detected on the page:
 
 <figure>
   {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/cMTmEHvebD2V2saRMJ4u.png", alt="Lighthouse audit showing all front-end JavaScript libraries detected on page", width="800", height="168" %}

--- a/site/en/docs/lighthouse/best-practices/no-document-write/index.md
+++ b/site/en/docs/lighthouse/best-practices/no-document-write/index.md
@@ -28,7 +28,7 @@ data from the network to be reparsed.
 
 ## How the Lighthouse `document.write()` audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) flags
+[Lighthouse](/docs/lighthouse/overview/) flags
 calls to `document.write()` that weren't blocked by Chrome:
 
 <figure>
@@ -39,7 +39,7 @@ For the most problematic uses,
 Chrome will either block calls to `document.write()`
 or emit a console warning about them, depending on the user's connection speed.
 Either way, the affected calls appear in the DevTools Console.
-See Google's [Intervening against `document.write()`](https://developers.google.com/web/updates/2016/08/removing-document-write)
+See Google's [Intervening against `document.write()`](/blog/removing-document-write/)
 article for more information.
 
 Lighthouse reports any remaining calls to `document.write()`

--- a/site/en/docs/lighthouse/best-practices/no-document-write/index.md
+++ b/site/en/docs/lighthouse/best-practices/no-document-write/index.md
@@ -53,7 +53,7 @@ and there are better alternatives.
 
 Remove all uses of `document.write()` in your code. If it's being used
 to inject third-party scripts, try using
-[asynchronous loading](https://developers.google.com/web/fundamentals/performance/critical-rendering-path/adding-interactivity-with-javascript#parser_blocking_versus_asynchronous_javascript)
+[asynchronous loading](https://https://web.dev/critical-rendering-path-adding-interactivity-with-javascript/#parser_blocking_versus_asynchronous_javascript)
 instead.
 
 If third-party code is using `document.write()`,
@@ -62,6 +62,6 @@ ask the provider to support asynchronous loading.
 ## Resources
 
 - [Source code for **Uses `document.write()`** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/dobetterweb/no-document-write.js)
-- [Intervening against `document.write()`](https://developers.google.com/web/updates/2016/08/removing-document-write)
-- [Parser blocking versus asynchronous JavaScript](https://developers.google.com/web/fundamentals/performance/critical-rendering-path/adding-interactivity-with-javascript#parser_blocking_versus_asynchronous_javascript)
+- [Intervening against `document.write()`](/blog/removing-document-write/)
+- [Parser blocking versus asynchronous JavaScript](https://web.dev/critical-rendering-path-adding-interactivity-with-javascript/#parser_blocking_versus_asynchronous_javascript)
 - [Speculative parsing](https://developer.mozilla.org/docs/Glossary/speculative_parsing)

--- a/site/en/docs/lighthouse/best-practices/no-document-write/index.md
+++ b/site/en/docs/lighthouse/best-practices/no-document-write/index.md
@@ -53,7 +53,7 @@ and there are better alternatives.
 
 Remove all uses of `document.write()` in your code. If it's being used
 to inject third-party scripts, try using
-[asynchronous loading](https://https://web.dev/critical-rendering-path-adding-interactivity-with-javascript/#parser_blocking_versus_asynchronous_javascript)
+[asynchronous loading](https://web.dev/critical-rendering-path-adding-interactivity-with-javascript/#parser_blocking_versus_asynchronous_javascript)
 instead.
 
 If third-party code is using `document.write()`,

--- a/site/en/docs/lighthouse/best-practices/no-vulnerable-libraries/index.md
+++ b/site/en/docs/lighthouse/best-practices/no-vulnerable-libraries/index.md
@@ -17,7 +17,7 @@ the intruder just needs to figure out how to exploit the vulnerability on your s
 
 ## How this Lighthouse audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) flags front-end JavaScript libraries with known security vulnerabilities:
+[Lighthouse](/docs/lighthouse/overview/) flags front-end JavaScript libraries with known security vulnerabilities:
 
 <figure>
   {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/7xN0qVP92s6g1XrNru1f.png", alt="Lighthouse audit showing any front-end JavaScript libraries with known security vulnerabilities used by the page", width="800", height="190" %}

--- a/site/en/docs/lighthouse/best-practices/notification-on-start/index.md
+++ b/site/en/docs/lighthouse/best-practices/notification-on-start/index.md
@@ -8,7 +8,7 @@ date: 2019-05-02
 updated: 2019-08-28
 ---
 
-Good notifications are [timely, relevant, and precise](https://developers.google.com/web/fundamentals/push-notifications/).
+Good notifications are [timely, relevant, and precise](https://web.dev/notifications/).
 If your page asks for permission to send notifications on page load,
 those notifications may not be relevant to your users or their needs.
 
@@ -45,4 +45,4 @@ To provide a better user experience:
 ## Resources
 
 - [Source code for **Requests the notification permission on page load** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/dobetterweb/notification-on-start.js)
-- [Web Push Notifications: Timely, Relevant, and Precise](https://developers.google.com/web/fundamentals/push-notifications/)
+- [Web Push Notifications: Timely, Relevant, and Precise](https://web.dev/notifications/)

--- a/site/en/docs/lighthouse/best-practices/notification-on-start/index.md
+++ b/site/en/docs/lighthouse/best-practices/notification-on-start/index.md
@@ -14,7 +14,7 @@ those notifications may not be relevant to your users or their needs.
 
 ## How the Lighthouse notification audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) flags pages that request notification permissions on load:
+[Lighthouse](/docs/lighthouse/overview/) flags pages that request notification permissions on load:
 
 <figure>
   {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/eKTrQAAdl1v7pQL0GYRc.png", alt="Lighthouse audit shows page requests notification permissions on load", width="800", height="213" %}

--- a/site/en/docs/lighthouse/best-practices/password-inputs-can-be-pasted-into/index.md
+++ b/site/en/docs/lighthouse/best-practices/password-inputs-can-be-pasted-into/index.md
@@ -43,7 +43,7 @@ Lighthouse doesn't detect that scenario, either.
 
 To quickly find and inspect the code that's preventing pasting:
 
-1. Expand the [**Event Listener Breakpoints**](https://developers.google.com/web/tools/chrome-devtools/javascript/breakpoints#event-listeners) pane.
+1. Expand the [**Event Listener Breakpoints**](/docs/devtools/javascript/breakpoints/#event-listeners) pane.
 1. Expand the **Clipboard** list.
 1. Select the **`paste`** checkbox.
 1. Paste some text into a password field on your page.

--- a/site/en/docs/lighthouse/best-practices/password-inputs-can-be-pasted-into/index.md
+++ b/site/en/docs/lighthouse/best-practices/password-inputs-can-be-pasted-into/index.md
@@ -20,7 +20,7 @@ to remember.
 
 ## How this Lighthouse audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) flags code that prevents users from pasting into password fields:
+[Lighthouse](/docs/lighthouse/overview/) flags code that prevents users from pasting into password fields:
 
 <figure>
   {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/0tAkhHny7nQu4pYJ9m9E.png", alt="Lighthouse audit shows page stops users from pasting into password fields", width="800", height="163" %}

--- a/site/en/docs/lighthouse/best-practices/uses-http2/index.md
+++ b/site/en/docs/lighthouse/best-practices/uses-http2/index.md
@@ -37,5 +37,5 @@ see [Setting up HTTP/2](https://dassur.ma/things/h2setup/).
 ## Resources
 
 - [Source code for **Does not use HTTP/2 for all of its resources** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/dobetterweb/uses-http2.js)
-- [Introduction to HTTP/2](https://developers.google.com/web/fundamentals/performance/http2/)
+- [Introduction to HTTP/2](https://web.dev/performance-http2/)
 - [HTTP/2 Frequently Asked Questions](https://http2.github.io/faq/)

--- a/site/en/docs/lighthouse/best-practices/uses-http2/index.md
+++ b/site/en/docs/lighthouse/best-practices/uses-http2/index.md
@@ -13,7 +13,7 @@ and with less data moving over the wire.
 
 ## How the Lighthouse HTTP/2 audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) lists all resources not served over HTTP/2:
+[Lighthouse](/docs/lighthouse/overview/) lists all resources not served over HTTP/2:
 
 <figure>
   {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/Gs0J63479ELUkMeI8MRS.png", alt="Lighthouse audit shows resources not served over HTTP/2 ", width="800", height="191" %}

--- a/site/en/docs/lighthouse/best-practices/uses-passive-event-listeners/index.md
+++ b/site/en/docs/lighthouse/best-practices/uses-passive-event-listeners/index.md
@@ -23,7 +23,7 @@ Most browsers support passive event listeners. See
 
 ## How the Lighthouse passive event listener audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/)
+[Lighthouse](/docs/lighthouse/overview/)
 flags event listeners that may delay page scrolling:
 
 <figure>

--- a/site/en/docs/lighthouse/best-practices/uses-passive-event-listeners/index.md
+++ b/site/en/docs/lighthouse/best-practices/uses-passive-event-listeners/index.md
@@ -65,6 +65,6 @@ explainer document for more information.
 ## Resources
 
 - [Source code for **Does not use passive listeners to improve scrolling performance** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js)
-- [Improving Scrolling Performance with Passive Event Listeners](https://developers.google.com/web/updates/2016/06/passive-event-listeners)
+- [Improving Scrolling Performance with Passive Event Listeners](/blog/passive-event-listeners/)
 - [Passive event listeners explainer](https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md)
 - [EventTarget.addEventListener()](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)

--- a/site/en/docs/lighthouse/overview/index.md
+++ b/site/en/docs/lighthouse/overview/index.md
@@ -7,13 +7,15 @@ date: 2016-09-27
 updated: 2022-05-24
 ---
 
-[Lighthouse](https://github.com/GoogleChrome/lighthouse) is an open-source, automated tool for improving the quality of web pages. You can run it against any web page, public or requiring authentication. It has audits for performance, accessibility, progressive web apps, SEO and more.
+[Lighthouse](https://github.com/GoogleChrome/lighthouse) is an open-source, automated tool for improving the quality of web pages. You can run it against any web page, public or requiring authentication. It has audits for performance, accessibility, progressive web apps, SEO, and more.
 
 <figure>
   {% Img src="image/MtjnObpuceYe3ijODN3a79WrxLU2/QXJ5lmcjHEFLTHg5B4o8.svg", class="float-right", alt="Lighthouse logo", width="150", height="150" %}
 </figure>
 
-You can run Lighthouse in Chrome DevTools, from the command line, or as a Node module. You give Lighthouse a URL to audit, it runs a series of audits against the page, and then it generates a report on how well the page did. From there, use the failing audits as indicators on how to improve the page. Each audit has a reference doc explaining why the audit is important, as well as how to fix it.
+You can run Lighthouse in Chrome DevTools, from the command line, or as a Node module. You give Lighthouse a URL to audit, it runs a series of audits against the page,
+and then it generates a report on how well the page did. From there, use the failing audits as indicators on how to improve the page. Each audit has a reference doc explaining why
+the audit is important, as well as how to fix it.
 
 You can also use [Lighthouse CI](https://github.com/GoogleChrome/lighthouse-ci/blob/main/docs/getting-started.md) to prevent regressions on your sites.
 
@@ -189,7 +191,7 @@ Lighthouse aims to provide guidance that is relevant and actionable for all web 
 
 ### Stack Packs
 
-Developers use many different technologies (backend/CMS/JavaScript frameworks) to build their web pages. Instead of only surfacing general recommendations, Lighthouse is now able to provide more relevant and actionable advice depending on the tools used.  
+Developers use many different technologies (backend/CMS/JavaScript frameworks) to build their web pages. Instead of only surfacing general recommendations, Lighthouse is now able to provide more relevant and actionable advice depending on the tools used.
 
 "Stack Packs" allow Lighthouse to detect what platform your site is built on and display specific stack-based recommendations. These recommendations are defined and curated by experts from the community.
 

--- a/site/en/docs/lighthouse/performance/bootup-time/index.md
+++ b/site/en/docs/lighthouse/performance/bootup-time/index.md
@@ -38,7 +38,7 @@ it slows down your page performance in several ways:
 
 ## How the Lighthouse JavaScript execution time audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/)
+[Lighthouse](/docs/lighthouse/overview/)
 shows a warning when JavaScript execution takes longer than 2&nbsp;seconds.
 The audit fails when execution takes longer than 3.5&nbsp;seconds:
 

--- a/site/en/docs/lighthouse/performance/critical-request-chains/index.md
+++ b/site/en/docs/lighthouse/performance/critical-request-chains/index.md
@@ -13,7 +13,7 @@ are series of dependent network requests important for page rendering.
 The greater the length of the chains and the larger the download sizes,
 the more significant the impact on page load performance.
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/)
+[Lighthouse](/docs/lighthouse/overview/)
 reports critical requests loaded with a high priority:
 
 <figure>

--- a/site/en/docs/lighthouse/performance/critical-request-chains/index.md
+++ b/site/en/docs/lighthouse/performance/critical-request-chains/index.md
@@ -8,7 +8,7 @@ date: 2019-05-02
 updated: 2020-04-29
 ---
 
-[Critical request chains](https://developers.google.com/web/fundamentals/performance/critical-rendering-path)
+[Critical request chains](https://web.dev/critical-rendering-path/)
 are series of dependent network requests important for page rendering.
 The greater the length of the chains and the larger the download sizes,
 the more significant the impact on page load performance.

--- a/site/en/docs/lighthouse/performance/dom-size/index.md
+++ b/site/en/docs/lighthouse/performance/dom-size/index.md
@@ -22,7 +22,7 @@ A large DOM tree can slow down your page performance in multiple ways:
 
   As users and scripts interact with your page,
   the browser must constantly
-  [recompute the position and styling of nodes](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations?utm_source=lighthouse&utm_medium=cli).
+  [recompute the position and styling of nodes](https://web.dev/reduce-the-scope-and-complexity-of-style-calculations/).
   A large DOM tree in combination with complicated style rules can severely slow down rendering.
 
 - **Memory performance**
@@ -60,12 +60,12 @@ and only create them after a relevant user interaction,
 such as a scroll or a button click.
 
 If you create DOM nodes at runtime,
-[Subtree Modification DOM Change Breakpoints](https://developers.google.com/web/tools/chrome-devtools/javascript/breakpoints#dom)
+[Subtree Modification DOM Change Breakpoints](/docs/devtools/dom/)
 can help you pinpoint when nodes get created.
 
 If you can't avoid a large DOM tree,
 another approach for improving rendering performance is simplifying your CSS selectors.
-See Google's [Reduce the Scope and Complexity of Style Calculations](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations)
+See Google's [Reduce the Scope and Complexity of Style Calculations](https://web.dev/reduce-the-scope-and-complexity-of-style-calculations)
 for more information.
 
 ## Stack-specific guidance
@@ -90,4 +90,4 @@ If you're rendering large lists, use [virtual scrolling](https://web.dev/virtual
 ## Resources
 
 - [Source code for **Avoid an excessive DOM size** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/dobetterweb/dom-size.js)
-- [Reduce the Scope and Complexity of Style Calculations](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations)
+- [Reduce the Scope and Complexity of Style Calculations](https://web.dev/reduce-the-scope-and-complexity-of-style-calculations/)

--- a/site/en/docs/lighthouse/performance/dom-size/index.md
+++ b/site/en/docs/lighthouse/performance/dom-size/index.md
@@ -33,7 +33,7 @@ A large DOM tree can slow down your page performance in multiple ways:
 
 ## How the Lighthouse DOM size audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/)
+[Lighthouse](/docs/lighthouse/overview/)
 reports the total DOM elements for a page, the page's maximum DOM depth,
 and its maximum child elements:
 

--- a/site/en/docs/lighthouse/performance/efficient-animated-content/index.md
+++ b/site/en/docs/lighthouse/performance/efficient-animated-content/index.md
@@ -40,7 +40,7 @@ and to convert it to a video called `my-animation.mp4`.
 ## Create WebM videos
 
 WebM videos are much smaller than MP4 videos,
-but not all browsers support WebM so it makes sense to generate both.
+but not all browsers support WebM, so it makes sense to generate both.
 
 To use FFmpeg to convert `my-animation.gif` to a WebM video,
 run the following command in your console:

--- a/site/en/docs/lighthouse/performance/estimated-input-latency/index.md
+++ b/site/en/docs/lighthouse/performance/estimated-input-latency/index.md
@@ -30,7 +30,7 @@ to the end of the trace, which is roughly 5&nbsp;seconds after
 [Time to Interactive](http://web.dev/tti/).
 If your latency is higher than 50&nbsp;ms, users may perceive your app as laggy.
 
-The [RAIL performance model](https://developers.google.com/web/fundamentals/performance/rail)
+The [RAIL performance model](https://web.dev/rail/)
 recommends that apps respond to user input within 100&nbsp;ms,
 while Lighthouse's Estimated Input Latency target score is 50&nbsp;ms. Why?
 Lighthouse uses a proxy metric—availability of the main thread—to measure
@@ -49,7 +49,7 @@ Approximately 90% of users will encounter Lighthouse's reported amount of input 
 To make your app respond to user input faster,
 optimize how your code runs in the browser.
 Check out the series of techniques outlined on Google's
-[Rendering Performance](https://developers.google.com/web/fundamentals/performance/rendering/) page.
+[Rendering Performance](https://web.dev/rendering-performance/) page.
 These tips range from offloading computation to web workers to free up the main thread,
 to refactoring your CSS selectors to perform fewer calculations,
 to using CSS properties that minimize the amount of browser-intensive operations.
@@ -64,17 +64,17 @@ nor does it does measure that your app's response to the user's input is visuall
 
 To measure Estimated Input Latency manually,
 make a recording with the Chrome DevTools Timeline.
-See [Do less main thread work](https://developers.google.com/web/tools/chrome-devtools/speed/get-started#main)
+See [Do less main thread work](/docs/devtools/lighthouse/#main)
 for an example of the workflow.
 The basic idea is to start a recording, perform the user input that you want to measure,
 stop the recording, and then analyze the flame chart to ensure that
-[all stages of the pixel pipeline](https://developers.google.com/web/fundamentals/performance/rendering/#the_pixel_pipeline)
+[all stages of the pixel pipeline](https://web.dev/rendering-performance/#the-pixel-pipeline)
 are complete within 50&nbsp;ms.
 
 ## Resources
 
 - [Source code for **Estimated Input Latency** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/metrics/estimated-input-latency.js)
-- [Lighthouse v3 Scoring Guide](https://developers.google.com/web/tools/lighthouse/v3/scoring)
-- [Measure Performance with the RAIL Model](https://developers.google.com/web/fundamentals/performance/rail)
-- [Rendering Performance](https://developers.google.com/web/fundamentals/performance/rendering/)
-- [Optimize Website Speed With Chrome DevTools](https://developers.google.com/web/tools/chrome-devtools/speed/get-started)
+- [Lighthouse v3 Scoring Guide](/docs/lighthouse/performance/performance-scoring/)
+- [Measure Performance with the RAIL Model](https://web.dev/rail/)
+- [Rendering Performance](https://web.dev/rendering-performance/)
+- [Optimize Website Speed With Chrome DevTools](/docs/devtools/overview/#start/)

--- a/site/en/docs/lighthouse/performance/estimated-input-latency/index.md
+++ b/site/en/docs/lighthouse/performance/estimated-input-latency/index.md
@@ -77,4 +77,4 @@ are complete within 50&nbsp;ms.
 - [Lighthouse v3 Scoring Guide](/docs/lighthouse/performance/performance-scoring/)
 - [Measure Performance with the RAIL Model](https://web.dev/rail/)
 - [Rendering Performance](https://web.dev/rendering-performance/)
-- [Optimize Website Speed With Chrome DevTools](/docs/devtools/overview/#start/)
+- [Optimize Website Speed With Chrome DevTools](/docs/devtools/overview/#start)

--- a/site/en/docs/lighthouse/performance/first-contentful-paint/index.md
+++ b/site/en/docs/lighthouse/performance/first-contentful-paint/index.md
@@ -80,7 +80,7 @@ see Google's [User-centric Performance Metrics][metrics] page.
 The [Tracking FP/FCP][tracking] section describes
 how to programmatically access FCP data and submit it to Google Analytics.
 
-See Google's [Assessing Loading Performance in Real Life with Navigation and Resource Timing](https://developers.google.com/web/fundamentals/performance/navigation-and-resource-timing/)
+See Google's [Assessing Loading Performance in Real Life with Navigation and Resource Timing](https://web.dev/navigation-and-resource-timing/)
 for more on collecting real-user metrics.
 
 {% Partial 'lighthouse-performance/improve.njk' %}
@@ -92,5 +92,5 @@ for more on collecting real-user metrics.
 - [Lighthouse Scoring Guide](/docs/lighthouse/performance/performance-scoring/)
 - [Paint Timing specification](https://w3c.github.io/paint-timing)
 
-[metrics]: https://developers.google.com/web/fundamentals/performance/user-centric-performance-metrics
+[metrics]: https://web.dev/user-centric-performance-metrics/
 [tracking]: https://developers.google.com/web/fundamentals/performance/user-centric-performance-metrics#tracking_fpfcp

--- a/site/en/docs/lighthouse/performance/first-cpu-idle/index.md
+++ b/site/en/docs/lighthouse/performance/first-cpu-idle/index.md
@@ -94,7 +94,7 @@ largely the same as the strategies for improving TTI.
 ## Resources
 
 - [Source code for **First CPU Idle** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/metrics/first-cpu-idle.js)
-- [Lighthouse v3 Scoring Guide](https://developers.google.com/web/tools/lighthouse/v3/scoring)
+- [Lighthouse v3 Scoring Guide](/docs/lighthouse/performance/performance-scoring/)
 - [First Interactive And Consistently Interactive](https://docs.google.com/document/d/1GGiI9-7KeY3TPqS3YT271upUVimo-XiL5mwWorDUD4c/edit)
 - [Time to Interactive](http://web.dev/tti/)
 

--- a/site/en/docs/lighthouse/performance/first-meaningful-paint/index.md
+++ b/site/en/docs/lighthouse/performance/first-meaningful-paint/index.md
@@ -104,7 +104,7 @@ see Google's [User-centric Performance Metrics][metrics] page.
 The [Tracking FMP using hero elements][tracking] section describes
 how to programmatically access FCP data and submit it to Google Analytics.
 
-See Google's [Assessing Loading Performance in Real Life with Navigation and Resource Timing](https://developers.google.com/web/fundamentals/performance/navigation-and-resource-timing/)
+See Google's [Assessing Loading Performance in Real Life with Navigation and Resource Timing](https://web.dev/navigation-and-resource-timing/)
 for more on collecting real-user metrics.
 The [User Timing marks and measures Lighthouse audit](/docs/lighthouse/performance/user-timings/)
 enables you to see User Timing data in your report.

--- a/site/en/docs/lighthouse/performance/font-display/index.md
+++ b/site/en/docs/lighthouse/performance/font-display/index.md
@@ -91,6 +91,6 @@ Specify `@font-display` when [defining custom fonts](https://devdocs.magento.com
 
 - [Source code for **Ensure text remains visible during webfont load** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/font-display.js)
 - [Avoid invisible text during loading](https://web.dev/avoid-invisible-text/)
-- [Controlling font performance with font displays](https://developers.google.com/web/updates/2016/02/font-display)
+- [Controlling font performance with font displays](/blog/font-display/)
 - [Preload web fonts to improve loading speed (codelab)](https://web.dev/codelab-preload-web-fonts/)
 - [Prevent layout shifting and flashes of invisible text (FOIT) by preloading optional fonts](https://web.dev/preload-optional-fonts/)

--- a/site/en/docs/lighthouse/performance/font-display/index.md
+++ b/site/en/docs/lighthouse/performance/font-display/index.md
@@ -8,13 +8,13 @@ date: 2019-05-02
 updated: 2020-04-29
 ---
 
-Fonts are often large files that take awhile to load.
+Fonts are often large files with slow load times.
 Some browsers hide text until the font loads,
 causing a [flash of invisible text (FOIT)](https://web.dev/avoid-invisible-text/).
 
 ## How the Lighthouse font-display audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/)
+[Lighthouse](/docs/lighthouse/overview/)
 flags any font URLs that may flash invisible text:
 
 <figure>

--- a/site/en/docs/lighthouse/performance/interactive/index.md
+++ b/site/en/docs/lighthouse/performance/interactive/index.md
@@ -105,7 +105,7 @@ how to programmatically access TTI data and submit it to Google Analytics.
 
 {% Aside %}
 TTI can be difficult to track in the wild.
-Tracking [First Input Delay](https://developers.google.com/web/updates/2018/05/first-input-delay)
+Tracking [First Input Delay](https://web.dev/fid/)
 can be a good proxy for TTI.
 {% endAside %}
 
@@ -116,10 +116,10 @@ can be a good proxy for TTI.
 - [Source code for **Time to Interactive** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/metrics/interactive.js)
 - [Lighthouse Scoring Guide](/docs/lighthouse/performance/performance-scoring/)
 - [First Interactive And Consistently Interactive](https://docs.google.com/document/d/1GGiI9-7KeY3TPqS3YT271upUVimo-XiL5mwWorDUD4c/edit)
-- [JavaScript Start-up Optimization](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/javascript-startup-optimization/)
-- [Reduce JavaScript Payloads with Tree Shaking](https://developers.google.com/web/fundamentals/performance/optimizing-javascript/tree-shaking/)
+- [JavaScript Start-up Optimization](https://web.dev/optimizing-content-efficiency-javascript-startup-optimization/)
+- [Reduce JavaScript Payloads with Tree Shaking](https://web.dev/reduce-javascript-payloads-with-tree-shaking/)
 - [Optimize third-party resources][3p]
 
-[metrics]: https://developers.google.com/web/fundamentals/performance/user-centric-performance-metrics
+[metrics]: https://web.dev/user-centric-performance-metrics/
 [tracking]: https://developers.google.com/web/fundamentals/performance/user-centric-performance-metrics#tracking_tti
 [3p]: https://web.dev/fast/#optimize-your-third-party-resources

--- a/site/en/docs/lighthouse/performance/interactive/index.md
+++ b/site/en/docs/lighthouse/performance/interactive/index.md
@@ -35,7 +35,7 @@ A page is considered fully interactive when:
 - The page responds to user interactions within 50&nbsp;milliseconds.
 
 {% Aside %}
-Both [First CPU Idle]](/docs/lighthouse/performance/first-cpu-idle/) and TTI
+Both [First CPU Idle](/docs/lighthouse/performance/first-cpu-idle/) and TTI
 measure when the page is ready for user input.
 First CPU Idle occurs when the user can _start_ to interact with the page;
 TTI occurs when the user is _fully_ able to interact with the page.

--- a/site/en/docs/lighthouse/performance/lighthouse-largest-contentful-paint/index.md
+++ b/site/en/docs/lighthouse/performance/lighthouse-largest-contentful-paint/index.md
@@ -71,5 +71,5 @@ See [How to improve Largest Contentful Paint on your site][improve].
 - [New in Chrome 77: Largest Contentful Paint][launch]
 
 [definition]: https://web.dev/lcp/#what-is-lcp
-[launch]: https://developers.google.com/web/updates/2019/09/nic77#lcp
+[launch]: /blog/new-in-chrome-77/#lcp
 [improve]: https://web.dev/lcp/#how-to-improve-lcp

--- a/site/en/docs/lighthouse/performance/lighthouse-max-potential-fid/index.md
+++ b/site/en/docs/lighthouse/performance/lighthouse-max-potential-fid/index.md
@@ -105,11 +105,11 @@ about how to evaluate the FID data you collect.
 - [How To Think About Speed Tools][tools]
 
 [analysis]: https://developers.google.com/web/updates/2018/05/first-input-delay#analyzing_and_reporting_on_fid_data
-[fid]: https://developers.google.com/web/updates/2018/05/first-input-delay
+[fid]: https://web.dev/fid/
 [tti]: https://web.dev/interactive/#how-to-improve-your-tti-score
-[fcp]: https://developers.google.com/web/fundamentals/performance/user-centric-performance-metrics#first_paint_and_first_contentful_paint
-[fid]: https://developers.google.com/web/updates/2018/05/first-input-delay
-[rum]: https://developers.google.com/web/fundamentals/performance/speed-tools#field_data
-[lab]: https://developers.google.com/web/fundamentals/performance/speed-tools#lab_data
+[fcp]: https://web.dev/user-centric-performance-metrics/#important-metrics-to-measure
+[fid]: https://web.dev/fid/
+[rum]: https://web.dev/speed-tools/#field-data
+[lab]: https://web.dev/speed-tools/#lab-data
 [longtask]: https://web.dev/long-tasks-devtools/#what-are-long-tasks
-[tools]: https://developers.google.com/web/fundamentals/performance/speed-tools
+[tools]: https://web.dev/speed-tools/

--- a/site/en/docs/lighthouse/performance/lighthouse-max-potential-fid/index.md
+++ b/site/en/docs/lighthouse/performance/lighthouse-max-potential-fid/index.md
@@ -104,7 +104,7 @@ about how to evaluate the FID data you collect.
 - [First paint and first contentful paint][fcp]
 - [How To Think About Speed Tools][tools]
 
-[analysis]: https://developers.google.com/web/updates/2018/05/first-input-delay#analyzing_and_reporting_on_fid_data
+[analysis]: https://web.dev/fid/#analyzing-and-reporting-on-fid-data
 [fid]: https://web.dev/fid/
 [tti]: https://web.dev/interactive/#how-to-improve-your-tti-score
 [fcp]: https://web.dev/user-centric-performance-metrics/#important-metrics-to-measure

--- a/site/en/docs/lighthouse/performance/mainthread-work-breakdown/index.md
+++ b/site/en/docs/lighthouse/performance/mainthread-work-breakdown/index.md
@@ -22,7 +22,7 @@ leading to a bad experience.
 
 ## How the Lighthouse main thread work audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/)
+[Lighthouse](/docs/lighthouse/overview/)
 flags pages that keep the main thread busy for longer than 4&nbsp;seconds
 during load:
 

--- a/site/en/docs/lighthouse/performance/mainthread-work-breakdown/index.md
+++ b/site/en/docs/lighthouse/performance/mainthread-work-breakdown/index.md
@@ -8,7 +8,7 @@ date: 2019-05-02
 updated: 2019-10-04
 ---
 
-The browser's [renderer process](https://developers.google.com/web/updates/2018/09/inside-browser-part3)
+The browser's [renderer process](/blog/inside-browser-part3/)
 is what turns your code into a web page that your users can interact with.
 By default, the [main thread](https://developer.mozilla.org/docs/Glossary/Main_thread)
 of the renderer process typically handles most code:
@@ -49,18 +49,18 @@ as the page loads.
 ### Script evaluation
 
 - [Optimize third-party JavaScript](https://web.dev/fast/#optimize-your-third-party-resources)
-- [Debounce your input handlers](https://developers.google.com/web/fundamentals/performance/rendering/debounce-your-input-handlers)
+- [Debounce your input handlers](https://web.dev/debounce-your-input-handlers/)
 - [Use web workers](https://web.dev/off-main-thread/)
 
 ### Style and layout
 
-- [Reduce the scope and complexity of style calculations](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations)
-- [Avoid large, complex layouts and layout thrashing](https://developers.google.com/web/fundamentals/performance/rendering/avoid-large-complex-layouts-and-layout-thrashing)
+- [Reduce the scope and complexity of style calculations](https://web.dev/reduce-the-scope-and-complexity-of-style-calculations/)
+- [Avoid large, complex layouts and layout thrashing](https://web.dev/avoid-large-complex-layouts-and-layout-thrashing/)
 
 ### Rendering
 
-- [Stick to compositor only properties and manage layer count](https://developers.google.com/web/fundamentals/performance/rendering/stick-to-compositor-only-properties-and-manage-layer-count)
-- [Simplify paint complexity and reduce paint areas](https://developers.google.com/web/fundamentals/performance/rendering/simplify-paint-complexity-and-reduce-paint-areas)
+- [Stick to compositor only properties and manage layer count](https://web.dev/stick-to-compositor-only-properties-and-manage-layer-count/)
+- [Simplify paint complexity and reduce paint areas](https://web.dev/simplify-paint-complexity-and-reduce-paint-areas/)
 
 ### Parsing HTML and CSS
 
@@ -81,4 +81,4 @@ as the page loads.
 
 - [Source code for **Minimize main thread work** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/mainthread-work-breakdown.js)
 - [Main thread (MDN)](https://developer.mozilla.org/docs/Glossary/Main_thread)
-- [Inside look at modern web browser (part 3)](https://developers.google.com/web/updates/2018/09/inside-browser-part3)
+- [Inside look at modern web browser (part 3)](/blog/inside-browser-part3/)

--- a/site/en/docs/lighthouse/performance/non-composited-animations/index.md
+++ b/site/en/docs/lighthouse/performance/non-composited-animations/index.md
@@ -52,7 +52,7 @@ See [Stick to compositor-only properties and manage layer count][compositor] and
 - [Simplify paint complexity and reduce paint areas][paint]
 - [Inside look at modern web browsers (part 3)][inside]
 
-[compositor]: https://developers.google.com/web/fundamentals/performance/rendering/stick-to-compositor-only-properties-and-manage-layer-count
-[animations]: https://www.html5rocks.com/en/tutorials/speed/high-performance-animations/
-[paint]: https://developers.google.com/web/fundamentals/performance/rendering/simplify-paint-complexity-and-reduce-paint-areas
-[inside]: https://developers.google.com/web/updates/2018/09/inside-browser-part3
+[compositor]: https://web.dev/stick-to-compositor-only-properties-and-manage-layer-count/
+[animations]: https://web.dev/animations-guide/
+[paint]: https://web.dev/simplify-paint-complexity-and-reduce-paint-areas/
+[inside]: /blog/inside-browser-part3/

--- a/site/en/docs/lighthouse/performance/non-composited-animations/index.md
+++ b/site/en/docs/lighthouse/performance/non-composited-animations/index.md
@@ -5,7 +5,7 @@ description: How to pass the "Avoid non-composited animations" Lighthouse audit.
 date: 2020-08-12
 ---
 
-Non-composited animations can appear janky (i.e. not smooth) on low-end phones or when
+Non-composited animations can appear [janky](https://en.wiktionary.org/wiki/jank) (not smooth) on low-end phones or when
 performance-heavy tasks are running on the main thread. Janky animations can increase the
 [Cumulative Layout Shift](https://web.dev/cls/) (CLS) of your page. Reducing CLS will improve your
 Lighthouse Performance score.

--- a/site/en/docs/lighthouse/performance/performance-scoring/index.md
+++ b/site/en/docs/lighthouse/performance/performance-scoring/index.md
@@ -133,8 +133,9 @@ impact on user-perceived performance.
 
 ### How metric scores are determined {: #metric-scores }
 
-Once Lighthouse is done gathering the performance metrics (mostly reported in milliseconds), it converts each raw metric value into a metric score from 0 to 100 by looking where the metric value falls on its Lighthouse scoring distribution. The scoring distribution is
-a log-normal distribution derived from the performance metrics of real website performance
+Once Lighthouse has gathered the performance metrics (mostly reported in milliseconds), it converts each raw metric
+value into a metric score from 0 to 100 by looking where the metric value falls on its Lighthouse scoring distribution.
+The scoring distribution is a log-normal distribution derived from the performance metrics of real website performance
 data on [HTTP Archive](https://httparchive.org/).
 
 For example, Largest Contentful Paint (LCP) measures when a user perceives that the
@@ -143,7 +144,12 @@ the user initiating the page load and the page rendering its primary content. Ba
 website data, top-performing sites render LCP in about 1,220ms, so that metric value is mapped to
 a score of 99.
 
-Going a bit deeper, the Lighthouse scoring curve model uses HTTPArchive data to determine two control points that then set the shape of a [log-normal](https://en.wikipedia.org/wiki/Weber%E2%80%93Fechner_law) curve. The 25th percentile of HTTPArchive data becomes a score of 50 (the median control point), and the 8th percentile becomes a score of 90 (the good/green control point). While exploring the scoring curve plot below, note that between 0.50 and 0.92, there's a near-linear relationship between metric value and score. Around a score of 0.96 is the "point of diminishing returns" as above it, the curve pulls away, requiring increasingly more metric improvement to improve an already high score.
+Going a bit deeper, the Lighthouse scoring curve model uses HTTPArchive data to determine two control points that then set
+the shape of a [log-normal](https://en.wikipedia.org/wiki/Weber%E2%80%93Fechner_law) curve. The 25th percentile of HTTPArchive
+data becomes a score of 50 (the median control point), and the 8th percentile becomes a score of 90 (the good/green control point).
+While exploring the scoring curve plot below, note that between 0.50 and 0.92, there's a near-linear relationship between metric value and score.
+Around a score of 0.96 is the "point of diminishing returns" as above it, the curve pulls away, requiring increasingly more metric improvement to
+improve an already high score.
 
 <figure>
   {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/y321cWrLLbuY4SHlvYCc.png", alt="Image of the scoring curve for TTI", width="600", height="329" %}
@@ -154,7 +160,9 @@ Going a bit deeper, the Lighthouse scoring curve model uses HTTPArchive data to 
 
 ### How desktop vs mobile is handled {: #desktop }
 
-As mentioned above, the score curves are determined from real performance data. Prior to Lighthouse v6, all score curves were based on mobile performance data, however a desktop Lighthouse run would use that. In practice, this led to artificially inflated desktop scores. Lighthouse v6 fixed this bug by using specific desktop scoring. While you certainly can expect overall changes in your perf score from 5 to 6, any scores for desktop will be significantly different.
+As mentioned above, the score curves are determined from real performance data. Prior to Lighthouse v6, all score curves were based on mobile performance data,
+however a desktop Lighthouse run would use that. In practice, this led to artificially inflated desktop scores. Lighthouse v6 fixed this bug by using specific desktop scoring.
+While you certainly can expect overall changes in your perf score from 5 to 6, any scores for desktop will be significantly different.
 
 ### How scores are color-coded {: #color-coding }
 
@@ -164,7 +172,8 @@ The metrics scores and the perf score are colored according to these ranges:
 - 50 to 89 (orange): Needs Improvement
 - 90 to 100 (green): Good
 
-To provide a good user experience, sites should strive to have a good score (90-100). A "perfect" score of 100 is extremely challenging to achieve and not expected. For example, taking a score from 99 to 100 needs about the same amount of metric improvement that would take a 90 to 94.
+To provide a good user experience, sites should strive to have a good score (90-100). A "perfect" score of 100 is extremely challenging to achieve and not expected.
+For example, taking a score from 99 to 100 needs about the same amount of metric improvement that would take a 90 to 94.
 
 ### What can developers do to improve their performance score?
 

--- a/site/en/docs/lighthouse/performance/performance-scoring/index.md
+++ b/site/en/docs/lighthouse/performance/performance-scoring/index.md
@@ -30,7 +30,7 @@ problems include:
 
 Furthermore, even though Lighthouse can provide you a single overall Performance score, it might be more
 useful to think of your site performance as a distribution of scores, rather than a single number.
-See the introduction of [User-Centric Performance Metrics](https://developers.google.com/web/fundamentals/performance/user-centric-performance-metrics)
+See the introduction of [User-Centric Performance Metrics](https://web.dev/user-centric-performance-metrics/)
 to understand why.
 
 ## How the Performance score is weighted {: #weightings }

--- a/site/en/docs/lighthouse/performance/redirects/index.md
+++ b/site/en/docs/lighthouse/performance/redirects/index.md
@@ -24,7 +24,7 @@ of the resource by hundreds of milliseconds.
 
 ## How the Lighthouse multiple redirects audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/)
+[Lighthouse](/docs/lighthouse/overview/)
 flags pages that have multiple redirects:
 
 <figure>

--- a/site/en/docs/lighthouse/performance/redirects/index.md
+++ b/site/en/docs/lighthouse/performance/redirects/index.md
@@ -38,11 +38,11 @@ A page fails this audit when it has two or more redirects.
 Point links to flagged resources
 to the resources' current locations.
 It's especially important to avoid redirects in resources
-required for your [Critical Rendering Path](https://developers.google.com/web/fundamentals/performance/critical-rendering-path/).
+required for your [Critical Rendering Path](https://web.dev/critical-rendering-path/).
 
 If you're using redirects to divert mobile users to the mobile version of your page,
 consider redesigning your site to use
-[Responsive Design](https://developers.google.com/web/fundamentals/design-and-ux/responsive/).
+[Responsive Design](https://web.dev/responsive-web-design-basics/).
 
 ## Stack-specific guidance
 

--- a/site/en/docs/lighthouse/performance/render-blocking-resources/index.md
+++ b/site/en/docs/lighthouse/performance/render-blocking-resources/index.md
@@ -66,7 +66,7 @@ When the page loads, it will have what it needs to handle the page's core functi
 If there's code in a render-blocking URL that's not critical,
 you can keep it in the URL,
 and then mark the URL with `async` or `defer` attributes
-(see also [Adding Interactivity with JavaScript](https://developers.google.com/web/fundamentals/performance/critical-rendering-path/adding-interactivity-with-javascript)).
+(see also [Adding Interactivity with JavaScript](https://web.dev/critical-rendering-path-adding-interactivity-with-javascript/)).
 
 Code that isn't being used at all should be removed (see [Remove unused code](https://web.dev/remove-unused-code/)).
 
@@ -86,7 +86,7 @@ to split up those styles into different files, organized by media query.
 Then add a media attribute to each stylesheet link.
 When loading a page,
 the browser only blocks the first paint to retrieve the stylesheets that match the user's device
-(see [Render-Blocking CSS](https://developers.google.com/web/fundamentals/performance/critical-rendering-path/render-blocking-css)).
+(see [Render-Blocking CSS](https://web.dev/critical-rendering-path-render-blocking-css/)).
 
 Finally, you'll want to minify your CSS to remove any extra whitespace or
 characters (see [Minify CSS](https://web.dev/minify-css/)).
@@ -124,4 +124,4 @@ resources](https://wordpress.org/plugins/search/defer+css+javascript/).
 - [Source code for **Eliminate render-blocking resources** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/byte-efficiency/render-blocking-resources.js)
 - [Reduce JavaScript payloads with code splitting](https://web.dev/reduce-javascript-payloads-with-code-splitting/)
 - [Remove unused code codelab](https://web.dev/codelab-remove-unused-code)
-- [JavaScript Start-up Optimization](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/javascript-startup-optimization/)
+- [JavaScript Start-up Optimization](https://web.dev/optimizing-content-efficiency-javascript-startup-optimization/)

--- a/site/en/docs/lighthouse/performance/render-blocking-resources/index.md
+++ b/site/en/docs/lighthouse/performance/render-blocking-resources/index.md
@@ -19,7 +19,7 @@ and removing anything unused.
 
 ## Which URLs get flagged as render-blocking resources?
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/)
+[Lighthouse](/docs/lighthouse/overview/)
 flags two types of render-blocking URLs: scripts and stylesheets.
 
 A `<script>` tag that:
@@ -36,7 +36,7 @@ A `<link rel="stylesheet">` tag that:
 
 ## How to identify critical resources
 
-The first step to reducing the impact of render-blocking resources,
+The first step towards reducing the impact of render-blocking resources
 is to identify what's critical and what's not.
 Use the [Coverage tab](/docs/devtools/coverage/)
 in Chrome DevTools to identify non-critical CSS and JS.

--- a/site/en/docs/lighthouse/performance/resource-summary/index.md
+++ b/site/en/docs/lighthouse/performance/resource-summary/index.md
@@ -8,7 +8,7 @@ date: 2019-05-02
 updated: 2019-10-04
 ---
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/)
+[Lighthouse](/docs/lighthouse/overview/)
 reports how many network requests were made and
 how much data was transferred while your page loaded:
 

--- a/site/en/docs/lighthouse/performance/third-party-facades/index.md
+++ b/site/en/docs/lighthouse/performance/third-party-facades/index.md
@@ -7,9 +7,12 @@ date: 2020-12-01
 #updated: 2020-12-01
 ---
 
-[Third-party resources](https://web.dev/third-party-javascript/) are often used for displaying ads or videos and integrating with social media. The default approach is to load third-party resources as soon as the page loads, but this can unnecessarily slow the page load. If the third-party content is not critical, this performance cost can be reduced by [lazy loading](https://web.dev/fast/#lazy-load-images-and-video) it.
+[Third-party resources](https://web.dev/third-party-javascript/) are often used for displaying ads or videos and integrating with social media.
+The default approach is to load third-party resources as soon as the page loads, but this can unnecessarily slow the page load. If the third-party
+content is not critical, this performance cost can be reduced by [lazy loading](https://web.dev/fast/#lazy-load-images-and-video) it.
 
-This audit highlights third-party embeds which can be lazily loaded on interaction. In that case, a _facade_ is used in place of the third-party content until the user interacts with it.
+This audit highlights third-party embeds which can be lazily loaded on interaction. In that case, a _facade_ is used in place of the third-party
+content until the user interacts with it.
 
 {% Aside 'key-term' %}
 

--- a/site/en/docs/lighthouse/performance/third-party-summary/index.md
+++ b/site/en/docs/lighthouse/performance/third-party-summary/index.md
@@ -21,7 +21,7 @@ longer:
   {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/Q7GdvYGsSGwIjdWvNhTE.png", alt="A screenshot of the Lighthouse Reduce the impact of third-party code audit", width="800", height="481" %}
 </figure>
 
-A third-party script is any script hosted on a domain that's different than the domain of the URL
+A third-party script is any script hosted on a domain that's different to the domain of the URL
 that you audited with Lighthouse. As the page loads, Lighthouse calculates how long each of the
 third-party scripts blocks the main thread. If the total blocking time is greater than 250&nbsp;ms
 the audit fails.

--- a/site/en/docs/lighthouse/performance/third-party-summary/index.md
+++ b/site/en/docs/lighthouse/performance/third-party-summary/index.md
@@ -36,6 +36,6 @@ optimization strategies.
 ## Resources
 
 - [Source code for **Reduce the impact of third-party code** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/third-party-summary.js)
-- [Loading Third-party JavaScript](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)
+- [Loading Third-party JavaScript](https://web.dev/optimizing-content-efficiency-loading-third-party-javascript/)
 
 [main thread]: https://developer.mozilla.org/docs/Glossary/Main_thread

--- a/site/en/docs/lighthouse/performance/time-to-first-byte/index.md
+++ b/site/en/docs/lighthouse/performance/time-to-first-byte/index.md
@@ -36,7 +36,8 @@ Optimizing the server to do work like this as quickly as possible is one way to 
 
 ## How to improve server response times
 
-The first step to improving server response times is to identify the core conceptual tasks that your server must complete in order to return page content, and then measure how long each of these tasks takes. Once you've identified the longest tasks, search for ways to speed them up.
+The first step to improving server response times is to identify the core conceptual tasks that your server must complete in order to return page content,
+and then measure how long each of these tasks takes. Once you've identified the longest tasks, search for ways to speed them up.
 
 There are many possible causes of slow server responses, and therefore many possible ways to improve:
 

--- a/site/en/docs/lighthouse/performance/total-byte-weight/index.md
+++ b/site/en/docs/lighthouse/performance/total-byte-weight/index.md
@@ -22,7 +22,7 @@ You can adjust the results to factor in purchasing power.
 
 ## How the Lighthouse network payload audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/)
+[Lighthouse](/docs/lighthouse/overview/)
 shows the total size in [kibibytes (KiB)](https://en.wikipedia.org/wiki/Kibibyte) of all resources requested by your page.
 The largest requests are presented first:
 
@@ -75,13 +75,13 @@ number of content items shown on a given page.
 
 ### Joomla
 
-Consider showing excerpts in your article categories (e.g. via a "read more"
+Consider showing excerpts in your article categories (one popular solution is a "read more"
 link), reducing the number of articles shown on a given page, breaking your long
 posts into multiple pages, or using a plugin to lazy-load comments.
 
 ### WordPress
 
-Consider showing excerpts in your post lists (e.g. via the "more" tag), reducing
+Consider showing excerpts in your post lists (you can use the "more" tag), reducing
 the number of posts shown on a given page, breaking your long posts into
 multiple pages, or using a plugin to lazy-load comments.
 

--- a/site/en/docs/lighthouse/performance/unminified-javascript/index.md
+++ b/site/en/docs/lighthouse/performance/unminified-javascript/index.md
@@ -28,7 +28,10 @@ webpack v4 includes a plugin for this library by default to create minified buil
 
 ### Drupal
 
-Ensure you have enabled **Aggregate JavaScript files** in the **Administration** &gt; **Configuration** &gt; **Development** page. You can also configure more advanced aggregation options through [additional modules](https://www.drupal.org/project/project_module?f%5B0%5D=&f%5B1%5D=&f%5B2%5D=im_vid_3%3A123&f%5B3%5D=&f%5B4%5D=sm_field_project_type%3Afull&f%5B5%5D=&f%5B6%5D=&text=javascript+aggregation&solrsort=iss_project_release_usage+desc&op=Search) to speed up your site by concatenating, minifying, and compressing your JavaScript assets.
+Ensure you have enabled **Aggregate JavaScript files** in the **Administration** &gt; **Configuration** &gt; **Development** page.
+You can also configure more advanced aggregation options through
+[additional modules](https://www.drupal.org/project/project_module?f%5B0%5D=&f%5B1%5D=&f%5B2%5D=im_vid_3%3A123&f%5B3%5D=&f%5B4%5D=sm_field_project_type%3Afull&f%5B5%5D=&f%5B6%5D=&text=javascript+aggregation&solrsort=iss_project_release_usage+desc&op=Search)
+to speed up your site by concatenating, minifying, and compressing your JavaScript assets.
 
 ### Joomla
 

--- a/site/en/docs/lighthouse/performance/unused-css-rules/index.md
+++ b/site/en/docs/lighthouse/performance/unused-css-rules/index.md
@@ -44,7 +44,7 @@ These extra network trips can significantly increase the time
 that users must wait before they see any content on their screens.
 
 Unused CSS also slows down a browser's construction of the
-[render tree](https://developers.google.com/web/fundamentals/performance/critical-rendering-path/render-tree-construction).
+[render tree](https://web.dev/critical-rendering-path-render-tree-construction/).
 The render tree is like the DOM tree, except that it also includes the styles for each node.
 To construct the render tree, a browser must walk the entire DOM tree, and check which CSS rules apply to each node.
 The more unused CSS there is,
@@ -53,7 +53,7 @@ the more time that a browser might potentially need to spend calculating the sty
 ## How to detect unused CSS {: #coverage }
 
 The Coverage tab of Chrome DevTools can help you discover critical and uncritical CSS.
-See [View used and unused CSS with the Coverage tab](https://developers.google.com/web/tools/chrome-devtools/css/reference#coverage).
+See [View used and unused CSS with the Coverage tab](/docs/devtools/css/reference/#coverage/).
 
 <figure>
   {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/ydgzuclRCAlY2nzrpDmk.png", alt="Chrome DevTools: Coverage tab", width="800", height="407" %}

--- a/site/en/docs/lighthouse/performance/unused-css-rules/index.md
+++ b/site/en/docs/lighthouse/performance/unused-css-rules/index.md
@@ -53,7 +53,7 @@ the more time that a browser might potentially need to spend calculating the sty
 ## How to detect unused CSS {: #coverage }
 
 The Coverage tab of Chrome DevTools can help you discover critical and uncritical CSS.
-See [View used and unused CSS with the Coverage tab](/docs/devtools/css/reference/#coverage/).
+See [View used and unused CSS with the Coverage tab](/docs/devtools/css/reference/#coverage).
 
 <figure>
   {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/ydgzuclRCAlY2nzrpDmk.png", alt="Chrome DevTools: Coverage tab", width="800", height="407" %}

--- a/site/en/docs/lighthouse/performance/unused-css-rules/index.md
+++ b/site/en/docs/lighthouse/performance/unused-css-rules/index.md
@@ -81,7 +81,7 @@ Learn more in [Defer non-critical CSS](https://web.dev/defer-non-critical-css/).
 
 ### Drupal
 
-Consider removing unused CSS rules and only attach the needed Drupal libraries
+Consider removing unused CSS rules. Only attach the needed Drupal libraries
 to the relevant page or component in a page. See the [Defining a
 library](https://www.drupal.org/docs/8/creating-custom-modules/adding-stylesheets-css-and-javascript-js-to-a-drupal-8-module#library)
 for details.

--- a/site/en/docs/lighthouse/performance/unused-javascript/index.md
+++ b/site/en/docs/lighthouse/performance/unused-javascript/index.md
@@ -103,8 +103,8 @@ plugins](https://wordpress.org/plugins/) loading unused JavaScript in your page.
 - [Find Unused JavaScript And CSS Code With The Coverage Tab In Chrome DevTools][coveragetab]
 - [class: `Coverage`][coverageclass]
 
-[crp]: https://developers.google.com/web/fundamentals/performance/critical-rendering-path/adding-interactivity-with-javascript
-[coveragetab]: https://developers.google.com/web/tools/chrome-devtools/coverage
+[crp]: https://web.dev/critical-rendering-path-adding-interactivity-with-javascript/
+[coveragetab]: /docs/devtools/css/reference/#coverage
 [coverageclass]: https://pptr.dev/#?product=Puppeteer&version=v4.0.0&show=api-class-coverage
 [split]: https://bundlers.tooling.report/code-splitting/
 [eliminate]: https://bundlers.tooling.report/transformations/dead-code/

--- a/site/en/docs/lighthouse/performance/unused-javascript/index.md
+++ b/site/en/docs/lighthouse/performance/unused-javascript/index.md
@@ -11,7 +11,7 @@ Unused JavaScript can slow down your page load speed:
 - If the JavaScript is [render-blocking][crp], the browser must
   download, parse, compile, and evaluate the script before it can proceed
   with all of the other work that's needed for rendering the page.
-- Even if the JavaScript is asynchronous (i.e. not render-blocking), the
+- Even if the JavaScript is asynchronous (not render-blocking), the
   code competes for bandwidth with other resources while it's downloading,
   which has significant performance implications. Sending unused code over
   the network is also wasteful for mobile users who don't have unlimited
@@ -19,7 +19,7 @@ Unused JavaScript can slow down your page load speed:
 
 ## How the unused JavaScript audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/)
+[Lighthouse](/docs/lighthouse/overview/)
 flags every JavaScript file with more than 20 kibibytes of unused code:
 
 <figure>

--- a/site/en/docs/lighthouse/performance/user-timings/index.md
+++ b/site/en/docs/lighthouse/performance/user-timings/index.md
@@ -20,7 +20,7 @@ extracting detailed timing data that you can use to optimize your code.
 You can access those data from JavaScript using the API
 or by viewing them on your [Chrome DevTools Timeline Recordings](https://developers.google.com/web/tools/chrome-devtools/evaluate-performance/reference).
 
-Check out the [HTML5 Rocks page about the User Timing API](https://www.html5rocks.com/en/tutorials/webperformance/usertiming/)
+Check out the [page about the User Timing API](https://web.dev/usertiming/)
 for a quick introduction to using it.
 
 ## How Lighthouse reports User Timing data
@@ -55,4 +55,4 @@ your components.
 
 - [Source code for **User Timing marks and measures** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/user-timings.js)
 - [User Timing API (MDN)](https://developer.mozilla.org/docs/Web/API/User_Timing_API)
-- [User Timing API (HTML5 Rocks)](https://www.html5rocks.com/en/tutorials/webperformance/usertiming/)
+- [User Timing API (web.dev)](https://www.html5rocks.com/en/tutorials/webperformance/usertiming/)

--- a/site/en/docs/lighthouse/performance/user-timings/index.md
+++ b/site/en/docs/lighthouse/performance/user-timings/index.md
@@ -18,7 +18,7 @@ gives you a way to measure your app's JavaScript performance.
 You do that by inserting API calls in your JavaScript and then
 extracting detailed timing data that you can use to optimize your code.
 You can access those data from JavaScript using the API
-or by viewing them on your [Chrome DevTools Timeline Recordings](https://developers.google.com/web/tools/chrome-devtools/evaluate-performance/reference).
+or by viewing them on your [Chrome DevTools Timeline Recordings](/docs/devtools/evaluate-performance/performance-reference/).
 
 Check out the [page about the User Timing API](https://web.dev/usertiming/)
 for a quick introduction to using it.
@@ -55,4 +55,4 @@ your components.
 
 - [Source code for **User Timing marks and measures** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/user-timings.js)
 - [User Timing API (MDN)](https://developer.mozilla.org/docs/Web/API/User_Timing_API)
-- [User Timing API (web.dev)](https://www.html5rocks.com/en/tutorials/webperformance/usertiming/)
+- [User Timing API (web.dev)](https://web.dev/usertiming/)

--- a/site/en/docs/lighthouse/performance/user-timings/index.md
+++ b/site/en/docs/lighthouse/performance/user-timings/index.md
@@ -28,7 +28,7 @@ for a quick introduction to using it.
 When your app uses the User Timing API to add marks (that is, time stamps)
 and measures (that is, measurements of the elapsed time between marks),
 you'll see them in your
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) report:
+[Lighthouse](/docs/lighthouse/overview/) report:
 
 <figure>
   {% Img src="image/tcFciHGuF3MxnTr1y5ue01OGLBn2/PWzo7o0AN7SpBeGKG2OD.png", alt="A screenshot of the Lighthouse User Timing marks and measures audit", width="800", height="408" %}

--- a/site/en/docs/lighthouse/performance/uses-long-cache-ttl/index.md
+++ b/site/en/docs/lighthouse/performance/uses-long-cache-ttl/index.md
@@ -18,7 +18,7 @@ the browser uses its local copy rather than getting it from the network.
 
 ## How the Lighthouse cache policy audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/)
+[Lighthouse](/docs/lighthouse/overview/)
 flags all static resources that aren't cached:
 
 <figure>
@@ -68,7 +68,7 @@ The `max-age` directive tells the browser how long it should cache the resource 
 This example sets the duration to `31536000`, which corresponds to 1 year:
 60&nbsp;seconds × 60&nbsp;minutes × 24&nbsp;hours × 365&nbsp;days = 31536000&nbsp;seconds.
 
-When possible, cache immutable static assets for a long time,
+You should cache immutable static assets for a long time,
 such as a year or longer.
 
 {% Aside %}

--- a/site/en/docs/lighthouse/performance/uses-optimized-images/index.md
+++ b/site/en/docs/lighthouse/performance/uses-optimized-images/index.md
@@ -40,7 +40,7 @@ Another approach is to run your images through an optimizer
 that you install onto your computer and run as a GUI.
 For example,
 with [ImageOptim](https://imageoptim.com/mac) you drag and drop images into its UI,
-and then it automatically compresses the images without compromising quality noticeably.
+and then it automatically compresses the images without noticeably compromising quality.
 If you're running a small site and can handle manually optimizing all images,
 this option is probably good enough.
 

--- a/site/en/docs/lighthouse/performance/uses-rel-preconnect/index.md
+++ b/site/en/docs/lighthouse/performance/uses-rel-preconnect/index.md
@@ -51,7 +51,7 @@ as the browser closes it, wasting all of that early connection work.
 In general,
 try to use `<link rel="preload">`,
 as it's a more comprehensive performance tweak,
-but do keep `<link rel="preconnect">` in your toolbelt for the edge cases like:
+but do keep `<link rel="preconnect">` in your tool belt for the edge cases like:
 
 - [Use-case: Knowing Where From, but not What You're Fetching](https://developers.google.com/web/fundamentals/performance/resource-prioritization#use-case_knowing_where_from_but_not_what_youre_fetching)
 - [Use-case: Streaming Media](https://developers.google.com/web/fundamentals/performance/resource-prioritization#use-case_knowing_where_from_but_not_what_youre_fetching)

--- a/site/en/docs/lighthouse/performance/uses-responsive-images/index.md
+++ b/site/en/docs/lighthouse/performance/uses-responsive-images/index.md
@@ -38,7 +38,7 @@ You can think of image CDNs like web service APIs for transforming images.
 
 Another strategy is to use vector-based image formats, like SVG.
 With a finite amount of code, an SVG image can scale to any size.
-See [Replace complex icons with SVG](https://developers.google.com/web/fundamentals/design-and-ux/responsive/images#replace_complex_icons_with_svg) to learn more.
+See [Replace complex icons with SVG](https://web.dev/responsive-images/#replace-complex-icons-with-svg) to learn more.
 
 Tools like
 [gulp-responsive](https://www.npmjs.com/package/gulp-responsive) or

--- a/site/en/docs/lighthouse/performance/uses-text-compression/index.md
+++ b/site/en/docs/lighthouse/performance/uses-text-compression/index.md
@@ -4,7 +4,7 @@ title: Enable text compression
 description: |
   Learn about how enabling text compression can improve your webpage load performance.
 date: 2019-05-02
-updated: 2020-06-04
+updated: 2022-12-03
 ---
 
 Text-based resources should be served with compression
@@ -54,8 +54,7 @@ Accept-Encoding: gzip, compress, br
 If the browser supports [Brotli](https://opensource.googleblog.com/2015/09/introducing-brotli-new-compression.html)
 (`br`) you should use Brotli because it can reduce the file size of the resources more than the
 other compression algorithms. Search for `how to enable Brotli compression in <X>`, where
-`<X>` is the name of your server. As of June 2020 Brotli is supported in all major browsers except
-Internet Explorer, desktop Safari, and Safari on iOS. See
+`<X>` is the name of your server. As of December 2022 Brotli is supported in all major browsers except Safari on iOS. See
 [Browser compatibility](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Encoding#Browser_compatibility)
 for updates.
 

--- a/site/en/docs/lighthouse/performance/uses-text-compression/index.md
+++ b/site/en/docs/lighthouse/performance/uses-text-compression/index.md
@@ -97,7 +97,7 @@ To compare the compressed and de-compressed sizes of a response:
 1. Press <code><kbd>Control</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd></code> (or <code><kbd>Command</kbd>+<kbd>Option</kbd>+<kbd>J</kbd></code> on Mac) to open DevTools.
 2. Click the **Network** tab.
 3. Enable large request rows.
-   See [Use large request rows](https://developers.google.com/web/tools/chrome-devtools/network/reference#request-rows).
+   See [Use large request rows](/docs/devtools/network/reference/#request-rows).
 4. Look at the **Size** column for the response you're interested in. The
    top value is the compressed size. The bottom value is the de-compressed
    size.

--- a/site/en/docs/lighthouse/pwa/apple-touch-icon/index.md
+++ b/site/en/docs/lighthouse/pwa/apple-touch-icon/index.md
@@ -18,7 +18,7 @@ user experience.
 
 ## How the Lighthouse Apple touch icon audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/)
+[Lighthouse](/docs/lighthouse/overview/)
 flags pages without a `<link rel="apple-touch-icon" href="/example.png">`
 tag in the `<head>`:
 

--- a/site/en/docs/lighthouse/pwa/content-width/index.md
+++ b/site/en/docs/lighthouse/pwa/content-width/index.md
@@ -16,7 +16,7 @@ content may be scaled down to fit, making text difficult to read.
 
 ## How the Lighthouse content width audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/)
+[Lighthouse](/docs/lighthouse/overview/)
 flags pages whose width isn't equal to the width of the viewport:
 
 <figure>

--- a/site/en/docs/lighthouse/pwa/content-width/index.md
+++ b/site/en/docs/lighthouse/pwa/content-width/index.md
@@ -32,7 +32,7 @@ The audit fails if `window.innerWidth` does not equal `window.outerWidth`.
 This audit is a roundabout way of determining
 if your page is optimized for mobile devices.
 See Google's
-[Responsive Web Design Basics](https://developers.google.com/web/fundamentals/design-and-ux/responsive/)
+[Responsive Web Design Basics](https://web.dev/responsive-web-design-basics/)
 for an overview of how to create a mobile-friendly page.
 
 You can ignore this audit if:
@@ -44,4 +44,4 @@ You can ignore this audit if:
 ## Resources
 
 - [Source code for **Content is not sized correctly for the viewport** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/content-width.js)
-- [Responsive Web Design Basics](https://developers.google.com/web/fundamentals/design-and-ux/responsive/)
+- [Responsive Web Design Basics](https://web.dev/responsive-web-design-basics/)

--- a/site/en/docs/lighthouse/pwa/installable-manifest/index.md
+++ b/site/en/docs/lighthouse/pwa/installable-manifest/index.md
@@ -35,7 +35,7 @@ it will fail the audit:
 - A [`start_url`](https://developer.mozilla.org/docs/Web/Manifest/start_url) property
 - A [`display`](https://developer.mozilla.org/docs/Web/Manifest/display)
   property set to `fullscreen`, `standalone`, or `minimal-ui`
-- A [`prefer_related_applications`](https://developers.google.com/web/fundamentals/app-install-banners/native)
+- A [`prefer_related_applications`](/blog/app-install-banners-native/)
   property set to a value other than `true`.
 
 {% Aside 'caution' %}

--- a/site/en/docs/lighthouse/pwa/installable-manifest/index.md
+++ b/site/en/docs/lighthouse/pwa/installable-manifest/index.md
@@ -18,7 +18,7 @@ required to make your app installable.
 
 ## How the Lighthouse web app manifest audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/)
+[Lighthouse](/docs/lighthouse/overview/)
 flags pages that don't have a [web app manifest](https://web.dev/add-manifest/)
 that meets minimum requirements for installability:
 

--- a/site/en/docs/lighthouse/pwa/is-on-https/index.md
+++ b/site/en/docs/lighthouse/pwa/is-on-https/index.md
@@ -37,22 +37,22 @@ If the event isn't heard within 10&nbsp;seconds, the audit fails.
 Consider hosting your site on a CDN. Most CDNs are secure by default.
 
 To learn how to enable HTTPS on your servers, see Google's
-[Enabling HTTPS on Your Servers](https://developers.google.com/web/fundamentals/security/encrypt-in-transit/enable-https).
+[Enabling HTTPS on Your Servers](https://web.dev/enabling-https-on-your-servers/).
 If you're running your own server and need a cheap and easy way to generate
 certificates, [Let's Encrypt](https://letsencrypt.org/) is a good option.
 
 If your page is already running on HTTPS but you're failing this audit,
-you may have problems with [mixed content](https://developers.google.com/web/fundamentals/security/prevent-mixed-content/what-is-mixed-content).
+you may have problems with [mixed content](https://web.dev/what-is-mixed-content/).
 A page has mixed content when the page itself is loaded over HTTPS,
 but it requests an unprotected (HTTP) resource. Check out the following doc on the
 Chrome DevTools Security panel to learn how to debug these situations:
-[Understand Security Issues With Chrome DevTools](https://developers.google.com/web/tools/chrome-devtools/debug/security).
+[Understand Security Issues With Chrome DevTools](/docs/devtools/security/).
 
 ## Resources
 
 - [Source code for **Does not use HTTPS** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/is-on-https.js)
-- [Why You Should Always Use HTTPS](https://developers.google.com/web/fundamentals/security/encrypt-in-transit/why-https)
-- [Enabling HTTPS on Your Servers](https://developers.google.com/web/fundamentals/security/encrypt-in-transit/enable-https)
-- [Understand Security Issues With Chrome DevTools](https://developers.google.com/web/tools/chrome-devtools/debug/security)
-- [What Is Mixed Content?](https://developers.google.com/web/fundamentals/security/prevent-mixed-content/what-is-mixed-content)
+- [Why You Should Always Use HTTPS](https://web.dev/why-https-matters/)
+- [Enabling HTTPS on Your Servers](https://web.dev/enabling-https-on-your-servers/)
+- [Understand Security Issues With Chrome DevTools](/docs/devtools/security/)
+- [What Is Mixed Content?](https://web.dev/what-is-mixed-content/)
 - [Let's Encrypt](https://letsencrypt.org/)

--- a/site/en/docs/lighthouse/pwa/is-on-https/index.md
+++ b/site/en/docs/lighthouse/pwa/is-on-https/index.md
@@ -19,7 +19,7 @@ For more information about why all sites should be protected with HTTPS, see
 
 ## How the Lighthouse HTTPS audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/)
+[Lighthouse](/docs/lighthouse/overview/)
 flags pages that aren't on HTTPS:
 
 <figure>

--- a/site/en/docs/lighthouse/pwa/load-fast-enough-for-pwa/index.md
+++ b/site/en/docs/lighthouse/pwa/load-fast-enough-for-pwa/index.md
@@ -19,7 +19,7 @@ to be considered a Progressive Web App. See the
 
 ## How the Lighthouse page load speed audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/)
+[Lighthouse](/docs/lighthouse/overview/)
 flags pages that don't load fast enough on mobile:
 
 <figure>

--- a/site/en/docs/lighthouse/pwa/load-fast-enough-for-pwa/index.md
+++ b/site/en/docs/lighthouse/pwa/load-fast-enough-for-pwa/index.md
@@ -45,9 +45,9 @@ If the time to interactive is more than 10&nbsp;seconds, the audit fails.
 ## Resources
 
 - [Source code for **Page load is not fast enough on mobile networks** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/load-fast-enough-for-pwa.js)
-- [Baseline Progressive Web App Checklist](https://developers.google.com/web/progressive-web-apps/checklist#baseline)
-- [Critical Rendering Path](https://developers.google.com/web/fundamentals/performance/critical-rendering-path/)
-- [Get Started With Analyzing Runtime Performance](https://developers.google.com/web/tools/chrome-devtools/evaluate-performance/)
-- [Record load performance](https://developers.google.com/web/tools/chrome-devtools/evaluate-performance/reference#record-load)
-- [Optimizing Content Efficiency](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/)
-- [Rendering Performance](https://developers.google.com/web/fundamentals/performance/rendering/)
+- [Baseline Progressive Web App Checklist](https://web.dev/pwa-checklist/#core)
+- [Critical Rendering Path](https://web.dev/critical-rendering-path/)
+- [Get Started With Analyzing Runtime Performance](/docs/devtools/evaluate-performance/)
+- [Record load performance](/docs/devtools/evaluate-performance/reference/#record-load)
+- [Optimizing Content Efficiency](https://web.dev/performance-optimizing-content-efficiency/)
+- [Rendering Performance](https://web.dev/rendering-performance/)

--- a/site/en/docs/lighthouse/pwa/maskable-icon-audit/index.md
+++ b/site/en/docs/lighthouse/pwa/maskable-icon-audit/index.md
@@ -13,7 +13,7 @@ icon, it ensures that the icon takes up all of the space that Android provides f
 
 ## How the Lighthouse maskable icon audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/)
+[Lighthouse](/docs/lighthouse/overview/)
 flags pages that do not have maskable icon support:
 
 <figure>

--- a/site/en/docs/lighthouse/pwa/offline-start-url/index.md
+++ b/site/en/docs/lighthouse/pwa/offline-start-url/index.md
@@ -19,7 +19,7 @@ This causes problems for users who have installed the app to their devices.
 
 ## How the Lighthouse `start_url` audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/)
+[Lighthouse](/docs/lighthouse/overview/)
 flags web apps whose start URL doesn't respond with a 200 when offline:
 
 <figure>

--- a/site/en/docs/lighthouse/pwa/pwa-cross-browser/index.md
+++ b/site/en/docs/lighthouse/pwa/pwa-cross-browser/index.md
@@ -15,19 +15,19 @@ Test your site in Chrome, Edge, Firefox, and Safari, and
 fix any issues that appear in each browser.
 
 If your page is a [Progressive Web App](https://web.dev/progressive-web-apps/#make-it-installable),
-consider using [Workbox](https://developers.google.com/web/tools/workbox),
+consider using [Workbox](/docs/workbox/),
 a high-level [service worker](https://web.dev/service-workers-cache-storage/) toolkit.
 Workbox is developed against a cross-browser test suite, and when possible,
 automatically falls back to alternative implementations
 of features that are missing from certain browsers:
 
-- The [`workbox-broadcast-cache-update`](https://developers.google.com/web/tools/workbox/modules/workbox-broadcast-cache-update)
+- The [`workbox-broadcast-cache-update`](/docs/workbox/modules/workbox-broadcast-update/)
   module uses the [Broadcast Channel API](https://developer.mozilla.org/docs/Web/API/Broadcast_Channel_API)
   if possible and falls back to a
   [`postMessage()`](https://developer.mozilla.org/docs/Web/API/Window/postMessage)
   implementation.
 - The [`workbox-background-sync`](https://developer.mozilla.org/docs/Web/API/Window/postMessage)
-  module uses the [Background Sync API](https://developers.google.com/web/tools/workbox/modules/workbox-background-sync)
+  module uses the [Background Sync API](/docs/workbox/reference/workbox-background-sync/)
   if possible and falls back to retrying queued events
   each time the service worker starts up.
 

--- a/site/en/docs/lighthouse/pwa/redirects-http/index.md
+++ b/site/en/docs/lighthouse/pwa/redirects-http/index.md
@@ -13,7 +13,7 @@ and how to set up HTTPS on your server.
 
 ## How the Lighthouse HTTP redirection audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/)
+[Lighthouse](/docs/lighthouse/overview/)
 flags pages that aren't redirected to HTTPS:
 
 <figure>

--- a/site/en/docs/lighthouse/pwa/service-worker/index.md
+++ b/site/en/docs/lighthouse/pwa/service-worker/index.md
@@ -5,7 +5,7 @@ description: |
   Learn how to register a service worker that supports Progressive Web App
   features like offline functionality, push notifications, and installability.
 date: 2019-05-04
-updated: 2020-06-10
+updated: 2022-12-03
 ---
 
 Registering a [service worker](https://web.dev/service-workers-cache-storage/)
@@ -19,12 +19,12 @@ Learn more in the [Service workers and the Cache Storage API](https://web.dev/se
 
 ## Browser compatibility
 
-All major browsers except Internet Explorer support service workers. See
+All major browsers support service workers. See
 [Browser compatibility](https://developer.mozilla.org/docs/Web/API/ServiceWorker#Browser_compatibility).
 
 ## How the Lighthouse service worker audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/)
+[Lighthouse](/docs/lighthouse/overview/)
 flags pages that don't register a service worker:
 
 <figure>

--- a/site/en/docs/lighthouse/pwa/service-worker/index.md
+++ b/site/en/docs/lighthouse/pwa/service-worker/index.md
@@ -54,7 +54,7 @@ Actually implementing those features requires more work:
 ## Resources
 
 - [Source code for **Does not register a service worker that controls page and `start_url`** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/service-worker.js)
-- [Service Workers: an Introduction](https://developers.google.com/web/fundamentals/primers/service-workers)
+- [Service Workers: an Introduction](/docs/workbox/service-worker-overview/)
 - [Service workers and the Cache Storage API](https://web.dev/service-workers-cache-storage/)
 - [What is network reliability and how do you measure it?](https://web.dev/network-connections-unreliable/)
 - [Make it installable](https://web.dev/codelab-make-installable/)

--- a/site/en/docs/lighthouse/pwa/splash-screen/index.md
+++ b/site/en/docs/lighthouse/pwa/splash-screen/index.md
@@ -17,7 +17,7 @@ providing a branded, engaging experience.
 
 ## How the Lighthouse splash screen audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/)
+[Lighthouse](/docs/lighthouse/overview/)
 flags pages that don't have a custom splash screen:
 
 <figure>
@@ -36,7 +36,7 @@ you meet the following requirements in your [web app manifest](https://web.dev/a
 - The `icons` array specifies an icon that is at least 512x512&nbsp;px.
 - The specified icon exists and is a PNG.
 
-See [Adding a Splash Screen for Installed Web Apps in Chrome 47](https://developers.google.com/web/updates/2015/10/splashscreen)
+See [Adding a Splash Screen for Installed Web Apps in Chrome 47](https://web.dev/add-manifest/#splash-screen)
 for more information.
 
 {% Aside %}

--- a/site/en/docs/lighthouse/pwa/themed-omnibox/index.md
+++ b/site/en/docs/lighthouse/pwa/themed-omnibox/index.md
@@ -53,7 +53,7 @@ Set the tag's `content` attribute to any valid CSS color value:
 ```
 
 Learn more about the `theme-color` meta tag in Google's
-[Support for `theme-color` in Chrome 39 for Android](https://developers.google.com/web/updates/2014/11/Support-for-theme-color-in-Chrome-39-for-Android).
+[Support for `theme-color` in Chrome 39 for Android](/blog/support-for-theme-color-in-chrome-39-for-android/).
 
 ### Step 2: Add the `theme_color` property to your web app manifest
 
@@ -77,4 +77,4 @@ according to the manifest's `theme_color`.
 
 - [Source code for **Does not set a theme color for the address bar** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/themed-omnibox.js)
 - [Add a web app manifest](https://web.dev/add-manifest/)
-- [Support for `theme-color` in Chrome 39 for Android](https://developers.google.com/web/updates/2014/11/Support-for-theme-color-in-Chrome-39-for-Android)
+- [Support for `theme-color` in Chrome 39 for Android](/blog/support-for-theme-color-in-chrome-39-for-android/)

--- a/site/en/docs/lighthouse/pwa/themed-omnibox/index.md
+++ b/site/en/docs/lighthouse/pwa/themed-omnibox/index.md
@@ -4,7 +4,7 @@ title: Does not set a theme color for the address bar
 description: |
   Learn how to set an address bar theme color for your Progressive Web App.
 date: 2019-05-04
-updated: 2020-06-17
+updated: 2020-12-03
 ---
 
 Theming the browser's address bar to match the brand colors
@@ -12,14 +12,14 @@ of your [Progressive Web App (PWA)](https://web.dev/progressive-web-apps/#make-i
 
 ## Browser compatibility
 
-At the time of writing, theming the browser address bar is supported on
-Android-based browsers. See
+As of December 2022, theming the browser address bar is supported on
+Android-based browsers, Google Chrome, and Microsoft Edge. See
 [Browser compatibility](https://developer.mozilla.org/docs/Web/Manifest/theme_color#Browser_compatibility)
 for updates.
 
 ## How the Lighthouse theme color audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/)
+[Lighthouse](/docs/lighthouse/overview/)
 flags pages that don't apply a theme to the address bar:
 
 <figure>

--- a/site/en/docs/lighthouse/pwa/viewport/index.md
+++ b/site/en/docs/lighthouse/pwa/viewport/index.md
@@ -59,5 +59,5 @@ Here's what each key-value pair does:
 ## Resources
 
 - [Source code for **Has a `<meta name="viewport">` tag with `width` or `initial-scale`** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/viewport.js)
-- [Responsive Web Design Basics](https://developers.google.com/web/fundamentals/design-and-ux/responsive/#set-the-viewport)
+- [Responsive Web Design Basics](https://web.dev/responsive-web-design-basics/#viewport)
 - [Using the viewport meta tag to control layout on mobile browsers](https://developer.mozilla.org/docs/Web/HTML/Viewport_meta_tag)

--- a/site/en/docs/lighthouse/pwa/viewport/index.md
+++ b/site/en/docs/lighthouse/pwa/viewport/index.md
@@ -18,7 +18,7 @@ width and scaling of the viewport so that it's sized correctly on all devices.
 
 ## How the Lighthouse viewport meta tag audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) flags pages
+[Lighthouse](/docs/lighthouse/overview/) flags pages
 without a viewport meta tag:
 
 <figure>

--- a/site/en/docs/lighthouse/pwa/without-javascript/index.md
+++ b/site/en/docs/lighthouse/pwa/without-javascript/index.md
@@ -61,11 +61,11 @@ about whether there's a problem with the page, their browsers, or their
 computers.
 
 To see how your site looks and performs when JavaScript is disabled, use
-Chrome DevTools' [Disable JavaScript](https://developers.google.com/web/tools/chrome-devtools/javascript/disable) feature.
+Chrome DevTools' [Disable JavaScript](/docs/devtools/javascript/disable/) feature.
 
 ## Resources
 
 - [Source code for **Does not provide fallback content when JavaScript is not available** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/without-javascript.js)
 - [Progressive Enhancement: What It Is, And How To Use It](https://www.smashingmagazine.com/2009/04/progressive-enhancement-what-it-is-and-how-to-use-it/)
-- [Critical Rendering Path](https://developers.google.com/web/fundamentals/performance/critical-rendering-path/)
-- [Disable JavaScript With Chrome DevTools](https://developers.google.com/web/tools/chrome-devtools/javascript/disable)
+- [Critical Rendering Path](https://web.dev/critical-rendering-path/)
+- [Disable JavaScript With Chrome DevTools](/docs/devtools/javascript/disable/)

--- a/site/en/docs/lighthouse/pwa/without-javascript/index.md
+++ b/site/en/docs/lighthouse/pwa/without-javascript/index.md
@@ -20,7 +20,7 @@ functionality should not rely on CSS or JavaScript.
 
 ## How the Lighthouse fallback content audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/)
+[Lighthouse](/docs/lighthouse/overview/)
 flags pages that don't contain _some_ content
 when JavaScript is unavailable:
 

--- a/site/en/docs/lighthouse/pwa/works-offline/index.md
+++ b/site/en/docs/lighthouse/pwa/works-offline/index.md
@@ -18,7 +18,7 @@ Learn more in the [What is network reliability and how do you measure it?](https
 
 ## How the Lighthouse offline audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/)
+[Lighthouse](/docs/lighthouse/overview/)
 flags pages that don't respond with an
 [HTTP 200 response](https://developer.mozilla.org/docs/Web/HTTP/Status#Successful_responses)
 when offline:

--- a/site/en/docs/lighthouse/pwa/works-offline/index.md
+++ b/site/en/docs/lighthouse/pwa/works-offline/index.md
@@ -36,7 +36,7 @@ and then attempts to retrieve the page using [`XMLHttpRequest`](https://develope
 
 {% Partial 'reliable/workbox.njk' %}
 
-1. Add a [service worker](https://developers.google.com/web/fundamentals/primers/service-workers) to your app.
+1. Add a [service worker](/docs/workbox/service-worker-overview/) to your app.
 2. Use the service worker to cache files locally.
 3. When offline, use the service worker as a network proxy to return the
    locally cached version of the file.
@@ -49,4 +49,4 @@ with the [Working with service workers](https://web.dev/codelab-service-workers)
 ## Resources
 
 - [What is network reliability and how do you measure it?](https://web.dev/network-connections-unreliable/)
-- [Service Workers: an Introduction](https://developers.google.com/web/fundamentals/primers/service-workers)
+- [Service Workers: an Introduction](/docs/workbox/service-worker-overview/)

--- a/site/en/docs/lighthouse/seo/canonical/index.md
+++ b/site/en/docs/lighthouse/seo/canonical/index.md
@@ -31,7 +31,7 @@ Using canonical links has many advantages:
 
 ## How the Lighthouse canonical links audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) flags any page
+[Lighthouse](/docs/lighthouse/overview/) flags any page
 with an invalid canonical link:
 
 <figure class="w-figure">
@@ -83,7 +83,7 @@ page.
 ### General guidelines
 
 - Make sure that the canonical URL is valid.
-- Use secure [HTTPS](https://developers.google.com/web/fundamentals/security/encrypt-in-transit/why-https) canonical URLs rather than HTTP whenever possible.
+- Use secure [HTTPS](https://web.dev/why-https-matters/) canonical URLs rather than HTTP whenever possible.
 - If you use [`hreflang` links](/docs/lighthouse/seo/hreflang/) to serve different versions of a page
   depending on a user's language or country, make sure that the canonical URL
   points to the proper page for that respective language or country.

--- a/site/en/docs/lighthouse/seo/font-size/index.md
+++ b/site/en/docs/lighthouse/seo/font-size/index.md
@@ -13,7 +13,7 @@ and may require users to zoom in to display text at a comfortable reading size.
 
 ## How the Lighthouse font size audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) flags pages
+[Lighthouse](/docs/lighthouse/overview/) flags pages
 with font sizes that are too small to read easily on mobile:
 
 <figure class="w-figure">

--- a/site/en/docs/lighthouse/seo/hreflang/index.md
+++ b/site/en/docs/lighthouse/seo/hreflang/index.md
@@ -13,7 +13,7 @@ a page so that they can display the correct version for each language or region.
 
 ## How the Lighthouse `hreflang` audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) flags
+[Lighthouse](/docs/lighthouse/overview/) flags
 incorrect `hreflang` links:
 
 <figure class="w-figure">

--- a/site/en/docs/lighthouse/seo/http-status-code/index.md
+++ b/site/en/docs/lighthouse/seo/http-status-code/index.md
@@ -19,7 +19,7 @@ _Crawling_ is how a search engine updates its index of content on the web.
 
 ## How the Lighthouse HTTP status code audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) flags pages
+[Lighthouse](/docs/lighthouse/overview/) flags pages
 that return an unsuccessful HTTP status code (in the 400s or 500s):
 
 <figure class="w-figure">

--- a/site/en/docs/lighthouse/seo/invalid-robots-txt/index.md
+++ b/site/en/docs/lighthouse/seo/invalid-robots-txt/index.md
@@ -57,7 +57,7 @@ crawled. They may stop crawling your entire site, which would prevent new
 content from being indexed.
 
 To check the HTTP status code, open `robots.txt` in Chrome and
-[check the request in Chrome DevTools](https://developers.google.com/web/tools/chrome-devtools/network/reference#analyze).
+[check the request in Chrome DevTools](/docs/devtools/network/reference/#analyze).
 
 ### Keep `robots.txt` smaller than 500 KiB
 

--- a/site/en/docs/lighthouse/seo/invalid-robots-txt/index.md
+++ b/site/en/docs/lighthouse/seo/invalid-robots-txt/index.md
@@ -17,7 +17,7 @@ crawl. An invalid `robots.txt` configuration can cause two types of problems:
 
 ## How the Lighthouse `robots.txt` audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) flags invalid
+[Lighthouse](/docs/lighthouse/overview/) flags invalid
 `robots.txt` files:
 
 <figure class="w-figure">

--- a/site/en/docs/lighthouse/seo/is-crawlable/index.md
+++ b/site/en/docs/lighthouse/seo/is-crawlable/index.md
@@ -15,7 +15,7 @@ Only block indexing for content that you don't want to appear in search results.
 
 ## How the Lighthouse indexing audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) flags pages
+[Lighthouse](/docs/lighthouse/overview/) flags pages
 that search engines can't index:
 
 <figure class="w-figure">
@@ -80,9 +80,9 @@ X-Robots-Tag: noindex
 
 ## Add additional control (optional)
 
-You may want more control over how search engines index your page. (For example,
+You may want more control over how search engines index your page. For example,
 maybe you don't want Google to index images, but you do want the rest of the page
-indexed.)
+indexed.
 
 For information about how to configure your `<meta>` elements and HTTP
 headers for specific search engines, see these guides:

--- a/site/en/docs/lighthouse/seo/link-text/index.md
+++ b/site/en/docs/lighthouse/seo/link-text/index.md
@@ -13,7 +13,7 @@ understand your content and how it relates to other pages.
 
 ## How the Lighthouse link text audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) flags links
+[Lighthouse](/docs/lighthouse/overview/) flags links
 without descriptive text:
 
 <figure class="w-figure">

--- a/site/en/docs/lighthouse/seo/meta-description/index.md
+++ b/site/en/docs/lighthouse/seo/meta-description/index.md
@@ -14,7 +14,7 @@ traffic.
 
 ## How the Lighthouse meta description audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) flags pages
+[Lighthouse](/docs/lighthouse/overview/) flags pages
 without a meta description:
 
 <figure class="w-figure">

--- a/site/en/docs/lighthouse/seo/plugins/index.md
+++ b/site/en/docs/lighthouse/seo/plugins/index.md
@@ -16,7 +16,7 @@ Also, most mobile devices don't support plugins, which
 
 ## How the Lighthouse plugins audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) flags pages
+[Lighthouse](/docs/lighthouse/overview/) flags pages
 that use plugins:
 
 <figure class="w-figure">

--- a/site/en/docs/lighthouse/seo/structured-data/index.md
+++ b/site/en/docs/lighthouse/seo/structured-data/index.md
@@ -17,7 +17,7 @@ might appear in a list of top stories relevant to something the user searched
 for.
 
 {% Aside 'note' %}
-The [Lighthouse](https://developers.google.com/web/tools/lighthouse/)
+The [Lighthouse](/docs/lighthouse/overview/)
 structured data audit is manual, so it does not affect your Lighthouse SEO
 score.
 {% endAside %}

--- a/site/en/docs/lighthouse/seo/tap-targets/index.md
+++ b/site/en/docs/lighthouse/seo/tap-targets/index.md
@@ -16,7 +16,7 @@ your page more mobile-friendly and accessible.
 
 ## How the Lighthouse tap targets audit fails
 
-[Lighthouse](https://developers.google.com/web/tools/lighthouse/) flags pages
+[Lighthouse](/docs/lighthouse/overview/) flags pages
 with tap targets that are too small or too close together:
 
 <figure class="w-figure">


### PR DESCRIPTION
- Removed instances of i.e. and e.g.
- Removed as many developers.google.com and html5rocks URLs as possible, particularly for the Workbox and DevTools docs the redirects weren't working
- Caught a few minor typos and suggested a few minor enhancements
- Updated browser compatibility in a couple of spots (and dated those pages)