### PR TITLE
Tag cleanup

### DIFF
--- a/site/en/blog/crx-scripting-api/index.md
+++ b/site/en/blog/crx-scripting-api/index.md
@@ -10,7 +10,7 @@ date: 2021-06-08
 hero: 'image/sQ51XsLqKMgSQMCZjIN0B7hlBO02/i5pqKwKHgLHAt7ZwaP0E.png'
 alt: ''
 tags:
-  - extensions
+  - extensions-news
 ---
 
 [Manifest V3][mv3-docs] introduces a number of changes to Chrome's extension platform. In this post,

--- a/site/en/blog/cws-analytics-revamp/index.md
+++ b/site/en/blog/cws-analytics-revamp/index.md
@@ -12,7 +12,7 @@ date: 2022-07-28
 hero: 'image/WlD8wC6g8khYWPJUsQceQkhXSlv1/wSy3XR59pIlrti6XMw8J.png'
 alt: ''
 tags:
-  - extensions
+  - extensions-news
   - cws
 ---
 

--- a/site/en/blog/cws-policy-revamp/index.md
+++ b/site/en/blog/cws-policy-revamp/index.md
@@ -11,7 +11,7 @@ date: 2022-11-01
 hero: 'image/WlD8wC6g8khYWPJUsQceQkhXSlv1/Z3DIUjSZNKZzmdYcNL6m.jpg'
 alt: 'Photo by Sara Cohen on Unsplash'
 tags:
-  - extensions
+  - extensions-news
   - cws
 ---
 

--- a/site/en/blog/extension-manifest-converter/index.md
+++ b/site/en/blog/extension-manifest-converter/index.md
@@ -13,7 +13,7 @@ authors:
   - solomonkinard
   - dotproto
 tags:
-  - extensions
+  - extensions-news
 hero: image/WlD8wC6g8khYWPJUsQceQkhXSlv1/GVDuhpIli5DeYmbiPlqG.jpg
 alt: A woodworking hand plane.
 ---

--- a/site/en/blog/extensions-getting-started-guides/index.md
+++ b/site/en/blog/extensions-getting-started-guides/index.md
@@ -8,7 +8,7 @@ date: 2022-10-06
 hero: 'image/BhuKGJaIeLNPW9ehns59NfwqKxF2/9mMec0BTzXrg4uMqJF63.jpg'
 alt: 'Two puzzle pieces coming together'
 tags:
-  - extensions
+  - extensions-news
 ---
 
 In this post, we're excited to share some significant improvements to the Chrome Extension getting started experience and a few ways you can be part of this dream.

--- a/site/en/blog/host-permissions/index.md
+++ b/site/en/blog/host-permissions/index.md
@@ -16,28 +16,31 @@ authors:
 
 In the future host permissions will be blocked by default when an extension is installed. A user gesture will be required to grant host permissions to your extension. We want to make it clearer to users what they're granting and why. 
 
-We don't know yet what the interface will look like. In the meantime, we're giving you a way to emulate how your extension will work when the user does not grant host permissions. This process involves a command line switch for launching Chrome and a temporary addition to the Extension install dialog box.
+We don't know yet what the interface will look like. In the meantime, we're giving you a way to emulate how your extension will work when the user does not grant host permissions. This process involves a packed extension, a command line switch for launching Chrome, and a temporary addition to the Extension installation dialog box.
 
 To simulate a user not granting permissions:
