### PR TITLE
Use Assert shortcode to check author data integrity

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -38,6 +38,7 @@ const {Aside} = require('./site/_shortcodes/Aside');
 const includeRaw = require('./site/_shortcodes/includeRaw');
 const {LanguageList} = require('./site/_shortcodes/LanguageList');
 const {Partial} = require('./site/_shortcodes/Partial');
+const {Assert} = require('webdev-infra/shortcodes/Assert');
 
 // Transforms
 const {domTransformer} = require('./site/_transforms/dom-transformer-pool');
@@ -148,6 +149,7 @@ module.exports = eleventyConfig => {
   eleventyConfig.addPairedShortcode('Aside', Aside);
   eleventyConfig.addPairedShortcode('Label', Label);
   eleventyConfig.addShortcode('LanguageList', LanguageList);
+  eleventyConfig.addShortcode('Assert', Assert);
   eleventyConfig.addNunjucksAsyncShortcode('Partial', Partial);
 
   // Empty shortcodes. They are added for backward compatibility with web.dev.

--- a/site/_includes/macros/card-authors.njk
+++ b/site/_includes/macros/card-authors.njk
@@ -9,6 +9,9 @@
   {% if authors.length < 3 %}
   {% for authorId in authors %}
   {% set authorTitle = 'i18n.authors.' + authorId + '.title' %}
+
+  {# {% Assert value=authorTitle | i18n(locale) | dump != '{}', error='No i18n data for author ' + authorId %} #}
+
   {% set authorImage = authorsData[authorId].image or site.defaultAvatarImg %}
   {% if authorImage %}
   <a href="/authors/{{authorId}}/" translate="no" class="card-authors__image">

--- a/site/_includes/macros/post-author.njk
+++ b/site/_includes/macros/post-author.njk
@@ -9,6 +9,8 @@
 {% set authorDescription = 'i18n.authors.' + authorId + '.description' %}
 {% set authorImage = authorsData[authorId].image or site.defaultAvatarImg %}
 
+{% Assert value=authorTitle | i18n(locale) | dump != '{}', error='No i18n data for author ' + authorId %}
+
 <div class="display-flex align-start">
   {% if authorImage %}
     <a href="/authors/{{authorId}}/" translate="no" class="card-authors__image">


### PR DESCRIPTION
Fixes https://github.com/GoogleChrome/developer.chrome.com/issues/4327 by using the new `{% Assert %}` shortcode, introduced in https://github.com/GoogleChrome/webdev-infra/pull/42.

This provides a more helpful error message in case of missing author data. Before:

```
[11ty] 2. (./site/_includes/layouts/home.njk) [Line 23, Column 27]
[11ty]   EleventyShortcodeError: Error with Nunjucks shortcode `Img` (via Template render error)
[11ty] 3. ERROR IN ./site/en/index.md, IMG image/tcFciHGuF3MxnTr1y5ue01OGLBn2/PFaMfvDZoPorronbpdU8.svg: alt text must be a string, received a object (via Template render error)
[11ty]
```

After:

```
[11ty] 1. Having trouble writing template: "dist/en/blog/index.html" (via EleventyTemplateError)
[11ty] 2. (./site/_includes/layouts/blog-landing.njk)
[11ty]   Template render error: (/Users/mrohmer/Workspace/developers-chrome-com/site/_includes/partials/tags.njk) [Line 6, Column 16]
[11ty]   EleventyShortcodeError: Error with Nunjucks shortcode `Assert` (via Template render error)
[11ty] 3. No i18n data for author matthias (via Template render error)
[11ty]
```

Needs https://github.com/GoogleChrome/webdev-infra/pull/42 to be merged and published.