### PR TITLE
Implemented offscreen API information into migration guides

### DIFF
--- a/site/en/docs/extensions/mv3/declare_permissions/index.md
+++ b/site/en/docs/extensions/mv3/declare_permissions/index.md
@@ -331,7 +331,7 @@ The following table lists the currently available permissions:
     </tr>
     <tr id="offscreen">
       <td><code>"offscreen"</code></td>
-      <td>Gives your extension access to the <a href="/docs/extensions/reference/offscreen/">chrome.offscreen</a> API, allowing developers to create off-screen documents to utilize DOM APIs without obtrusively opening new windows or tabs that interrupt the user experience. Off-screen documents do not have the same permissions as the rest of the extension, but have access to the [chrome.runtime](/docs/extensions/reference/runtime/) messaging API to communicate with the service worker. 
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/offscreen/">chrome.offscreen</a> API, allowing developers to create off-screen documents to utilize DOM APIs without obtrusively opening new windows or tabs that interrupt the user experience. Off-screen documents do not have the same APIs as the rest of the extension, but have access to the [chrome.runtime](/docs/extensions/reference/runtime/) messaging API to communicate with the service worker. 
     <tr id="topSites">
       <td><code>"topSites"</code></td>
       <td>Gives your extension access to the <a href="/docs/extensions/reference/topSites/">chrome.topSites</a> API.</td>

--- a/site/en/docs/extensions/mv3/declare_permissions/index.md
+++ b/site/en/docs/extensions/mv3/declare_permissions/index.md
@@ -329,6 +329,10 @@ The following table lists the currently available permissions:
         many circumstances your extension will not need to declare the <code>"tabs"</code> permission to make use of
         these APIs.</td>
     </tr>
+    <tr id="offscreen">
+      <td><code>"offscreen"</code></td>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/offscreen/">chrome.offscreen</a> API, allowing developers to create off-screen documents to utilize DOM APIs without obtrusively opening new windows or tabs that interrupt the user experience. Off-screen documents are treated as web pages, and do not have the same permissions as the service worker.</td>
+    </tr>
     <tr id="topSites">
       <td><code>"topSites"</code></td>
       <td>Gives your extension access to the <a href="/docs/extensions/reference/topSites/">chrome.topSites</a> API.</td>

--- a/site/en/docs/extensions/mv3/declare_permissions/index.md
+++ b/site/en/docs/extensions/mv3/declare_permissions/index.md
@@ -331,7 +331,7 @@ The following table lists the currently available permissions:
     </tr>
     <tr id="offscreen">
       <td><code>"offscreen"</code></td>
-      <td>Gives your extension access to the <a href="/docs/extensions/reference/offscreen/">chrome.offscreen</a> API, allowing developers to create off-screen documents to utilize DOM APIs without obtrusively opening new windows or tabs that interrupt the user experience. Off-screen documents do not have the same APIs as the rest of the extension, but have access to the [chrome.runtime](/docs/extensions/reference/runtime/) messaging API to communicate with the service worker. 
+      <td>Gives access to the <a href="/docs/extensions/reference/offscreen/">chrome.offscreen</a> API, allowing developers to create off-screen documents to use DOM APIs without obtrusively opening new windows or tabs that interrupt the user experience. Off-screen documents do not have the same APIs as the rest of the extension, but have access to the [chrome.runtime](/docs/extensions/reference/runtime/) messaging API to communicate with the service worker. 
     <tr id="topSites">
       <td><code>"topSites"</code></td>
       <td>Gives your extension access to the <a href="/docs/extensions/reference/topSites/">chrome.topSites</a> API.</td>

--- a/site/en/docs/extensions/mv3/declare_permissions/index.md
+++ b/site/en/docs/extensions/mv3/declare_permissions/index.md
@@ -331,8 +331,7 @@ The following table lists the currently available permissions:
     </tr>
     <tr id="offscreen">
       <td><code>"offscreen"</code></td>
