### PR TITLE
update Private Network Access blog post

### DIFF
--- a/site/en/blog/private-network-access-update-2023-02-02/index.md
+++ b/site/en/blog/private-network-access-update-2023-02-02/index.md
@@ -12,7 +12,7 @@ tags:
   - security
 ---
 
-Feedback from websites currently participating in the [Private Network Access from non-secure contexts deprecation trial](https://developer.chrome.com/origintrials/#/view_trial/4081387162304512001) has emphasized the difficulty in migrating affected websites to HTTPS. As a result, the trial is extended until Chrome 113 inclusive. Chrome 114, the first milestone without support for the trial, will roll out to Beta in early May 2023 and Stable in the end of May 2023.
+Feedback from websites currently participating in the [Private Network Access from non-secure contexts deprecation trial](/origintrials/#/view_trial/4081387162304512001) has emphasized the difficulty in migrating affected websites to HTTPS. As a result, the trial is extended until Chrome 113 inclusive. Chrome 114, the first milestone without support for the trial, will roll out to Beta in early May 2023 and Stable in the end of May 2023.
 
 A permission prompt will be built to allow mix-content requests from HTTPs public websites to plaintext private devices. An overview for it, please check the [feature explainer](https://github.com/WICG/local-network-access/blob/main/permission_prompt/explainer.md) and the [developer walk through document](https://docs.google.com/document/d/1W70cFFaBGWd0EeOOMxJh9zkmxZ903vKUaGjyF-w7HcY/edit#heading=h.qof2sn5s8r89). We will put out a blog post with more details in the future once it is ready.
 

--- a/site/en/blog/private-network-access-update-2023-02-02/index.md
+++ b/site/en/blog/private-network-access-update-2023-02-02/index.md
@@ -14,7 +14,7 @@ tags:
 
 Feedback from websites currently participating in the [Private Network Access from non-secure contexts deprecation trial](/origintrials/#/view_trial/4081387162304512001) has emphasized the difficulty in migrating affected websites to HTTPS. As a result, the trial is extended until Chrome 113 inclusive. Chrome 114, the first milestone without support for the trial, will roll out to Beta in early May 2023 and Stable in the end of May 2023.
 
-A permission prompt will be built to allow mix-content requests from HTTPs public websites to plaintext private devices. For more information, please check the [feature explainer](https://github.com/WICG/local-network-access/blob/main/permission_prompt/explainer.md) for an overview and the [developer walks through document](https://docs.google.com/document/d/1W70cFFaBGWd0EeOOMxJh9zkmxZ903vKUaGjyF-w7HcY/edit#heading=h.qof2sn5s8r89) to overview developers' possible approaches to achieve. We will put out a blog post with more details in the future once it is ready.
+A permission prompt will be built to allow mix-content requests from HTTPs public websites to plaintext private devices. For more information, please check the [feature explainer](https://github.com/WICG/local-network-access/blob/main/permission_prompt/explainer.md) for an overview and the [developer walks through document](https://docs.google.com/document/d/1W70cFFaBGWd0EeOOMxJh9zkmxZ903vKUaGjyF-w7HcY/edit#heading=h.qof2sn5s8r89) to see developers' possible approaches need to achieve. We will put out a blog post with more details in the future once it is ready.
 
 For further information, please see [Private Network Access update: Introducing a deprecation trial](/blog/private-network-access-update/).
 

--- a/site/en/blog/private-network-access-update-2023-02-02/index.md
+++ b/site/en/blog/private-network-access-update-2023-02-02/index.md
@@ -23,6 +23,6 @@ Let us know by filing an issue with Chromium at [crbug.com](crbug.com) and set
 the component to `Blink>SecurityFeature>CORS>PrivateNetworkAccess` or open an issue
 under [Private Network Access WICG specification Github repository](https://github.com/WICG/local-network-access/issues).
 
-Thank you for all the effort you put with us to make the web safer!
+Thank you for helping us make the web safer!
 
 

--- a/site/en/blog/private-network-access-update-2023-02-02/index.md
+++ b/site/en/blog/private-network-access-update-2023-02-02/index.md
@@ -21,7 +21,7 @@ If you host a website within a private network that expects requests from
 public networks, we are interested in your feedback and use cases.
 Let us know by filing an issue with Chromium at [crbug.com](crbug.com) and set
 the component to `Blink>SecurityFeature>CORS>PrivateNetworkAccess` or open an issue
-under [Private Network Access WICG specification Github repository](https://github.com/WICG/local-network-access/issues).
+in the [Private Network Access WICG specification Github repository](https://github.com/WICG/local-network-access/issues).
 
 Thank you for helping us make the web safer!
 

--- a/site/en/blog/private-network-access-update-2023-02-02/index.md
+++ b/site/en/blog/private-network-access-update-2023-02-02/index.md
@@ -12,7 +12,7 @@ tags:
   - security
 ---
 
-Feedback from websites currently participating in the [Private Network Access from non-secure contexts deprecation trial](https://developer.chrome.com/origintrials/#/view_trial/4081387162304512001) has emphasized the difficulty in migrating affected websites to HTTPS. As a result, the trial is extended until Chrome 113 inclusive. Chrome 114, the first milestone without support for the trial, will roll out to Beta in April 2023 and Stable in May 2023.
+Feedback from websites currently participating in the [Private Network Access from non-secure contexts deprecation trial](https://developer.chrome.com/origintrials/#/view_trial/4081387162304512001) has emphasized the difficulty in migrating affected websites to HTTPS. As a result, the trial is extended until Chrome 113 inclusive. Chrome 114, the first milestone without support for the trial, will roll out to Beta in early May 2023 and Stable in the end of May 2023.
 
 For further information, please see [Private Network Access update: Introducing a deprecation trial](/blog/private-network-access-update/).
 

--- a/site/en/blog/private-network-access-update-2023-02-02/index.md
+++ b/site/en/blog/private-network-access-update-2023-02-02/index.md
@@ -15,7 +15,7 @@ tags:
 Due to massive deprecation trial feedbacks mentioning the difficulty of deprecating HTTP
 private webpages and migrating those with TSL certification, we are now announcing an extension of the trial period until Chrome 113. Chrome 113 will roll out to Beta in April 2023 and Stable in May 2023.
 
-For further information, please follow [Private Network Access update: Introducing a deprecation trial](/blog/private-network-access-update/).
+For further information, please see [Private Network Access update: Introducing a deprecation trial](/blog/private-network-access-update/). 
 
 If you host a website within a private network that expects requests from
 public networks, we are interested in your feedback and use cases.

--- a/site/en/blog/private-network-access-update-2023-02-02/index.md
+++ b/site/en/blog/private-network-access-update-2023-02-02/index.md
@@ -1,0 +1,28 @@
+---
+layout: 'layouts/blog-post.njk'
+title: "Private Network Access update: Announce extension of the Deprecation Trial"
+authors:
+  - lyf
+description: Chrome is deprecating access to private network endpoints from non-secure public websites as part of the Private Network Access specification and is currently in a stage of deprecation trial until Chrome 113 at the moment.
+date: 2023-02-02
+hero: 'image/YLflGBAPWecgtKJLqCJHSzHqe2J2/dwtN0NkxkBmIz1EyhzAm.jpg'
+alt: 'Photo by Sara Cohen on Unsplash'
+tags:
+  - chrome-113
+  - security
+---
+
+Due to massive deprecation trial feedbacks mentioning the difficulty of deprecating HTTP
+private webpages and migrating those with TSL certification, we are now announcing an extension of the trial period until Chrome 113. Chrome 113 will roll out to Beta in April 2023 and Stable in May 2023.
+
+For further information, please follow [Private Network Access update: Introducing a deprecation trial](/blog/private-network-access-update/).
+
+If you are hosting a website within a private network that expects requests from
+public networks, we are interested in your feedback and use cases.
+Let us know by filing an issue with Chromium at [crbug.com](crbug.com) and set
+the component to `Blink>SecurityFeature>CORS>PrivateNetworkAccess` or open an issue
+under [Private Network Access WICG specification Github repository](https://github.com/WICG/local-network-access/issues).
+
+Thank you for all the effort you put with us to make the web safer!
+
+

--- a/site/en/blog/private-network-access-update-2023-02-02/index.md
+++ b/site/en/blog/private-network-access-update-2023-02-02/index.md
@@ -12,8 +12,7 @@ tags:
   - security
 ---
 
-Due to massive deprecation trial feedbacks mentioning the difficulty of deprecating HTTP
-private webpages and migrating those with TSL certification, we are now announcing an extension of the trial period until Chrome 113. Chrome 113 will roll out to Beta in April 2023 and Stable in May 2023.
+Feedback from websites currently participating in the [Private Network Access from non-secure contexts deprecation trial](https://developer.chrome.com/origintrials/#/view_trial/4081387162304512001) has emphasized the difficulty in migrating affected websites to HTTPS. As a result, the trial is extended until Chrome 113 inclusive. Chrome 114, the first milestone without support for the trial, will roll out to Beta in April 2023 and Stable in May 2023.
 
 For further information, please see [Private Network Access update: Introducing a deprecation trial](/blog/private-network-access-update/).
 

--- a/site/en/blog/private-network-access-update-2023-02-02/index.md
+++ b/site/en/blog/private-network-access-update-2023-02-02/index.md
@@ -14,7 +14,7 @@ tags:
 
 Feedback from websites currently participating in the [Private Network Access from non-secure contexts deprecation trial](/origintrials/#/view_trial/4081387162304512001) has emphasized the difficulty in migrating affected websites to HTTPS. As a result, the trial is extended until Chrome 113 inclusive. Chrome 114, the first milestone without support for the trial, will roll out to Beta in early May 2023 and Stable in the end of May 2023.
 
-A permission prompt will be built to allow mix-content requests from HTTPs public websites to plaintext private devices. An overview for it, please check the [feature explainer](https://github.com/WICG/local-network-access/blob/main/permission_prompt/explainer.md) and the [developer walk through document](https://docs.google.com/document/d/1W70cFFaBGWd0EeOOMxJh9zkmxZ903vKUaGjyF-w7HcY/edit#heading=h.qof2sn5s8r89). We will put out a blog post with more details in the future once it is ready.
+A permission prompt will be built to allow mix-content requests from HTTPs public websites to plaintext private devices. For more information, please check the [feature explainer](https://github.com/WICG/local-network-access/blob/main/permission_prompt/explainer.md) for an overview and the [developer walks through document](https://docs.google.com/document/d/1W70cFFaBGWd0EeOOMxJh9zkmxZ903vKUaGjyF-w7HcY/edit#heading=h.qof2sn5s8r89) to overview developers' possible approaches to achieve. We will put out a blog post with more details in the future once it is ready.
 
 For further information, please see [Private Network Access update: Introducing a deprecation trial](/blog/private-network-access-update/).
 

--- a/site/en/blog/private-network-access-update-2023-02-02/index.md
+++ b/site/en/blog/private-network-access-update-2023-02-02/index.md
@@ -15,7 +15,7 @@ tags:
 Due to massive deprecation trial feedbacks mentioning the difficulty of deprecating HTTP
 private webpages and migrating those with TSL certification, we are now announcing an extension of the trial period until Chrome 113. Chrome 113 will roll out to Beta in April 2023 and Stable in May 2023.
 
-For further information, please see [Private Network Access update: Introducing a deprecation trial](/blog/private-network-access-update/). 
+For further information, please see [Private Network Access update: Introducing a deprecation trial](/blog/private-network-access-update/).
 
 If you host a website within a private network that expects requests from
 public networks, we are interested in your feedback and use cases.

--- a/site/en/blog/private-network-access-update-2023-02-02/index.md
+++ b/site/en/blog/private-network-access-update-2023-02-02/index.md
@@ -3,7 +3,7 @@ layout: 'layouts/blog-post.njk'
 title: "Private Network Access update: Announce extension of the Deprecation Trial"
 authors:
   - lyf
-description: Chrome is deprecating access to private network endpoints from non-secure public websites as part of the Private Network Access specification and is currently in a stage of deprecation trial until Chrome 113 at the moment.
+description: Chrome is deprecating access to private network endpoints from non-secure public websites as part of the Private Network Access specification. A deprecation trial is available until Chrome 113.
 date: 2023-02-02
 hero: 'image/YLflGBAPWecgtKJLqCJHSzHqe2J2/dwtN0NkxkBmIz1EyhzAm.jpg'
 alt: 'Photo by Sara Cohen on Unsplash'

--- a/site/en/blog/private-network-access-update-2023-02-02/index.md
+++ b/site/en/blog/private-network-access-update-2023-02-02/index.md
@@ -17,7 +17,7 @@ private webpages and migrating those with TSL certification, we are now announci
 
 For further information, please follow [Private Network Access update: Introducing a deprecation trial](/blog/private-network-access-update/).
 
-If you are hosting a website within a private network that expects requests from
+If you host a website within a private network that expects requests from
 public networks, we are interested in your feedback and use cases.
 Let us know by filing an issue with Chromium at [crbug.com](crbug.com) and set
 the component to `Blink>SecurityFeature>CORS>PrivateNetworkAccess` or open an issue

--- a/site/en/blog/private-network-access-update-2023-02-02/index.md
+++ b/site/en/blog/private-network-access-update-2023-02-02/index.md
@@ -14,6 +14,8 @@ tags:
 
 Feedback from websites currently participating in the [Private Network Access from non-secure contexts deprecation trial](https://developer.chrome.com/origintrials/#/view_trial/4081387162304512001) has emphasized the difficulty in migrating affected websites to HTTPS. As a result, the trial is extended until Chrome 113 inclusive. Chrome 114, the first milestone without support for the trial, will roll out to Beta in early May 2023 and Stable in the end of May 2023.
 
+A permission prompt will be built to allow mix-content requests from HTTPs public websites to plaintext private devices. An overview for it, please check the [feature explainer](https://github.com/WICG/local-network-access/blob/main/permission_prompt/explainer.md) and the [developer walk through document](https://docs.google.com/document/d/1W70cFFaBGWd0EeOOMxJh9zkmxZ903vKUaGjyF-w7HcY/edit#heading=h.qof2sn5s8r89). We will put out a blog post with more details in the future once it is ready.
+
 For further information, please see [Private Network Access update: Introducing a deprecation trial](/blog/private-network-access-update/).
 
 If you host a website within a private network that expects requests from

--- a/site/en/blog/private-network-access-update/index.md
+++ b/site/en/blog/private-network-access-update/index.md
@@ -6,16 +6,21 @@ authors:
   - lyf
 description: Chrome is deprecating access to private network endpoints from non-secure public websites in Chrome 94 as part of the Private Network Access specification. Read on for recommended actions.
 date: 2021-08-26
-updated: 2022-08-12
+updated: 2023-02-02
 hero: image/YLflGBAPWecgtKJLqCJHSzHqe2J2/dwtN0NkxkBmIz1EyhzAm.jpg
 alt: A private sign in German
 tags:
   - chrome-94
+  - chrome-113
+  - security
 ---
 
 **Updates**
 
-- **August 12, 2022**: The  timeline has been updated, and deprecation
+- **January 19, 2023**: The timeline has been updated, and deprecation
+   will not occur until Chrome 113.
+
+- **August 12, 2022**: The timeline has been updated, and deprecation
    will not occur until Chrome 109.
 
 - **February 10, 2022**: An updated article is published at [Private Network
@@ -37,7 +42,7 @@ Chrome will introduce the following changes:
 * Blocking requests to private networks from insecure public websites starting in
   Chrome 94.
 * Introducing a [deprecation trial](#whats-deprecation-trial) which will end in Chrome
-  109. It will allow developers to request a time extension for chosen origins,
+  113. It will allow developers to request a time extension for chosen origins,
   which will not be affected during the deprecation trial.
 * Introducing a Chrome policy which will allow managed Chrome deployments to
   bypass the deprecation permanently. Available in Chrome 92.
@@ -75,8 +80,10 @@ strategies:
   for the deprecation trial.
 * September 2021: Chrome 94 rolls out to Stable. Web developers should have signed
   up for the deprecation trial and deployed trial tokens to production.
-* December 2022: Chrome 109 rolls out to Beta.
-* February 2023: Chrome 109 rolls out to Stable. The deprecation trial ends. Chrome
+* December 2022: Origin trial survey sent and feedback received. The deprecation
+  trial has been extended to Chrome 113.
+* April 2023: Chrome 113 rolls out to Beta.
+* May 2023: Chrome 113 rolls out to Stable. The deprecation trial ends. Chrome
   blocks all private network requests from public, non-secure contexts.
 
 ## What is Private Network Access 
@@ -141,7 +148,7 @@ still mention the earlier milestone.
 
 This deprecation is accompanied by a deprecation trial, allowing web developers
 whose websites make use of the deprecated feature to continue using it until
-Chrome 109 by registering for tokens. See [below](#register-deprecation-trial)
+Chrome 113 by registering for tokens. See [below](#register-deprecation-trial)
 for instructions on how to register and enable the trial on your website.
 
 A pair of [Chrome policies](#policies) can be leveraged to disable the
@@ -149,7 +156,7 @@ deprecation either entirely or on specific origins, indefinitely. This allows
 managed Chrome installations, for example, those in corporate settings, to
 avoid breakage.
 
-### Chrome 109
+### Chrome 113
 
 The deprecation trial ends. All websites must be migrated off of the deprecated
 feature, or their users' policies configured to continue enabling the feature.
@@ -262,7 +269,7 @@ You can bypass the lack of a valid TLS certificate signed by a trusted CA by
 using [WebTransport](https://w3c.github.io/webtransport) and its [certificate
 pinning
 mechanism](https://w3c.github.io/webtransport/#dom-webtransportoptions-servercertificatefingerprints).
-This allows establishing secure connections to local devices that might have a
+This allows establishing secure connections to private devices that might have a
 self-signed certificate for example. WebTransport connections allow
 bidirectional data transfer, but not fetch requests. You can combine this
 approach with a service worker to transparently proxy HTTP requests over the


### PR DESCRIPTION
Changes proposed in this pull request:

- Deprecation trial for non-secure context has been extended to M113.