### PR TITLE
Fixed typo in CSS color-mix() article

### DIFF
--- a/site/en/blog/css-color-mix/index.md
+++ b/site/en/blog/css-color-mix/index.md
@@ -199,7 +199,7 @@ both produce a vibrant result, while srgb and oklab produce unsaturated colors.
   <figcaption><a href="https://codepen.io/web-dot-dev/pen/VwBdxGm">Try the demo</a></figcaption>
 </figure>
 
-If you want consistency and subtly, use oklab. In the following demo which mixes
+If you want consistency and subtlety, use oklab. In the following demo which mixes
 blue and black, hsl and hwb produce overly vibrant and hue shifted colors while
 srgb and oklab produce a darker blue.
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Changes `subtly` to `subtlety` in the article CSS color-mix()

Thank you so much for writing this @argyleink, all these articles about colour are fascinating. If you ever want to package them into a short book, then it's an instant buy from me.