### PR TITLE
I18N extension docs inconsistency with observed behavior

### DIFF
--- a/site/en/docs/extensions/mv3/user_interface/index.md
+++ b/site/en/docs/extensions/mv3/user_interface/index.md
@@ -580,7 +580,7 @@ Specify the name of the message in the `"default_title"` field of the manifest. 
   "name": "Tab Flipper",
   ...
   "action": {
-    "default_title": "__MSG_tooltip__"
+    "default_title": "tooltip"
   },
   "default_locale": "en"
   ...


### PR DESCRIPTION
_locale message ~reference~ defnition should be without \_\_MSG\_\_

Fixes <not-found>

Changes proposed in this pull request:

- \_\_MSG_tooltip\_\_ where ~referenced~ defined in ~manifest.json~ messages.json should be "tooltip"
-
-