-      <td>Gives your extension access to the <a href="/docs/extensions/reference/offscreen/">chrome.offscreen</a> API, allowing developers to create off-screen documents to utilize DOM APIs without obtrusively opening new windows or tabs that interrupt the user experience. Off-screen documents are treated as web pages, and do not have the same permissions as the service worker.</td>
-    </tr>
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/offscreen/">chrome.offscreen</a> API, allowing developers to create off-screen documents to utilize DOM APIs without obtrusively opening new windows or tabs that interrupt the user experience. Off-screen documents do not have the same permissions as the rest of the extension, but have access to the [chrome.runtime](/docs/extensions/reference/runtime/) messaging API to communicate with the service worker. 
     <tr id="topSites">
       <td><code>"topSites"</code></td>
       <td>Gives your extension access to the <a href="/docs/extensions/reference/topSites/">chrome.topSites</a> API.</td>

--- a/site/en/docs/extensions/mv3/declare_permissions/index.md
+++ b/site/en/docs/extensions/mv3/declare_permissions/index.md
@@ -331,7 +331,7 @@ The following table lists the currently available permissions:
     </tr>
     <tr id="offscreen">
       <td><code>"offscreen"</code></td>
-      <td>Gives access to the <a href="/docs/extensions/reference/offscreen/">chrome.offscreen</a> API, allowing developers to create off-screen documents to use DOM APIs without obtrusively opening new windows or tabs that interrupt the user experience. Off-screen documents do not have the same APIs as the rest of the extension, but have access to the [chrome.runtime](/docs/extensions/reference/runtime/) messaging API to communicate with the service worker. 
+      <td>Gives your extension access to the <a href="/docs/extensions/reference/offscreen/"><code>chrome.offscreen</code></a> API, allowing developers to create off-screen documents to use DOM APIs without obtrusively opening new windows or tabs that interrupt the user experience. Offscreen documents do not have the same API access as the rest of the extension, but have access to the [`chrome.runtime`](/docs/extensions/reference/runtime/) messaging API to communicate with the service worker. 
     <tr id="topSites">
       <td><code>"topSites"</code></td>
       <td>Gives your extension access to the <a href="/docs/extensions/reference/topSites/">chrome.topSites</a> API.</td>

--- a/site/en/docs/extensions/mv3/migrating_to_service_workers/index.md
+++ b/site/en/docs/extensions/mv3/migrating_to_service_workers/index.md
@@ -261,8 +261,8 @@ For extensions that need to unobtrusively utilize APIs that require DOM access w
 // for Manifest V3 service workers
 chrome.offscreen.createDocument({
   url: chrome.runtime.getURL('offscreen.html'),
-  reasons: ['TESTING'],
-  justification: 'ignored',
+  reasons: ['CLIPBOARD'],
+  justification: 'testing the offscreen API',
 });
 ```
 

--- a/site/en/docs/extensions/mv3/migrating_to_service_workers/index.md
+++ b/site/en/docs/extensions/mv3/migrating_to_service_workers/index.md
@@ -254,7 +254,7 @@ Operations with a Web Worker][18].
 
 ### Offscreen Documents
 
-For extensions that need to unobtrusively use APIs that require DOM access without visually opening up a new window or tab, developers can now use the [offscreen API](/docs/extensions/reference/offscreen/). This API allows developers to open and close undisplayed documents packaged with the extension for DOM-related tasks without disrupting the user experience. Offscreen documents do not share APIs with the extension's service worker, and function as fully functional web pages for the extension to interact with.
+For extensions that need to unobtrusively use APIs that require DOM access without visually opening up a new window or tab, developers can now use the [Offscreen API](/docs/extensions/reference/offscreen/). This API allows developers to open and close undisplayed documents packaged with the extension for DOM-related tasks without disrupting the user experience. Offscreen documents do not share APIs with the extension's service worker, and function as fully functional web pages for the extension to interact with.
 
 ```js
 // background.js

