### PR TITLE
Update links for chrome-extensions-samples reorg.

### DIFF
--- a/site/en/blog/new-in-extensions-1/index.md
+++ b/site/en/blog/new-in-extensions-1/index.md
@@ -95,5 +95,5 @@ Extension and site specific:
 
 m89
 
-[war-example]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api/web-accessible-resources
+[war-example]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/web-accessible-resources
 [war-docs]: https://developer.chrome.com/docs/extensions/mv3/manifest/web_accessible_resources/

--- a/site/en/docs/apps/app_storage/index.md
+++ b/site/en/docs/apps/app_storage/index.md
@@ -287,9 +287,9 @@ the remote folder layout is **not** guaranteed to remain backwards compatible be
 [4]: /docs/apps/offline_apps/
 [5]: /docs/extensions/reference/fileSystem/
 [6]: /docs/extensions/reference/syncFileSystem/
-[7]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/apps/samples/filesystem-access
-[8]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/apps/samples/syncfs-editor
-[9]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/apps/samples/storage
+[7]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/_archive/apps/samples/filesystem-access
+[8]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/_archive/apps/samples/syncfs-editor
+[9]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/_archive/apps/samples/storage
 [10]: /docs/apps/contentSecurityPolicy/
 [11]: /docs/apps/app_external/#external
 [12]: /docs/apps/app_external/#webview

--- a/site/en/docs/apps/first_app/index.md
+++ b/site/en/docs/apps/first_app/index.md
@@ -139,7 +139,7 @@ These command line options to Chrome may help you iterate:
 [1]: https://blog.chromium.org/2020/08/changes-to-chrome-app-support-timeline.html
 [2]: /apps/migration
 [3]: publish_app
-[4]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/apps/samples/hello-world
+[4]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/_archive/apps/samples/hello-world
 [5]: manifest
 [6]: manifestVersion
 [7]: app_lifecycle#lifecycle

--- a/site/en/docs/extensions/mv2/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv2/architecture-overview/index.md
@@ -286,8 +286,8 @@ custom Chrome with the following resources.
 [doc-options-page]: /docs/extensions/mv2/options
 [doc-ui-popup]: /docs/extensions/mv2/user_interface/#popup
 [doc-ui]: /docs/extensions/mv2/user_interface/
-[sample-mail-checker]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/mv2-archive/extensions/gmail
-[sample-mappy]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/mv2-archive/extensions/mappy
+[sample-mail-checker]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/_archive/mv2/extensions/gmail
+[sample-mappy]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/_archive/mv2/extensions/mappy
 [section-background]: #background_script
 [section-content-scripts]: #contentScripts
 [section-options-page]: #optionsPage

--- a/site/en/docs/extensions/mv2/desktop_notifications/index.md
+++ b/site/en/docs/extensions/mv2/desktop_notifications/index.md
@@ -109,6 +109,6 @@ unnecessary if you declare the "notifications" permission.
 [5]: http://dev.chromium.org/developers/design-documents/desktop-notifications/api-specification
 [6]: /docs/extensions/extension#method-getBackgroundPage
 [7]: /docs/extensions/extension#method-getViews
-[8]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/notifications/
+[8]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/_archive/mv2/api/notifications/
 [9]: /docs/extensions/mv2/samples
 [10]: http://www.html5rocks.com/tutorials/notifications/quick/

--- a/site/en/docs/extensions/mv2/getstarted/index.md
+++ b/site/en/docs/extensions/mv2/getstarted/index.md
@@ -437,7 +437,7 @@ What's next?
 [declarative-content]: /declarativeContent
 [developer-chrome-docs]: /docs/
 [devguide-mv2]: /docs/extensions/mv2/devguide/
-[get-started-sample]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/mv2-archive/tutorials/get_started_complete
+[get-started-sample]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/_archive/mv2/tutorials/get_started_complete
 [icons]: /user_interface#icons
 [images-zip]: https://storage.googleapis.com/web-dev-uploads/file/WlD8wC6g8khYWPJUsQceQkhXSlv1/qwlTyQ1ah3RmqsgDhRkL.zip "images.zip"
 [manifest]: /docs/extensions/mv2/manifest

--- a/site/en/docs/extensions/mv2/index.md
+++ b/site/en/docs/extensions/mv2/index.md
@@ -36,7 +36,7 @@ have a look at the following starting pages:
 Beyond that, you might find useful entry points in these pages:
 
 * Learn the scope of things in the [Extension development overview](/docs/extensions/mv2/devguide/)
