### PR TITLE
Remove duplicate Chrome 110 tag

### DIFF
--- a/site/_data/i18n/tags.yml
+++ b/site/_data/i18n/tags.yml
@@ -224,9 +224,6 @@ chrome109:
 chrome110:
   en: Chrome 110
 
-chrome110:
-  en: Chrome 110
-
 beta:
   en: Beta
 


### PR DESCRIPTION
Removes duplicate tag that is breaking the build.