### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "glob": "^7.1.7",
         "google-auth-library": "^8.5.2",
         "gorko": "^0.2.1",
+        "gray-matter": "^4.0.3",
         "gulp": "^4.0.2",
         "js-yaml": "^4.1.0",
         "lit-element": "^2.4.0",


### PR DESCRIPTION
Our package-lock.json got out of sync which probably causes service updates to fail for the production Cloud Build jobs, the build itself works fine.