### PR TITLE
Fix broken urls

### DIFF
--- a/site/en/docs/apps/contentSecurityPolicy/index.md
+++ b/site/en/docs/apps/contentSecurityPolicy/index.md
@@ -86,7 +86,7 @@ external web pages][6]).
 
 [1]: https://blog.chromium.org/2020/08/changes-to-chrome-app-support-timeline.html
 [2]: /apps/migration
-[3]: http://www.html5rocks.com/en/tutorials/security/content-security-policy/
+[3]: https://web.dev/csp/
 [4]: app_external#sandboxing
 [5]: app_external#external
 [6]: app_external#webview

--- a/site/en/docs/extensions/mv3/index.md
+++ b/site/en/docs/extensions/mv3/index.md
@@ -43,5 +43,5 @@ Thank you for being a member of the extension developer community. We're glad yo
 [gg-extensions]: https://groups.google.com/a/chromium.org/g/chromium-extensions
 [gh-ext-samples]: https://github.com/GoogleChrome/chrome-extensions-samples
 [github-ext-doc]: https://github.com/GoogleChrome/developer.chrome.com
-[gs-tuts]: /docs/extensions/mv3/getstarted/#tutorials
+[gs-tuts]: /docs/extensions/mv3/getstarted/#tutorial
 [so-extension-tag]: https://stackoverflow.com/questions/tagged/google-chrome-extension

--- a/site/en/docs/extensions/mv3/sandboxingEval/index.md
+++ b/site/en/docs/extensions/mv3/sandboxingEval/index.md
@@ -149,7 +149,7 @@ properly execute. The [Writing Secure Web Apps and Chrome Extensions][14] presen
 I/O 2012 gives some good examples of these technique in action, and is worth 56 minutes of your
 time.
 
-[1]: /docs/extensions/mv3/contentSecurityPolicy
+[1]: /docs/extensions/mv3/manifest/content_security_policy/#default-policy
 [2]: /docs/extensions/mv3/contentSecurityPolicy
 [3]: https://angularjs.org/
 [4]: https://crbug.com/107538


### PR DESCRIPTION
## Updates to https://developer.chrome.com/docs/extensions/mv3/

Updates tutorials fragment URL:

**From**: https://developer.chrome.com/docs/extensions/mv3/getstarted/#tutorials
**To**: https://developer.chrome.com/docs/extensions/mv3/getstarted/#tutorial

Correct Header ID seen here:

https://github.com/GoogleChrome/developer.chrome.com/blob/0e0ea440dfc926804426753d33cba299d56406a0/site/en/docs/extensions/mv3/getstarted/index.md?plain=1#L23


## Updates to https://developer.chrome.com/docs/apps/contentSecurityPolicy/

Link http://www.html5rocks.com/en/tutorials/security/content-security-policy/
redirects to https://web.dev/csp/ - so update in source


## Updates to https://developer.chrome.com/docs/extensions/mv3/sandboxingEval/

https://developer.chrome.com/docs/extensions/mv3/contentSecurityPolicy/ throws 404

Updated to https://developer.chrome.com/docs/extensions/mv3/manifest/content_security_policy/#default-policy
