### PR TITLE
Adds a sample docs-landing page as a percy target

### DIFF
--- a/.percy.js
+++ b/.percy.js
@@ -1,6 +1,7 @@
 const SNAPSHOTS = [
   '/en/content-types/author-individual/index.html',
   '/en/content-types/blog-post/index.html',
+  '/en/content-types/docs-landing/index.html',
 ];
 
 module.exports = {

--- a/site/en/content-types/content-types.11tydata.js
+++ b/site/en/content-types/content-types.11tydata.js
@@ -1,0 +1,4 @@
+module.exports = {
+  disable_algolia: true,
+  noindex: true,
+};

--- a/site/en/content-types/docs-landing/devtools/index.md
+++ b/site/en/content-types/docs-landing/devtools/index.md
@@ -1,0 +1,3 @@
+---
+title: 'Sample Docs A'
+---

--- a/site/en/content-types/docs-landing/index.md
+++ b/site/en/content-types/docs-landing/index.md
@@ -1,0 +1,33 @@
+---
+title: >-
+  Docs landing - this page type pulls the requested urls from `_data/docs/projects`
+  and, while maintaining the groups, provides large icon based links through to them.
+description: ''
+layout: 'layouts/docs-landing.njk'
+type: landing
+i18n:
+  projects:
+    a:
+      heading: Project A
+    b:
+      heading: Project B
+    c:
+      heading: Project C - a demonstration of what happens when a project has a long title and > 3 children
+override:docs:
+  projects:
+    a:
+      - url: devtools
+    b:
+      - url: devtools
+      - url: workbox
+    c:
+      - url: devtools
+      - url: devtools
+      - url: devtools
+      - url: workbox
+      - url: devtools
+      - url: devtools
+  workbox:
+    styles:
+      project_icon_color: 'color-project-workbox'
+---

--- a/site/en/content-types/docs-landing/workbox/index.md
+++ b/site/en/content-types/docs-landing/workbox/index.md
@@ -1,0 +1,3 @@
+---
+title: 'Sample Docs B'
+---


### PR DESCRIPTION
Further steps towards: #3955 

Changes proposed in this pull request:

- Adds a sample docs-landing page and takes a snapshot on deployment.