### PR TITLE
Clarify behaviour when MacCtrl is used on other platforms.

### DIFF
--- a/site/en/docs/extensions/reference/commands/index.md
+++ b/site/en/docs/extensions/reference/commands/index.md
@@ -80,7 +80,7 @@ Modifier key strings
     - To use the Control key on macOS, replace `Ctrl` with `MacCtrl` when defining the `"mac"`
       shortcut.
 
-    - Including `MacCtrl` in other shortcuts will cause the extension to be uninstallable.
+    - Using `MacCtrl` in the combination for another platform will cause a validation error and prevent the extension from being installed.
 
 - `Shift` is an optional modifier on all platforms.
 


### PR DESCRIPTION
A comment about MacCtrl in the commands docs was unclear about what would happen if this keyword was used on platforms other than macOS. I've reworded it to avoid using "uninstallable" and hopefully clarify the intended meaning.