### PR TITLE
Fix a minor typo in docs

### DIFF
--- a/site/en/docs/extensions/mv3/getstarted/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/index.md
@@ -18,7 +18,7 @@ Welcome to the Getting Started Guides! The purpose of this page is to describe e
 : Briefly covers some fundamental concepts of Chrome Extension development like web technologies and commonly used extension components. In addition, it includes what to be aware of when designing and distributing an extension in the Chrome Web Store. 
 
 [Development Basics][doc-dev-basics]
-: Introduces the extension development workflow by creating a _Hello, Extensions_ example. It walks through loading the extension during development, locating logs and errors, choosing a project structure, and using Typescript.
+: Introduces the extension development workflow by creating a "Hello, Extensions" example. It walks through loading the extension during development, locating logs and errors, choosing a project structure, and using Typescript.
 
 ## Extension tutorials {: #tutorial } 
 


### PR DESCRIPTION
Changes proposed in this pull request should fix minor typo :

- In the different pages ,  `Hello, Extension`  is mentioned as ` "Hello, Extension"` . So it seems like minor typo here.
- For example : 
   - [ "Hello, Extension" in development-basics page ](https://github.com/GoogleChrome/developer.chrome.com/blob/0e0ea440dfc926804426753d33cba299d56406a0/site/en/docs/extensions/mv3/getstarted/development-basics/index.md?plain=1#L13)
   - [ "Hello, Extension" in extensions-101 page ](https://github.com/GoogleChrome/developer.chrome.com/blob/0e0ea440dfc926804426753d33cba299d56406a0/site/en/docs/extensions/mv3/getstarted/extensions-101/index.md?plain=1#L91-L92)