### PR TITLE
fix: translation of  [Does not use]

### DIFF
--- a/site/zh/docs/lighthouse/best-practices/uses-http2/index.md
+++ b/site/zh/docs/lighthouse/best-practices/uses-http2/index.md
@@ -1,6 +1,6 @@
 ---
 layout: 'layouts/doc-post.njk'
-title: 不要为其所有资源使用 HTTP/2
+title: 没有为所有资源使用 HTTP/2
 description: 了解为什么 HTTP/2 对页面加载时间很重要以及如何在服务器上启用 HTTP/2。
 date: 2019-05-02
 updated: 2019-08-28
@@ -26,6 +26,6 @@ Lighthouse 会收集页面请求的所有资源，并检查每个资源的 HTTP 
 
 ## 资源
 
-- [**不要为其所有资源使用 HTTP/2**审计的源代码](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/dobetterweb/uses-http2.js)
+- [**没有为所有资源使用 HTTP/2**审计的源代码](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/dobetterweb/uses-http2.js)
 - [HTTP/2 简介](https://developers.google.com/web/fundamentals/performance/http2/)
 - [HTTP/2 常见问题](https://http2.github.io/faq/)


### PR DESCRIPTION
Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- In the English version, combining the context of this article, I think it means that we should use HTTP2 for as many resources as we can. But in the Chinese version, the meaning changed to [For some resources, you should not use http2]. So I changed the translation to [You didn't use http2 for all resouces]. Or I can change it to '为所有的资源使用 Http/2' [Use HTTP/2 for all of your resources] 
-
-