### PR TITLE
Fix authors in the blog post for user activation

### DIFF
--- a/site/en/blog/user-activation/index.md
+++ b/site/en/blog/user-activation/index.md
@@ -10,7 +10,7 @@ alt: >
   Mobile phone
 authors:
   - mustaqahmed
-  - jpmedley
+  - joemedley
 ---
 
 To prevent malicious scripts from abusing sensitive APIs like popups,

--- a/site/en/blog/user-activation/index.md
+++ b/site/en/blog/user-activation/index.md
@@ -9,7 +9,8 @@ hero: 'image/C47gYyWYVMMhDmtYSLOWazuyePF2/DCC9GuTXo9NPmluPCqG1.png'
 alt: >
   Mobile phone
 authors:
-  - addyosmani
+  - mustaqahmed
+  - jpmedley
 ---
 
 To prevent malicious scripts from abusing sensitive APIs like popups,


### PR DESCRIPTION
The original author names for "Making user activation consistent across APIs" were dropped in this migration PR: https://github.com/GoogleChrome/developer.chrome.com/pull/2320.

cc: @jpmedley

This resolves a part of #3084.