-* Pick something from the [samples page](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/mv2-archive), install it, and start hacking on it.
+* Pick something from the [samples page](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/_archive/mv2), install it, and start hacking on it.
 * Look for answers in the [Extensions FAQ page](/docs/extensions/mv2/faq/)
 
 In addition to the documentation here, many developers find helpful community content at:

--- a/site/en/docs/extensions/mv2/messaging/index.md
+++ b/site/en/docs/extensions/mv2/messaging/index.md
@@ -344,6 +344,6 @@ native app. For more examples and for help in viewing the source code, see [Samp
 [37]: /docs/extensions/mv2/security#content_scripts
 [38]: /docs/extensions/mv2/security#sanitize
 [39]: https://en.wikipedia.org/wiki/Cross-site_scripting
-[40]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/messaging
+[40]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/_archive/mv2/api/messaging
 [41]: /docs/apps/nativeMessaging#examples
 [42]: /docs/extensions/mv2/samples

--- a/site/en/docs/extensions/mv2/overview/index.md
+++ b/site/en/docs/extensions/mv2/overview/index.md
@@ -122,7 +122,7 @@ or by pressing `Ctrl+Shift+F` on your keyboard.
 [4]: https://chrome.google.com/webstore/developer/dashboard
 [5]: https://chrome.google.com/webstore
 [6]: /docs/webstore
-[7]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/mv2-archive/tutorials/hello_extensions
+[7]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/_archive/mv2/tutorials/hello_extensions
 [8]: /docs/extensions/reference/browserAction
 [9]: https://storage.googleapis.com/web-dev-uploads/image/WlD8wC6g8khYWPJUsQceQkhXSlv1/gmKIT88Ha1z8VBMJFOOH.png
 [10]: /docs/extensions/mv2/getstarted

--- a/site/en/docs/extensions/mv2/richNotifications/index.md
+++ b/site/en/docs/extensions/mv2/richNotifications/index.md
@@ -189,7 +189,7 @@ can pop-up even when the app or extension isn't running.
 [4]: /docs/extensions/reference/notifications#type-NotificationOptions
 [5]: /docs/extensions/reference/notifications#type-TemplateType
 [6]: /docs/extensions/reference/gcm
-[7]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/apps/samples/gcm-notifications
+[7]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/_archive/apps/samples/gcm-notifications
 [8]: /docs/apps/contentSecurityPolicy/
 [9]: /docs/apps/app_external
 [10]: /docs/extensions/reference/events

--- a/site/en/docs/extensions/mv2/tut_analytics/index.md
+++ b/site/en/docs/extensions/mv2/tut_analytics/index.md
@@ -162,4 +162,4 @@ An example extension that uses these techniques is available in the [samples rep
 [6]: /docs/extensions/mv2/tabs
 [7]: /docs/extensions/mv2/tut_debugging
 [8]: https://developers.google.com/analytics/devguides/collection/gajs/eventTrackerGuide
-[9]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/tutorials/analytics/
+[9]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/_archive/mv2/tutorials/analytics/

--- a/site/en/docs/extensions/mv3/favicon/index.md
+++ b/site/en/docs/extensions/mv3/favicon/index.md
@@ -109,8 +109,8 @@ There are two favicon examples in the [chrome-extension-samples][gh-samples] rep
 [doc-manifest]: /docs/extensions/mv3/manifest/
 [doc-perms-warn]: /docs/extensions/mv3/permission_warnings/#permissions_with_warnings
 [doc-war]: /docs/extensions/mv3/manifest/web_accessible_resources/
-[gh-favicon-api]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api/favicon
-[gh-favicon-cs]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/examples/favicon-cs
+[gh-favicon-api]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/favicon
+[gh-favicon-cs]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples/sample.favicon-cs
 [gh-samples]: https://github.com/GoogleChrome/chrome-extensions-samples/
 [mdn-favicon]: https://developer.mozilla.org/docs/Glossary/Favicon
 [runtime-geturl]: /docs/extensions/reference/runtime/#method-getURL

--- a/site/en/docs/extensions/mv3/getstarted/development-basics/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/development-basics/index.md
@@ -250,7 +250,7 @@ extension and Chrome Web store documentation:
 [hello-icon]: https://storage.googleapis.com/web-dev-uploads/image/WlD8wC6g8khYWPJUsQceQkhXSlv1/gmKIT88Ha1z8VBMJFOOH.png
 [mdn-ide]: https://developer.mozilla.org/docs/Glossary/IDE
 [npm-chrome-types]: https://www.npmjs.com/package/chrome-types
-[sample-hello-world]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/tutorials/hello-world
+[sample-hello-world]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples/tutorial.hello-world
 [tut-focus-mode]: /docs/extensions/mv3/getstarted/tut-focus-mode
 [tut-reading-time]: /docs/extensions/mv3/getstarted/tut-reading-time
 [tut-tabs-manager]: /docs/extensions/mv3/getstarted/tut-tabs-manager

--- a/site/en/docs/extensions/mv3/getstarted/tut-focus-mode/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/tut-focus-mode/index.md
@@ -351,8 +351,8 @@ development learning journey. We recommend the following learning paths:
 [doc-promises]: /docs/extensions/mv3/promises/
 [doc-sw]: /docs/extensions/mv3/service_workers/
 [doc-welcome]: /docs/extensions/mv3/
-[github-focus-mode-icons]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/tutorials/focus-mode/images
-[github-focus-mode]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/tutorials/focus-mode
+[github-focus-mode-icons]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples/tutorial.focus-mode/images
+[github-focus-mode]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples/tutorial.focus-mode
 [mdn-indexeddb]: https://developer.mozilla.org/docs/Web/API/IndexedDB_API
 [runtime-oninstalled]: /docs/extensions/reference/runtime#event-onInstalled
 [tut-reading-time-step1]: /docs/extensions/mv3/getstarted/tut-reading-time#step-1

--- a/site/en/docs/extensions/mv3/getstarted/tut-reading-time/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/tut-reading-time/index.md
@@ -287,8 +287,8 @@ development learning journey. We recommend the following learning path:
 [doc-perms]:/docs/extensions/mv3/permission_warnings/
 [doc-promises]: /docs/extensions/mv3/promises/
 [doc-welcome]:/docs/extensions/mv3/
-[github-reading-time]:https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/tutorials/reading-time
-[github-rt-icons]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/tutorials/reading-time/images
+[github-reading-time]:https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples/tutorial.reading-time
+[github-rt-icons]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples/tutorial.reading-time/images
 [man-desc]: /docs/extensions/mv3/manifest/description
 [man-name]: /docs/extensions/mv3/manifest/name/
 [man-ver]: /docs/extensions/mv3/manifest/version

--- a/site/en/docs/extensions/mv3/getstarted/tut-tabs-manager/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/tut-tabs-manager/index.md
@@ -369,8 +369,8 @@ development learning journey. We recommend the following learning path:
 [doc-overview]: /docs/extensions/mv3/architecture-overview/
 [doc-ui]: /docs/extensions/mv3/user_interface/
 [doc-welcome]: /docs/extensions/mv3/
-[github-tabs-manager-icons]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/tutorials/tabs-manager/images
-[github-tabs-manager]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/tutorials/tabs-manager
+[github-tabs-manager-icons]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples/tutorial.tabs-manager/images
+[github-tabs-manager]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples/tutorial.tabs-manager
 [mdn-collator]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator
 [mdn-spread-syntax]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Spread_syntax
 [mdn-top-level]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/await#top_level_await

--- a/site/en/docs/extensions/mv3/manifest/activeTab/index.md
+++ b/site/en/docs/extensions/mv3/manifest/activeTab/index.md
@@ -99,7 +99,7 @@ The following user gestures enable `activeTab`:
 
 [insert-css-method]: /docs/extensions/reference/scripting#method-insertCSS
 [1]: /docs/extensions/reference/action
-[2]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/examples/page-redder
+[2]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples/sample.page-redder
 [3]: /docs/extensions/reference/action
 [4]: /docs/extensions/reference/contextMenus
 [7]: /docs/extensions/reference/tabs#type-Tab

--- a/site/en/docs/extensions/mv3/manifest/web_accessible_resources/index.md
+++ b/site/en/docs/extensions/mv3/manifest/web_accessible_resources/index.md
@@ -87,7 +87,7 @@ listed as web accessible. Note these corner cases:
 
 The [Web Accessible Resources example][war-example] demonstrates the use of this element in a working extension.
 
-[war-example]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api/web-accessible-resources
+[war-example]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/web-accessible-resources
 [1]: /docs/extensions/reference/extension/#method-getURL
 [2]: https://www.w3.org/TR/cors/
 [3]: /docs/extensions/reference/webRequest/

--- a/site/en/docs/extensions/mv3/messaging/index.md
+++ b/site/en/docs/extensions/mv3/messaging/index.md
@@ -353,7 +353,7 @@ directory.
 [37]: /docs/extensions/mv3/security#content_scripts
 [38]: /docs/extensions/mv3/security#sanitize
 [39]: https://en.wikipedia.org/wiki/Cross-site_scripting
-[40]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/messaging
+[40]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/_archive/mv2/api/messaging
 [41]: /docs/apps/nativeMessaging/#examples
 [42]: /docs/extensions/mv3/samples
 [43]: /docs/extensions/mv3/manifest/externally_connectable

--- a/site/en/docs/extensions/mv3/mv3-migration/index.md
+++ b/site/en/docs/extensions/mv3/mv3-migration/index.md
@@ -619,7 +619,7 @@ when you migrate to Manifest V3.
 [doc-whats-new]: /docs/extensions/whatsnew/
 [enterprise-force-list]: https://cloud.google.com/docs/chrome-enterprise/policies/?policy=ExtensionInstallForcelist
 [enterprise-settings]: https://cloud.google.com/docs/chrome-enterprise/policies/?policy=ExtensionSettings
-[github-samples-content]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/reference/mv3/intro/mv3-migration/content-scripts
+[github-samples-content]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples/reference.mv3-content-scripts
 [manifest-sandbox]: /docs/extensions/mv3/manifest/sandbox
 [mdn-cdn]: https://developer.mozilla.org/docs/Glossary/CDN
 [mdn-eval]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/eval

--- a/site/en/docs/extensions/mv3/permission_warnings/index.md
+++ b/site/en/docs/extensions/mv3/permission_warnings/index.md
@@ -376,7 +376,7 @@ This can be avoided by making the new feature optional and adding new permission
 [doc-match-patterns]: /docs/extensions/mv3/match_patterns
 [doc-perms]: /docs/extensions/mv3/declare_permissions
 [file-scheme-allow]: /docs/extensions/reference/extension#method-isAllowedFileSchemeAccess
-[gh-opt-perms]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/examples/optional-permissions
+[gh-opt-perms]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples/sample.optional-permissions
 [incognito-allow]: /docs/extensions/reference/extension#method-isAllowedIncognitoAccess
 [section-update]: #update_permissions
 [section-view-warnings]: #view_warnings

--- a/site/en/docs/extensions/mv3/richNotifications/index.md
+++ b/site/en/docs/extensions/mv3/richNotifications/index.md
@@ -182,7 +182,7 @@ can pop-up even when the extension isn't running.
 [4]: /docs/extensions/reference/notifications#type-NotificationOptions
 [5]: /docs/extensions/reference/notifications#type-TemplateType
 [6]: /docs/extensions/reference/gcm
-[7]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/apps/samples/gcm-notifications
+[7]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/_archive/apps/samples/gcm-notifications
 [8]: /docs/apps/contentSecurityPolicy
 [9]: /docs/apps/app_external
 [10]: /docs/extensions/reference/events

--- a/site/en/docs/extensions/mv3/samples/index.md
+++ b/site/en/docs/extensions/mv3/samples/index.md
@@ -17,14 +17,20 @@ APIs. Use these to learn how extensions work or as a starting point for building
 
 The examples are currently located under the following directories:
 
-[api/][gh-api]
+[api-samples/][gh-api]
 : Extensions designed to demonstrate the capabilities of a specific API. For example, the [Action API example][gh-action] showcases extension IU elements such as the popup, tooltip, and badges among others. 
 
-[examples/][gh-examples]
+[functional-samples/sample...][gh-functional-samples]
 : Complete extensions that implement all the basic features for a given purpose.
 
-[tutorials/][gh-tutorials]
+[functional-samples/tutorial...][gh-functional-samples]
 : Examples covered in the [tutorials][gs-tutorials]. A few examples include [Tabs manager][tut-tabs-man], [Focus mode][tut-fm], and [Reading time][tut-rt].
+
+[functional-samples/cookbook...][gh-functional-samples]
+: Examples demonstrating a particular concept.
+
+[functional-samples/reference...][gh-functional-samples]
+: Examples linked to documentation on this site.
 
 {% Details %}
 {% DetailsSummary %}
@@ -60,10 +66,9 @@ If you encounter any problems with an example, let us know by [posting an issue]
 [gh-action]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/action
 [gh-api]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples
 [gh-contributing]: https://github.com/GoogleChrome/chrome-extensions-samples/blob/main/CONTRIBUTING.md
-[gh-examples]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/examples
 [gh-issues]: https://github.com/GoogleChrome/chrome-extensions-samples/issues
 [gh-samples]: https://github.com/GoogleChrome/chrome-extensions-samples
-[gh-tutorials]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples
+[gh-functional-samples]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples
 [gs-tutorials]: /docs/extensions/mv3/getstarted/#tutorial
 [tut-fm]: /docs/extensions/mv3/getstarted/tut-focus-mode/
 [tut-rt]: /docs/extensions/mv3/getstarted/tut-reading-time/

--- a/site/en/docs/extensions/mv3/samples/index.md
+++ b/site/en/docs/extensions/mv3/samples/index.md
@@ -57,13 +57,13 @@ Read the instructions carefully; each extension is different. For example, some 
 If you encounter any problems with an example, let us know by [posting an issue][gh-issues]. If you want to submit a new extension, check out the [Contributing Guide][gh-contributing] to find out how to submit a new example to this collection.
 
 [dev-basics-locally]: /docs/extensions/mv3/getstarted/development-basics/
-[gh-action]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api/action
-[gh-api]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api
+[gh-action]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/action
+[gh-api]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples
 [gh-contributing]: https://github.com/GoogleChrome/chrome-extensions-samples/blob/main/CONTRIBUTING.md
 [gh-examples]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/examples
 [gh-issues]: https://github.com/GoogleChrome/chrome-extensions-samples/issues
 [gh-samples]: https://github.com/GoogleChrome/chrome-extensions-samples
-[gh-tutorials]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/tutorials
+[gh-tutorials]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples
 [gs-tutorials]: /docs/extensions/mv3/getstarted/#tutorial
 [tut-fm]: /docs/extensions/mv3/getstarted/tut-focus-mode/
 [tut-rt]: /docs/extensions/mv3/getstarted/tut-reading-time/

--- a/site/en/docs/extensions/mv3/tut_analytics/index.md
+++ b/site/en/docs/extensions/mv3/tut_analytics/index.md
@@ -164,4 +164,4 @@ An example extension that uses these techniques is available in the [samples rep
 [6]: /docs/extensions/mv3/tabs
 [7]: /docs/extensions/mv3/tut_debugging
 [8]: https://developers.google.com/analytics/devguides/collection/gajs/eventTrackerGuide
-[9]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/tutorials/analytics/
+[9]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/_archive/mv2/tutorials/analytics/

--- a/site/en/docs/extensions/mv3/user_interface/index.md
+++ b/site/en/docs/extensions/mv3/user_interface/index.md
@@ -618,12 +618,12 @@ capabilities.
 [manifest-file]:/docs/extensions/mv3/manifest/
 [omnibox-inputentered]: /docs/extensions/reference/omnibox#event-onInputEntered
 [runtime-oninstalled]: /docs/extensions/reference/runtime#event-onInstalled
-[sample-action-api]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api/action
-[sample-action]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api/action
-[sample-context-menu]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api/contextMenus/global_context_search
+[sample-action-api]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/action
+[sample-action]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/action
+[sample-context-menu]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/contextMenus/global_context_search
 [sample-drink]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/examples/water_alarm_notification
-[sample-new-tab-search]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api/omnibox/new-tab-search
-[sample-tab-flipper]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api/default_command_override
+[sample-new-tab-search]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/omnibox/new-tab-search
+[sample-tab-flipper]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/default_command_override
 [section-onclick]: #click
 [section-popup]: #popup
 [notifications-create]: /docs/extensions/reference/notifications#method-create

--- a/site/en/docs/extensions/reference/action/index.md
+++ b/site/en/docs/extensions/reference/action/index.md
@@ -294,4 +294,4 @@ chrome.runtime.onInstalled.addListener(() => {
 [html-canvas]: https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement
 [html-offscreencanvas]: https://developer.mozilla.org/docs/Web/API/OffscreenCanvas
 [repo-samples]: https://github.com/GoogleChrome/chrome-extensions-samples
-[sample-example]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api/action
+[sample-example]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/action

--- a/site/en/docs/extensions/reference/bookmarks/index.md
+++ b/site/en/docs/extensions/reference/bookmarks/index.md
@@ -74,5 +74,5 @@ help in viewing the source code, see [Samples][6].
 [2]: #type-BookmarkTreeNode
 [3]: #method-create
 [4]: #type-BookmarkTreeNode
-[5]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/bookmarks/basic/
+[5]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/_archive/mv2/api/bookmarks/basic/
 [6]: /docs/extensions/mv2/samples

--- a/site/en/docs/extensions/reference/browserAction/index.md
+++ b/site/en/docs/extensions/reference/browserAction/index.md
@@ -142,5 +142,5 @@ directory. For other examples and for help in viewing the source code, see [Samp
 [15]: #manifest
 [16]: #method-setPopup
 [17]: /extensions/pageAction
-[18]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/browserAction/
+[18]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/_archive/mv2/api/browserAction/
 [19]: /docs/extensions/mv2/samples

--- a/site/en/docs/extensions/reference/cookies/index.md
+++ b/site/en/docs/extensions/reference/cookies/index.md
@@ -29,5 +29,5 @@ You can find a simple example of using the cookies API in the
 the source code, see [Samples][3].
 
 [1]: /docs/extensions/mv3/declare_permissions
-[2]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/cookies
+[2]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/cookies/cookie-clearer
 [3]: /docs/extensions/mv3/samples

--- a/site/en/docs/extensions/reference/cookies/index.md
+++ b/site/en/docs/extensions/reference/cookies/index.md
@@ -29,5 +29,5 @@ You can find a simple example of using the cookies API in the
 the source code, see [Samples][3].
 
 [1]: /docs/extensions/mv3/declare_permissions
-[2]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api/cookies
+[2]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/cookies
 [3]: /docs/extensions/mv3/samples

--- a/site/en/docs/extensions/reference/downloads/index.md
+++ b/site/en/docs/extensions/reference/downloads/index.md
@@ -24,5 +24,5 @@ You can find simple examples of using the `chrome.downloads` API in the [example
 directory. For other examples and for help in viewing the source code, see [Samples][3].
 
 [1]: /docs/extensions/mv3/manifest
-[2]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/downloads/
+[2]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/_archive/mv2/api/downloads/
 [3]: /docs/extensions/mv2/samples

--- a/site/en/docs/extensions/reference/fontSettings/index.md
+++ b/site/en/docs/extensions/reference/fontSettings/index.md
@@ -64,5 +64,5 @@ directory. For other examples and for help in viewing the source code, see [Samp
 
 [1]: /docs/extensions/mv3/manifest
 [2]: https://www.w3.org/TR/CSS21/fonts.html#generic-font-families
-[3]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/fontSettings/
+[3]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/_archive/mv2/api/fontSettings/
 [4]: /docs/extensions/mv2/samples

--- a/site/en/docs/extensions/reference/history/index.md
+++ b/site/en/docs/extensions/reference/history/index.md
@@ -41,6 +41,6 @@ directory][9]. For other examples and for help in viewing the source code, see [
 [5]: #tt_keyword
 [6]: #tt_keyword_generated
 [7]: #tt_keyword
-[8]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/history/
+[8]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/_archive/mv2/api/history/
 [9]: https://chromium.googlesource.com/chromium/src/+/master/chrome/test/data/extensions/api_test/history/
 [10]: /docs/extensions/mv2/samples

--- a/site/en/docs/extensions/reference/i18n/index.md
+++ b/site/en/docs/extensions/reference/i18n/index.md
@@ -352,8 +352,8 @@ For more details on calling `detectLanguage(inputText)`, see the [API reference]
 [11]: #linux
 [12]: #chrome-os
 [13]: https://www.chromium.org/developers/creating-and-using-profiles
-[14]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/mv2-archive/api/i18n/
-[15]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/mv2-archive/extensions/news/
+[14]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/_archive/mv2/api/i18n/
+[15]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/_archive/mv2/extensions/news/
 [16]: /docs/extensions/mv3/samples
 [17]: /docs/extensions/mv3/i18n-messages/#placeholders
 [18]: #method-getMessage

--- a/site/en/docs/extensions/reference/input_ime/index.md
+++ b/site/en/docs/extensions/reference/input_ime/index.md
@@ -46,5 +46,5 @@ For an example of using this API, see the [basic input.ime sample][2]. For other
 help in viewing the source code, see [Samples][3].
 
 [1]: /docs/extensions/mv3/manifest
-[2]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/input.ime/basic/
+[2]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/_archive/mv2/api/input.ime/basic/
 [3]: /docs/extensions/mv2/samples

--- a/site/en/docs/extensions/reference/pageAction/index.md
+++ b/site/en/docs/extensions/reference/pageAction/index.md
@@ -93,5 +93,5 @@ For other examples and for help in viewing the source code, see [Samples][8].
 [4]: #method-show
 [5]: #method-hide
 [6]: /docs/extensions/browserAction
-[7]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/pageAction/
+[7]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/_archive/mv2/api/pageAction/
 [8]: /docs/extensions/mv2/samples

--- a/site/en/docs/extensions/reference/runtime/index.md
+++ b/site/en/docs/extensions/reference/runtime/index.md
@@ -184,7 +184,7 @@ See the [Manifest V3 - Web Accessible Resources demo][github-war-sample] for mor
 [doc-native-messaging]: /docs/apps/nativeMessaging/
 [doc-native-messaging]: /docs/extensions/mv3/messaging/#native-messaging
 [doc-war]: /docs/extensions/mv3/manifest/web_accessible_resources/
-[github-war-sample]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api/web-accessible-resources
+[github-war-sample]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/web-accessible-resources
 [method-connect]: #method-connect
 [method-connectnative]: #method-connectNative
 [method-getmanifest]: #method-getManifest

--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -254,8 +254,8 @@ For more Tabs API extensions demos, explore any of the following:
 [doc-match]: /docs/extensions/mv3/match_patterns/
 [doc-perms]: /docs/extensions/mv3/permission_warnings/
 [doc-promises]: /docs/extensions/mv3/promises/
-[mv2-tabs-samples]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/mv2-archive/api/tabs/
-[mv3-tabs-manager]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/tutorials/tabs-manager
+[mv2-tabs-samples]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/_archive/mv2/api/tabs/
+[mv3-tabs-manager]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples/tutorial.tabs-manager
 [samples-repo]: https://github.com/GoogleChrome/chrome-extensions-samples
 [section-manifest]: #manifest
 [tab]: #type-Tab

--- a/site/en/docs/extensions/reference/webNavigation/index.md
+++ b/site/en/docs/extensions/reference/webNavigation/index.md
@@ -124,7 +124,7 @@ The following transition qualifiers exist:
 <table><tbody><tr><th>Transition qualifier</th><th>Description</th></tr><tr><td>"client_redirect"</td><td>One or more redirects caused by JavaScript or meta refresh tags on the page happened during the navigation.</td></tr><tr><td>"server_redirect"</td><td>One or more redirects caused by HTTP headers sent from the server happened during the navigation.</td></tr><tr><td>"forward_back"</td><td>The user used the Forward or Back button to initiate the navigation.</td></tr><tr><td>"from_address_bar"</td><td>The user initiated the navigation from the address bar (aka Omnibox).</td></tr></tbody></table>
 
 [1]: /docs/extensions/mv3/manifest/
-[2]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/mv2-archive/api/webNavigation/
+[2]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/_archive/mv2/api/webNavigation/
 [3]: /docs/extensions/mv2/samples
 [4]: https://support.google.com/chrome/answer/177873
 [5]: https://support.google.com/chrome/answer/1385029

--- a/site/en/docs/extensions/reference/windows/index.md
+++ b/site/en/docs/extensions/reference/windows/index.md
@@ -49,7 +49,7 @@ other examples and for help in viewing the source code, see [Samples][14].
 [8]: /docs/extensions/reference/tabs#type-Tab
 [9]: /docs/extensions/reference/tabs#method-query
 [10]: /docs/extensions/mv2/event_pages
-[11]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/mv2-archive/api/windows/
-[12]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/mv2-archive/api/tabs/inspector/tabs_api.html
-[13]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/mv2-archive/api/tabs/inspector/
+[11]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/_archive/mv2/api/windows/
+[12]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/_archive/mv2/api/tabs/inspector/tabs_api.html
+[13]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/_archive/mv2/api/tabs/inspector/
 [14]: /docs/extensions/mv2/samples


### PR DESCRIPTION
We're doing a move around of some of the folders in https://github.com/GoogleChrome/chrome-extensions-samples/pull/825. This PR updates any references to that repository in the documentation to make sure links keep working.