### PR TITLE
Add a link to the current OT landing page

### DIFF
--- a/site/en/blog/expanding-privacy-sandbox-testing/index.md
+++ b/site/en/blog/expanding-privacy-sandbox-testing/index.md
@@ -6,6 +6,7 @@ description: >
   you can test and give feedback to shape the future of the APIs.
 layout: 'layouts/blog-post.njk'
 date: 2022-07-27
+updated: 2023-01-05
 authors:
   - rowan_m
   - barbsmith
@@ -15,6 +16,11 @@ alt: >
 tags:
   - privacy
 ---
+
+{% Aside %}
+**See updated guidance for the [Relevance and measurement unified origin
+trial](/docs/privacy-sandbox/unified-origin-trial/).**
+{% endAside %}
 
 Today we shared an [updated plan and timeline for Privacy Sandbox for the
 web](https://blog.google/products/chrome/update-testing-privacy-sandbox-web/)

--- a/site/en/blog/privacy-sandbox-origin-trial-increase/index.md
+++ b/site/en/blog/privacy-sandbox-origin-trial-increase/index.md
@@ -10,6 +10,7 @@ subhead: >
   Chrome Stable users.
 layout: 'layouts/blog-post.njk'
 date: 2022-10-24
+updated: 2023-01-05
 authors:
   - cilvento
 hero: 'image/VWw0b3pM7jdugTkwI6Y81n6f5Yc2/7Hid7vSdQtp0RNThvO5J.png'
@@ -18,6 +19,11 @@ alt: >
 tags:
   - privacy
 ---
+
+{% Aside %}
+**See updated guidance for the [Relevance and measurement unified origin
+trial](/docs/privacy-sandbox/unified-origin-trial/).**
+{% endAside %}
 
 This week, no sooner than October 26, we will begin increasing the Privacy
 Sandbox Relevance and Measurement origin trial population towards 5% of Chrome

--- a/site/en/blog/privacy-sandbox-unified-origin-trial/index.md
+++ b/site/en/blog/privacy-sandbox-unified-origin-trial/index.md
@@ -5,7 +5,7 @@ description: >
   unified experimentation across the Privacy Sandbox relevance and measurement APIs: Topics, FLEDGE, and Attribution Reporting.
 layout: 'layouts/blog-post.njk'
 date: 2022-03-31
-updated: 2022-06-27
+updated: 2023-01-05
 authors:
   - rowan_m
 hero: 'image/VWw0b3pM7jdugTkwI6Y81n6f5Yc2/1Eh5fSHWhurUuED3WGU1.png'
@@ -15,6 +15,11 @@ tags:
   - privacy
   - origin-trials
 ---
+
+{% Aside %}
+**See updated guidance for the [Relevance and measurement unified origin
+trial](/docs/privacy-sandbox/unified-origin-trial/).**
+{% endAside %}
 
 The [Privacy Sandbox](https://privacysandbox.com/open-web/) includes a selection
 of proposals to enable advertising use cases without the need for cross-site


### PR DESCRIPTION
Updates existing blog posts to ensure there's a link to the current, up-to-date documentation.