### PR TITLE
Remove Topics updates page byline, as requested

### DIFF
--- a/site/en/docs/privacy-sandbox/topics/latest/index.md
+++ b/site/en/docs/privacy-sandbox/topics/latest/index.md
@@ -50,8 +50,6 @@ Topics and develop best practices for its use in digital advertising products. I
 Topics we encourage you to share your plans and insights on the 
 [Topics API Tester List](https://github.com/patcg-individual-drafts/topics/blob/main/topics-tester-list.md).   
 
-— Posted by Leeron Israel, Privacy Sandbox Product Manager for the Topics API.
-
 ## Ecosystem feedback on Topics for Q3 2022
 
 **October 27, 2022**
@@ -103,7 +101,7 @@ the Topics proposal](https://github.com/patcg-individual-drafts/topics/issues) o
 also provide feedback via the
 [Privacy Sandbox feedback form](https://docs.google.com/forms/d/e/1FAIpQLSePSeywmcwuxLFsttajiv7NOhND1WoYtKgNJYxw_AGR8LR1Dg/viewform).
 
- Here are some specific areas where the Chrome team is seeking input from testers and other
+Here are some specific areas where the Chrome team is seeking input from testers and other
 stakeholders.
 
 ### Topics taxonomy


### PR DESCRIPTION
Agree in Topics meeting just now. Authors are listed at the top of the page — no need to repeat.
