### PR TITLE
[ext-doc] Extension sample page rewrite

### DIFF
--- a/site/en/docs/extensions/mv3/samples/index.md
+++ b/site/en/docs/extensions/mv3/samples/index.md
@@ -9,46 +9,67 @@ description: Intro to extension examples GitHub repository
 
 ## Overview {: #overview }
 
-We aim to provide examples of extensions that address various use cases and call appropriate Chrome
-APIs. Use these to learn how extensions work or as a starting point for building your own
-extensions. These extension examples are available on the [Extensions sample GitHub
-repository][gh-samples].
+The [Extensions sample GitHub
+repository][gh-samples] aims to provide examples of extensions that address various use cases and call appropriate Chrome
+APIs. Use these to learn how extensions work or as a starting point for building your own extensions.
 
-## Categories {: #categories }
+## Choose a category {: #categories }
 
 The examples are currently located under the following directories:
 
-api/
-: Includes extensions that demonstrate the capabilities of a specific API. For example: the action API extension showcases all the 
+[api/][gh-api]
+: Includes extensions that demonstrate the capabilities of a specific API.
 
-examples/
-: a complete extension that implements all the basic features for a given purpose. For example:
+[examples/][gh-examples]
+: a complete extension that implements all the basic features for a given purpose.
 
-cookbooks/
-: extensions that demonstrate a single feature or pattern. For example
+[tutorials/][gh-tutorials]
+: this folder contains examples of how to build an extension over a series of steps. For example: Tabs manager, Focus mode, Reading time, etc.
 
-tutorials/
-: this folder contains examples of how to build an extension over a series of steps. For example: Tabs manager, Focus Mode, Reading Time
+{% Details %}
+{% DetailsSummary %}
+💡 **TIP**: Find an example quickly.
+{% endDetailsSummary %}
 
-💡 Tip to find a particular use of a Chrome API in the repository
+To find a particular example of a Chrome API in the repository, search the repository for "chrome._API_". The following example looks for all uses of "chrome.tabs":
 
