### PR TITLE
style: set primary color for social media icon on hover

### DIFF
--- a/site/_scss/blocks/_social-icon.scss
+++ b/site/_scss/blocks/_social-icon.scss
@@ -3,4 +3,8 @@
     height: auto;
     width: 32px;
   }
+
+  :hover {
+    color: var(--color-primary);
+  }
 }


### PR DESCRIPTION
Fixes #3682

Changes proposed in this pull request:

- Author's social media links on hover become light blue
- The color used is --color-primary