### PR TITLE
Add missing i18n for tags, properly handle free-form labels for `{% Compare %}`, use webdev-infra i18n filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "unistore": "^3.5.2",
         "uslug": "^1.0.4",
         "web-vitals": "^3.0.4",
-        "webdev-infra": "1.0.41",
+        "webdev-infra": "1.0.42",
         "xss": "^1.0.14"
       },
       "devDependencies": {
@@ -114,30 +114,30 @@
       "integrity": "sha512-5R+DsT9LJ9tXiSQ4y+KLFppCkQyXhzAm1AIuBWE/sbU0hSXY5pkhoqQYEcPJQFg/nglL+wD55iv2j+7O96UAvg=="
     },
     "node_modules/@11ty/eleventy": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-1.0.1.tgz",
-      "integrity": "sha512-2fJDHVBkRr1SB7CqBexwoLdiOGUE0f22O+Ie1TT/FI65XQZWshgHVZzvmZfmtKvQW4qtaC/FuJG3wMxkXfel7w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-1.0.2.tgz",
+      "integrity": "sha512-03ER4zukR6BgwppI5DHRE11lc+8B0fWsBrqacVWo3o49QkdEFXnEWjhyI9qd9LrPlgQHK2/MYyxuOvNwecyCLQ==",
       "dependencies": {
         "@11ty/dependency-tree": "^2.0.1",
         "@11ty/eleventy-utils": "^1.0.1",
         "@iarna/toml": "^2.2.5",
         "@sindresorhus/slugify": "^1.1.2",
-        "browser-sync": "^2.27.9",
+        "browser-sync": "^2.27.10",
         "chokidar": "^3.5.3",
         "cross-spawn": "^7.0.3",
         "debug": "^4.3.4",
         "dependency-graph": "^0.11.0",
-        "ejs": "^3.1.6",
+        "ejs": "^3.1.8",
         "fast-glob": "^3.2.11",
         "graceful-fs": "^4.2.10",
         "gray-matter": "^4.0.3",
         "hamljs": "^0.6.2",
         "handlebars": "^4.7.7",
         "is-glob": "^4.0.3",
-        "kleur": "^4.1.4 ",
-        "liquidjs": "^9.36.1",
+        "kleur": "^4.1.5",
+        "liquidjs": "^9.40.0",
         "lodash": "^4.17.21",
-        "luxon": "^2.3.2",
+        "luxon": "^2.5.0",
         "markdown-it": "^12.3.2",
         "minimist": "^1.2.6",
         "moo": "^0.5.1",
@@ -145,7 +145,7 @@
         "mustache": "^4.2.0",
         "normalize-path": "^3.0.0",
         "nunjucks": "^3.2.3",
-        "path-to-regexp": "^6.2.0",
+        "path-to-regexp": "^6.2.1",
         "please-upgrade-node": "^3.2.0",
         "pretty": "^2.0.0",
         "pug": "^3.0.2",
@@ -2259,6 +2259,11 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/@mdn/browser-compat-data": {
+      "version": "5.2.23",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.23.tgz",
+      "integrity": "sha512-El3EaBt6EzO8DrRgpaJKLwik+wdImyIxL6Nbp9iQSddDIfmrFvF+Chz2LYBQoLEUCg8wjwEVRMA44TwlhW3rjQ=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.3",
@@ -13178,9 +13183,9 @@
       }
     },
     "node_modules/kleur": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
-      "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
       "engines": {
         "node": ">=6"
       }