-## How to test the examples {: #testing }
+<figure>
+{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/2OW6hjG5RLoupNCzZk8u.png", alt="Searching for chrome.tabs in the extension Github repository", width="800", height="122", class="screenshot screenshot--filled"  %}  <figcaption>
+Chrome.tabs search in the extension Github repository
+  </figcaption>
+</figure>
+
+
+
+{% endDetails %}
+
+## Try them out {: #testing }
 
 To test these examples in your local machine, follow these steps
 
-1. Clone the repository
+1. Clone the repository.
 1. Navigate to the directory of the extension you want to try.
-1. [Load your extension locally][dev-basics-locally]
+1. [Load your extension locally][dev-basics-locally].
 
-Each extension example includes a `readMe.MD` with detailed instructions on how the extension works.
+Each extension example includes a `README.md` with detailed instructions on how the extension works.
 Read it carefully; some extensions run when you click on the extension icon, and others run automatically but only run specific sites. 
+
+{% Aside %}
 
 💡 **TIP**: Extensions cannot run on chrome://extensions, so make sure you navigate to another page before testing an extension. 
 
-## How to collaborate {: #collaborating }
+{% endAside %}
 
 
 
+## Contributing {: #collaborating }
 
+If you encounter any problems with an example, let us know by [posting an issue][gh-issues]. If you want to submit a new extension, check out the [Contributing Guide][gh-contributing] to find out how to submit a new example to the collection.
+
+[gh-issues]: https://github.com/GoogleChrome/chrome-extensions-samples/issues
+[gh-examples]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/examples
+[gh-tutorials]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/tutorials
+[gh-api]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api
 [gh-samples]: https://github.com/GoogleChrome/chrome-extensions-samples
 [dev-basics-locally]: /docs/extensions/mv3/getstarted/development-basics/
+[gh-contributing]: https://github.com/GoogleChrome/chrome-extensions-samples/blob/main/CONTRIBUTING.md

--- a/site/en/docs/extensions/mv3/samples/index.md
+++ b/site/en/docs/extensions/mv3/samples/index.md
@@ -18,13 +18,13 @@ APIs. Use these to learn how extensions work or as a starting point for building
 The examples are currently located under the following directories:
 
 [api/][gh-api]
-: These extensions were designed to demonstrate the capabilities of a specific API. For example, the [Action API example][gh-action] showcases extension IU elements such as the popup, tooltip, and badges among others. 
+: Extensions designed to demonstrate the capabilities of a specific API. For example, the [Action API example][gh-action] showcases extension IU elements such as the popup, tooltip, and badges among others. 
 
 [examples/][gh-examples]
-: These are complete extensions that implement all the basic features for a given purpose.
+: Complete extensions that implement all the basic features for a given purpose.
 
 [tutorials/][gh-tutorials]
-: These examples include step-by-step instructions on how to build an extension. A few examples include [Tabs manager][tut-tabs-man], [Focus mode][tut-fm], and [Reading time][tut-rt].
+: Examples covered in the [tutorials][gs-tutorials]. A few examples include [Tabs manager][tut-tabs-man], [Focus mode][tut-fm], and [Reading time][tut-rt].
 
 {% Details %}
 {% DetailsSummary %}
@@ -64,6 +64,7 @@ If you encounter any problems with an example, let us know by [posting an issue]
 [gh-issues]: https://github.com/GoogleChrome/chrome-extensions-samples/issues
 [gh-samples]: https://github.com/GoogleChrome/chrome-extensions-samples
 [gh-tutorials]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/tutorials
+[gs-tutorials]: /docs/extensions/mv3/getstarted/#tutorial
 [tut-fm]: /docs/extensions/mv3/getstarted/tut-focus-mode/
 [tut-rt]: /docs/extensions/mv3/getstarted/tut-reading-time/
 [tut-tabs-man]: /docs/extensions/mv3/getstarted/tut-tabs-manager/

--- a/site/en/docs/extensions/mv3/samples/index.md
+++ b/site/en/docs/extensions/mv3/samples/index.md
@@ -2,7 +2,7 @@
 layout: "layouts/doc-post.njk"
 title: "Samples"
 seoTitle: "Chrome Extension examples"
-date: 2022-12-12
+date: 2022-12-16
 # updated: 2021-07-22
 description: Intro to extension examples GitHub repository 
 ---

--- a/site/en/docs/extensions/mv3/samples/index.md
+++ b/site/en/docs/extensions/mv3/samples/index.md
@@ -1,9 +1,54 @@
 ---
 layout: "layouts/doc-post.njk"
 title: "Samples"
-#date: TODO
-#updated: TODO
-#description: TODO
+seoTitle: "Chrome Extension examples"
+date: 2022-12-12
+# updated: 2021-07-22
+description: Intro to extension examples GitHub repository 
 ---
 
-Samples for Chrome Extensions are available [on GitHub](https://github.com/GoogleChrome/chrome-extensions-samples).
+## Overview {: #overview }
+
+We aim to provide examples of extensions that address various use cases and call appropriate Chrome
+APIs. Use these to learn how extensions work or as a starting point for building your own
+extensions. These extension examples are available on the [Extensions sample GitHub
+repository][gh-samples].
+
+## Categories {: #categories }
+
+The examples are currently located under the following directories:
+
+api/
+: Includes extensions that demonstrate the capabilities of a specific API. For example: the action API extension showcases all the 
+
+examples/
+: a complete extension that implements all the basic features for a given purpose. For example:
+
+cookbooks/
+: extensions that demonstrate a single feature or pattern. For example
+
+tutorials/
+: this folder contains examples of how to build an extension over a series of steps. For example: Tabs manager, Focus Mode, Reading Time
+
+💡 Tip to find a particular use of a Chrome API in the repository
+
+## How to test the examples {: #testing }
+
+To test these examples in your local machine, follow these steps
+
+1. Clone the repository
+1. Navigate to the directory of the extension you want to try.
+1. [Load your extension locally][dev-basics-locally]
+
+Each extension example includes a `readMe.MD` with detailed instructions on how the extension works.
+Read it carefully; some extensions run when you click on the extension icon, and others run automatically but only run specific sites. 
+
+💡 **TIP**: Extensions cannot run on chrome://extensions, so make sure you navigate to another page before testing an extension. 
+
+## How to collaborate {: #collaborating }
+
+
+
+
+[gh-samples]: https://github.com/GoogleChrome/chrome-extensions-samples
+[dev-basics-locally]: /docs/extensions/mv3/getstarted/development-basics/

--- a/site/en/docs/extensions/mv3/samples/index.md
+++ b/site/en/docs/extensions/mv3/samples/index.md
@@ -35,7 +35,7 @@ To find all examples of a specific Chrome API use Github's search engine to look
 
 <figure>
 {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/2OW6hjG5RLoupNCzZk8u.png", alt="Searching for chrome.tabs in the extension Github repository", width="800", height="122", class="screenshot screenshot--filled"  %}  <figcaption>
-Chrome.tabs search in the extension Github repository
+<code>Chrome.tabs</code> search in the extension Github repository.
   </figcaption>
 </figure>
 
@@ -49,8 +49,8 @@ To test these examples in your local machine, follow these steps:
 1. Navigate to the directory of the extension you want to try.
 1. [Load your extension locally][dev-basics-locally].
 
-Each extension example includes a `README.md` with detailed instructions on how the extension works.
-Read it carefully; each extension is different. For example, some extensions run by clicking on the extension icon, while others run automatically but only run on specific sites. 
+Each extension example includes a `README.md` with instructions on how the extension works.
+Read the instructions carefully; each extension is different. For example, some extensions run by clicking on the extension icon, while others run automatically but only run on specific sites. 
 
 ## Contributing samples {: #collaborating }
 

--- a/site/en/docs/extensions/mv3/samples/index.md
+++ b/site/en/docs/extensions/mv3/samples/index.md
@@ -2,8 +2,8 @@
 layout: "layouts/doc-post.njk"
 title: "Samples"
 seoTitle: "Chrome Extension examples"
-date: 2022-12-16
-# updated: 2021-07-22
+date: 2020-12-11
+updated: 2022-12-16
 description: Intro to extension examples GitHub repository 
 ---
 

--- a/site/en/docs/extensions/mv3/samples/index.md
+++ b/site/en/docs/extensions/mv3/samples/index.md
@@ -52,7 +52,7 @@ To test these examples in your local machine, follow these steps:
 Each extension example includes a `README.md` with detailed instructions on how the extension works.
 Read it carefully; each extension is different. For example, some extensions run by clicking on the extension icon, while others run automatically but only run on specific sites. 
 
-## Contribute to this repository {: #collaborating }
+## Contributing samples {: #collaborating }
 
 If you encounter any problems with an example, let us know by [posting an issue][gh-issues]. If you want to submit a new extension, check out the [Contributing Guide][gh-contributing] to find out how to submit a new example to this collection.
 

--- a/site/en/docs/extensions/mv3/samples/index.md
+++ b/site/en/docs/extensions/mv3/samples/index.md
@@ -52,7 +52,7 @@ To test these examples in your local machine, follow these steps
 1. [Load your extension locally][dev-basics-locally].
 
 Each extension example includes a `README.md` with detailed instructions on how the extension works.
-Read it carefully; some extensions run when you click on the extension icon, and others run automatically but only run specific sites. 
+Read it carefully; each extension is different. For example, some extensions run by clicking on the extension icon, others run automatically but only run specific sites, among others. 
 
 {% Aside %}
 

--- a/site/en/docs/extensions/mv3/samples/index.md
+++ b/site/en/docs/extensions/mv3/samples/index.md
@@ -10,28 +10,28 @@ description: Intro to extension examples GitHub repository
 ## Overview {: #overview }
 
 The [Extensions sample GitHub
-repository][gh-samples] aims to provide examples of extensions that address various use cases and call appropriate Chrome
+repository][gh-samples] provides examples of extensions that address various use cases and call appropriate Chrome
 APIs. Use these to learn how extensions work or as a starting point for building your own extensions.
 
-## Choose a category {: #categories }
+## Browse by category {: #categories }
 
 The examples are currently located under the following directories:
 
 [api/][gh-api]
-: Includes extensions that demonstrate the capabilities of a specific API.
+: These extensions were designed to demonstrate the capabilities of a specific API. For example, the [Action API example][gh-action] showcases extension IU elements such as the popup, tooltip, and badges among others. 
 
 [examples/][gh-examples]
-: a complete extension that implements all the basic features for a given purpose.
+: These are complete extensions that implement all the basic features for a given purpose.
 
 [tutorials/][gh-tutorials]
-: this folder contains examples of how to build an extension over a series of steps. For example: Tabs manager, Focus mode, Reading time, etc.
+: These examples include step-by-step instructions on how to build an extension. A few examples include [Tabs manager][tut-tabs-man], [Focus mode][tut-fm], and [Reading time][tut-rt].
 
 {% Details %}
 {% DetailsSummary %}
-💡 **TIP**: Find an example quickly.
+💡 **TIP**: How can I find examples of a particular API quickly?
 {% endDetailsSummary %}
 
-To find a particular example of a Chrome API in the repository, search the repository for "chrome._API_". The following example looks for all uses of "chrome.tabs":
+To find all examples of a specific Chrome API use Github's search engine to look for "chrome.NAME_OF_API" in this repository. The following example searches for all uses of "chrome.tabs":
 
 <figure>
 {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/2OW6hjG5RLoupNCzZk8u.png", alt="Searching for chrome.tabs in the extension Github repository", width="800", height="122", class="screenshot screenshot--filled"  %}  <figcaption>
@@ -39,37 +39,31 @@ Chrome.tabs search in the extension Github repository
   </figcaption>
 </figure>
 
-
-
 {% endDetails %}
 
 ## Try them out {: #testing }
 
-To test these examples in your local machine, follow these steps
+To test these examples in your local machine, follow these steps:
 
 1. Clone the repository.
 1. Navigate to the directory of the extension you want to try.
 1. [Load your extension locally][dev-basics-locally].
 
 Each extension example includes a `README.md` with detailed instructions on how the extension works.
-Read it carefully; each extension is different. For example, some extensions run by clicking on the extension icon, others run automatically but only run specific sites, among others. 
+Read it carefully; each extension is different. For example, some extensions run by clicking on the extension icon, while others run automatically but only run on specific sites. 
 
-{% Aside %}
+## Contribute to this repository {: #collaborating }
 
-💡 **TIP**: Extensions cannot run on chrome://extensions, so make sure you navigate to another page before testing an extension. 
+If you encounter any problems with an example, let us know by [posting an issue][gh-issues]. If you want to submit a new extension, check out the [Contributing Guide][gh-contributing] to find out how to submit a new example to this collection.
 
-{% endAside %}
-
-
-
-## Contributing {: #collaborating }
-
-If you encounter any problems with an example, let us know by [posting an issue][gh-issues]. If you want to submit a new extension, check out the [Contributing Guide][gh-contributing] to find out how to submit a new example to the collection.
-
-[gh-issues]: https://github.com/GoogleChrome/chrome-extensions-samples/issues
-[gh-examples]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/examples
-[gh-tutorials]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/tutorials
-[gh-api]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api
-[gh-samples]: https://github.com/GoogleChrome/chrome-extensions-samples
 [dev-basics-locally]: /docs/extensions/mv3/getstarted/development-basics/
+[gh-action]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api/action
+[gh-api]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api
 [gh-contributing]: https://github.com/GoogleChrome/chrome-extensions-samples/blob/main/CONTRIBUTING.md
+[gh-examples]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/examples
+[gh-issues]: https://github.com/GoogleChrome/chrome-extensions-samples/issues
+[gh-samples]: https://github.com/GoogleChrome/chrome-extensions-samples
+[gh-tutorials]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/tutorials
+[tut-fm]: /docs/extensions/mv3/getstarted/tut-focus-mode/
+[tut-rt]: /docs/extensions/mv3/getstarted/tut-reading-time/
+[tut-tabs-man]: /docs/extensions/mv3/getstarted/tut-tabs-manager/


### PR DESCRIPTION
Fixes #4487

Changes proposed in this pull request:

- Describes how to use the [chrome-extensions-examples](https://github.com/GoogleChrome/chrome-extensions-samples) repository.

**Staged link**
[Samples](https://deploy-preview-4605--developer-chrome-com.netlify.app/docs/extensions/mv3/samples/)