### PR TITLE
DevTools 110: Recorder and perf panels

### DIFF
--- a/site/en/docs/devtools/performance/reference/index.md
+++ b/site/en/docs/devtools/performance/reference/index.md
@@ -40,8 +40,8 @@ opposed to running.
 
 1.  Go to the page that you want to analyze.
 2.  Open the **Performance** panel of DevTools.
-3.  Click **Reload page**
-    {% Img src="image/admin/LLUc63dXLxWMXnoL8kyr.png", alt="Reload Page.", width="24", height="25" %}. DevTools
+3.  Click **Start profiling and reload page**
+    {% Img src="image/admin/LLUc63dXLxWMXnoL8kyr.png", alt="Start profiling and reload page.", width="20", height="20" %}. DevTools first navigates to `about:blank` to clear any remaining screenshots and traces. Then DevTools
     records performance metrics while the page reloads and then automatically stops the recording a
     couple seconds after the load finishes.
 

--- a/site/en/docs/devtools/recorder/index.md
+++ b/site/en/docs/devtools/recorder/index.md
@@ -85,7 +85,10 @@ In the next sections, we will walk you through how to record, replay and audit t
 1. In the payment details form, fill in the *Name* and *Email* textboxes, and check the *I would like to receive order updates and promotional messages.* checkbox.
     {% Img src="image/dPDCek3EhZgLQPGtEG3y0fTn4v82/UOewwKwP99GldzuTtIL7.png", alt="Payment details form.", width="800", height="519" %}
 1. Click on the *Submit* button to complete the checkout process.
-1. In the **Recorder** panel. Click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/atK0ZIkmafgOnagKckde.svg", alt="End recording.", width="20", height="20" %} **End recording** button to end the recording.
+   {% Aside 'gotchas' %}
+   You can manually [edit steps](#edit-steps) even before you end the recording.
+   {% endAside %}
+1. In the **Recorder** panel, click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/atK0ZIkmafgOnagKckde.svg", alt="End recording.", width="20", height="20" %} **End recording** button to end the recording.
 
 
 ## Replay a user flow {: #replay }
@@ -127,7 +130,7 @@ Learn how to [analyze your page's runtime performance](/devtools/evaluate-perfor
 
 Let's walk through the basic options to edit the steps within the recorded workflow.
 
-For a comprehensive list of editing options, see [Edit steps](/docs/devtools/recorder/reference/##edit-steps) in features reference.
+For a comprehensive list of editing options, see [Edit steps](/docs/devtools/recorder/reference/#edit-steps) in features reference.
 
 ### Expand steps {: #expand-step }
 

--- a/site/en/docs/devtools/recorder/reference/index.md
+++ b/site/en/docs/devtools/recorder/reference/index.md
@@ -5,7 +5,7 @@ authors:
   - sofiayem
   - jecelynyeen
 date: 2022-06-21
-updated: 2023-01-09
+updated: 2023-02-07
 description: "A comprehensive reference of Chrome DevTools Recorder panel features."
 tags:
   - test
@@ -135,7 +135,7 @@ Similar to the 3rd party libraries above, you can build your own library on top 
 
 Like any code, sometimes you have to debug the recorded user flows.
 
-To help you debug, the **Recorder** panel lets you slow down the replays, set breakpoints, and step through the execution.
+To help you debug, the **Recorder** panel lets you slow down the replays, set breakpoints, step through the execution, and inspect code in various formats in parallel with steps.
 
 ### Slow down the replay
 
@@ -153,6 +153,22 @@ By default, the **Recorder** replays the user flow as fast as it can. To underst
 {% Aside 'gotchas' %}
 You can use these slow replay options only in the **Recorder**. To add timeouts to the recording itself, see [Adjust timeouts for steps](/docs/devtools/recorder/reference/#adjust-timeout).
 {% endAside %}
+
+### Inspect code {: #inspect-code }
+
+To inspect the code of a user flow in various formats:
+
+1. Open a recording in the **Recorder** panel.
+1. Click **Show code** in the top right corner of the steps list.
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/KhynxMityVxQeMJuNdU9.png", alt="The Show code button.", width="800", height="669" %}
+1. The **Recorder** shows a side-by-side view of the steps and their code. As you hover over a step, the **Recorder** highlights its respective code.
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/3K7idCdrqrZHmMR5Kczc.png", alt="The side-by-side view of the steps and their code.", width="800", height="685" %}
+1. Expand the format drop-down list to select a format that you use to [export user flows](#export-flows).
+
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/fefVto1d2oXvkmBD9DPQ.png", alt="The format drop-down list.", width="800", height="685" %}
+
+   It can be one of the three default formats (JSON, [@puppeteer/replay](https://github.com/puppeteer/replay), [Puppeteer script](https://pptr.dev/)) or a format provided by an [extension](#recorder-extension).
+1. Proceed to debug your recording by [editing step parameters and values](#edit-steps). The code view isn't editable.
 
 ### Set breakpoints and execute step by step {: #breakpoints-and-step-through }
 

--- a/site/en/docs/devtools/recorder/reference/index.md
+++ b/site/en/docs/devtools/recorder/reference/index.md
@@ -161,14 +161,16 @@ To inspect the code of a user flow in various formats:
 1. Open a recording in the **Recorder** panel.
 1. Click **Show code** in the top right corner of the steps list.
    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/KhynxMityVxQeMJuNdU9.png", alt="The Show code button.", width="800", height="669" %}
-1. The **Recorder** shows a side-by-side view of the steps and their code. As you hover over a step, the **Recorder** highlights its respective code.
+1. The **Recorder** shows a side-by-side view of the steps and their code. 
    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/3K7idCdrqrZHmMR5Kczc.png", alt="The side-by-side view of the steps and their code.", width="800", height="685" %}
+1. As you hover over a step, the **Recorder** highlights its respective code in any format, including those provided by [extensions](#recorder-extension).
+   {% Video src="video/NJdAV9UgKuN8AhoaPBquL7giZQo1/u4YeMnjPuw9nINCPdViD.mp4", autoplay=true, controls=true, loop=true, class="screenshot" %}
 1. Expand the format drop-down list to select a format that you use to [export user flows](#export-flows).
 
    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/fefVto1d2oXvkmBD9DPQ.png", alt="The format drop-down list.", width="800", height="685" %}
 
    It can be one of the three default formats (JSON, [@puppeteer/replay](https://github.com/puppeteer/replay), [Puppeteer script](https://pptr.dev/)) or a format provided by an [extension](#recorder-extension).
-1. Proceed to debug your recording by [editing step parameters and values](#edit-steps). The code view isn't editable.
+1. Proceed to debug your recording by [editing step parameters and values](#edit-steps). The code view isn't editable but it updates accordingly as you make changes to steps on the left.
 
 ### Set breakpoints and execute step by step {: #breakpoints-and-step-through }
 


### PR DESCRIPTION
Documented:
- https://developer.chrome.com/blog/new-in-devtools-110/#perf
- https://developer.chrome.com/blog/new-in-devtools-110/#recorder-code
- https://developer.chrome.com/blog/new-in-devtools-110/#recorder-edit

The [selector types](https://developer.chrome.com/blog/new-in-devtools-110/#recorder-selector) were [already documented](http://localhost:8080/docs/devtools/recorder/reference/#selector), then I forgot to roll back the updates, so now no update is required. (๏_๏ )

Publish tomorrow.