--- a/site/en/docs/extensions/mv3/migrating_to_service_workers/index.md
+++ b/site/en/docs/extensions/mv3/migrating_to_service_workers/index.md
@@ -254,7 +254,7 @@ Operations with a Web Worker][18].
 
 ### Offscreen Documents
 
-For extensions that need to unobtrusively utilize APIs that require DOM access without visually opening up a new window or tab, developers can now use the [offscreen API](/docs/extensions/reference/offscreen/). This API allows developers to open and close undisplayed documents packaged with the extension for DOM-related tasks without disrupting user experience. Offscreen documents do not share APIs with the extension's service worker, and function as fully functional web pages for the extension to interact with.
+For extensions that need to unobtrusively use APIs that require DOM access without visually opening up a new window or tab, developers can now use the [offscreen API](/docs/extensions/reference/offscreen/). This API allows developers to open and close undisplayed documents packaged with the extension for DOM-related tasks without disrupting the user experience. Offscreen documents do not share APIs with the extension's service worker, and function as fully functional web pages for the extension to interact with.
 
 ```js
 // background.js

--- a/site/en/docs/extensions/mv3/migrating_to_service_workers/index.md
+++ b/site/en/docs/extensions/mv3/migrating_to_service_workers/index.md
@@ -254,7 +254,7 @@ Operations with a Web Worker][18].
 
 ### Offscreen Documents
 
-For extensions that need to unobtrusively utilize APIs that require DOM access without visually opening up a new window or tab, developers can now use the [offscreen API](/docs/extensions/reference/offscreen/). This API allows developers to open and close undisplayed documents packaged with the extension for DOM-related tasks without disrupting user experience. Offscreen documents do not share permissions with the extension's service worker, and function as fully functional web pages for the extension to interact with.
+For extensions that need to unobtrusively utilize APIs that require DOM access without visually opening up a new window or tab, developers can now use the [offscreen API](/docs/extensions/reference/offscreen/). This API allows developers to open and close undisplayed documents packaged with the extension for DOM-related tasks without disrupting user experience. Offscreen documents do not share APIs with the extension's service worker, and function as fully functional web pages for the extension to interact with.
 
 ```js
 // background.js

--- a/site/en/docs/extensions/mv3/migrating_to_service_workers/index.md
+++ b/site/en/docs/extensions/mv3/migrating_to_service_workers/index.md
@@ -259,12 +259,11 @@ For extensions that need to unobtrusively utilize APIs that require DOM access w
 ```js
 // background.js
 // for Manifest V3 service workers
-chrome.offscreen.createDocument(
-        {
-          url: chrome.runtime.getURL('offscreen.html'),
-          reasons: ['TESTING'],
-          justification: 'ignored',
-        });
+chrome.offscreen.createDocument({
+  url: chrome.runtime.getURL('offscreen.html'),
+  reasons: ['TESTING'],
+  justification: 'ignored',
+});
 ```
 
 [2]: https://developers.google.com/web/fundamentals/primers/service-workers/

