### PR TITLE
Fix #4994: Minor issue with Focus-Mode Extension Tutorials

### DIFF
--- a/site/en/docs/extensions/mv3/getstarted/tut-focus-mode/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/tut-focus-mode/index.md
@@ -252,8 +252,8 @@ Just for fun, let's add a shortcut to make it easier to enable or disable focus 
   "commands": {
     "_execute_action": {
       "suggested_key": {
-        "default": "Ctrl+Q",
-        "mac": "Command+Q"
+        "default": "Ctrl+B",
+        "mac": "Command+B"
       }
     }
   }
@@ -284,7 +284,7 @@ First, open any of the following pages:
 - [Publish in the Chrome Web Store][cws-publish]
 - [Scripting API][api-scripting]
 
-Then, click on the extension action. If you set up a keyboard shortcut (link), you can test it by pressing `Ctrl + Q` or `Cmd + Q`.
+Then, click on the extension action. If you set up a keyboard shortcut (link), you can test it by pressing `Ctrl + B` or `Cmd + B`.
 
 It should go from this:
 

--- a/site/en/docs/extensions/mv3/getstarted/tut-focus-mode/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/tut-focus-mode/index.md
@@ -39,7 +39,7 @@ Create a file called `manifest.json` and include the following code.
 {
   "manifest_version": 3,
   "name": "Focus Mode",
-  "description": "Enable reading mode on Chrome's official Extensions and Chrome Web Store documentation.",
+  "description": "Enable focus mode on Chrome's official Extensions and Chrome Web Store documentation.",
   "version": "1.0",
   "icons": {
     "16": "images/icon-16.png",
@@ -252,8 +252,8 @@ Just for fun, let's add a shortcut to make it easier to enable or disable focus 
   "commands": {
     "_execute_action": {
       "suggested_key": {
-        "default": "Ctrl+U",
-        "mac": "Command+U"
+        "default": "Ctrl+Q",
+        "mac": "Command+Q"
       }
     }
   }
@@ -284,7 +284,7 @@ First, open any of the following pages:
 - [Publish in the Chrome Web Store][cws-publish]
 - [Scripting API][api-scripting]
 
-Then, click on the extension action. If you set up a keyboard shortcut (link), you can test it by pressing `Ctrl + U` or `Cmd + U`.
+Then, click on the extension action. If you set up a keyboard shortcut (link), you can test it by pressing `Ctrl + Q` or `Cmd + Q`.
 
 It should go from this:
 

--- a/site/en/docs/extensions/mv3/getstarted/tut-tabs-manager/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/tut-tabs-manager/index.md
@@ -108,7 +108,7 @@ A popup is similar to a web page with one exception: it can't run inline JavaScr
 
 {% Aside %}
 
-💡 **TIP**: You can use [top level await][mdn-top-level] by adding `type="module”` to the script
+💡 **TIP**: You can use [top level await][mdn-top-level] by adding `type="module"` to the script
 tag.
 
 {% endAside %}
@@ -153,7 +153,7 @@ Many methods in the Tabs API can be used without requesting any permission. Howe
 
 Narrow [host permissions][doc-match] allow us to protect user privacy by granting elevated permission to **specific sites**. This will grant access to the `title`, and `URL` properties, as well as additional capabilities. Add the highlighted code to the `manifest.json` file:
 
-```json/2-3
+```json/2-4
 {
   ...
   "host_permissions": [


### PR DESCRIPTION
Fixes [#4994](https://github.com/GoogleChrome/developer.chrome.com/issues/4994)

Changes proposed in this pull request:

- fixes small typo in `type="module”`
- Update the description value in focus mode extension [docs](https://github.com/GoogleChrome/developer.chrome.com/blob/ee5272a42af61da906bf9de941e9eac0838208eb/site/en/docs/extensions/mv3/getstarted/tut-focus-mode/index.md?plain=1#L42).  so that it is in sync with [github example](https://github.com/GoogleChrome/chrome-extensions-samples/blob/b5c62b1c6fd96d58eb6b301658557f787283b78d/tutorials/focus-mode/manifest.json#L4) 
- Updates keyboard shortcut (link) from `Ctrl + U` to `Ctrl + Q` in focus mode extension docs