### PR TITLE
feat: add a frontmatter key for sharing image on the social media

### DIFF
--- a/site/_includes/partials/meta.njk
+++ b/site/_includes/partials/meta.njk
@@ -26,7 +26,7 @@
 <meta property="og:type" content="website" />
 <meta property="og:url" content="{{ currentUrl }}" />
 
-{% set socialImage = sharingImage or thumbnail or hero or site.defaultSocialImage %}
+{% set socialImage = sharing_image or thumbnail or hero or site.defaultSocialImage %}
 
 {% if socialImage %}
   {# Twitter thumbanils are 507px on their website, so this is a 3x version. #}

--- a/site/_includes/partials/meta.njk
+++ b/site/_includes/partials/meta.njk
@@ -26,7 +26,7 @@
 <meta property="og:type" content="website" />
 <meta property="og:url" content="{{ currentUrl }}" />
 
-{% set socialImage = sharingimage or thumbnail or hero or site.defaultSocialImage %}
+{% set socialImage = sharingImage or thumbnail or hero or site.defaultSocialImage %}
 
 {% if socialImage %}
   {# Twitter thumbanils are 507px on their website, so this is a 3x version. #}

--- a/site/_includes/partials/meta.njk
+++ b/site/_includes/partials/meta.njk
@@ -26,7 +26,7 @@
 <meta property="og:type" content="website" />
 <meta property="og:url" content="{{ currentUrl }}" />
 
-{% set socialImage = thumbnail or hero or site.defaultSocialImage %}
+{% set socialImage = imagesharing or thumbnail or hero or site.defaultSocialImage %}
 
 {% if socialImage %}
   {# Twitter thumbanils are 507px on their website, so this is a 3x version. #}

--- a/site/_includes/partials/meta.njk
+++ b/site/_includes/partials/meta.njk
@@ -26,7 +26,7 @@
 <meta property="og:type" content="website" />
 <meta property="og:url" content="{{ currentUrl }}" />
 
-{% set socialImage = imagesharing or thumbnail or hero or site.defaultSocialImage %}
+{% set socialImage = sharingimage or thumbnail or hero or site.defaultSocialImage %}
 
 {% if socialImage %}
   {# Twitter thumbanils are 507px on their website, so this is a 3x version. #}

--- a/site/en/blog/_example/index.md
+++ b/site/en/blog/_example/index.md
@@ -55,7 +55,7 @@ alt: >
 # Optional
 # Image sharing on social media should be at least 828 x 416
 # https://developer.chrome.com/docs/handbook/how-to/add-media/
-# sharingimage: 'image/BrQidfK9jaQyIHwdw91aVpkPiib2/EnMzOm0mBytBA3AzlCG6.png'
+# sharingImage: 'image/BrQidfK9jaQyIHwdw91aVpkPiib2/EnMzOm0mBytBA3AzlCG6.png'
 ---
 
 A few rules:

--- a/site/en/blog/_example/index.md
+++ b/site/en/blog/_example/index.md
@@ -51,6 +51,11 @@ hero: 'image/BrQidfK9jaQyIHwdw91aVpkPiib2/EnMzOm0mBytBA3AzlCG6.png'
 # Required if there is a hero or social image
 alt: >
   An alternative text description of your hero or social image.
+
+# Optional
+# Image sharing on social media should be at least 828 x 416
+# https://developer.chrome.com/docs/handbook/how-to/add-media/
+# imagesharing: 'image/BrQidfK9jaQyIHwdw91aVpkPiib2/EnMzOm0mBytBA3AzlCG6.png'
 ---
 
 A few rules:

--- a/site/en/blog/_example/index.md
+++ b/site/en/blog/_example/index.md
@@ -55,7 +55,7 @@ alt: >
 # Optional
 # Image sharing on social media should be at least 828 x 416
 # https://developer.chrome.com/docs/handbook/how-to/add-media/
-# sharingImage: 'image/BrQidfK9jaQyIHwdw91aVpkPiib2/EnMzOm0mBytBA3AzlCG6.png'
+# sharing_image: 'image/BrQidfK9jaQyIHwdw91aVpkPiib2/EnMzOm0mBytBA3AzlCG6.png'
 ---
 
 A few rules:

--- a/site/en/blog/_example/index.md
+++ b/site/en/blog/_example/index.md
@@ -55,7 +55,7 @@ alt: >
 # Optional
 # Image sharing on social media should be at least 828 x 416
 # https://developer.chrome.com/docs/handbook/how-to/add-media/
-# imagesharing: 'image/BrQidfK9jaQyIHwdw91aVpkPiib2/EnMzOm0mBytBA3AzlCG6.png'
+# sharingimage: 'image/BrQidfK9jaQyIHwdw91aVpkPiib2/EnMzOm0mBytBA3AzlCG6.png'
 ---
 
 A few rules:

--- a/site/en/docs/handbook/how-to/add-a-blog-post/index.md
+++ b/site/en/docs/handbook/how-to/add-a-blog-post/index.md
@@ -37,6 +37,19 @@ shortcode snippet, it should look like this:
 
 Paste that into the `hero` field in your YAML frontmatter.
 
+### Social sharing image 
+
+Social sharing image is the visual thumbnail that appears when a post or page 
+is shared on social media platforms like Twitter and Facebook.
+
+Follow the [add media guide](/docs/handbook/how-to/add-media/) to upload your
+image to our CDN. Once you've uploaded the image, copy the path out of the
+shortcode snippet, it should look like this:
+
+`'image/BrQidfK9jaQyIHwdw91aVpkPiib2/EnMzOm0mBytBA3AzlCG6.png'`
+
+Paste that into the `sharingImage` field in your YAML frontmatter.
+
 ## Components
 
 See the [components guide](/docs/handbook/components/) for a full list of

--- a/site/en/docs/handbook/how-to/add-a-blog-post/index.md
+++ b/site/en/docs/handbook/how-to/add-a-blog-post/index.md
@@ -43,8 +43,11 @@ Social sharing image is the visual thumbnail that appears when a post or page
 is shared on social media platforms like Twitter and Facebook.
 
 Follow the [add media guide](/docs/handbook/how-to/add-media/) to upload your
-image to our CDN. Once you've uploaded the image, copy the path out of the
-shortcode snippet, it should look like this:
+image to our CDN or use the [sharing image generator](https://web-dev-uploads.web.app/sharing-image-generator)
+to generate the social sharing image. 
+
+Once you've uploaded the image or generated the sharing image, copy the path out,
+it should look like this:
 
 `'image/BrQidfK9jaQyIHwdw91aVpkPiib2/EnMzOm0mBytBA3AzlCG6.png'`
 

--- a/site/en/docs/handbook/how-to/add-a-blog-post/index.md
+++ b/site/en/docs/handbook/how-to/add-a-blog-post/index.md
@@ -48,7 +48,7 @@ shortcode snippet, it should look like this:
 
 `'image/BrQidfK9jaQyIHwdw91aVpkPiib2/EnMzOm0mBytBA3AzlCG6.png'`
 
-Paste that into the `sharingImage` field in your YAML frontmatter.
+Paste that into the `sharing_image` field in your YAML frontmatter.
 
 ## Components
 


### PR DESCRIPTION
Fixes https://github.com/GoogleChrome/developer.chrome.com/issues/4734, Fixes https://github.com/GoogleChrome/developer.chrome.com/issues/3124

Changes proposed in this pull request:

- Adds a new frontmatter key named `imagesharing` for sharing image on the social media