@@ -13712,9 +13717,9 @@
       }
     },
     "node_modules/liquidjs": {
-      "version": "9.37.0",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-9.37.0.tgz",
-      "integrity": "sha512-qDj9iiNdB+QNZTR4iKjiQzoHQma7V8Itx5oZG/ZCP7xjebh1LI+s5IG2ZYUbs1ALO6hBzmW36Ptd8RR4eohuDA==",
+      "version": "9.43.0",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-9.43.0.tgz",
+      "integrity": "sha512-qZZuL5Emja2UgCqiLewiw9bvwZQwm19TTGFxDkonVzB4YSTOZ8tuTVo/7Uu/AeW1cL2Qb/at3DSoV8wwyFXQCw==",
       "bin": {
         "liquid": "bin/liquid.js",
         "liquidjs": "bin/liquid.js"
@@ -14179,9 +14184,9 @@
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
     },
     "node_modules/luxon": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.4.0.tgz",
-      "integrity": "sha512-w+NAwWOUL5hO0SgwOHsMBAmZ15SoknmQXhSO0hIbJCAmPKSsGeK8MlmhYh2w6Iib38IxN2M+/ooXWLbeis7GuA==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.5.2.tgz",
+      "integrity": "sha512-Yg7/RDp4nedqmLgyH0LwgGRvMEKVzKbUdkBYyCosbHgJ+kaOUx0qzSiSatVc3DFygnirTPYnMM2P5dg2uH1WvA==",
       "engines": {
         "node": ">=12"
       }
@@ -24631,20 +24636,27 @@
       "integrity": "sha512-Yau8qf1AJ/dm6MY180Bi0qpCIuWmAfKAnOqmxLecGfIHn0+ND3H4JOhXeY73Pyi9zjSF5J4SNUewHLNUzU7mmA=="
     },
     "node_modules/webdev-infra": {
-      "version": "1.0.41",
-      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.41.tgz",
-      "integrity": "sha512-ILSdx0bfG1Bwo00VBPpK7b+sOpNYLkvA+ZtBq/EgPSqftnRc/8hmr9J0j09bXcKypDJEkoTlxy4bPy1KvZymGw==",
+      "version": "1.0.42",
+      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.42.tgz",
+      "integrity": "sha512-ckCXadeoKnrUCTaJ+15ee0n491mW+t+fW10hakv49DAdjX53Efm63yuSS9HXt6n7m2fDl/koVw8I16gp0NW+Og==",
       "dependencies": {
+        "@11ty/eleventy": "1.0.2",
+        "@11ty/eleventy-cache-assets": "^2.3.0",
         "@imgix/js-core": "^3.1.3",
         "@justinribeiro/lite-youtube": "^0.9.1",
+        "@mdn/browser-compat-data": "5.2.23",
         "@swc/html": "0.0.18",
         "async-transforms": "^1.0.9",
         "browser-media-mime-type": "^1.0.0",
         "common-tags": "^1.8.0",
         "csso": "5.0.5",
         "fast-glob": "3.2.12",
+        "js-yaml": "4.1.0",
         "lit-element": "^2.5.1",
+        "lodash.get": "4.4.2",
+        "lodash.set": "4.3.2",
         "markdown-it": "^12.3.2",
+        "nunjucks": "3.2.3",
         "piscina": "^3.2.0",
         "purgecss": "5.0.0",
         "querystring": "^0.2.1",
@@ -25238,30 +25250,30 @@
       "integrity": "sha512-5R+DsT9LJ9tXiSQ4y+KLFppCkQyXhzAm1AIuBWE/sbU0hSXY5pkhoqQYEcPJQFg/nglL+wD55iv2j+7O96UAvg=="
     },
     "@11ty/eleventy": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-1.0.1.tgz",
-      "integrity": "sha512-2fJDHVBkRr1SB7CqBexwoLdiOGUE0f22O+Ie1TT/FI65XQZWshgHVZzvmZfmtKvQW4qtaC/FuJG3wMxkXfel7w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-1.0.2.tgz",
+      "integrity": "sha512-03ER4zukR6BgwppI5DHRE11lc+8B0fWsBrqacVWo3o49QkdEFXnEWjhyI9qd9LrPlgQHK2/MYyxuOvNwecyCLQ==",
       "requires": {
         "@11ty/dependency-tree": "^2.0.1",
         "@11ty/eleventy-utils": "^1.0.1",
         "@iarna/toml": "^2.2.5",
         "@sindresorhus/slugify": "^1.1.2",
-        "browser-sync": "^2.27.9",
+        "browser-sync": "^2.27.10",
         "chokidar": "^3.5.3",
         "cross-spawn": "^7.0.3",
         "debug": "^4.3.4",
         "dependency-graph": "^0.11.0",
-        "ejs": "^3.1.6",
+        "ejs": "^3.1.8",
         "fast-glob": "^3.2.11",
         "graceful-fs": "^4.2.10",
         "gray-matter": "^4.0.3",
         "hamljs": "^0.6.2",
         "handlebars": "^4.7.7",
         "is-glob": "^4.0.3",
-        "kleur": "^4.1.4 ",
-        "liquidjs": "^9.36.1",
+        "kleur": "^4.1.5",
+        "liquidjs": "^9.40.0",
         "lodash": "^4.17.21",
-        "luxon": "^2.3.2",
+        "luxon": "^2.5.0",
         "markdown-it": "^12.3.2",
         "minimist": "^1.2.6",
         "moo": "^0.5.1",
@@ -25269,7 +25281,7 @@
         "mustache": "^4.2.0",
         "normalize-path": "^3.0.0",
         "nunjucks": "^3.2.3",
-        "path-to-regexp": "^6.2.0",
+        "path-to-regexp": "^6.2.1",
         "please-upgrade-node": "^3.2.0",
         "pretty": "^2.0.0",
         "pug": "^3.0.2",
@@ -26962,6 +26974,11 @@
           }
         }
       }
