### PR TITLE
[ext-docs] New doc: Fetching favicons in MV3

### DIFF
--- a/site/_data/docs/extensions/toc.yml
+++ b/site/_data/docs/extensions/toc.yml
@@ -55,7 +55,7 @@
   sections:
     - url: /docs/extensions/mv3/settings_override
     - url: /docs/extensions/mv3/devtools
-    - url: /docs/extensions/mv3/https://github.com/GoogleChrome/developer.chrome.com/pull/4308
+    - url: /docs/extensions/mv3/favicon
     - url: /docs/extensions/mv3/tut_oauth
     - url: /docs/extensions/mv3/override
     - url: /docs/extensions/mv3/richNotifications

--- a/site/_data/docs/extensions/toc.yml
+++ b/site/_data/docs/extensions/toc.yml
@@ -55,6 +55,7 @@
   sections:
     - url: /docs/extensions/mv3/settings_override
     - url: /docs/extensions/mv3/devtools
+    - url: /docs/extensions/mv3/https://github.com/GoogleChrome/developer.chrome.com/pull/4308
     - url: /docs/extensions/mv3/tut_oauth
     - url: /docs/extensions/mv3/override
     - url: /docs/extensions/mv3/richNotifications

--- a/site/en/docs/extensions/mv3/favicon/index.md
+++ b/site/en/docs/extensions/mv3/favicon/index.md
@@ -1,46 +1,56 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Working with favicons"
-seoTitle: "Chrome Extensions: Working with favicons"
-date: 2023-01-10
+title: "Fetching favicons"
+seoTitle: "Fetching with favicons in Chrome extensions"
+date: 2023-01-11
 # updated: 2023-02-14
-description: How to access a websites' favicon in a Chrome extension.
+description: How to get a websites' favicon in a Chrome extension.
 ---
 
 ## Overview {: #overview }
 
-A favicon (short for "favorite icon") is a small icon that is displayed in the browser's address bar. Favicons are typically used to identify and differentiate websites.
-
+A [favicon][mdn-favicon] (short for "favorite icon") is a small icon that is displayed in the browser's address bar. Favicons are typically used to identify and differentiate websites.
 This article describes how to retrieve a website’s favicon in a Manifest version 3 extension.
 
-## Accessing a websites favicon {: #how-to} 
+## Accessing a websites' favicon {: #how-to } 
 
-To retrieve the favicon of a website, you need the `"favicon"` permission in the manifest and construct the following URL:
+To retrieve the favicon of a website, you need to construct the following URL:
 
 ```text
-chrome-extension://EXTENSION_ID/_favicon/?pageUrl=EXAMPLE_URL&size=32
+chrome-extension://EXTENSION_ID/_favicon/?pageUrl=EXAMPLE_URL&size=FAV_SIZE
 ```
 
-The `EXTENSION_ID` is the extension's unique ID and `EXAMPLE_URL` is the website you want to retrieve the favicon from.
+`EXTENSION_ID`
+: The ID of your extension.
 
-These steps are described:  
+`EXAMPLE_URL`
+: The URL of the favicon's website.
 
-### Update the manifest {: #manifest }
+`FAV_SIZE`
+: The size of the favicon. For example: 16, 32, or 64.
 
-```json
+The following steps describe how to construct this URL in a Chrome extension:  
+
+### Step 1: Update the manifest {: #manifest }
+
+First, you must request the `"favicon"` permission in the [manifest][doc-manifest].
+
+```json/4
 {
-  "name": "My favicon extension", 
+  "name": "Favicon API in a popup",
   "manifest_version": 3,
-  ...  
+  ...
   "permissions": ["favicon"],
   ...
 }
 ```
 
+In addition, when fetching favicons in [content scripts][doc-cs], the `"_favicon/*"` folder must be declared as a [web accessible resource][doc-war]. For example:
 
-```json
+```json/10-16
 {
-  ...
+  "name": "Favicon API in content scripts",
+  "manifest_version": 3,
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
@@ -59,39 +69,41 @@ These steps are described:
 }
 ```
 
-### Construct the URL {: #url }
+### Step 2: Construct the URL {: #url }
 
