### PR TITLE
Force downgrade to gcloud SDK version 413 due to GCS permissions error

### DIFF
--- a/.cloudbuild/external.yaml
+++ b/.cloudbuild/external.yaml
@@ -43,6 +43,7 @@ steps:
     args:
       - '-c'
       - |
+        gcloud components update --version=413.0.0
         gsutil rsync external/data/ gs://external-dcc-data
 
 options:


### PR DESCRIPTION
The January 19th release of the GCloud SDK introduced an issue accessing buckets via `gsutil`. The recommended fix for now is to downgrade, which unfortunately adds ~3 minutes execution time for the `build-external` job.