### PR TITLE
DevTools 109: Inline evaluation during debugging

### DIFF
--- a/site/en/docs/devtools/javascript/index.md
+++ b/site/en/docs/devtools/javascript/index.md
@@ -176,8 +176,8 @@ code that you want to pause on, use a line-of-code breakpoint:
     executed.
 3.  Click **Resume script execution**
     {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/lk63wTlzwXWuRIdSsKP4.png", alt="Resume Script Execution", width="26", height="20" %}. The
-    script continues executing until it reaches line 32. On lines 29, 30, and 31, DevTools prints
-    out the values of `addend1`, `addend2`, and `sum` to the right of each line's semi-colon.
+    script continues executing until it reaches line 32. On lines 29, 30, and 31, DevTools [shows
+    the values](/docs/devtools/javascript/reference/#inline-eval) of `addend1`, `addend2`, and `sum` inline next to their declarations.
 
 {% Img src="image/admin/99Omb7ALyJB7MfYpuqXp.png", alt="DevTools pauses on the line-of-code breakpoint on line 32.", width="800", height="571" %}
 

--- a/site/en/docs/devtools/javascript/reference/index.md
+++ b/site/en/docs/devtools/javascript/reference/index.md
@@ -21,8 +21,21 @@ See [Get Started With Debugging JavaScript In Chrome DevTools][1] to learn the b
 ## Pause code with breakpoints {: #breakpoints }
 
 Set a breakpoint so that you can pause your code in the middle of its execution.
+To learn how to set breakpoints, see [Pause Your Code With Breakpoints][2].
 
-See [Pause Your Code With Breakpoints][2] to learn how to set breakpoints.
+### Check values when paused {: #inline-eval }
+
+While the execution is paused, the debugger evaluates all variables, constants, and objects up to a breakpoint and shows their current values inline next to the corresponding declarations.
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/mUySGJfdYgR3URwClr67.png", alt="Inline evaluations displayed next to declarations.", width="800", height="363" %}
+
+You can use the [**Console**](/docs/devtools/console/) to query the evaluated variables, constants, and objects.
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/e1Cyyoa0bLLGDnm3SU4D.png", alt="Using the Console to query the evaluated variables, constants and objects.", width="800", height="613" %}
+
+{% Aside 'gotchas' %}
+While the execution is paused, you can also [restart the current function](/docs/devtools/javascript/reference/#restart-frame) and even [live-edit](/docs/devtools/javascript/reference/#live-edit) it.
+{% endAside %}
 
 ### Preview class/function properties on hover {: #properties }
 

--- a/site/en/docs/devtools/javascript/reference/index.md
+++ b/site/en/docs/devtools/javascript/reference/index.md
@@ -25,7 +25,7 @@ To learn how to set breakpoints, see [Pause Your Code With Breakpoints][2].
 
 ### Check values when paused {: #inline-eval }
 
-While the execution is paused, the debugger evaluates all variables, constants, and objects up to a breakpoint and shows their current values inline next to the corresponding declarations.
+While the execution is paused, the debugger evaluates all variables, constants, and objects within the current function up to a breakpoint. The debugger shows the current values inline next to the corresponding declarations.
 
 {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/mUySGJfdYgR3URwClr67.png", alt="Inline evaluations displayed next to declarations.", width="800", height="363" %}
 


### PR DESCRIPTION
Documented the missing explanation for inline evaluation during debugging.

(M109 improves this evaluation for weak refs and new targets but that is expected as a part of a general workflow)