### PR TITLE
Use CJS export in example config

### DIFF
--- a/site/en/docs/workbox/the-ways-of-workbox/index.md
+++ b/site/en/docs/workbox/the-ways-of-workbox/index.md
@@ -69,7 +69,7 @@ To start using the CLI, run the wizard with `npx workbox wizard`. The wizard wil
 
 ```js
 // A config for `generateSW`
-export default {
+module.exports = {
   globDirectory: 'dist/',
   globPatterns: [
     '**/*.{css,woff2,png,svg,jpg,js}'


### PR DESCRIPTION
Changes proposed in this pull request:

- Use CJS export in example config

Why? Because otherwise it gives the following error:

```
$ npx workbox generateSW workbox-config.js
Please pass in a valid CommonJS module that exports your configuration.

Unexpected token 'export' …
```

Even `npx workbox wizard` generates config with CJS export:

```js
module.exports = {
	globDirectory: '.',
	globPatterns: [
		'**/*.{json,jpg}'
	],
	swDest: 'sw.js',
	ignoreURLParametersMatching: [
		/^utm_/,
		/^fbclid$/
	]
};
```