### PR TITLE
Link Prerender extension posts

### DIFF
--- a/site/en/blog/extension-instantnav/index.md
+++ b/site/en/blog/extension-instantnav/index.md
@@ -9,6 +9,7 @@ hero: 'image/zKrSUSkPboWMTTSEkowJbqw5Egi2/r5IdmaTdE5wBS2d6CCQY.png'
 alt: >
   Instant navigation in a tab.
 date: 2022-11-30
+updated: 2022-12-14
 tags:
  - extensions-news
 ---
@@ -19,8 +20,8 @@ preloading navigations. See below for details.
 Chrome has been working hard at making navigation fast. Instant Navigation
 technologies such as [Back/Forward Cache](https://web.dev/bfcache/)
 ([shipped](https://chromestatus.com/feature/6279906713403392) on desktop in
-Chrome 96) and [Speculation Rules](https://chromestatus.com/feature/5740655424831488)
-(shipped in Chrome 103) improve both the going back and going forward
+Chrome 96) and [Speculation Rules](/blog/prerender-pages/)
+([shipped](https://chromestatus.com/feature/5740655424831488) in Chrome 103) improve both the going back and going forward
 experience. In this post we will explore the updates we’ve made to browser
 extensions APIs to accommodate these new workflows.
 

--- a/site/en/blog/extension-instantnav/index.md
+++ b/site/en/blog/extension-instantnav/index.md
@@ -9,7 +9,6 @@ hero: 'image/zKrSUSkPboWMTTSEkowJbqw5Egi2/r5IdmaTdE5wBS2d6CCQY.png'
 alt: >
   Instant navigation in a tab.
 date: 2022-11-30
-updated: 2022-12-14
 tags:
  - extensions-news
 ---

--- a/site/en/blog/prerender-pages/index.md
+++ b/site/en/blog/prerender-pages/index.md
@@ -7,7 +7,7 @@ description: |
 authors:
  - tunetheweb
 date: 2022-12-02
-updated: 2022-12-14
+#updated: 2022-12-02
 hero: image/W3z1f5ZkBJSgL1V1IfloTIctbIF3/eohdiqaZlxnWen7TT66M.jpg
 alt: City road at dusk with a long exposure of car lights giving impression of speed
 tags:

--- a/site/en/blog/prerender-pages/index.md
+++ b/site/en/blog/prerender-pages/index.md
@@ -7,7 +7,7 @@ description: |
 authors:
  - tunetheweb
 date: 2022-12-02
-#updated: 2022-12-02
+updated: 2022-12-14
 hero: image/W3z1f5ZkBJSgL1V1IfloTIctbIF3/eohdiqaZlxnWen7TT66M.jpg
 alt: City road at dusk with a long exposure of car lights giving impression of speed
 tags:
@@ -343,6 +343,10 @@ Be aware that some prerendering may be taking place due to the address bar prere
 
 Remember to also look at pages which have no prerenders, as that could indicate these pages are not eligible for prerendering, even from the address bar. That may mean you are not benefiting from this performance enhancement. The Chrome team is looking to add extra tooling to test for Prerender eligibility perhaps [similar to the bfcache testing tool](https://web.dev/bfcache/#test-to-ensure-your-pages-are-cacheable), and also potentially add an API to expose why a prerender failed.
 
+## Impact on extensions
+
+See the dedicated post on [Chrome Extensions: Extending API to support Instant Navigation](/blog/extension-instantnav/) which details some additional considerations extension authors may need to think about for prerendered pages.
+
 ## Feedback
 
 Prerendering is in active development by the Chrome team, and there are plenty of plans to expand the scope of what has been made available in the Chrome 108 release. We welcome any feedback on [the GitHub repo](https://github.com/WICG/nav-speculation/issues) or via [our issue tracker](https://bugs.chromium.org/p/chromium/issues/list), and look forward to hearing and sharing case studies of this exciting new API.
@@ -352,6 +356,7 @@ Prerendering is in active development by the Chrome team, and there are plenty o
 - [Introducing NoState Prefetch](/blog/nostate-prefetch/)
 - [Speculation Rules API](https://github.com/jeremyroman/alternate-loading-modes/blob/main/triggers.md#speculation-rules)
 - [The Navigational speculation GitHub repo](https://github.com/WICG/nav-speculation/)
+- [Chrome Extensions: Extending API to support Instant Navigation](/blog/extension-instantnav/)
 
 ## Acknowledgements
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Links the [Prerender pages](https://developer.chrome.com/blog/prerender-pages/) and [Extensions post on Prerender](https://developer.chrome.com/blog/extension-instantnav/)