### PR TITLE
fix: deleted trailing comma from description

### DIFF
--- a/site/en/docs/extensions/mv3/getstarted/tut-reading-time/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/tut-reading-time/index.md
@@ -49,7 +49,7 @@ extension. Create a `manifest.json` file in the _root_ of the project and add th
   "manifest_version": 3,
   "name": "Reading time",
   "version": "1.0",
-  "description": "Add the reading time to Chrome Extension documentation articles",
+  "description": "Add the reading time to Chrome Extension documentation articles"
 }
 ```
 


### PR DESCRIPTION
Fixes #4656

Changes proposed in this pull request:

- Removed trailing comma from description.