+
+1. If you do not have a way to [install your extension from a server](/docs/extensions/mv3/external_extensions/#prereq-server) (you would likely only do this for an enterprise extension), you will need to [create a packed extension](/docs/extensions/mv3/external_extensions/#create-crx).
 
 1. Launch Chrome 109 or later with the following flag per the [instructions on the Chromium developer site](https://chromium.googlesource.com/playground/chromium-org-site/+/refs/heads/main/for-testers/command-line-flags.md#how-to-specify-command-line-flags).
 
    `--enable-features=AllowWithholdingExtensionPermissionsOnInstall`
 
-   For example, if you are testing your extension in Chrome Canaray, you would use the following command line:
+   For example, if you are testing your extension in Chrome Canaray on mac, you would use the following command line:
 
    ```bash
    /Applications/Google\ Chrome\ Canary.app/Contents/cOS/Google\ Chrome\ Canary --enable-features=AllowWithholdingExtensionPermissionsOnInstall
    ```
 
-1. Load your extension unpacked or install an extension from the Chrome Webstore.
+1. Load your extension [packed](/docs/extensions/mv3/external_extensions#chrome-crx) or install an extension from the Chrome Web Store.
 
-1. The Extension install dialog box appears with a new checkbox to “grant access to all requested sites”
+1. The Add dialog box appears with a new checkbox to “grant access to all requested sites”.
 
-   * To withhold host permissions, leave the box unchecked.
-   * To grant host permissions, check the box (current behavior). 
+1. Leave the checkbox unchecked. This will load the extension with the new behavior.
 
-1. See how your extension would behave with host permissions withheld. 
+   {% Img src="image/sQ51XsLqKMgSQMCZjIN0B7hlBO02/JwEbz8Vc3UCk1qzlRFEq.png", alt="ALT_TEXT_HERE", width="800", height="332" %}
+
+1. See how your extension would behave with host permissions withheld, and correct any problems you encounter.
 
 If you need to toggle host permissions, you can do so using the extension icon's context menu. Right-click the extension icon and view the menu named, "This Can Read and Change Site Data". (If this menu is missing, your extension does not request host permissions.)
 

--- a/site/en/blog/host-permissions/index.md
+++ b/site/en/blog/host-permissions/index.md
@@ -3,7 +3,7 @@ title: Simulating restricted host permissions
 description: >
   "In the future, host permissions will be blocked by default when an extension is installed. Though we're still working on the user interface, we're giving you a way to emulate how your extension will work when the user does not grant host permissions."
 layout: 'layouts/blog-post.njk'
-date: 2022-12-05
+date: 2022-12-12
 hero: 'image/sQ51XsLqKMgSQMCZjIN0B7hlBO02/EiCV49QB0MW6Ze05OFdg.jpeg'
 alt: >
   A walk sign against a partly cloudy sky.

--- a/site/en/blog/host-permissions/index.md
+++ b/site/en/blog/host-permissions/index.md
@@ -32,7 +32,7 @@ To simulate a user not granting permissions:
    /Applications/Google\ Chrome\ Canary.app/Contents/cOS/Google\ Chrome\ Canary --enable-features=AllowWithholdingExtensionPermissionsOnInstall
    ```
 
-1. Load your extension [packed](/docs/extensions/mv3/external_extensions#chrome-crx) or install an extension from the Chrome Web Store.
+1. Load your extension [packed](/docs/extensions/mv3/external_extensions#chrome-crx) or install an extension from the [Chrome Web Store](https://chrome.google.com/webstore/category/extensions).
 
 1. The Add dialog box appears with a new checkbox to “grant access to all requested sites”.
 

--- a/site/en/blog/host-permissions/index.md
+++ b/site/en/blog/host-permissions/index.md
@@ -9,7 +9,7 @@ alt: >
   A walk sign against a partly cloudy sky.
 tags:
   - chrome-109
-  - extensions
+  - extensions-news
 authors:
   - joemedley
 ---

--- a/site/en/blog/host-permissions/index.md
+++ b/site/en/blog/host-permissions/index.md
@@ -1,0 +1,37 @@
+---
+title: Simulating restricted host permissions
+description: >
+  "In the future, host permissions will be blocked by default when an extension is installed. Though we're still working on the user interface, we're giving you a way to emulate how your extension will work when the user does not grant host permissions."
+layout: 'layouts/blog-post.njk'
+date: 2022-12-02
+hero: 'image/sQ51XsLqKMgSQMCZjIN0B7hlBO02/EiCV49QB0MW6Ze05OFdg.jpeg'
+alt: >
+  A walk sign against a partly cloudy sky.
+tags:
+  - chrome-109
+  - extensions
+authors:
+  - joemedley
+---
+
+In the future host permissions will be blocked by default when an extension is installed. A user gesture will be required to grant host permissions to your extension. We want to make it clearer to users what they're granting and why. 
+
+We don't know yet what the interface will look like. In the meantime, we're giving you a way to emulate how your extension will work when the user does not grant host permissions. This process involves a command line switch for launching Chrome and a temporary addition to the Extension install dialog box.
+
+To simulate a user not granting permissions:
+
+1. Launch Chrome 109 or later with the following flag per the instructions on the Chromium developer site.
+
+`--enable-features=AllowWithholdingExtensionPermissionsOnInstall`
+
+1. Load your extension unpacked or install an extension from the Chrome Webstore.
+1. The Extension install dialog box appears with a new checkbox to “grant access to all requested sites”
+   * To withhold host permissions, leave the box unchecked.
+   * To grant host permissions, check the box (current behavior). 
+
+1. See how your extension would behave with host permissions withheld. 
+
+If you need to toggle host permissions, you can do so using the extension icon's context menu. Right-click the extension icon and view the menu named, "This Can Read and Change Site Data". (If this menu is missing, your extension does not request host permissions.)
+
+Photo by <a href="https://unsplash.com/@markkoenig?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Mark König</a> on <a href="https://unsplash.com/s/photos/permission?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Unsplash</a>
+  

--- a/site/en/blog/host-permissions/index.md
+++ b/site/en/blog/host-permissions/index.md
@@ -4,7 +4,7 @@ description: >
   "In the future, host permissions will be blocked by default when an extension is installed. Though we're still working on the user interface, we're giving you a way to emulate how your extension will work when the user does not grant host permissions."
 layout: 'layouts/blog-post.njk'
 date: 2022-12-12
-hero: 'image/sQ51XsLqKMgSQMCZjIN0B7hlBO02/EiCV49QB0MW6Ze05OFdg.jpeg'
+hero: 'image/sQ51XsLqKMgSQMCZjIN0B7hlBO02/T3Cmk9KsDZxK4oxF2l9p.jpeg'
 alt: >
   A walk sign against a partly cloudy sky.
 tags:

--- a/site/en/blog/host-permissions/index.md
+++ b/site/en/blog/host-permissions/index.md
@@ -3,7 +3,7 @@ title: Simulating restricted host permissions
 description: >
   "In the future, host permissions will be blocked by default when an extension is installed. Though we're still working on the user interface, we're giving you a way to emulate how your extension will work when the user does not grant host permissions."
 layout: 'layouts/blog-post.njk'
-date: 2022-12-02
+date: 2022-12-05
 hero: 'image/sQ51XsLqKMgSQMCZjIN0B7hlBO02/EiCV49QB0MW6Ze05OFdg.jpeg'
 alt: >
   A walk sign against a partly cloudy sky.
@@ -20,12 +20,20 @@ We don't know yet what the interface will look like. In the meantime, we're givi
 
 To simulate a user not granting permissions:
 
-1. Launch Chrome 109 or later with the following flag per the instructions on the Chromium developer site.
+1. Launch Chrome 109 or later with the following flag per the [instructions on the Chromium developer site](https://chromium.googlesource.com/playground/chromium-org-site/+/refs/heads/main/for-testers/command-line-flags.md#how-to-specify-command-line-flags).
 
-`--enable-features=AllowWithholdingExtensionPermissionsOnInstall`
+   `--enable-features=AllowWithholdingExtensionPermissionsOnInstall`
+
+   For example, if you are testing your extension in Chrome Canaray, you would use the following command line:
+
+   ```bash
+   /Applications/Google\ Chrome\ Canary.app/Contents/cOS/Google\ Chrome\ Canary --enable-features=AllowWithholdingExtensionPermissionsOnInstall
+   ```
 
 1. Load your extension unpacked or install an extension from the Chrome Webstore.
+
 1. The Extension install dialog box appears with a new checkbox to “grant access to all requested sites”
+
    * To withhold host permissions, leave the box unchecked.
    * To grant host permissions, check the box (current behavior). 
 

--- a/site/en/blog/more-mv2-transition/index.md
+++ b/site/en/blog/more-mv2-transition/index.md
@@ -9,7 +9,7 @@ date: 2022-09-28
 hero: image/sQ51XsLqKMgSQMCZjIN0B7hlBO02/fjebBemTd8DpKrEe3ya3.png
 alt: Image with extensions logo and text saying Manifest V3 transition timeline
 tags:
-  - extensions
+  - extensions-news
 
 ---
 Last year, we [announced](/blog/mv2-transition/) a timeline for the phasing out of Manifest V2 extensions as we shift our focus to Manifest V3. This change will give Chrome users increased safety and peace of mind while browsing and installing extensions by providing more transparency and control over permissions, adding stricter protocols for accessing resources outside the extension’s context, and ensuring that extensions work well on all devices.

--- a/site/en/blog/mv2-transition/index.md
+++ b/site/en/blog/mv2-transition/index.md
@@ -10,7 +10,7 @@ updated: 2022-10-03
 hero: image/sQ51XsLqKMgSQMCZjIN0B7hlBO02/fjebBemTd8DpKrEe3ya3.png
 alt: Image with extensions logo and text saying Manifest V3 transition timeline
 tags:
-  - extensions
+  - extensions-news
 
 ---
 

--- a/site/en/blog/mv3-actions/index.md
+++ b/site/en/blog/mv3-actions/index.md
@@ -11,7 +11,7 @@ date: 2021-06-23
 hero: 'image/sQ51XsLqKMgSQMCZjIN0B7hlBO02/cAjp0aky7GBuS3ZK9sXB.png'
 alt: ''
 tags:
-  - extensions
+  - extensions-news
 ---
 
 Since the launch of Chrome extensions, the platform has allowed developers to expose extension

--- a/site/en/blog/new-in-extensions-1/index.md
+++ b/site/en/blog/new-in-extensions-1/index.md
@@ -13,7 +13,7 @@ authors:
   - solomonkinard
   - dotproto
 tags:
-  - extensions
+  - extensions-news
   - privacy
   - security
 draft: true

--- a/site/en/blog/policy-update-2sv/index.md
+++ b/site/en/blog/policy-update-2sv/index.md
@@ -12,7 +12,8 @@ updated: 2021-08-04
 hero: image/SHhb2PDKzXTggPGAYpv8JgR81pX2/xfq9HeQEyYWIuxsuTQOh.jpg
 alt: The Roman aqueduct at Segovia, Spain
 tags:
-  - extensions
+  - extensions-news
+  - cws
 
 ---
 

--- a/site/en/blog/policy-update-kwspam-and-circumvention/index.md
+++ b/site/en/blog/policy-update-kwspam-and-circumvention/index.md
@@ -11,7 +11,8 @@ date: 2021-09-27
 hero: image/SHhb2PDKzXTggPGAYpv8JgR81pX2/9fCG7BsR8e5Md58xiGMV.jpg
 alt: Candle reflected in a window
 tags:
-  - extensions
+  - extensions-news
+  - cws
 
 ---
 

--- a/site/en/docs/extensions/mv3/external_extensions/index.md
+++ b/site/en/docs/extensions/mv3/external_extensions/index.md
@@ -2,7 +2,7 @@
 layout: "layouts/doc-post.njk"
 title: "Alternative extension installation methods"
 date: 2012-09-17
-updated: 2022-01-28
+updated: 2022-12-12
 description: How to install Chrome Extensions via preferences JSON or Windows registry.
 ---
 
@@ -49,6 +49,31 @@ extensions][malicious-mac]).
 
 ## Before you begin {: #prereqs }
 
+### Creating a CRX file {: #create-crx }
+
+Some of the installation methods described here require a CRX file. The procedure below describes creating one. It must be done with a private key file, which you can create with OpenSLL or any other method of creating a key file. If you do not have one, Chrome will create one for you.
+
+To create a CRX file.
+
+1. Go to `chrome://extensions`.
+
+1. On the top left of the screen, click Pack Extensions. The Pack extensions dialog box appears.
+
+   {% Img src="image/sQ51XsLqKMgSQMCZjIN0B7hlBO02/z4KrJBv7gE0S7wmXhrU2.png", alt="ALT_TEXT_HERE", width="800", height="469" %}
+
+1. Locate the Extensions root directory box and click Browse. A folder selection dialog box appears.
+
+1. Locate the root directory containing your extension files and click Select. The Pack extensions dialog reappears. The Extensions root directory box will contain the path to the location you just selected.
+
+1. (Optional) Locate the Private key file box and click Browse. A folder selection dialog box appears.
+
+1. Locate your private key file and click Open. The Pack extensions dialog reappears. The Private key file box will contain the path to the file you just selected.
+
+1. Click Pack extension. A confirmation dialog box appears.
+
+1. Click OK.
+
+
 ### Installing from the Chrome Web Store {: #prereq-cws }
 
 If you are distributing an extension hosted in the Chrome Web Store, you must first [publish the
@@ -63,7 +88,19 @@ id", width="800", height="165" %}
 
 <!-- Add screenshot -->
 
-### Installing from Local CRX file {: #prereq-crx }
+### Installing a CRX file in Chrome {: #chrome-crx }
+
+1. Open Chrome and go to `chrome://extensions`. The Chrome Extensions page appears.
+
+1. Open the directory where your CRX file is located.
+
+1. Drag the CRX file on the the Chrome Extensions page. The Add box appears.
+
+   {% Img src="image/sQ51XsLqKMgSQMCZjIN0B7hlBO02/I3qx5JXDNpOQPPrnwoxa.png", alt="ALT_TEXT_HERE", width="800", height="332" %}
+
+1. Click Add extension.
+
+### Installing a CRX file on Linux systems {: #prereq-crx }
 
 If you are distributing to Linux users from a local file, you will need to [package a CRX
 file][packing] and note the following information:

--- a/site/en/docs/extensions/mv3/external_extensions/index.md
+++ b/site/en/docs/extensions/mv3/external_extensions/index.md
@@ -63,7 +63,7 @@ To create a CRX file.
 
 1. Locate the Extensions root directory box and click Browse. A folder selection dialog box appears.
 
-1. Locate the root directory containing your extension files and click Select. The Pack extensions dialog reappears. The Extensions root directory box now contains the path to the location you just selected.
+1. Locate the root directory containing your extension files and click Select. The Pack extension dialog reappears. The Extensions root directory box now contains the path to the location you just selected.
 
 1. (Optional) Locate the Private key file box and click Browse. A folder selection dialog box appears.
 

--- a/site/en/docs/extensions/mv3/external_extensions/index.md
+++ b/site/en/docs/extensions/mv3/external_extensions/index.md
@@ -57,7 +57,7 @@ To create a CRX file.
 
 1. Go to `chrome://extensions`.
 
-1. On the top left of the screen, click Pack Extensions. The Pack extensions dialog box appears.
+1. On the top left of the screen, click Pack Extension. The Pack extension dialog box appears.
 
    {% Img src="image/sQ51XsLqKMgSQMCZjIN0B7hlBO02/z4KrJBv7gE0S7wmXhrU2.png", alt="The Pack extension dialog box.", width="800", height="469" %}
 

--- a/site/en/docs/extensions/mv3/external_extensions/index.md
+++ b/site/en/docs/extensions/mv3/external_extensions/index.md
@@ -51,7 +51,7 @@ extensions][malicious-mac]).
 
 ### Creating a CRX file {: #create-crx }
 
-Some of the installation methods described here require a CRX file. The procedure below describes creating one. It must be done with a private key file, which you can create with OpenSLL or any other method of creating a key file. If you do not have one, Chrome will create one for you.
+Some of the installation methods described here require a CRX file. The procedure below shows how to do this. It requires a private key file, which you can create with OpenSLL or any other method of creating a key file. If you do not have one, Chrome will create one for you.
 
 To create a CRX file.
 
@@ -59,15 +59,15 @@ To create a CRX file.
 
 1. On the top left of the screen, click Pack Extensions. The Pack extensions dialog box appears.
 
-   {% Img src="image/sQ51XsLqKMgSQMCZjIN0B7hlBO02/z4KrJBv7gE0S7wmXhrU2.png", alt="ALT_TEXT_HERE", width="800", height="469" %}
+   {% Img src="image/sQ51XsLqKMgSQMCZjIN0B7hlBO02/z4KrJBv7gE0S7wmXhrU2.png", alt="The Pack extension dialog box.", width="800", height="469" %}
 
 1. Locate the Extensions root directory box and click Browse. A folder selection dialog box appears.
 
-1. Locate the root directory containing your extension files and click Select. The Pack extensions dialog reappears. The Extensions root directory box will contain the path to the location you just selected.
+1. Locate the root directory containing your extension files and click Select. The Pack extensions dialog reappears. The Extensions root directory box now contains the path to the location you just selected.
 
 1. (Optional) Locate the Private key file box and click Browse. A folder selection dialog box appears.
 
-1. Locate your private key file and click Open. The Pack extensions dialog reappears. The Private key file box will contain the path to the file you just selected.
+1. Locate your private key file and click Open. The Pack extensions dialog reappears. The Private key file box now contains the path to the file you just selected.
 
 1. Click Pack extension. A confirmation dialog box appears.
 
@@ -94,9 +94,9 @@ id", width="800", height="165" %}
 
 1. Open the directory where your CRX file is located.
 
-1. Drag the CRX file on the the Chrome Extensions page. The Add box appears.
+1. Drag the CRX file on to the Chrome Extensions page. The Add dialog box appears.
 
-   {% Img src="image/sQ51XsLqKMgSQMCZjIN0B7hlBO02/I3qx5JXDNpOQPPrnwoxa.png", alt="ALT_TEXT_HERE", width="800", height="332" %}
+   {% Img src="image/sQ51XsLqKMgSQMCZjIN0B7hlBO02/I3qx5JXDNpOQPPrnwoxa.png", alt="Add dialog box.", width="800", height="332" %}
 
 1. Click Add extension.
 


### PR DESCRIPTION
Let's use "- extensions-news" for ephemeral extensions items and reserve "- extensions" for things that a perennial. (We may never need a perennial tag since all extensions articles are under the same structure. I want to make this change now, while it is easy. 