### PR TITLE
Doc titles and descriptions: Chrome concepts

### DIFF
--- a/site/en/docs/web-platform/origin-trial-troubleshooting/index.md
+++ b/site/en/docs/web-platform/origin-trial-troubleshooting/index.md
@@ -1,7 +1,12 @@
 ---
 layout: 'layouts/doc-post.njk'
-title: Troubleshooting Chrome's origin trials
-subhead: Origin trials are a way to test a new or experimental web platform feature. This guide explains how to troubleshoot common problems with trial tokens in meta tags, headers, and scripts. You'll also learn about debugging support in Chrome DevTools.
+title: Troubleshoot Chrome origin trials
+subhead: >
+  Address common problems with trial tokens in meta tags, headers, and
+  scripts.
+description: >
+  Address common problems with trial tokens in meta tags, headers, and
+  scripts. You'll also learn about debugging support in Chrome DevTools.
 authors:
   - samdutton
 date: 2021-08-11
@@ -23,7 +28,6 @@ If you encounter a bug with origin trials in Chrome, please
 [submit a new issue](https://github.com/GoogleChrome/OriginTrials/issues/new) on the Chrome origin 
 trials GitHub repo.
 {% endAside %}
-
 
 ## Checklist
 
@@ -124,14 +128,14 @@ From Chrome 93 DevTools provides origin trial information in the
 Application panel for the selected frame.
 
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/D31iwicSkRzUJLTlhAZh.png", alt="Chrome DevTools 
-origin trials information in the Application panel", width="800", height="424" %}
+origin trials information in the Application panel.", width="800", height="424" %}
 
 Expand the top frame to inspect origin trial tokens available for a subframe. For example, for the 
 demo page at [ot-iframe.glitch.me](https://ot-iframe.glitch.me), you can see that the page in the 
 iframe provides a token.
 
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/CMxi5ePZrKhoa5lpaIrf.png", alt="Chrome DevTools 
-  Application panel, showing origin trial tokens for page in iframe", width="800", height="403" %}
+  Application panel, showing origin trial tokens for page in iframe.", width="800", height="403" %}
 
 * **Token Status**: Whether the page has a valid token. Note that for some origin trials there may be 
 other factors, such as geographical restrictions, that mean the origin trial feature is not 
@@ -141,8 +145,9 @@ explains the meaning of each of the codes for origin trials.
 token.
 * **Expiry Time**: the maximum (latest) possible expiry date/time for the token, which will normally 
 match the end of the trial. This is not the same as the Valid Until date for the token displayed 
-on your origin trial's My Registrations](/origintrials/#/trials/my) 
-page, which shows how long the token is currently valid for, and [can be extended](https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md#21-what-does-the-valid-until-date-mean-for-my-tokens).
+in [My Registrations](/origintrials/#/trials/my),
+, which shows how long the token is currently valid for, and
+[can be extended](https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md#21-what-does-the-valid-until-date-mean-for-my-tokens).
 * **Usage Restriction**: Usage limits, which [can be set](https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md#20-what-are-the-options-for-usage-restrictions-on-tokens) for some trials.
 * **Third Party**: Whether [third-party matching](https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md#18-how-can-i-enable-an-experimental-feature-as-embedded-content-on-different-domains) 
 is enabled for the token. This is available for some origin trials, where a trial feature needs to 
@@ -228,10 +233,9 @@ include the scheme, hostname, or port.<br>
 
 ---
 
-## It's not working! 🤔
+## It's not working! <span role="img" aria="Thinking emoji.">🤔</span>
 
 If your origin trial isn't working as expected, make sure you've met the following conditions.
-
 
 ### You're testing in Chrome, not Chromium or another browser {: #chrome}
 
@@ -282,21 +286,24 @@ Make sure to use appropriate keywords and syntax for origin trial tokens.
 {: #whole}
 
 {% Aside 'caution' %}
-These examples truncate the token value. Make sure to **check the whole token**—or at least the start 
+These examples truncate the token value. Make sure to **check the whole token**, or at least the start 
 and end of it! It's easy to accidentally leave out a character.
 
 A complete token looks like this:
 
-<pre>Bj3DysCv1VjknU4jJvkDEwnQZK/vmse1rcd5jZogunrkwtKW92
+```txt
+Bj3DysCv1VjknU4jJvkDEwnQZK/vmse1rcd5jZogunrkwtKW92
 vmygya6gyKe5GveTObBy3NT5DiC8yiiXnXGwMAAABZeyJvcmlnaW9i7
 iJodHXwczovL3NpbXBsLmluZm86NDQzIiwiZmVhdHVyZSI6Ik5BIiwi
-ZXhwaXH5IjoxNjMxNjYzOTk5LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=</pre>
+ZXhwaXH5IjoxNjMxNjYzOTk5LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=
+```
+
 {% endAside %}
 
 For first-party usage, a token can be provided in an `origin-trial` meta tag:
 
 ```html
-    <meta http-equiv="origin-trial" content="Aj4DysCv3VjknU3...">
+<meta http-equiv="origin-trial" content="Aj4DysCv3VjknU3...">
 ```
 
 Alternatively, a token can be provided in an `Origin-Trial` response header. Here's an example using 
@@ -328,7 +335,6 @@ Third-party tokens **must** be provided via JavaScript.
 
 {% endAside %}
 
-
 ### First-party token origin matches page origin {: #origin-first}
 
 Make sure the **Web Origin** value selected when you register for a trial matches the origin of the 
@@ -337,7 +343,7 @@ page that has the meta tag or header which provides the token.
 For example, if you selected `https://example.com` as the **Web Origin**:
 
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/GFlAHALbXwTlJWRw7yxc.jpg", alt="Chrome Origin Trials 
-page showing https://example.com selected as Web Origin", width="800", height="549" %}
+page showing https://example.com selected as Web Origin.", width="800", height="549" %}
 
 You might get a token value like this:
 
@@ -349,14 +355,14 @@ Check that this value matches the token used on the page you're troubleshooting.
 For a token provided in a meta tag, check the HTML:
 
 ```html
-    <meta http-equiv="origin-trial" content="Aj4DysCv3VjknU3...">
+  <meta http-equiv="origin-trial" content="Aj4DysCv3VjknU3...">
 ```
 
 For a token provided in a header, you can check the token value from the 
 [Chrome DevTools Network panel](/docs/devtools/network/) under **Response Headers**:
 
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/g0PNnOiSxlaqdSHkmBLx.png", alt="Chrome DevTools 
-Network panel showing origin trials response header", width="800", height="616" %}
+Network panel showing origin trials response header.", width="800", height="616" %}
 
 
 ### First-party token is served from the origin that uses it {: #token-first}
@@ -374,12 +380,13 @@ out a feature in a third-party context. Not every origin trial offers third-part
 
 ### Third-party token origin matches script origin {: #origin-third}
 
-You can register to participate in an origin trial for scripts that are injected on other origins. 
+You can register to participate in an origin trial for scripts that are injected on other origins.
+
 For example, if you want scripts that are served from `javascript-library.example` to take part in 
 an origin trial, you need to register a token with third-party matching for `javascript-library.example`. 
 
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/IExwqTS7Snel52lr04AG.png", alt="Chrome origin trials 
-registration page showing third-party matching selected", width="800", height="612" %}
+registration page showing third-party matching selected.", width="800", height="612" %}
 
 The origin value for a third-party token must match the origin of the script that injects it.
 
@@ -472,12 +479,13 @@ My Registrations page showing Valid Until date", width="800", height="612" %}
 Chrome DevTools displays Status `Success` if the token is still valid:
 
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/fO8LVqZb8Hv0kIg6HdK7.png", alt="Chrome DevTools 
-origin trials information in the Application panel, highlighting Status: Success", width="800", height="424" %}
+origin trials information in the Application panel, highlighting Status: Success.", width="800", height="424" %}
 
-If your token has expired, DevTools will display Status `Expired` and your [My&nbsp;Registrations&nbsp;page](/origintrials/#/trials/my) for the trial will display an **Expired Tokens** section:
+If your token has expired, DevTools will display the status `Expired` and your
+[My Registrations page](/origintrials/#/trials/my) will display an **Expired Tokens** section.
 
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/l61ghrJpV0SvwGlRbXlz.png", alt="Chrome origin trials 
-My Registrations page showing expired tokens", width="800", height="591" %}
+My Registrations page showing expired tokens.", width="800", height="591" %}
 
 
 ### The origin trial hasn't ended {: #trial-ended}
@@ -485,7 +493,7 @@ My Registrations page showing expired tokens", width="800", height="591" %}
 You can check the end date for an origin trial from its [registration page](/origintrials/#/trials/active):
 
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/0f2Wdcfj3D3UwZmWx33S.png", alt="Chrome Origin Trials
-page for First Party Sets & SameParty with Trial Available details highlighted", width="800", height="737" %}
+page for First Party Sets & SameParty with Trial Available details highlighted.", width="800", height="737" %}
 
 For trials that have ended, DevTools will display something like this:
 
@@ -512,9 +520,9 @@ Some origin trials are unavailable to certain users, even if a valid token is pr
 
 If a trial isn't available for the current user, Chrome DevTools will display a `TrialNotAllowed` warning:
 
-{% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/jToK0McIe9AgqCS3rymo.png", alt="Chrome DevTools 
-origin trials information in the Application panel showing TrialNotAllowed warning", width="800", 
-height="424" %}
+{% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/jToK0McIe9AgqCS3rymo.png",
+alt="Chrome DevTools origin trials information in the Application panel showing TrialNotAllowed warning.",
+width="800", height="424" %}
 
 Information about usage restrictions and availability will be provided for each origin trial.
 
@@ -531,8 +539,8 @@ The origin trial feature will be disabled if total usage by all Chrome users exc
 DevTools will show the token status as disabled.
 
 {% Aside %}
-★ The **Expected Usage** field on the trial registration page doesn't impact your origin trial 
-token. It's purely informational for Chrome's origin trial team. 
+The **Expected Usage** field on the trial registration page doesn't impact your
+origin trial token. It's purely informational for Chrome's origin trial team. 
 {% endAside %}
 
 Some trials also provide an option to limit usage, which means origin trial features will be 
@@ -540,7 +548,7 @@ disabled for some users. This option is made available from the registration pag
 trial that offers it:
 
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/Nj4PiSu4vVNS3tcw61JC.png", alt="Chrome origin trials 
-registration page showing usage restrictions", width="800", height="711" %}
+registration page showing usage restrictions.", width="800", height="711" %}
 
 If you're noticing that access by your users to an origin trial feature is lower than expected, 
 make sure that 'Standard Limit' is selected.
@@ -575,18 +583,19 @@ directive. You can check for response headers in the Chrome DevTools Network pan
 full list of allowed features in the Application panel.
 
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/AcG4YbivB3L4lM43vIRe.png", alt="Chrome DevTools 
-  Application panel, showing Permissions Policy Allowed Feature", width="800", height="408" %}
+  Application panel, showing Permissions Policy Allowed Feature.", width="800", height="408" %}
 
 
 ### What about the workers? {: #workers}
 
 Origin trials features can be made available to service workers, shared workers, and dedicated 
 workers. However, the only way to enable access for service workers and shared workers is to provide 
-a token in an `Origin-Trial` header. Dedicated workers inherit access to features enabled by their 
-parent document.
+a token in an `Origin-Trial` header.
+
+Dedicated workers inherit access to features enabled by their parent document.
 
 
-###  Token is provided before feature is accessed {: #token-before-access}
+### Token is provided before feature is accessed {: #token-before-access}
 
 Make sure that an origin trial token is provided _before_ a trial feature is accessed. 
 For example, if a page provides a token via JavaScript, make sure the code to provide the token 
@@ -603,8 +612,8 @@ is run before code that attempts to access the trial feature.
 
 ## Find out more
 
--  [Getting started with Chrome's origin trials](/docs/web-platform/origin-trials/)
--  [What are third-party origin trials?](/docs/web-platform/third-party-origin-trials/)
+-  [Get started with Chrome's origin trials](/docs/web-platform/origin-trials/)
+-  [Third-party origin trials](/docs/web-platform/third-party-origin-trials/)
 -  [Origin trials guide for web developers](https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md)
 -  [Origin trial explainer](https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/explainer.md)
 -  [Running an origin trial](https://www.chromium.org/blink/origin-trials/running-an-origin-trial)

--- a/site/en/docs/web-platform/origin-trials/index.md
+++ b/site/en/docs/web-platform/origin-trials/index.md
@@ -1,7 +1,11 @@
 ---
 layout: 'layouts/doc-post.njk'
-title: Getting started with Chrome's origin trials
-subhead: Origin trials are a way to test a new or experimental web platform feature, and give feedback to the web standards community on the feature's usability, practicality, and effectiveness, before the feature is made available to all users.
+title: Get started with origin trials
+subhead: Test a new or experimental web platform feature.
+description: >
+  Test a new or experimental web platform feature. Give feedback to the
+  web standards community on the feature's usability, practicality, and
+  effectiveness, before the feature is made available to all users.
 authors:
   - samdutton
 date: 2020-06-22

--- a/site/en/docs/web-platform/third-party-origin-trials/index.md
+++ b/site/en/docs/web-platform/third-party-origin-trials/index.md
@@ -1,8 +1,13 @@
 ---
 layout: 'layouts/doc-post.njk'
-title: What are third-party origin trials?
-subhead: Origin trials are a way to test a new or experimental web platform feature. A third-party origin trial makes it possible for providers of embedded content to try out a new feature across multiple sites.
-authors:
+title: Third-party origin trials
+subhead: >
+  Providers of embedded content can test new or experimental web platform
+  features.
+description: >
+  Learn how providers of embedded content can test new or experimental web
+  platform features across multiple sites.
+author:
   - samdutton
 date: 2020-10-01
 updated: 2022-04-11
@@ -12,7 +17,7 @@ tags:
   - origin-trials
 ---
 
-[Origin trials](/blog/origin-trials/) are a way to test a new or experimental web platform
+[Origin trials](/docs/web-platform/origin-trials/) are a way to test a new or experimental web platform
 feature.
 
 Origin trials are usually only available on a first-party basis: they only work for a single
@@ -25,12 +30,12 @@ Third-party origin trials make it possible for providers of embedded content to 
 feature across multiple sites by [providing a token using JavaScript](#provide-token).
 
 {% Img src="image/8WbTDNrhLsU0El80frMBGE4eMCD3/fCachIuiBjh3XPo10CrN.png", alt="Diagram showing how
-   third-party origin trials enable a single registration token to be used across multiple origins",
+   third-party origin trials enable a single registration token to be used across multiple origins.",
    width="800", height="400" %}
 
 Third-party origin trials don't make sense for all features. Chrome will only make the third-party
 origin trial option available for features where embedding code on third-party sites is a common use
-case.  [Getting started with Chrome's origin trials](https://developers.chrome.com/origintrials/)
+case.  [Get started with Chrome's origin trials](https://developers.chrome.com/origintrials/)
 provides more general information about how to participate in Chrome origin trials.
 
 If you participate in an origin trial as a third-party provider, it will be your responsibility to
@@ -42,7 +47,9 @@ to provide troubleshooting support.
 Supporting third-party origin trials allows for broader participation, but also increases the
 potential for overuse or abuse of experimental features, so a "trusted tester" approach is more
 appropriate. The greater reach of third-party origin trials requires additional scrutiny and
-additional responsibility for web developers that participate as third-party providers. Requests to
+additional responsibility for web developers that participate as third-party providers.
+
+Requests to
 enable a third-party origin trial may be reviewed in order to avoid problematic third-party scripts
 affecting multiple sites. The Origin Trials Developer Guide explains the
 [approval process](https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md#18-how-can-i-enable-an-experimental-feature-as-embedded-content-on-different-domains).
@@ -68,11 +75,13 @@ on progress with third-party origin trials.
 1. Click the Register button to submit your request.
 1. Your third-party token will be issued immediately, unless further review of the request is
    required. (Depending on the trial, token requests may require review.)
-1. If review is required, you'll be notified by email when the review is complete and your
-   third-party token is ready.
-
+1. If review is required, you'll be notified by email when the review is
+   complete and your third-party token is ready.
    <figure class="w-figure">
-     {% Img src="image/8WbTDNrhLsU0El80frMBGE4eMCD3/r07Zb0QoHnlgiItETR6q.png", alt="Chrome origin trials registration page for the Conversion Measurement API, with third-party matching checkbox selected.", width="800", height="618" %}
+     {% Img
+       src="image/8WbTDNrhLsU0El80frMBGE4eMCD3/r07Zb0QoHnlgiItETR6q.png",
+       alt="Chrome origin trials registration page for the Conversion Measurement API, with third-party matching checkbox selected.",
+       width="800", height="618" %}
      <figcaption class="w-figcaption">Registration page for the Conversion Measurement trial.</figcaption>
    </figure>
 
@@ -99,7 +108,7 @@ using a token provided by JavaScript from a different origin.
 {% endAside %}
 
 
-## Provide feedback
+## Share feedback
 
 If you're registering for a third-party origin trial and have feedback to share on the process or
 ideas on how we can improve it, [create an Issue](https://github.com/GoogleChrome/OriginTrials/issues/new)


### PR DESCRIPTION
- Shorten / simplify certain doc titles
- Add descriptions for TOC
- Shorted subheaders
- Add punctuation to img alt text
- Fix old links

[Get started with origin trials](https://deploy-preview-4680--developer-chrome-com.netlify.app/docs/web-platform/origin-trials/)
[Third-party OTs](https://deploy-preview-4680--developer-chrome-com.netlify.app/docs/web-platform/third-party-origin-trials/)
[Troubleshoot](https://deploy-preview-4680--developer-chrome-com.netlify.app/docs/web-platform/origin-trial-troubleshooting/)