### PR TITLE
Fix typo on 'input_components'

### DIFF
--- a/site/en/docs/extensions/mv3/manifest/input_components/index.md
+++ b/site/en/docs/extensions/mv3/manifest/input_components/index.md
@@ -1,9 +1,9 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Manifest - input_component"
+title: "Manifest - input_components"
 date: 2022-10-28
 updated: 
-description: Reference documentation for the input_component property of manifest.json.
+description: Reference documentation for the input_components property of manifest.json.
 ---
 
 An optional Manifest key enabling the use of the  [`input.ime` API](/docs/extensions/reference/input_ime/) (Input Method Editor) for use with ChromeOS. This allows your extension to handle keystrokes, set the composition, and open assistive windows. Developers must also declare the `"input"` permission in the extension's `"permissions"` array. 


### PR DESCRIPTION
This PR renames a directory from
`site/en/docs/extensions/mv3/manifest/input_component/`
to
`site/en/docs/extensions/mv3/manifest/input_components/`
to fix a dangling link from [the manifest doc](https://developer.chrome.com/docs/extensions/mv3/manifest/).