--- a/site/en/docs/extensions/mv3/migrating_to_service_workers/index.md
+++ b/site/en/docs/extensions/mv3/migrating_to_service_workers/index.md
@@ -252,6 +252,21 @@ function buildCanvas(width, height) {
 For additional guidance on working with `OffscreenCanvas`, see [OffscreenCanvas—Speed up Your Canvas
 Operations with a Web Worker][18].
 
+### Offscreen Documents
+
+For extensions that need to unobtrusively utilize APIs that require DOM access without visually opening up a new window or tab, developers can now use the [offscreen API](/docs/extensions/reference/offscreen/). This API allows developers to open and close undisplayed documents packaged with the extension for DOM-related tasks without disrupting user experience. Offscreen documents do not share permissions with the extension's service worker, and function as fully functional web pages for the extension to interact with.
+
+```js
+// background.js
+// for Manifest V3 service workers
+chrome.offscreen.createDocument(
+        {
+          url: chrome.runtime.getURL('offscreen.html'),
+          reasons: ['TESTING'],
+          justification: 'ignored',
+        });
+```
+
 [2]: https://developers.google.com/web/fundamentals/primers/service-workers/
 [3]: #events
 [4]: #workers

--- a/site/en/docs/extensions/reference/offscreen/index.md
+++ b/site/en/docs/extensions/reference/offscreen/index.md
@@ -15,7 +15,11 @@ You must declare the "offscreen" permission in the [extension manifest][1] to us
   ...
 }
 ```
-Offscreen documents are treated as web pages, and do not share the same permissions as service workers. Offscreen Windows cannot be focused, and cannot have their opener set using the [chrome.windows API](docs/extensions/reference/windows/) method `windows.setSelfAsOpener`.
+Pages loaded as offscreen documents are handled differently from other types of extensions pages. The extension's permissions carry over to offscreen documents, but extension API access is heavily limited. Currently, an offscreen document can only use the `chrome.runtime` APIs to send and receive messages; all other extension APIs are not exposed. Other notable differences between offscreen documents and normal pages are as follows:
+
+* Offscreen document's URL must be a static HTML file bundled with the extension.
+* Offscreen documents cannot be focused.
+* Offscreen documents cannot have their `opener` property set using the [`chrome.windows` API](docs/extensions/reference/windows/) method `windows.setSelfAsOpener`.
 
 ## Examples
 The following methods create and close an offscreen document. Only a single Document can be open at a time. 

--- a/site/en/docs/extensions/reference/offscreen/index.md
+++ b/site/en/docs/extensions/reference/offscreen/index.md
@@ -17,7 +17,7 @@ You must declare the `"offscreen"` permission in the [extension manifest][1] to 
 ```
 Pages loaded as offscreen documents are handled differently from other types of extension pages. The extension's permissions carry over to offscreen documents, but extension API access is heavily limited. Currently, an offscreen document can only use the `chrome.runtime` APIs to send and receive messages; all other extension APIs are not exposed. Other notable differences between offscreen documents and normal pages are as follows:
 
-* Offscreen document's URL must be a static HTML file bundled with the extension.
+* An offscreen document's URL must be a static HTML file bundled with the extension.
 * Offscreen documents cannot be focused.
 * Offscreen documents cannot have their `opener` property set using the [`chrome.windows` API](docs/extensions/reference/windows/) method `windows.setSelfAsOpener()`.
 * An extension can only have one offscreen document open at a time. If the extension is running in split mode with an active incognito profile, both the normal and incognito profiles can each have one offscreen document. 

