### PR TITLE
Make the capitalization of the #ssp anchor consistent

### DIFF
--- a/site/en/docs/privacy-sandbox/glossary/index.md
+++ b/site/en/docs/privacy-sandbox/glossary/index.md
@@ -19,7 +19,7 @@ if something is missing!
 
 ## Ad auction (FLEDGE)
 
-In FLEDGE, an ad auction is run by a seller (ikely to be an [SSP](#SSP) or maybe the publisher itself), in JavaScript code in the browser on the
+In FLEDGE, an ad auction is run by a seller (ikely to be an [SSP](#ssp) or maybe the publisher itself), in JavaScript code in the browser on the
 user's device, to sell ad space on a site that displays ads.
 
 {: #creative}
@@ -380,7 +380,7 @@ includes aggregated user data and detailed conversion data.
 
 Summary reports were formerly known as aggregate reports.
 
-## Supply-side platform, Sell-side platform {: #SSP}
+## Supply-side platform, Sell-side platform {: #ssp}
 
 An adtech service used to automate selling ad inventory. SSPs allow publishers
 to offer their inventory (empty rectangles where ads will go) to multiple ad


### PR DESCRIPTION
The anchor to the glossary entry for "Supply-side platform, Sell-side platform" was #SSP, which didn't work for links that used the all-lower-case #ssp. On the glossary page itself, there were two links to #SSP and one to #ssp. From all other pages on the GoogleChrome/developer.chrome.com repo, the link was always to #ssp. (https://github.com/GoogleChrome/developer.chrome.com/search?q=%22%23SSP%22). The anchor for the glossary entry for "Demand-side platform (DSP)" is the all-lower-case #dsp. As such, changing SSP's anchor to all-lower-case as well.

Fixes #4708 