+    },
+    "@mdn/browser-compat-data": {
+      "version": "5.2.23",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.23.tgz",
+      "integrity": "sha512-El3EaBt6EzO8DrRgpaJKLwik+wdImyIxL6Nbp9iQSddDIfmrFvF+Chz2LYBQoLEUCg8wjwEVRMA44TwlhW3rjQ=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
@@ -35380,9 +35397,9 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
     "kleur": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
-      "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA=="
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="
     },
     "known-css-properties": {
       "version": "0.21.0",
@@ -35808,9 +35825,9 @@
       }
     },
     "liquidjs": {
-      "version": "9.37.0",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-9.37.0.tgz",
-      "integrity": "sha512-qDj9iiNdB+QNZTR4iKjiQzoHQma7V8Itx5oZG/ZCP7xjebh1LI+s5IG2ZYUbs1ALO6hBzmW36Ptd8RR4eohuDA=="
+      "version": "9.43.0",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-9.43.0.tgz",
+      "integrity": "sha512-qZZuL5Emja2UgCqiLewiw9bvwZQwm19TTGFxDkonVzB4YSTOZ8tuTVo/7Uu/AeW1cL2Qb/at3DSoV8wwyFXQCw=="
     },
     "list-to-array": {
       "version": "1.1.0",
@@ -36165,9 +36182,9 @@
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
     },
     "luxon": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.4.0.tgz",
