### PR TITLE
Docs collection documentation.

### DIFF
--- a/site/_data/docs/handbook/toc.yml
+++ b/site/_data/docs/handbook/toc.yml
@@ -7,6 +7,7 @@
     - url: /docs/handbook/how-to/add-a-blog-post
     - url: /docs/handbook/how-to/add-an-api
     - url: /docs/handbook/how-to/add-a-collection-page
+    - url: /docs/handbook/how-to/add-a-collection-docs-page
     - url: /docs/handbook/how-to/add-media
     - url: /docs/handbook/how-to/add-an-author
     - url: /docs/handbook/how-to/add-a-tag

--- a/site/_includes/layouts/collection-in-docs.njk
+++ b/site/_includes/layouts/collection-in-docs.njk
@@ -39,7 +39,7 @@
 
           {# Use tag to generate collection #}
           {% for post in collections.tags[collection_tag].posts.en %}
-            {% if loop.index0 < 6 %}
+            {% if loop.index0 < 12 %}
               {{ blogCard(post) }}
             {% endif %}
           {% endfor %}

--- a/site/en/docs/handbook/how-to/add-a-collection-docs-page/index.md
+++ b/site/en/docs/handbook/how-to/add-a-collection-docs-page/index.md
@@ -1,8 +1,8 @@
 ---
 layout: 'layouts/doc-post.njk'
 title: Add a collection page
-description: 'Add a landing page for a project or initiative.'
-date: 2022-12-14
+description: 'Add a landing page within a doc set for a project or initiative.'
+date: 2022-12-15
 ---
 
 These collections can live in your documentation as either tradition [collections](/docs/handbook/how-to/add-a-collection-page/), which are built with tags, or like a [landing page](/docs/handbook/how-to/add-a-landing-page/) with a customized set of docs or articles.

--- a/site/en/docs/handbook/how-to/add-a-collection-docs-page/index.md
+++ b/site/en/docs/handbook/how-to/add-a-collection-docs-page/index.md
@@ -1,0 +1,78 @@
+---
+layout: 'layouts/doc-post.njk'
+title: Add a collection page
+description: 'Add a landing page for a project or initiative.'
+date: 2022-12-14
+---
+
+These collections can live in your documentation as either tradition [collections](/docs/handbook/how-to/add-a-collection-page/), which are built with tags, or like a [landing page](/docs/handbook/how-to/add-a-landing-page/) with a customized set of docs or articles.
+
+## Choose the collection method
+
+* For an ordered set, list the articles.
+* For an unordered set, use a tag.
+
+### List of articles
+
+If you'd like a set of docs and articles in a custom order, you can add the URL string of each to the list of `articles` in the page YAML.
+
+```yaml
+articles:
+  - url: /docs/.../
+  - url: /articles/.../
+```
+
+The existence of an `articles` list will always be prioritized over tags.
+
+### Tagged collection.
+
+Choose a tag for your collection. It will become the `<COLLECTION_NAME>`. You can use an
+[existing tag](https://github.com/GoogleChrome/developer.chrome.com/blob/main/site/_data/i18n/tags.yml)
+or [create a new one](/docs/handbook/how-to/add-a-tag/).
+
+#### Tag content
+
+Make sure all posts / articles / docs that will be bart of the collection are
+tagged with the chosen tag (such as, `tags: ["capabilities"]`).
+
+## Create collection landing page
+
+Create a new page in your `site/en/docs/` directory:
+
+```bash
+├── site
+│   ├── en
+│   │   ├── docs
+│   │   │   ├── <Your Doc Set>
+│   │   │   │   ├── <COLLECTION_NAME>
+│   │   │   │   │     └── index.md
+```
+
+### Configure the page
+
+Add the following frontmatter to the `index.md` file:
+
+```bash
+---
+title: '<COLLECTION_NAME_OR_CUSTOM_TITLE>'
+description: '...'
+subhead: '...'
+layout: 'layouts/collection-in-docs.njk'
+collection_tag: '<CUSTOM-TAG-NAME>'
+articles:
+  - url: /docs/.../
+  - url: /articles/.../
+---
+```
+
+The existence of an `articles` list will always be prioritized over tags.
+
+You can leave the content of the `index.md` empty, or add custom markup as needed.
+
+Content supports markdown syntax with some additional features and shortcodes.
+See the [components guide](/docs/handbook/components/) for a full list of supported elements.
+
+We use an image CDN and GCS bucket to ensure that images and
+videos are served in a performant, responsive manner.
+Take a look at the guide on [uploading media](/docs/handbook/how-to/add-media)
+to learn how to add images and videos to your docs.

--- a/site/en/docs/handbook/how-to/add-a-collection-docs-page/index.md
+++ b/site/en/docs/handbook/how-to/add-a-collection-docs-page/index.md
@@ -1,7 +1,8 @@
 ---
 layout: 'layouts/doc-post.njk'
 title: Add a collection page
-description: 'Add a landing page within a doc set for a project or initiative.'
+description: >
+  Add a landing page within a doc set for a project or initiative.
 date: 2022-12-15
 ---
 

--- a/site/en/docs/handbook/how-to/add-a-collection-docs-page/index.md
+++ b/site/en/docs/handbook/how-to/add-a-collection-docs-page/index.md
@@ -25,7 +25,7 @@ articles:
 
 The existence of an `articles` list will always be prioritized over tags.
 
-### Tagged collection.
+### Tagged collection
 
 Choose a tag for your collection. It will become the `<COLLECTION_NAME>`. You can use an
 [existing tag](https://github.com/GoogleChrome/developer.chrome.com/blob/main/site/_data/i18n/tags.yml)

--- a/site/en/docs/handbook/how-to/add-a-collection-page/index.md
+++ b/site/en/docs/handbook/how-to/add-a-collection-page/index.md
@@ -12,10 +12,14 @@ Choose a tag for your collection. It will become the `<COLLECTION_NAME>`. You ca
 [existing tag](https://github.com/GoogleChrome/developer.chrome.com/blob/main/site/_data/i18n/tags.yml)
 or [create a new one](/docs/handbook/how-to/add-a-tag/).
 
-## Tag content
+### Tag content
 
 Make sure all posts / articles / docs that will be bart of the collection are
-tagged with the chosen tag (e.g. `tags: [“capabilities”]`).
+tagged with the chosen tag.
+
+```yaml
+tags: ["<COLLECTION_NAME>"]
+```
 
 ## Create collection landing page
 
@@ -32,7 +36,7 @@ Create a new page in the `site/en` directory:
 
 Add the following frontmatter to the `index.md` file:
 
-```bash
+```yaml
 ---
 title: '<COLLECTION_NAME_OR_CUSTOM_TITLE>'
 description: '<COLLECTION_DESCRIPTION>'

--- a/site/en/docs/handbook/how-to/add-a-collection-page/index.md
+++ b/site/en/docs/handbook/how-to/add-a-collection-page/index.md
@@ -1,7 +1,8 @@
 ---
 layout: 'layouts/doc-post.njk'
 title: Add a collection page
-description: 'Add a landing page for a project or initiative.'
+description: >
+  Add a landing page for a project or initiative
 date: 2022-03-08
 ---
 

--- a/site/en/docs/handbook/how-to/add-a-glitch-embed/index.md
+++ b/site/en/docs/handbook/how-to/add-a-glitch-embed/index.md
@@ -1,6 +1,6 @@
 ---
 layout: 'layouts/doc-post.njk'
-title: Add a Glitch Embed
+title: Add a Glitch embed
 description: 'Add a Glitch embed to a post.'
 date: 2020-11-23
 ---

--- a/site/en/docs/handbook/how-to/add-a-landing-page/index.md
+++ b/site/en/docs/handbook/how-to/add-a-landing-page/index.md
@@ -1,11 +1,11 @@
 ---
 layout: 'layouts/doc-post.njk'
-title: Add a Landing Page
-description: 'Add a Landing Page'
+title: Add a landing page
+description: 'Add a landing page'
 date: 2022-12-29
 ---
 
-## Featured Card
+## Create a Featured Card
 
 Feature Card contains content and actions that relate information about a single topic. You can use HTML entities (```&mdash;```) or basic Markdown styling (```*emphasis*```) inside these string arguments.
 

--- a/site/en/docs/handbook/how-to/add-a-youtube-embed/index.md
+++ b/site/en/docs/handbook/how-to/add-a-youtube-embed/index.md
@@ -1,6 +1,6 @@
 ---
 layout: 'layouts/doc-post.njk'
-title: Add a YouTube Embed
+title: Add a YouTube embed
 description: 'Add a YouTube embed to a post.'
 date: 2020-11-30
 ---

--- a/site/en/docs/handbook/how-to/add-an-iframe/index.md
+++ b/site/en/docs/handbook/how-to/add-an-iframe/index.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/doc-post.njk'
-title: Add an IFrame
-description: 'Add an IFrame to a post.'
+title: Add an iframe
+description: 'Add an iframe to a post.'
 date: 2020-11-23
 ---
 


### PR DESCRIPTION
Documentation for our new docs collection page.

An existing implementation of this is [Debugging Attribution Reporting](https://developer.chrome.com/docs/privacy-sandbox/attribution-reporting-debugging/)

Instructions: https://deploy-preview-4635--developer-chrome-com.netlify.app/docs/handbook/how-to/add-a-collection-docs-page/