### PR TITLE
Add permission warning for sessions

### DIFF
--- a/site/en/docs/extensions/mv3/permission_warnings/index.md
+++ b/site/en/docs/extensions/mv3/permission_warnings/index.md
@@ -303,7 +303,7 @@ the steps in [Viewing Warnings](#view_warnings).
     <tr id="sessionstabs">
       <td><code>"sessions"</code> and <code>"tabs"</code></td>
       <td>Grants the extension access to the <a href="/docs/extensions/reference/sessions">chrome.sessions</a> API and privileged fields of the <a
-          href="/extensions/tabs#type-Tab"><code>Tab</code></a> objects.</td>
+          href="/docs/extensions/reference/tabs/#perms"><code>Tab</code></a> objects.</td>
       <td><strong>Read your browsing history on all your signed-in devices</strong></td>
     </tr>
     <tr id="system.storage">

--- a/site/en/docs/extensions/mv3/permission_warnings/index.md
+++ b/site/en/docs/extensions/mv3/permission_warnings/index.md
@@ -297,12 +297,12 @@ the steps in [Viewing Warnings](#view_warnings).
     </tr>
     <tr id="sessionshistory">
       <td><code>"sessions"</code> and <code>"history"</code></td>
-      <td>Grants the extension access to the <a href="/docs/extensions/reference/sessions">chrome.system.storage</a> API.</td>
+      <td>Grants the extension access to the <a href="/docs/extensions/reference/sessions">chrome.sessions</a> API.</td>
       <td><strong>Read and change your browsing history on all your signed-in devices</strong></td>
     </tr>
     <tr id="sessionstabs">
       <td><code>"sessions"</code> and <code>"tabs"</code></td>
-      <td>Grants the extension access to the <a href="/docs/extensions/reference/sessions">chrome.system.storage</a> API.</td>
+      <td>Grants the extension access to the <a href="/docs/extensions/reference/sessions">chrome.sessions</a> API.</td>
       <td><strong>Read your browsing history on all your signed-in devices</strong></td>
     </tr>
     <tr id="system.storage">

--- a/site/en/docs/extensions/mv3/permission_warnings/index.md
+++ b/site/en/docs/extensions/mv3/permission_warnings/index.md
@@ -295,6 +295,16 @@ the steps in [Viewing Warnings](#view_warnings).
       <td>Grants the extension access to the <a href="/docs/extensions/reference/proxy">chrome.proxy</a> API.</td>
       <td><strong>Read and change all your data on all websites</strong></td>
     </tr>
+    <tr id="sessionshistory">
+      <td><code>"sessions"</code> and <code>"history"</code></td>
+      <td>Grants the extension access to the <a href="/docs/extensions/reference/sessions">chrome.system.storage</a> API.</td>
+      <td><strong>Read and change your browsing history on all your signed-in devices</strong></td>
+    </tr>
+    <tr id="sessionstabs">
+      <td><code>"sessions"</code> and <code>"tabs"</code></td>
+      <td>Grants the extension access to the <a href="/docs/extensions/reference/sessions">chrome.system.storage</a> API.</td>
+      <td><strong>Read your browsing history on all your signed-in devices</strong></td>
+    </tr>
     <tr id="system.storage">
       <td><code>"system.storage"</code></td>
       <td>Grants the extension access to the <a href="/docs/extensions/reference/system.storage">chrome.system.storage</a> API.</td>

--- a/site/en/docs/extensions/mv3/permission_warnings/index.md
+++ b/site/en/docs/extensions/mv3/permission_warnings/index.md
@@ -297,12 +297,13 @@ the steps in [Viewing Warnings](#view_warnings).
     </tr>
     <tr id="sessionshistory">
       <td><code>"sessions"</code> and <code>"history"</code></td>
-      <td>Grants the extension access to the <a href="/docs/extensions/reference/sessions">chrome.sessions</a> API.</td>
+      <td>Grants the extension access to the <a href="/docs/extensions/reference/sessions">chrome.sessions</a> API and <a href="/docs/extensions/reference/history">chrome.history</a> API.</td>
       <td><strong>Read and change your browsing history on all your signed-in devices</strong></td>
     </tr>
     <tr id="sessionstabs">
       <td><code>"sessions"</code> and <code>"tabs"</code></td>
-      <td>Grants the extension access to the <a href="/docs/extensions/reference/sessions">chrome.sessions</a> API.</td>
+      <td>Grants the extension access to the <a href="/docs/extensions/reference/sessions">chrome.sessions</a> API and privileged fields of the <a
+          href="/extensions/tabs#type-Tab"><code>Tab</code></a> objects.</td>
       <td><strong>Read your browsing history on all your signed-in devices</strong></td>
     </tr>
     <tr id="system.storage">


### PR DESCRIPTION
Fixes the documentation. Add documentation that a warning message will be visible if you use the `sessions` + `history` and `sessions` + `tabs` permission. https://developer.chrome.com/docs/extensions/reference/sessions/