--- a/site/en/docs/extensions/reference/offscreen/index.md
+++ b/site/en/docs/extensions/reference/offscreen/index.md
@@ -15,7 +15,7 @@ You must declare the `"offscreen"` permission in the [extension manifest][1] to 
   ...
 }
 ```
-Pages loaded as offscreen documents are handled differently from other types of extensions pages. The extension's permissions carry over to offscreen documents, but extension API access is heavily limited. Currently, an offscreen document can only use the `chrome.runtime` APIs to send and receive messages; all other extension APIs are not exposed. Other notable differences between offscreen documents and normal pages are as follows:
+Pages loaded as offscreen documents are handled differently from other types of extension pages. The extension's permissions carry over to offscreen documents, but extension API access is heavily limited. Currently, an offscreen document can only use the `chrome.runtime` APIs to send and receive messages; all other extension APIs are not exposed. Other notable differences between offscreen documents and normal pages are as follows:
 
 * Offscreen document's URL must be a static HTML file bundled with the extension.
 * Offscreen documents cannot be focused.

--- a/site/en/docs/extensions/reference/offscreen/index.md
+++ b/site/en/docs/extensions/reference/offscreen/index.md
@@ -19,7 +19,7 @@ Pages loaded as offscreen documents are handled differently from other types of 
 
 * Offscreen document's URL must be a static HTML file bundled with the extension.
 * Offscreen documents cannot be focused.
-* Offscreen documents cannot have their `opener` property set using the [`chrome.windows` API](docs/extensions/reference/windows/) method `windows.setSelfAsOpener`.
+* Offscreen documents cannot have their `opener` property set using the [`chrome.windows` API](docs/extensions/reference/windows/) method `windows.setSelfAsOpener()`.
 
 ## Reasons
 Reasons, listed [below](/docs/extensions/reference/offscreen/#type-Reason), are set upon  document creation to determine the document's lifespan. Currently, the AUDIO_PLAYBACK reason has specialized lifetime enforcement (CreateAudioLifetimeEnforcer). All others use generic idle detection   (CreateEmptyEnforcer).

--- a/site/en/docs/extensions/reference/offscreen/index.md
+++ b/site/en/docs/extensions/reference/offscreen/index.md
@@ -22,7 +22,7 @@ Pages loaded as offscreen documents are handled differently from other types of 
 * Offscreen documents cannot have their `opener` property set using the [`chrome.windows` API](docs/extensions/reference/windows/) method `windows.setSelfAsOpener()`.
 
 ## Reasons
-Reasons, listed [below](/docs/extensions/reference/offscreen/#type-Reason), are set upon  document creation to determine the document's lifespan. Currently, the AUDIO_PLAYBACK reason has specialized lifetime enforcement (CreateAudioLifetimeEnforcer). All others use generic idle detection   (CreateEmptyEnforcer).
+Reasons, listed [below](/docs/extensions/reference/offscreen/#type-Reason), are set upon document creation to determine the document's lifespan. Currently, the `AUDIO_PLAYBACK` reason has specialized lifetime enforcement (`CreateAudioLifetimeEnforcer`). All others use generic idle detection (`CreateEmptyEnforcer`).
 
 ## Examples
 The following methods create and close an offscreen document. Only a single Document can be open at a time. 

--- a/site/en/docs/extensions/reference/offscreen/index.md
+++ b/site/en/docs/extensions/reference/offscreen/index.md
@@ -2,4 +2,31 @@
 api: offscreen
 ---
 
-<!-- Intentionally blank -->
+## Manifest
+You must declare the "offscreen" permission in the [extension manifest][1] to use the input.ime API. For example:
+
+```json
+{
+  "name": "My extension",
+  ...
+  "permissions": [
+    "offscreen"
+  ],
+  ...
+}
+```
+Offscreen documents are treated as web pages, and do not share the same permissions as service workers. Offscreen Windows cannot be focused, and cannot have their opener set using the [chrome.windows API](docs/extensions/reference/windows/) method `windows.setSelfAsOpener`.
+
+## Examples
+The following methods create and close an offscreen document. Only a single Document can be open at a time. 
+
+```js
+     chrome.offscreen.createDocument(
+            {
+              url: chrome.runtime.getURL('off_screen.html'),
+              reasons: ['CLIPBOARD'],
+              justification: 'ignored',
+            });
+
+chrome.offscreen.closeDocument()
+```

--- a/site/en/docs/extensions/reference/offscreen/index.md
+++ b/site/en/docs/extensions/reference/offscreen/index.md
@@ -3,7 +3,7 @@ api: offscreen
 ---
 
 ## Manifest
-You must declare the "offscreen" permission in the [extension manifest][1] to use the input.ime API. For example:
+You must declare the "offscreen" permission in the [extension manifest][1] to use the Offscreen API. For example:
 
 ```json
 {

--- a/site/en/docs/extensions/reference/offscreen/index.md
+++ b/site/en/docs/extensions/reference/offscreen/index.md
@@ -3,7 +3,7 @@ api: offscreen
 ---
 
 ## Manifest
-You must declare the "offscreen" permission in the [extension manifest][1] to use the Offscreen API. For example:
+You must declare the `"offscreen"` permission in the [extension manifest][1] to use the Offscreen API. For example:
 
 ```json
 {

--- a/site/en/docs/extensions/reference/offscreen/index.md
+++ b/site/en/docs/extensions/reference/offscreen/index.md
@@ -20,6 +20,7 @@ Pages loaded as offscreen documents are handled differently from other types of 
 * Offscreen document's URL must be a static HTML file bundled with the extension.
 * Offscreen documents cannot be focused.
 * Offscreen documents cannot have their `opener` property set using the [`chrome.windows` API](docs/extensions/reference/windows/) method `windows.setSelfAsOpener()`.
+* An extension can only have one offscreen document open at a time. If the extension is running in split mode with an active incognito profile, both the normal and incognito profiles can each have one offscreen document. 
 
 ## Reasons
 Reasons, listed [below](/docs/extensions/reference/offscreen/#type-Reason), are set upon document creation to determine the document's lifespan. Currently, the `AUDIO_PLAYBACK` reason has specialized lifetime enforcement (`CreateAudioLifetimeEnforcer`). All others use generic idle detection (`CreateEmptyEnforcer`).

--- a/site/en/docs/extensions/reference/offscreen/index.md
+++ b/site/en/docs/extensions/reference/offscreen/index.md
@@ -25,12 +25,11 @@ Pages loaded as offscreen documents are handled differently from other types of 
 The following methods create and close an offscreen document. Only a single Document can be open at a time. 
 
 ```js
-     chrome.offscreen.createDocument(
-            {
-              url: chrome.runtime.getURL('off_screen.html'),
-              reasons: ['CLIPBOARD'],
-              justification: 'ignored',
-            });
+chrome.offscreen.createDocument({
+  url: chrome.runtime.getURL('off_screen.html'),
+  reasons: ['CLIPBOARD'],
+  justification: 'ignored',
+});
 
 chrome.offscreen.closeDocument()
 ```

--- a/site/en/docs/extensions/reference/offscreen/index.md
+++ b/site/en/docs/extensions/reference/offscreen/index.md
@@ -21,6 +21,9 @@ Pages loaded as offscreen documents are handled differently from other types of 
 * Offscreen documents cannot be focused.
 * Offscreen documents cannot have their `opener` property set using the [`chrome.windows` API](docs/extensions/reference/windows/) method `windows.setSelfAsOpener`.
 
+## Reasons
+Reasons, listed [below](/docs/extensions/reference/offscreen/#type-Reason), are set upon  document creation to determine the document's lifespan. Currently, the AUDIO_PLAYBACK reason has specialized lifetime enforcement (CreateAudioLifetimeEnforcer). All others use generic idle detection   (CreateEmptyEnforcer).
+
 ## Examples
 The following methods create and close an offscreen document. Only a single Document can be open at a time. 
 
@@ -28,7 +31,7 @@ The following methods create and close an offscreen document. Only a single Docu
 chrome.offscreen.createDocument({
   url: chrome.runtime.getURL('off_screen.html'),
   reasons: ['CLIPBOARD'],
-  justification: 'ignored',
+  justification: 'reason for needing the document',
 });
 
 chrome.offscreen.closeDocument()


### PR DESCRIPTION
Changes proposed in this pull request:

Implements new offscreen documentation into the migration guide.

**Staging pages**
- [/docs/extensions/mv3/declare_permissions](https://deploy-preview-4765--developer-chrome-com.netlify.app/docs/extensions/mv3/declare_permissions/)
- [/docs/extensions/mv3/migrating_to_service_workers/](https://deploy-preview-4765--developer-chrome-com.netlify.app/docs/extensions/mv3/migrating_to_service_workers/)
- [/docs/extensions/reference/offscreen/](https://deploy-preview-4765--developer-chrome-com.netlify.app/docs/extensions/reference/offscreen/)