### PR TITLE
[ext-docs] Fix link to CSP docs in the sandbox key doc

### DIFF
--- a/site/en/docs/extensions/mv3/manifest/sandbox/index.md
+++ b/site/en/docs/extensions/mv3/manifest/sandbox/index.md
@@ -51,11 +51,10 @@ used by sandboxed pages (e.g. stylesheets or JavaScript source files) do not nee
 
 ["Using eval in Chrome Extensions. Safely."][4] goes into more detail about implementing a
 sandboxing workflow that enables the use of libraries that would otherwise have issues executing under
-extension's [default Content Security Policy][5].
+extension's [default Content Security Policy][doc-csp].
 
 [1]: /docs/apps/webview_tag
-[2]: /docs/extensions/mv3/contentSecurityPolicy
 [3]: https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox
 [4]: /docs/extensions/mv3/sandboxingEval
-[5]: /docs/extensions/mv3/contentSecurityPolicy
 [6]: /docs/extensions/mv3/tabs#manifest_version
+[doc-csp]: /docs/extensions/mv3/manifest/content_security_policy/

--- a/site/en/docs/extensions/mv3/manifest/sandbox/index.md
+++ b/site/en/docs/extensions/mv3/manifest/sandbox/index.md
@@ -15,7 +15,7 @@ Being in a sandbox has two implications:
 
 1.  A sandboxed page will not have access to extension APIs, or direct access to
     non-sandboxed pages (it may communicate with them via `postMessage()`).
-2.  A sandboxed page is not subject to the [Content Security Policy (CSP)][2] used by the rest of
+2.  A sandboxed page is not subject to the [Content Security Policy (CSP)][doc-csp] used by the rest of
     the extension (it has its own separate CSP value). This means that, for example, it can
     use inline script and `eval`.
 


### PR DESCRIPTION
Fixes #4644

✅ Fixes link to [csp](https://developer.chrome.com/docs/extensions/mv3/manifest/content_security_policy/) docs, in the sandbox doc.

❌ **Does not** audit or improve the content of the sandbox doc.