### PR TITLE
Update webdev-infra to 1.0.43

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "unistore": "^3.5.2",
         "uslug": "^1.0.4",
         "web-vitals": "^3.0.4",
-        "webdev-infra": "1.0.42",
+        "webdev-infra": "1.0.43",
         "xss": "^1.0.14"
       },
       "devDependencies": {
@@ -2261,9 +2261,9 @@
       }
     },
     "node_modules/@mdn/browser-compat-data": {
-      "version": "5.2.23",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.23.tgz",
-      "integrity": "sha512-El3EaBt6EzO8DrRgpaJKLwik+wdImyIxL6Nbp9iQSddDIfmrFvF+Chz2LYBQoLEUCg8wjwEVRMA44TwlhW3rjQ=="
+      "version": "5.2.33",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.33.tgz",
+      "integrity": "sha512-CEhwV3X4w6Hv1SiaWQFtChNGZ/p7VwdFRQ4dL6ieYACMm6EI0XTWtA1L+afkbV4eCB8bS63cmSYVyzsETZryDA=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.3",
@@ -24636,15 +24636,15 @@
       "integrity": "sha512-Yau8qf1AJ/dm6MY180Bi0qpCIuWmAfKAnOqmxLecGfIHn0+ND3H4JOhXeY73Pyi9zjSF5J4SNUewHLNUzU7mmA=="
     },
     "node_modules/webdev-infra": {
-      "version": "1.0.42",
-      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.42.tgz",
-      "integrity": "sha512-ckCXadeoKnrUCTaJ+15ee0n491mW+t+fW10hakv49DAdjX53Efm63yuSS9HXt6n7m2fDl/koVw8I16gp0NW+Og==",
+      "version": "1.0.43",
+      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.43.tgz",
+      "integrity": "sha512-0vAJk9I1XVY8uc6mkN3IapAOvFNurXil/aWBV6mEKlj2MK3v1bfdwmbDDQJuvdXVv7lrWBZVX3gdgQEDhV6lfA==",
       "dependencies": {
         "@11ty/eleventy": "1.0.2",
         "@11ty/eleventy-cache-assets": "^2.3.0",
         "@imgix/js-core": "^3.1.3",
         "@justinribeiro/lite-youtube": "^0.9.1",
-        "@mdn/browser-compat-data": "5.2.23",
+        "@mdn/browser-compat-data": "5.2.33",
         "@swc/html": "0.0.18",
         "async-transforms": "^1.0.9",
         "browser-media-mime-type": "^1.0.0",
@@ -26976,9 +26976,9 @@
       }
     },
     "@mdn/browser-compat-data": {
-      "version": "5.2.23",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.23.tgz",
-      "integrity": "sha512-El3EaBt6EzO8DrRgpaJKLwik+wdImyIxL6Nbp9iQSddDIfmrFvF+Chz2LYBQoLEUCg8wjwEVRMA44TwlhW3rjQ=="
+      "version": "5.2.33",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.33.tgz",
+      "integrity": "sha512-CEhwV3X4w6Hv1SiaWQFtChNGZ/p7VwdFRQ4dL6ieYACMm6EI0XTWtA1L+afkbV4eCB8bS63cmSYVyzsETZryDA=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
@@ -44361,15 +44361,15 @@
       "integrity": "sha512-Yau8qf1AJ/dm6MY180Bi0qpCIuWmAfKAnOqmxLecGfIHn0+ND3H4JOhXeY73Pyi9zjSF5J4SNUewHLNUzU7mmA=="
     },
     "webdev-infra": {
-      "version": "1.0.42",
-      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.42.tgz",
-      "integrity": "sha512-ckCXadeoKnrUCTaJ+15ee0n491mW+t+fW10hakv49DAdjX53Efm63yuSS9HXt6n7m2fDl/koVw8I16gp0NW+Og==",
+      "version": "1.0.43",
+      "resolved": "https://registry.npmjs.org/webdev-infra/-/webdev-infra-1.0.43.tgz",
+      "integrity": "sha512-0vAJk9I1XVY8uc6mkN3IapAOvFNurXil/aWBV6mEKlj2MK3v1bfdwmbDDQJuvdXVv7lrWBZVX3gdgQEDhV6lfA==",
       "requires": {
         "@11ty/eleventy": "1.0.2",
         "@11ty/eleventy-cache-assets": "^2.3.0",
         "@imgix/js-core": "^3.1.3",
         "@justinribeiro/lite-youtube": "^0.9.1",
-        "@mdn/browser-compat-data": "5.2.23",
+        "@mdn/browser-compat-data": "5.2.33",
         "@swc/html": "0.0.18",
         "async-transforms": "^1.0.9",
         "browser-media-mime-type": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "unistore": "^3.5.2",
     "uslug": "^1.0.4",
     "web-vitals": "^3.0.4",
-    "webdev-infra": "1.0.42",
+    "webdev-infra": "1.0.43",
     "xss": "^1.0.14"
   },
   "optionalDependencies": {


### PR DESCRIPTION
This updates @mdn/browser-compat-data to the latest version, 5.2.33, behind the scenes.