### PR TITLE
fix : replace unavailable link

### DIFF
--- a/site/en/docs/apps/manifest/sandbox/index.md
+++ b/site/en/docs/apps/manifest/sandbox/index.md
@@ -64,7 +64,7 @@ Sandboxed page may only be specified when using [`manifest_version`][8] 2 or abo
 
 [1]: https://blog.chromium.org/2020/08/changes-to-chrome-app-support-timeline.html
 [2]: /apps/migration
-[3]: /apps/webview_tag
+[3]: /extensions/reference/webviewTag/
 [4]: /extensions/contentSecurityPolicy
 [5]: https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox
 [6]: /extensions/sandboxingEval


### PR DESCRIPTION
replaced link from /apps/webview_tag to  /extensions/reference/webviewTag/ because the link to /apps/webview_tag returned 404

Changes proposed in this pull request:

-removed link to /apps/webview_tag
-added link to /extensions/reference/webviewTag/