### PR TITLE
Fix link to chromestatus.com

### DIFF
--- a/site/en/blog/new-in-chrome-109/index.md
+++ b/site/en/blog/new-in-chrome-109/index.md
@@ -72,7 +72,7 @@ additional changes in Chrome 109.
 
 * [What's new in Chrome DevTools (109)](/blog/new-in-devtools-109/)
 * [Chrome 109 deprecations and removals](/blog/deps-rems-109/)
-* [ChromeStatus.com updates for Chrome 109](https://www.chromestatus.com/features#milestone%3D108)
+* [ChromeStatus.com updates for Chrome 109](https://www.chromestatus.com/features#milestone%3D109)
 * [Chromium source repository change list](https://chromium.googlesource.com/chromium/src/+log/108.0.5359.70..109.0.5414.91)
 * [Chrome release calendar](https://chromiumdash.appspot.com/schedule)
 


### PR DESCRIPTION
The link to ChromeStatus.com now points to milestone 109, instead of 108.