### PR TITLE
Changed casing in 2 words

### DIFF
--- a/site/en/docs/extensions/mv3/getstarted/tut-reading-time/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/tut-reading-time/index.md
@@ -194,8 +194,8 @@ if (article) {
 
 - [Regular
   expressions][mdn-regular-expressions] used to count only the words inside the `<article>` element.
-- [InsertAdjacentElement()][mdn-insert-adjacent] used to insert the reading time node after the element.
-- The [Classlist][mdn-classlist] property used to add CSS class names to the element class attribute.
+- [insertAdjacentElement()][mdn-insert-adjacent] used to insert the reading time node after the element.
+- The [classList][mdn-classlist] property used to add CSS class names to the element class attribute.
 - [Optional chaining][mdn-optional-chaining] used to access an object property that may be undefined or null.
 - [Nullish coalescing][mdn-nullish-coalescing] returns the `<heading>` if the `<date>` is null or undefined.
 


### PR DESCRIPTION
In line 197, I changed 'InsertAdjacentElement()' to 'insertAdjacentElement()' and in line 198, 'Classlist ' to 'classList', so that the text matches the title of the linked articles and the proper name of the function and the property.