### PR TITLE
Remove unused CSS and add max-width for Table of Contents

### DIFF
--- a/site/_scss/blocks/_toc.scss
+++ b/site/_scss/blocks/_toc.scss
@@ -50,8 +50,6 @@ toc-active {
 
   li {
     line-height: 1.2;
-    overflow: hidden;
-    text-overflow: ellipsis;
 
     &::before {
       display: none;

--- a/site/_scss/blocks/_toc.scss
+++ b/site/_scss/blocks/_toc.scss
@@ -1,12 +1,5 @@
 .toc-container {
-  max-width: 100%;
-}
-
-.toc-container-under-navigation-tree {
-  margin-left: 1.5rem;
-  margin-top: 2rem;
-  position: sticky;
-  top: 0;
+  max-width: px-to-rem(300px);
 }
 
 .toc > summary {
@@ -59,7 +52,6 @@ toc-active {
     line-height: 1.2;
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;
 
     &::before {
       display: none;


### PR DESCRIPTION
Follow-up to #4436, which tried to fix #4071, which caused #4703.

This PR removes the properties introduced with #4436 and also the introduced `.toc-container-under-navigation-tree` selector, as it is not used anywhere.

Additionally it brings a new attempt to fix the original issue #4701 by limiting the width of the TOC to 300px. That fits the pattern of the left-side navigation, which is limited to 250px.