-The following code uses `runtime.getURL()` to get a   
-
-retrieves the 32 px favicon of www.google.com and displays it in a popup:  
+The following function uses [`runtime.getURL()`][runtime-geturl] to create a fully-qualified URL pointing to the `"/_favicon/"` folder. Then it returns a new query string with the URL and size of the favicon. Finally, the extension appends the image to the body. 
 
 ```js
 function faviconURL(u) {
   const url = new URL(chrome.runtime.getURL("/_favicon/"));
-  url.searchParams.set("pageUrl", u); // this encodes the URL as well
+  url.searchParams.set("pageUrl", u);
   url.searchParams.set("size", "32");
   return url.toString();
 }
 
-window.onload = e => {
-  const img = document.createElement('img');
-  // chrome-extension://EXTENSION_ID/_favicon/?pageUrl=https%3A%2F%2Fwww.google.com&size=32
-  img.src = faviconURL("https://www.google.com") 
-  document.body.appendChild(img);
-  ;
-}
+const img = document.createElement('img');
+img.src = faviconURL("https://www.google.com") 
+document.body.appendChild(img);
 ```
 
-### Example {: #example }
+This example is a `www.google.com` 32px favicon URL that includes a random extension ID:
 
-<!-- ASIDE
-For this to work in a content script, remember to add _favicon as a war -->
+```text
+chrome-extension://eghkbfdcoeikaepkldh/_favicon/?pageUrl=https%3A%2F%2Fwww.google.com&size=32
+```
 
+### Extension examples {: #example }
 
+There are two favicon examples in the [chrome-extension-samples][gh-samples] repository:
 
+- [Favicon API][gh-favicon-api] example in a popup. 
+- [Favicon content script][gh-favicon-cs] example. 
+
+[doc-cs]: /docs/extensions/mv3/content_scripts/
 [doc-manifest]: /docs/extensions/mv3/manifest/
 [doc-war]: /docs/extensions/mv3/manifest/web_accessible_resources/
-[doc-cs]: /docs/extensions/mv3/content_scripts/
 [gh-favicon-api]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api/favicon
 [gh-favicon-cs]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/example/favicon-cs
+[gh-samples]: https://github.com/GoogleChrome/chrome-extensions-samples/
 [mdn-favicon]: https://developer.mozilla.org/docs/Glossary/Favicon
+[runtime-geturl]: /docs/extensions/reference/runtime/#method-getURL

--- a/site/en/docs/extensions/mv3/favicon/index.md
+++ b/site/en/docs/extensions/mv3/favicon/index.md
@@ -4,15 +4,15 @@ title: "Fetching favicons"
 seoTitle: "Fetching with favicons in Chrome extensions"
 date: 2023-01-11
 # updated: 2023-02-14
-description: How to get a websites' favicon in a Chrome extension.
+description: How to get a website's favicon in a Chrome extension.
 ---
 
 ## Overview {: #overview }
 
 A [favicon][mdn-favicon] (short for "favorite icon") is a small icon that is displayed in the browser's address bar. Favicons are typically used to identify and differentiate websites.
-This article describes how to retrieve a website’s favicon in a Manifest version 3 extension.
+This article describes how to retrieve a website’s favicon in a Manifest V3 extension.
 
-## Accessing a websites' favicon {: #how-to } 
+## Accessing a website's favicon {: #how-to } 
 
 To retrieve the favicon of a website, you need to construct the following URL:
 
@@ -31,7 +31,7 @@ chrome-extension://EXTENSION_ID/_favicon/?pageUrl=EXAMPLE_URL&size=FAV_SIZE
 
 The following steps describe how to construct this URL in a Chrome extension:  
 
-### Step 1: Update the manifest {: #manifest }
+### Step 1: update the manifest {: #manifest }
 
 First, you must request the `"favicon"` permission in the [manifest][doc-manifest].
 
@@ -75,9 +75,9 @@ In addition, when fetching favicons in [content scripts][doc-cs], the `"_favicon
 }
 ```
 
-### Step 2: Construct the URL {: #url }
+### Step 2: construct the URL {: #url }
 
