### PR TITLE
Popover explainer links

### DIFF
--- a/site/en/blog/pop-ups-theyre-making-a-resurgence/index.md
+++ b/site/en/blog/pop-ups-theyre-making-a-resurgence/index.md
@@ -10,7 +10,7 @@ tags:
   - css
   - html
 date: 2022-09-13
-last_updated: 2022-12-01
+last_updated: 2023-01-25
 ---
 
 {% Aside 'caution' %}
@@ -29,13 +29,13 @@ There are often two major concerns when building popovers:
 - How to make sure it gets placed above the rest of your content in an appropriate place.
 - How to make it accessible (keyboard friendly, focusable, and so on).
 
-The built-in Popover API has a [variety of goals](https://open-ui.org/components/popup.research.explainer#goals), all with the same overarching goal of making it easy for developers to build this pattern. Notable of those goals are:
+The built-in Popover API has a [variety of goals](https://open-ui.org/components/popover.research.explainer#goals), all with the same overarching goal of making it easy for developers to build this pattern. Notable of those goals are:
 
 - Make it easy to display an element and its descendants above the rest of the document.
 - Make it accessible.
 - Not require JavaScript for most common behaviors  (light dismiss, singleton, stacking, and so on).
 
-You can check out the full spec for pop-ups on the [OpenUI site](https://open-ui.org/components/popup.research.explainer).
+You can check out the full spec for pop-ups on the [OpenUI site](https://open-ui.org/components/popover.research.explainer).
 
 ## Browser compatibility
 
@@ -382,7 +382,7 @@ The Popover API allows you to specify three types of popover which differ in beh
   - related by triggering attributes on child elements such as `popovertoggletarget`, `popovershowtarget`, and so on.
   - related by the `anchor` attribute (Under development CSS Anchoring API).
 - Light dismiss.
-- Opening dismisses other popovers that are not [ancestral popovers](https://open-ui.org/components/popup.research.explainer#nearest-open-ancestral-popover). Have a play with the demo below that highlights how nesting with ancestral popovers works. See how changing some of the `popoverhidetarget`/`popovershowtarget` instances to `popovertoggletarget` changes things.
+- Opening dismisses other popovers that are not [ancestral popovers](https://open-ui.org/components/popover.research.explainer#nearest-open-ancestral-popover). Have a play with the demo below that highlights how nesting with ancestral popovers works. See how changing some of the `popoverhidetarget`/`popovershowtarget` instances to `popovertoggletarget` changes things.
 - Light dismissing one dismisses all, but dismissing one in the stack only dismisses those above it in the stack.
 
 {% Codepen {
@@ -512,7 +512,7 @@ This demo has popovers with audible pops, so we'll need JavaScript to play the a
 
 Accessibility is at the forefront of thinking with the Popover API. Accessibility mappings associate the popover with its trigger element, as needed. This means you don't need to declare `aria-*` attributes such as `aria-haspopup`, assuming you use one of the triggering attributes like `popovertoggletarget`.
 
-For focus management, you can use the autofocus attribute to move focus to an element inside a popover. This is the same as for a Dialog, but the difference comes when returning focus, and that's because of light dismiss. In most cases, closing a popover returns focus to the previously focused element. But focus gets moved to a clicked element on light dismiss, if it can get focus. Check out the [section about focus management](https://open-ui.org/components/popup.research.explainer#focus-management) in the explainer.
+For focus management, you can use the autofocus attribute to move focus to an element inside a popover. This is the same as for a Dialog, but the difference comes when returning focus, and that's because of light dismiss. In most cases, closing a popover returns focus to the previously focused element. But focus gets moved to a clicked element on light dismiss, if it can get focus. Check out the [section about focus management](https://open-ui.org/components/popover.research.explainer#focus-management) in the explainer.
 
 
 {% Codepen {
@@ -932,7 +932,7 @@ This demo shows how you could use popover to implement a floating action button 
 
 So, that’s an intro to popover, coming down the road as part of the Open UI initiative. Used sensibly, it’s going to be a fantastic addition to the web platform.
 
-Be sure to check out [Open UI](https://open-ui.org). The [popover explainer](https://open-ui.org/components/popup.research.explainer/) is kept up to date as the API evolves. And here's [the collection](https://codepen.io/collection/vBJmGx) for all the demos.
+Be sure to check out [Open UI](https://open-ui.org). The [popover explainer](https://open-ui.org/components/popover.research.explainer/) is kept up to date as the API evolves. And here's [the collection](https://codepen.io/collection/vBJmGx) for all the demos.
 
 Thanks for “popping” by!
 

--- a/site/en/blog/top-layer-devtools/index.md
+++ b/site/en/blog/top-layer-devtools/index.md
@@ -6,6 +6,7 @@ description: >
 authors:
     - alinavarkki
 date: 2022-07-21
+last_updated: 2023-01-25
 hero: 'image/dPDCek3EhZgLQPGtEG3y0fTn4v82/56D6d9pfdEWRPQdima0W.jpg'
 alt: ''
 tags:
@@ -31,7 +32,7 @@ The [top layer](https://fullscreen.spec.whatwg.org/#new-stacking-layer) can be d
 Multiple elements can be inside the top layer at the same time. When that happens, they stack on top of each other, the last one on top. In other words, all of the top layer elements are placed in a *last in, first out* (LIFO) stack in the top layer.
 
 The `<dialog>` element is not the only element that the browser renders into a top layer. Currently, the top layer elements are:
-[pop-ups](https://open-ui.org/components/popup.research.explainer), [modal dialogs](https://developer.mozilla.org/docs/Web/HTML/Element/dialog), and elements in a [fullscreen mode](https://developer.mozilla.org/docs/Web/API/Fullscreen_API).
+[popovers](https://open-ui.org/components/popover.research.explainer), [modal dialogs](https://developer.mozilla.org/docs/Web/HTML/Element/dialog), and elements in a [fullscreen mode](https://developer.mozilla.org/docs/Web/API/Fullscreen_API).
 
 Examine the following dialog implementation:
 

--- a/site/en/blog/what-is-the-top-layer/index.md
+++ b/site/en/blog/what-is-the-top-layer/index.md
@@ -9,7 +9,7 @@ alt: "Layered mountains."
 tags:
   - css
   - html
-date: 2022-08-22
+date: 2023-01-25
 ---
 
 The top layer sits above its related `document` in the browser viewport, and each `document` has one associated top layer. This means that elements promoted to the top layer needn't worry about `z-index` or DOM hierarchy. They also get a neat `::backdrop` pseudo-element to play with. The [Fullscreen API](https://fullscreen.spec.whatwg.org/#new-stacking-layer) spec goes into more details as [Fullscreen](https://developer.mozilla.org/docs/Web/API/Element/requestFullScreen) was a great example of the top layer in use before [`dialog` support](https://caniuse.com/dialog) came along.
@@ -35,7 +35,7 @@ How have we mimicked the top layer until now? Well, it's not uncommon to see dev
 %}
 
 
-With new built-in components and APIs like `<dialog>` and ["Pop-up"](https://open-ui.org/components/popup.research.explainer), you won't need to resort to these workarounds. You can promote content to the top layer. 
+With new built-in components and APIs like `<dialog>` and ["Popover"](https://open-ui.org/components/popover.research.explainer), you won't need to resort to these workarounds. You can promote content to the top layer. 
 
 UI frameworks allow us to co-locate promoted elements with their component counterparts. But, they often get separated in the DOM when it comes to rendering.
 
@@ -90,6 +90,6 @@ A brief intro to the top layer. Making it possible to say "Bye!" to things like:
 }
 ```
 
-What would you push into the Top Layer? Have you tried out [`dialog`](https://developer.mozilla.org/docs/Web/HTML/Element/dialog)? Or checked out the [OpenUI Pop-up API](https://open-ui.org/components/popup.research.explainer)? Let us know!
+What would you push into the Top Layer? Have you tried out [`dialog`](https://developer.mozilla.org/docs/Web/HTML/Element/dialog)? Or checked out the [OpenUI Popover API](https://open-ui.org/components/popover.research.explainer)? Let us know!
 
 

--- a/site/en/docs/web-platform/popover-api/backdrop-pseudo-element/index.md
+++ b/site/en/docs/web-platform/popover-api/backdrop-pseudo-element/index.md
@@ -7,7 +7,7 @@ authors:
   - chrisdavidmills
   - jheyy
 date: 2022-10-19
-updated: 2022-11-10
+updated: 2023-01-25
 ---
 
 The **`::backdrop`** [CSS](https://developer.mozilla.org/docs/Web/CSS) [pseudo-element](https://developer.mozilla.org/docs/Web/CSS/Pseudo-elements) sits behind an open [popover](/docs/web-platform/popover-api/) in the stacking order, but in front of the rest of the document, and spans the entire width and height of the viewport. It allows the rest of the content to be styled while the popover is open—for example you might want to blur or darken it.
@@ -42,4 +42,4 @@ p[popover]::backdrop {
 * [The Popover API](/docs/web-platform/popover-api/)
 * [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
 * [Chrome Platform Status: The Popover API](https://chromestatus.com/feature/5463833265045504) 
-* [Open UI: Popover API Explainer](https://open-ui.org/components/popup.research.explainer)
+* [Open UI: Popover API Explainer](https://open-ui.org/components/popover.research.explainer)

--- a/site/en/docs/web-platform/popover-api/hidepopover-method/index.md
+++ b/site/en/docs/web-platform/popover-api/hidepopover-method/index.md
@@ -7,7 +7,7 @@ authors:
   - chrisdavidmills
   - jheyy
 date: 2022-10-19
-updated: 2022-11-10
+updated: 2023-01-25
 ---
 
 The **`hidePopover()`** instance method of the [`Element`](https://developer.mozilla.org/docs/Web/API/Element) interface dismisses a [popover](/docs/web-platform/popover-api/) element.
@@ -57,4 +57,4 @@ popover.hidePopover();
 * [The Popover API](/docs/web-platform/popover-api/)
 * [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
 * [Chrome Platform Status: The Popover API](https://chromestatus.com/feature/5463833265045504) 
-* [Open UI: Popover API Explainer](https://open-ui.org/components/popup.research.explainer)
+* [Open UI: Popover API Explainer](https://open-ui.org/components/popover.research.explainer)

--- a/site/en/docs/web-platform/popover-api/index.md
+++ b/site/en/docs/web-platform/popover-api/index.md
@@ -7,10 +7,10 @@ authors:
   - chrisdavidmills
   - jheyy
 date: 2022-10-19
-updated: 2022-11-10
+updated: 2023-01-25
 ---
 
-The Popover API provides developers with a standard, consistent, flexible mechanism for displaying popover content on top of other page content. Popovers can be light dismissed with a close signal. Close signals include closing by clicking out of the popover or pressing <kbd>Esc</kbd>, and opening other [non-ancestral popovers](https://open-ui.org/components/popup.research.explainer#nearest-open-ancestral-popover). Typical use cases include user-interactive elements like action menus, form element suggestions, content pickers, teaching UI, and the Listbox portion of a `<select>` control.
+The Popover API provides developers with a standard, consistent, flexible mechanism for displaying popover content on top of other page content. Popovers can be light dismissed with a close signal. Close signals include closing by clicking out of the popover or pressing <kbd>Esc</kbd>, and opening other [non-ancestral popovers](https://open-ui.org/components/popover.research.explainer#nearest-open-ancestral-popover). Typical use cases include user-interactive elements like action menus, form element suggestions, content pickers, teaching UI, and the Listbox portion of a `<select>` control.
 
 ## Current status
 
@@ -21,7 +21,7 @@ The Popover API provides developers with a standard, consistent, flexible mechan
 
 ## Concepts and usage
 
-Popovers are used constantly, all over the web. Developers keep having to reimplement popover styling, positioning and z-index stacking, focus management, keyboard interactions, and accessibility semantics for each new project. As well as duplication of work, this has also resulted in an inconsistent end-user experience across different apps. In answer to this, the [Open UI group](https://open-ui.org/) published a [proposal for the Popover API](https://open-ui.org/components/popup.research.explainer).
+Popovers are used constantly, all over the web. Developers keep having to reimplement popover styling, positioning and z-index stacking, focus management, keyboard interactions, and accessibility semantics for each new project. As well as duplication of work, this has also resulted in an inconsistent end-user experience across different apps. In answer to this, the [Open UI group](https://open-ui.org/) published a [proposal for the Popover API](https://open-ui.org/components/popover.research.explainer).
 
 Any HTML element can be turned into a popover using the [`popover`](/docs/web-platform/popover-api/popover-attribute) attribute. The Popover API provides the following default behavior:
 
@@ -29,8 +29,8 @@ Any HTML element can be turned into a popover using the [`popover`](/docs/web-pl
 * Popovers are also given a default fixed position in the center of the viewport, padding, and a border.
 * When shown, popovers are promoted to the [top layer](/blog/what-is-the-top-layer/) (above `document` and outside of `document` flow).
 * Popovers have light dismiss. By that, we mean you can close the popover with a close signal, such as clicking outside the popover, keyboard-navigating to another element, or pressing the Esc key.
-* Popovers are designed to be accessible, with an element defined as a popover trigger automatically getting [`aria-haspopup`](https://developer.mozilla.org/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup) semantics. In addition, focus into the popover can be controlled using `autofocus` and, when the popover is light dismissed, a heuristic determines where focus should go next. For example, focus could go back to the previously-focused element, or an element clicked outside of the popover. See [Focus Management](https://open-ui.org/components/popup.research.explainer#focus-management) for more details.
-* Opening a popover dismisses other popovers that are not [ancestral popovers](https://open-ui.org/components/popup.research.explainer#nearest-open-ancestral-popover).
+* Popovers are designed to be accessible, with an element defined as a popover trigger automatically getting [`aria-haspopup`](https://developer.mozilla.org/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup) semantics. In addition, focus into the popover can be controlled using `autofocus` and, when the popover is light dismissed, a heuristic determines where focus should go next. For example, focus could go back to the previously-focused element, or an element clicked outside of the popover. See [Focus Management](https://open-ui.org/components/popover.research.explainer#focus-management) for more details.
+* Opening a popover dismisses other popovers that are not [ancestral popovers](https://open-ui.org/components/popover.research.explainer#nearest-open-ancestral-popover).
 
 {% Aside 'key-term' %}
 A _popover trigger_ is an element that causes a change in the state of the popover it is associated with, for example a `<button>` that shows and dismisses the popover.
@@ -189,4 +189,4 @@ Your feedback on the API is welcome. [Send an email](mailto:public-open-ui@w3.or
 
 * [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
 * [Chrome Platform Status: The Popover API](https://chromestatus.com/feature/5463833265045504) 
-* [Open UI: Popover API Explainer](https://open-ui.org/components/popup.research.explainer)
+* [Open UI: Popover API Explainer](https://open-ui.org/components/popover.research.explainer)

--- a/site/en/docs/web-platform/popover-api/open-pseudo-class/index.md
+++ b/site/en/docs/web-platform/popover-api/open-pseudo-class/index.md
@@ -7,7 +7,7 @@ authors:
   - chrisdavidmills
   - jheyy
 date: 2022-10-19
-updated: 2022-11-10
+updated: 2023-01-25
 ---
 
 The **`:open`** [CSS](https://developer.mozilla.org/docs/Web/CSS) [pseudo-class](https://developer.mozilla.org/docs/Web/CSS/Pseudo-classes) allows a [popover](/docs/web-platform/popover-api/) to be styled, but only when it is being shown.
@@ -45,4 +45,4 @@ p[popover]:open {
 * [The Popover API](/docs/web-platform/popover-api/)
 * [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
 * [Chrome Platform Status: The Popover API](https://chromestatus.com/feature/5463833265045504) 
-* [Open UI: Popover API Explainer](https://open-ui.org/components/popup.research.explainer)
+* [Open UI: Popover API Explainer](https://open-ui.org/components/popover.research.explainer)

--- a/site/en/docs/web-platform/popover-api/popover-attribute/index.md
+++ b/site/en/docs/web-platform/popover-api/popover-attribute/index.md
@@ -7,7 +7,7 @@ authors:
   - chrisdavidmills
   - jheyy
 date: 2022-10-19
-updated: 2022-11-10
+updated: 2023-01-25
 ---
 
 The **`popover`** [global attribute](https://developer.mozilla.org/docs/Web/HTML/Global_attributes) is an [emumerated](https://developer.mozilla.org/docs/Glossary/Enumerated) attribute that turns an element into a [popover](/docs/web-platform/popover-api/).
@@ -44,4 +44,4 @@ The attribute can have any of the following values:
 * [The Popover API](/docs/web-platform/popover-api/)
 * [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
 * [Chrome Platform Status: The Popover API](https://chromestatus.com/feature/5463833265045504) 
-* [Open UI: Popover API Explainer](https://open-ui.org/components/popup.research.explainer)
+* [Open UI: Popover API Explainer](https://open-ui.org/components/popover.research.explainer)

--- a/site/en/docs/web-platform/popover-api/popover-property/index.md
+++ b/site/en/docs/web-platform/popover-api/popover-property/index.md
@@ -7,7 +7,7 @@ authors:
   - chrisdavidmills
   - jheyy
 date: 2022-10-19
-updated: 2022-11-10
+updated: 2023-01-25
 ---
 
 The `popover` property of the [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/Element) interface turns an element into a [popover](/docs/web-platform/popover-api/). It is the DOM definition of the HTML [`popover`](/docs/web-platform/popover-api/popover-attribute) attribute.
@@ -46,4 +46,4 @@ popover.popover = 'manual';
 * [The Popover API](/docs/web-platform/popover-api/)
 * [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
 * [Chrome Platform Status: The Popover API](https://chromestatus.com/feature/5463833265045504) 
-* [Open UI: Popover API Explainer](https://open-ui.org/components/popup.research.explainer)
+* [Open UI: Popover API Explainer](https://open-ui.org/components/popover.research.explainer)

--- a/site/en/docs/web-platform/popover-api/popoverhide-event/index.md
+++ b/site/en/docs/web-platform/popover-api/popoverhide-event/index.md
@@ -7,7 +7,7 @@ authors:
   - chrisdavidmills
   - jheyy
 date: 2022-10-19
-updated: 2022-11-10
+updated: 2023-01-25
 ---
 
 The `popoverhide` event of the [`Element`](https://developer.mozilla.org/docs/Web/API/Element) interface fires on a [popover](/docs/web-platform/popover-api/) element when it is dismissed.
@@ -50,4 +50,4 @@ popover.onpopoverhide = () => {
 * [The Popover API](/docs/web-platform/popover-api/)
 * [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
 * [Chrome Platform Status: The Popover API](https://chromestatus.com/feature/5463833265045504) 
-* [Open UI: Popover API Explainer](https://open-ui.org/components/popup.research.explainer)
+* [Open UI: Popover API Explainer](https://open-ui.org/components/popover.research.explainer)

--- a/site/en/docs/web-platform/popover-api/popoverhidetarget-attribute/index.md
+++ b/site/en/docs/web-platform/popover-api/popoverhidetarget-attribute/index.md
@@ -7,7 +7,7 @@ authors:
   - chrisdavidmills
   - jheyy
 date: 2022-10-19
-updated: 2022-11-10
+updated: 2023-01-25
 ---
 
 The **`popoverhidetarget`** attribute creates a trigger element that dismisses an associated shown [popover](/docs/web-platform/popover-api/).
@@ -36,4 +36,4 @@ The attribute takes a string value equal to the ID of the popover element that y
 * [The Popover API](/docs/web-platform/popover-api/)
 * [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
 * [Chrome Platform Status: The Popover API](https://chromestatus.com/feature/5463833265045504) 
-* [Open UI: Popover API Explainer](https://open-ui.org/components/popup.research.explainer)
+* [Open UI: Popover API Explainer](https://open-ui.org/components/popover.research.explainer)

--- a/site/en/docs/web-platform/popover-api/popoverhidetarget-property/index.md
+++ b/site/en/docs/web-platform/popover-api/popoverhidetarget-property/index.md
@@ -7,7 +7,7 @@ authors:
   - chrisdavidmills
   - jheyy
 date: 2022-10-19
-updated: 2022-11-10
+updated: 2023-01-25
 ---
 
 The `popoverHideTarget` property of the [`HTMLInputElement`](https://developer.mozilla.org/docs/Web/API/HTMLInputElement) and [`HTMLButtonElement`](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement) interfaces creates a trigger element that dismisses an associated shown [popover](/docs/web-platform/popover-api/). It is the DOM definition of the HTML [`popoverhidetarget`](/docs/web-platform/popover-api/popoverhidetarget-attribute) attribute.
@@ -40,4 +40,4 @@ popover.popoverHideTarget = 'my-popover';
 * [The Popover API](/docs/web-platform/popover-api/)
 * [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
 * [Chrome Platform Status: The Popover API](https://chromestatus.com/feature/5463833265045504) 
-* [Open UI: Popover API Explainer](https://open-ui.org/components/popup.research.explainer)
+* [Open UI: Popover API Explainer](https://open-ui.org/components/popover.research.explainer)

--- a/site/en/docs/web-platform/popover-api/popovershow-event/index.md
+++ b/site/en/docs/web-platform/popover-api/popovershow-event/index.md
@@ -7,7 +7,7 @@ authors:
   - chrisdavidmills
   - jheyy
 date: 2022-10-19
-updated: 2022-11-10
+updated: 2023-01-25
 ---
 
 The `popovershow` event of the [`Element`](https://developer.mozilla.org/docs/Web/API/Element) interface fires on a [popover](/docs/web-platform/popover-api/) element when it is shown.
@@ -50,4 +50,4 @@ popover.onpopovershow = () => {
 * [The Popover API](/docs/web-platform/popover-api/)
 * [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
 * [Chrome Platform Status: The Popover API](https://chromestatus.com/feature/5463833265045504) 
-* [Open UI: Popover API Explainer](https://open-ui.org/components/popup.research.explainer)
+* [Open UI: Popover API Explainer](https://open-ui.org/components/popover.research.explainer)

--- a/site/en/docs/web-platform/popover-api/popovershowtarget-attribute/index.md
+++ b/site/en/docs/web-platform/popover-api/popovershowtarget-attribute/index.md
@@ -7,7 +7,7 @@ authors:
   - chrisdavidmills
   - jheyy
 date: 2022-10-19
-updated: 2022-11-10
+updated: 2023-01-25
 ---
 
 The **`popovershowtarget`** attribute creates a trigger element that shows an associated hidden [popover](/docs/web-platform/popover-api/).
@@ -36,4 +36,4 @@ The attribute takes a string value equal to the ID of the popover element that y
 * [The Popover API](/docs/web-platform/popover-api/)
 * [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
 * [Chrome Platform Status: The Popover API](https://chromestatus.com/feature/5463833265045504) 
-* [Open UI: Popover API Explainer](https://open-ui.org/components/popup.research.explainer)
+* [Open UI: Popover API Explainer](https://open-ui.org/components/popover.research.explainer)

--- a/site/en/docs/web-platform/popover-api/popovershowtarget-property/index.md
+++ b/site/en/docs/web-platform/popover-api/popovershowtarget-property/index.md
@@ -7,7 +7,7 @@ authors:
   - chrisdavidmills
   - jheyy
 date: 2022-10-19
-updated: 2022-11-10
+updated: 2023-01-25
 ---
 
 The `popoverShowTarget` property of the [`HTMLInputElement`](https://developer.mozilla.org/docs/Web/API/HTMLInputElement) and [`HTMLButtonElement`](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement) interfaces creates a trigger element that shows an associated hidden [popover](/docs/web-platform/popover-api/). It is the DOM definition of the HTML [`popovershowtarget`](/docs/web-platform/popover-api/popovershowtarget-attribute) attribute.
@@ -40,4 +40,4 @@ popover.popoverShowTarget = 'my-popover';
 * [The Popover API](/docs/web-platform/popover-api/)
 * [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
 * [Chrome Platform Status: The Popover API](https://chromestatus.com/feature/5463833265045504) 
-* [Open UI: Popover API Explainer](https://open-ui.org/components/popup.research.explainer)
+* [Open UI: Popover API Explainer](https://open-ui.org/components/popover.research.explainer)

--- a/site/en/docs/web-platform/popover-api/popovertoggletarget-attribute/index.md
+++ b/site/en/docs/web-platform/popover-api/popovertoggletarget-attribute/index.md
@@ -7,7 +7,7 @@ authors:
   - chrisdavidmills
   - jheyy
 date: 2022-10-19
-updated: 2022-11-10
+updated: 2023-01-25
 ---
 
 The **`popovertoggletarget`** attribute creates a trigger element that toggles an associated [popover](/docs/web-platform/popover-api/) between shown and hidden states.
@@ -36,4 +36,4 @@ The attribute takes a string value equal to the ID of the popover element that y
 * [The Popover API](/docs/web-platform/popover-api/)
 * [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
 * [Chrome Platform Status: The Popover API](https://chromestatus.com/feature/5463833265045504) 
-* [Open UI: Popover API Explainer](https://open-ui.org/components/popup.research.explainer)
+* [Open UI: Popover API Explainer](https://open-ui.org/components/popover.research.explainer)

--- a/site/en/docs/web-platform/popover-api/popovertoggletarget-property/index.md
+++ b/site/en/docs/web-platform/popover-api/popovertoggletarget-property/index.md
@@ -7,7 +7,7 @@ authors:
   - chrisdavidmills
   - jheyy
 date: 2022-10-19
-updated: 2022-11-10
+updated: 2023-01-25
 ---
 
 The `popoverToggleTarget` property of the [`HTMLInputElement`](https://developer.mozilla.org/docs/Web/API/HTMLInputElement) and [`HTMLButtonElement`](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement) interfaces creates a trigger element that toggles an associated [popover](/docs/web-platform/popover-api/) between shown and hidden states. It is the DOM definition of the HTML [`popovertoggletarget`](/docs/web-platform/popover-api/popovertoggletarget-attribute) attribute.
@@ -40,4 +40,4 @@ popover.popoverToggleTarget = 'my-popover';
 * [The Popover API](/docs/web-platform/popover-api/)
 * [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
 * [Chrome Platform Status: The Popover API](https://chromestatus.com/feature/5463833265045504) 
-* [Open UI: Popover API Explainer](https://open-ui.org/components/popup.research.explainer)
+* [Open UI: Popover API Explainer](https://open-ui.org/components/popover.research.explainer)

--- a/site/en/docs/web-platform/popover-api/showpopover-method/index.md
+++ b/site/en/docs/web-platform/popover-api/showpopover-method/index.md
@@ -7,7 +7,7 @@ authors:
   - chrisdavidmills
   - jheyy
 date: 2022-10-19
-updated: 2022-11-10
+updated: 2023-01-25
 ---
 
 The **`showPopover()`** instance method of the [`Element`](https://developer.mozilla.org/docs/Web/API/Element) interface shows a [popover](/docs/web-platform/popover-api/) element.
@@ -56,4 +56,4 @@ popover.showPopOver();
 * [The Popover API](/docs/web-platform/popover-api/)
 * [Pop-ups: They're making a resurgence!](/blog/pop-ups-theyre-making-a-resurgence/), by Jhey Tompkins
 * [Chrome Platform Status: The Popover API](https://chromestatus.com/feature/5463833265045504) 
-* [Open UI: Popover API Explainer](https://open-ui.org/components/popup.research.explainer)
+* [Open UI: Popover API Explainer](https://open-ui.org/components/popover.research.explainer)


### PR DESCRIPTION
- Changes were made on the Open UI site and the explainer link has been updated to reflect the name change of the API