### PR TITLE
refactor: rename "gotchas" aside type to "important"

### DIFF
--- a/site/_data/i18n/common.yml
+++ b/site/_data/i18n/common.yml
@@ -78,9 +78,23 @@ success:
   en: 'Success'
   es: 'Éxito'
 
+gotchas:
+  en: 'Gotchas'
+  es: 'Gotchas'
+  ja: '注意事項'
+  ko: '주의사항'
+  pt: 'Gotchas'
+  ru: 'Особенности'
+  zh: '注意事项'
+
 important:
   en: 'Important'
   es: 'Importante'
+  ja: '重要'
+  ko: '중요한'
+  pt: 'Importante'
+  ru: 'Важный'
+  zh: '重要的'
 
 key-term:
   en: 'Key Term'

--- a/site/_data/i18n/common.yml
+++ b/site/_data/i18n/common.yml
@@ -78,12 +78,9 @@ success:
   en: 'Success'
   es: 'Éxito'
 
-gotchas:
-  en: 'Gotchas'
-  es: 'Gotchas'
-
 important:
   en: 'Important'
+  es: 'Importante'
 
 key-term:
   en: 'Key Term'

--- a/site/_includes/macros/render-type.njk
+++ b/site/_includes/macros/render-type.njk
@@ -491,13 +491,13 @@
       </span>
     {% endif %}
     {% if feature.minManifest %}
-      <span class="aside--gotchas tag-pill type--label rounded-lg" title="Minimum manifest version">
+      <span class="aside--important tag-pill type--label rounded-lg" title="Minimum manifest version">
         {{ feature.minManifest }}+
       </span>
     {% endif %}
 
     {% if feature.disallowServiceWorkers %}
-      <span class="aside--gotchas tag-pill type--label rounded-lg" title="Not available in Service Workers">
+      <span class="aside--important tag-pill type--label rounded-lg" title="Not available in Service Workers">
         Foreground only
       </span>
     {% endif %}

--- a/site/_scss/blocks/_aside.scss
+++ b/site/_scss/blocks/_aside.scss
@@ -44,7 +44,7 @@
     color: var(--color-green-darkest);
   }
   
-  &--gotchas {
+  &--important {
     --link-color: var(--color-purple-darkest);
     --link-visited-color: var(--color-purple-darkest);
     --link-rgb-background: var(--rgb-purple-darkest);

--- a/site/_shortcodes/Aside.js
+++ b/site/_shortcodes/Aside.js
@@ -22,7 +22,6 @@ const icons = {
   warning: loadIcon('warning'),
   success: loadIcon('done'),
   objective: loadIcon('done'),
-  gotchas: loadIcon('lightbulb-outline'),
   important: loadIcon('lightbulb-outline'),
   'key-term': loadIcon('ink-highlighter'),
   codelab: loadIcon('code'),
@@ -37,6 +36,12 @@ function Aside(content, type = 'note') {
   // @ts-ignore: `this` has type of `any`
   const locale = this.ctx.locale || defaultLocale;
   let text;
+
+  // implement backwards compatibility for old "gotchas" type, rewrite to "important" type
+  if (type === 'gotchas') {
+    type = 'important';
+  }
+
   if (type !== 'note') {
     text = i18n(`i18n.common.${type}`, locale);
   }

--- a/site/en/docs/handbook/components/index.md
+++ b/site/en/docs/handbook/components/index.md
@@ -94,17 +94,17 @@ Use the success aside to describe a successful action or an error-free status.
 Use the success aside to describe a successful action or an error-free status.
 {% endAside %}
 
-### Gotchas asides
+### Important asides
 
 ```md
-{% raw %}{% Aside 'gotchas' %}
-Use the gotcha aside to indicate a common problem that the reader wouldn't know
+{% raw %}{% Aside 'important' %}
+Use the important aside to indicate a common problem that the reader wouldn't know
 without specialized knowledge of the topic.
 {% endAside %}{% endraw %}
 ```
 
-{% Aside 'gotchas' %}
-Use the gotchas aside to indicate a common problem that the reader wouldn't know
+{% Aside 'important' %}
+Use the important aside to indicate a common problem that the reader wouldn't know
 without specialized knowledge of the topic.
 {% endAside %}
 


### PR DESCRIPTION
Fixes #3380

Changes proposed in this pull request:

- Add "important" Spanish translation
- Remove "gotchas" translations
- Use `.aside--important` class where `.aside--gotchas` was previously used
- Rewrite previous uses of "gotchas" type to "important" without modifying affected articles
- Update handbook gotchas demo to an important aside demo