-The following function uses [`runtime.getURL()`][runtime-geturl] to create a fully-qualified URL pointing to the `"/_favicon/"` folder. Then it returns a new string representing the URL with several query parameters. Finally, the extension appends the image to the body. 
+The following function uses [`runtime.getURL()`][runtime-geturl] to create a fully-qualified URL pointing to the `"_favicon/"` folder. Then it returns a new string representing the URL with several query parameters. Finally, the extension appends the image to the body. 
 
 ```js
 function faviconURL(u) {

--- a/site/en/docs/extensions/mv3/favicon/index.md
+++ b/site/en/docs/extensions/mv3/favicon/index.md
@@ -45,6 +45,12 @@ First, you must request the `"favicon"` permission in the [manifest][doc-manifes
 }
 ```
 
+{% Aside 'caution' %}
+
+The `"favicon"` permission [triggers a warning][doc-perms-warn] unless other similar permissions are already requested, such as `"tabs"` or host permission. 
+
+{% endAside %}
+
 In addition, when fetching favicons in [content scripts][doc-cs], the `"_favicon/*"` folder must be declared as a [web accessible resource][doc-war]. For example:
 
 ```json/10-16
@@ -101,9 +107,11 @@ There are two favicon examples in the [chrome-extension-samples][gh-samples] rep
 
 [doc-cs]: /docs/extensions/mv3/content_scripts/
 [doc-manifest]: /docs/extensions/mv3/manifest/
+[doc-perms-warn]: /docs/extensions/mv3/permission_warnings/#permissions_with_warnings
 [doc-war]: /docs/extensions/mv3/manifest/web_accessible_resources/
 [gh-favicon-api]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api/favicon
 [gh-favicon-cs]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/example/favicon-cs
 [gh-samples]: https://github.com/GoogleChrome/chrome-extensions-samples/
 [mdn-favicon]: https://developer.mozilla.org/docs/Glossary/Favicon
 [runtime-geturl]: /docs/extensions/reference/runtime/#method-getURL
+

--- a/site/en/docs/extensions/mv3/favicon/index.md
+++ b/site/en/docs/extensions/mv3/favicon/index.md
@@ -98,11 +98,11 @@ This example is a `www.google.com` 32px favicon URL that includes a random exten
 chrome-extension://eghkbfdcoeikaepkldh/_favicon/?pageUrl=https%3A%2F%2Fwww.google.com&size=32
 ```
 
-### Extension examples {: #example }
+## Extension examples {: #example }
 
 There are two favicon examples in the [chrome-extension-samples][gh-samples] repository:
 
-- [Favicon API][gh-favicon-api] example in a popup. 
+- [Favicon popup][gh-favicon-api] example. 
 - [Favicon content script][gh-favicon-cs] example. 
 
 [doc-cs]: /docs/extensions/mv3/content_scripts/

