### PR TITLE
Added missing comma to manifest demo file permissions array

### DIFF
--- a/site/en/docs/extensions/mv3/manifest/activeTab/index.md
+++ b/site/en/docs/extensions/mv3/manifest/activeTab/index.md
@@ -38,7 +38,7 @@ See the [Page Redder][2] sample extension:
   "name": "Page Redder",
   "version": "2.0",
   "permissions": [
-    "activeTab"
+    "activeTab",
     "scripting"
   ],
   "background": {


### PR DESCRIPTION
the comma (,) was missing in the manifest demo file.

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

index.md changes. Comma was missing in manifest demo file for permissions array
-
-