### PR TITLE
Replace page not found

### DIFF
--- a/site/en/docs/lighthouse/performance/non-composited-animations/index.md
+++ b/site/en/docs/lighthouse/performance/non-composited-animations/index.md
@@ -46,7 +46,7 @@ See [Stick to compositor-only properties and manage layer count][compositor] and
 
 ## Resources
 
-- [Source code for the _Avoid non-composited animations_ audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/non-composited-animations.js)
+- [Source code for the _Avoid non-composited animations_ audit](https://github.com/GoogleChrome/lighthouse/blob/main/core/audits/non-composited-animations.js)
 - [Stick to compositor-only properties and manage layer count][compositor]
 - [High-performance animations][animations]
 - [Simplify paint complexity and reduce paint areas][paint]


### PR DESCRIPTION
Changes proposed in this pull request:

- replaced `Source code for the Avoid non-composited animations audit` link to https://github.com/GoogleChrome/lighthouse/blob/main/core/audits/non-composited-animations.js