--- a/site/en/docs/extensions/mv3/favicon/index.md
+++ b/site/en/docs/extensions/mv3/favicon/index.md
@@ -77,7 +77,7 @@ In addition, when fetching favicons in [content scripts][doc-cs], the `"_favicon
 
 ### Step 2: Construct the URL {: #url }
 
-The following function uses [`runtime.getURL()`][runtime-geturl] to create a fully-qualified URL pointing to the `"/_favicon/"` folder. Then it returns a new query string with the URL and size of the favicon. Finally, the extension appends the image to the body. 
+The following function uses [`runtime.getURL()`][runtime-geturl] to create a fully-qualified URL pointing to the `"/_favicon/"` folder. Then it returns a new string representing the URL with several query parameters. Finally, the extension appends the image to the body. 
 
 ```js
 function faviconURL(u) {

--- a/site/en/docs/extensions/mv3/favicon/index.md
+++ b/site/en/docs/extensions/mv3/favicon/index.md
@@ -1,0 +1,29 @@
+---
+layout: "layouts/doc-post.njk"
+title: "Working with favicons"
+seoTitle: "Chrome Extensions: Working with favicons"
+date: 2023-01-10
+# updated: 2023-02-14
+description: How to use favicons in Chrome extensions.
+---
+
+## Overview {: #overview }
+
+## Accessing a websites favicon {: #how-to} 
+
+### Update the manifest {: #manifest }
+
+### Construct the URL {: #url }
+
+### Example {: #example }
+
+<!-- ASIDE
+For this to work in a content script, remember to add _favicon as a war -->
+
+
+
+[doc-manifest]: /docs/extensions/mv3/manifest/
+[doc-war]: /docs/extensions/mv3/manifest/web_accessible_resources/
+[doc-cs]: /docs/extensions/mv3/content_scripts/
+[gh-favicon-api]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api/favicon
+[gh-favicon-cs]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/example/favicon-cs

--- a/site/en/docs/extensions/mv3/favicon/index.md
+++ b/site/en/docs/extensions/mv3/favicon/index.md
@@ -4,16 +4,83 @@ title: "Working with favicons"
 seoTitle: "Chrome Extensions: Working with favicons"
 date: 2023-01-10
 # updated: 2023-02-14
-description: How to use favicons in Chrome extensions.
+description: How to access a websites' favicon in a Chrome extension.
 ---
 
 ## Overview {: #overview }
 
+A favicon (short for "favorite icon") is a small icon that is displayed in the browser's address bar. Favicons are typically used to identify and differentiate websites.
+
+This article describes how to retrieve a website’s favicon in a Manifest version 3 extension.
+
 ## Accessing a websites favicon {: #how-to} 
+
+To retrieve the favicon of a website, you need the `"favicon"` permission in the manifest and construct the following URL:
+
+```text
+chrome-extension://EXTENSION_ID/_favicon/?pageUrl=EXAMPLE_URL&size=32
+```
+
+The `EXTENSION_ID` is the extension's unique ID and `EXAMPLE_URL` is the website you want to retrieve the favicon from.
+
+These steps are described:  
 
 ### Update the manifest {: #manifest }
 
+```json
+{
+  "name": "My favicon extension", 
+  "manifest_version": 3,
+  ...  
+  "permissions": ["favicon"],
+  ...
+}
+```
+
+
+```json
+{
+  ...
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"]
+    }
+  ],
+  "permissions": ["favicon"],
+  "web_accessible_resources": [
+    {
+      "resources": ["_favicon/*"],
+      "matches": ["<all_urls>"],
+      "extension_ids": ["*"]
+    }
+  ]
+  ...
+}
+```
+
 ### Construct the URL {: #url }
+
+The following code uses `runtime.getURL()` to get a   
+
+retrieves the 32 px favicon of www.google.com and displays it in a popup:  
+
+```js
+function faviconURL(u) {
+  const url = new URL(chrome.runtime.getURL("/_favicon/"));
+  url.searchParams.set("pageUrl", u); // this encodes the URL as well
+  url.searchParams.set("size", "32");
+  return url.toString();
+}
+
+window.onload = e => {
+  const img = document.createElement('img');
+  // chrome-extension://EXTENSION_ID/_favicon/?pageUrl=https%3A%2F%2Fwww.google.com&size=32
+  img.src = faviconURL("https://www.google.com") 
+  document.body.appendChild(img);
+  ;
+}
+```
 
 ### Example {: #example }
 
@@ -27,3 +94,4 @@ For this to work in a content script, remember to add _favicon as a war -->
 [doc-cs]: /docs/extensions/mv3/content_scripts/
 [gh-favicon-api]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api/favicon
 [gh-favicon-cs]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/example/favicon-cs
+[mdn-favicon]: https://developer.mozilla.org/docs/Glossary/Favicon

--- a/site/en/docs/extensions/mv3/favicon/index.md
+++ b/site/en/docs/extensions/mv3/favicon/index.md
@@ -95,7 +95,7 @@ document.body.appendChild(img);
 This example is a `www.google.com` 32px favicon URL that includes a random extension ID:
 
 ```text
-chrome-extension://eghkbfdcoeikaepkldh/_favicon/?pageUrl=https%3A%2F%2Fwww.google.com&size=32
+chrome-extension://eghkbfdcoeikaepkldhfgphlaiojonpc/_favicon/?pageUrl=https%3A%2F%2Fwww.google.com&size=32
 ```
 
 ## Extension examples {: #example }


### PR DESCRIPTION
Fixes #3286  

Changes proposed in this pull request:

- Add instructions on how to use the Favicon API on MV3 extensions.

**Related PRs**

- Favicon API popup refactor and add favicon example in a content script [PR#806](https://github.com/GoogleChrome/chrome-extensions-samples/pull/806)