### PR TITLE
feat(social): add social links to post author macro, fixes #926

### DIFF
--- a/site/_includes/macros/post-author.njk
+++ b/site/_includes/macros/post-author.njk
@@ -5,9 +5,10 @@
 #}
 {% macro postAuthor(authorId, locale) %}
 
+{% set author = authorsData[authorId] %}
 {% set authorTitle = 'i18n.authors.' + authorId + '.title' %}
 {% set authorDescription = 'i18n.authors.' + authorId + '.description' %}
-{% set authorImage = authorsData[authorId].image or site.defaultAvatarImg %}
+{% set authorImage = author.image or site.defaultAvatarImg %}
 
 <div class="display-flex align-start">
   {% if authorImage %}
@@ -23,9 +24,30 @@
     </a>
   {% endif %}
   <div class="display-flex direction-column align-start gap-left-300 type--small">
-    {% if authorsData[authorId] %}
-      <a href="/authors/{{authorId}}/" translate="no" class="surface display-inline-flex color-text">{{ authorTitle | i18n(locale) }}</a>
+    {% if author %}
+      <a href="/authors/{{authorId}}/" translate="no" class="surface display-inline-flex color-text">{{ authorTitle |
+        i18n(locale) }}</a>
       <p class="color-secondary-text">{{ authorDescription | i18n(locale) }}</p>
+
+      <!-- Start author social links -->
+      <div class="post-authors-social">
+        {% if author.homepage %}
+          <a href="{{ author.homepage }}" class="link">{{ 'i18n.common.website' | i18n(locale) }}</a>
+        {% endif %}
+        {% if author.twitter %}
+          <a href="https://twitter.com/{{ author.twitter }}" class="link">Twitter</a>
+        {% endif %}
+        {% if author.github %}
+          <a href="https://github.com/{{ author.github }}" class="link">GitHub</a>
+        {% endif %}
+        {% if author.glitch %}
+          <a href="https://glitch.com/@{{ author.glitch }}" class="link">Glitch</a>
+        {% endif %}
+        {% if author.mastodon %}
+          <a href="{{ author.mastodon }}" class="link">Mastodon</a>
+        {% endif %}
+      </div>
+      <!-- End author social links -->
     {% else %}
       <p>{{ authorId }}</p>
     {% endif %}

--- a/site/_scss/blocks/_post-authors.scss
+++ b/site/_scss/blocks/_post-authors.scss
@@ -3,3 +3,8 @@
   gap: get-size(500);
   grid-template-columns: repeat(auto-fit, minmax(px-to-rem(220px), 1fr));
 }
+
+.post-authors-social {
+  display: flex;
+  gap: get-size(200);
+}


### PR DESCRIPTION
Fixes #926

Changes proposed in this pull request:

- Add social links to post-author macro
- Add simple CSS for links

![image](https://user-images.githubusercontent.com/11811422/212569432-8cc95834-6ec4-4a61-8ab6-da080e2f8cfb.png)


@devnook I think that the links for the post card and the authors page may be able to be made into one macro, and just have a flag to display images or text, but I didn't want to introduce that unless you agreed. I think this is the minimum required for the feature.