-      "integrity": "sha512-w+NAwWOUL5hO0SgwOHsMBAmZ15SoknmQXhSO0hIbJCAmPKSsGeK8MlmhYh2w6Iib38IxN2M+/ooXWLbeis7GuA=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.5.2.tgz",
+      "integrity": "sha512-Yg7/RDp4nedqmLgyH0LwgGRvMEKVzKbUdkBYyCosbHgJ+kaOUx0qzSiSatVc3DFygnirTPYnMM2P5dg2uH1WvA=="
     },
     "magic-string": {
       "version": "0.25.7",
@@ -44344,20 +44361,27 @@
       "integrity": "sha512-Yau8qf1AJ/dm6MY180Bi0qpCIuWmAfKAnOqmxLecGfIHn0+ND3H4JOhXeY73Pyi9zjSF5J4SNUewHLNUzU7mmA=="
     },
     "webdev-infra": {
-      "version": "1.0.41",
-      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.41.tgz",
-      "integrity": "sha512-ILSdx0bfG1Bwo00VBPpK7b+sOpNYLkvA+ZtBq/EgPSqftnRc/8hmr9J0j09bXcKypDJEkoTlxy4bPy1KvZymGw==",
+      "version": "1.0.42",
+      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.42.tgz",
+      "integrity": "sha512-ckCXadeoKnrUCTaJ+15ee0n491mW+t+fW10hakv49DAdjX53Efm63yuSS9HXt6n7m2fDl/koVw8I16gp0NW+Og==",
       "requires": {
+        "@11ty/eleventy": "1.0.2",
+        "@11ty/eleventy-cache-assets": "^2.3.0",
         "@imgix/js-core": "^3.1.3",
         "@justinribeiro/lite-youtube": "^0.9.1",
+        "@mdn/browser-compat-data": "5.2.23",
         "@swc/html": "0.0.18",
         "async-transforms": "^1.0.9",
         "browser-media-mime-type": "^1.0.0",
         "common-tags": "^1.8.0",
         "csso": "5.0.5",
         "fast-glob": "3.2.12",
+        "js-yaml": "4.1.0",
         "lit-element": "^2.5.1",
+        "lodash.get": "4.4.2",
+        "lodash.set": "4.3.2",
         "markdown-it": "^12.3.2",
+        "nunjucks": "3.2.3",
         "piscina": "^3.2.0",
         "purgecss": "5.0.0",
         "querystring": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "unistore": "^3.5.2",
     "uslug": "^1.0.4",
     "web-vitals": "^3.0.4",
-    "webdev-infra": "1.0.41",
+    "webdev-infra": "1.0.42",
     "xss": "^1.0.14"
   },
   "optionalDependencies": {

--- a/site/_data/i18n/authors.yaml
+++ b/site/_data/i18n/authors.yaml
@@ -1106,17 +1106,17 @@ greenido:
   title:
     en: Ido Green
   description:
-    en: ''
+    en: 'Senior technology leader and entrepreneur at heart'
 christianliebel:
   title:
     en: Christian Liebel
   description:
-    en: ''
+    en: 'Consultant, Thinktecture AG'
 jonathangarbee:
   title:
     en: Jonathan Garbee
   description:
-    en: ''
+    en: 'Front-end engineer with a passion for usability and accessibility'
 noraoneill:
   title:
     en: "Nora O'Neill"

--- a/site/_data/i18n/checkbox_group.yml
+++ b/site/_data/i18n/checkbox_group.yml
@@ -1,5 +1,0 @@
-select_all:
-  en: 'Select all'
-
-reset:
-  en: 'Reset'

--- a/site/_data/i18n/common.yml
+++ b/site/_data/i18n/common.yml
@@ -247,3 +247,9 @@ bug_report:
     en: about reporting a bug.
   report_cta:
     en: Report a bug.
+
+checkbox_group:
+  reset: 
+    en: Reset
+  select_all:
+    en: Select all

--- a/site/_data/i18n/tags.yml
+++ b/site/_data/i18n/tags.yml
@@ -263,3 +263,57 @@ webauthn:
 
 passkeys:
   en: Passkeys
+
+monitoring:
+  en: Monitoring
+
+web-app-manifest:
+  en: Web app manifest
+
+cors:
+  en: CORS
+
+video:
+  en: Video
+
+idle-detection:
+  en: Idle detection
+
+backpressure:
+  en: Backpressure
+
+websocket:
+  en: Web Socket
+
+websocketstream:
+  en: WebSocketStream
+
+service-worker:
+  en: Service Worker
+
+caching:
+  en: Caching
+
+feedback:
+  en: Feedback
+
+api:
+  en: API
+
+notification-triggers:
+  en: Notification triggers
+
+contacts:
+  en: Contacts
+
+shape-detection:
+  en: Shape detection
+
+wake-lock:
+  en: Wake Lock
+
+notifications:
+  en: Notifications
+
+sensors:
+  en: Sensors

--- a/site/_includes/partials/event-card.njk
+++ b/site/_includes/partials/event-card.njk
@@ -67,7 +67,7 @@
     <div class="event-card__details gap-top-400 grid-cols-1 grid-gap-400 lg:grid-cols-2">
       {% for session in event.sessions %}
         {% if session.type === 'speaker' %}
-          {% set alt = session.speaker.title or session.title %}
+          {% set alt = session.speaker.title | i18n or session.title %}
           {% set sessionImage = session.speaker.image %}
           {% set sessionTitle = session.speaker.title | i18n %}
 

--- a/site/_shortcodes/Compare.js
+++ b/site/_shortcodes/Compare.js
@@ -36,7 +36,14 @@ function Compare(content, type, labelOverride) {
 
   let label;
   if (labelOverride) {
-    label = i18n(`i18n.common.compare_${labelOverride}`, locale);
+    // Someone might pass in an available compare_* subkey, but can also
+    // provide a free form string. Try to i18n the subkey first, and
+    // if that doesn't exist, use the free form string.
+    try {
+      label = i18n(`i18n.common.compare_${labelOverride}`, locale);
+    } catch (e) {
+      label = labelOverride;
+    }
   } else {
     label = i18n(`i18n.common.compare_${type}`, locale);
   }
@@ -49,7 +56,7 @@ function Compare(content, type, labelOverride) {
   return `<div class="compare pad-left-300" data-type="${type}">
 
 <p class="compare__label pad-bottom-200">
-  ${label}
+  Rambazamba: ${label}
 </p>
 
 ${content}

--- a/site/_shortcodes/Compare.js
+++ b/site/_shortcodes/Compare.js
@@ -56,7 +56,7 @@ function Compare(content, type, labelOverride) {
   return `<div class="compare pad-left-300" data-type="${type}">
 
 <p class="compare__label pad-bottom-200">
-  Rambazamba: ${label}
+  ${label}
 </p>
 
 ${content}

--- a/site/en/articles/content-indexing-api/index.md
+++ b/site/en/articles/content-indexing-api/index.md
@@ -11,7 +11,6 @@ tags:
   - capabilities
   - service-worker
   - chrome-80
-  - index
   - caching
 hero: image/admin/tuIkBEm2DdHBYy62dDac.jpg
 alt: Index cards in a filing cabinet.

--- a/site/en/docs/handbook/style-guide/index.njk
+++ b/site/en/docs/handbook/style-guide/index.njk
@@ -502,7 +502,11 @@ line-height: 160%;
     {% Img src='image/BrQidfK9jaQyIHwdw91aVpkPiib2/TDNgfhI9byR4eeGQ0Xxv.png', alt='Screenshot', height="302", width="770", class="screenshot screenshot--filled" %}
   </div>
 
-  <checkbox-group show="4" i18n="{{ 'i18n.checkbox_group' | i18n(locale) | dump }}">
+  {% set checkboxGroupI18n = {
+    reset: 'i18n.common.checkbox_group.reset'|i18n, 
+    select_all: 'i18n.common.checkbox_group.select_all'|i18n
+  } %}
+  <checkbox-group show="4" i18n='{{ checkboxGroupI18n|dump|safe }}''>
     <label><input type="checkbox" /> Option 1</label>
     <label><input type="checkbox" /> Option 2</label>
     <label><input type="checkbox" disabled /> Option 3</label>


### PR DESCRIPTION
Fixes https://github.com/GoogleChrome/developer.chrome.com/issues/4930, fixes https://github.com/GoogleChrome/developer.chrome.com/issues/4954. Follow-up to https://github.com/GoogleChrome/developer.chrome.com/issues/4327.

https://github.com/GoogleChrome/developer.chrome.com/pull/3998 introduced a new `<checkbox-group>` web component, originally meant for the events page but currently not used, which uses an object for interface copy. To enable this, the i18n filter was changed to flatten translations into an object, if no specific translation could be found. 

By this change some templates now receive an empty object from the i18n filter, instead of undefined. This leads to `[object Object]` showing up in weird places, like in #4930 or #4954 or confusing error messages like described in #4327.

To fix, this PR makes d.c.c use the i18n filter from the webdev-infra package, which is an optimized version of the one from web.dev. This version of the filter throws an error instead of returning `{}` for an undefined translation. That also revealed that for a lot of tags there weren't any translations, preventing tag pages for those tags getting generated or showing up on the tags overview page, and also made `[object Object]` showing up in a lot of RSS feeds.

The missing author descriptions are taken from the people's LinkedIn profiles, verified it's them by looking at their linked Twitter profiles.

Additionally this PR alters the `{% Compare %}` shortcode to properly handle the `labelOverride` argument (#4954). The fix without updating the i18n filter would have been to check if `i18n` returned an empty object, which would be weird. With the behaviour described above it can now properly try/catch. By looking through the current uses of the `labelOverride` argument, which almost always is free-form, this seems to follow the user expectation of what that argument is there for.

All in all this PR brings down the results for searching for `[object Object]` in the build output (`./dist`) down from 180x to just 1x in the main.js bundle, where it's actually expected.

The change has been tested by diffing the `dist` directory of `npm run production` before and after the change, which only lists the new tags pages and the article pages that previously had `[object Object]` in their tag lists. Additionally I searched for `i18n.` in the build output, which revealed that some of the `alt` attributes on the /meet-the-team page also weren't translated correctly, that's also fixed.