### PR TITLE
Update Google Cloud Build staging job to use secret version 2

### DIFF
--- a/.cloudbuild/stage.yaml
+++ b/.cloudbuild/stage.yaml
@@ -39,5 +39,5 @@ options:
 
 availableSecrets:
   secretManager:
-    - versionName: projects/dcc-staging/secrets/GITHUB_TOKEN/versions/1
+    - versionName: projects/dcc-staging/secrets/GITHUB_TOKEN/versions/2
       env: 'GITHUB_TOKEN'


### PR DESCRIPTION
Well, that's a simple one for a change.

The previous secret stored a token that was only valid for 30 days. I now issued a token valid for a year, which is the current maximum for the new fine-grained GitHub PATs. The new token will expire on Sat, Jan 13 2024. Advice on what's the best way to track this is much appreciated.