### PR TITLE
Add how to test FedCM without 3PC instruction

### DIFF
--- a/site/en/docs/privacy-sandbox/fedcm/index.md
+++ b/site/en/docs/privacy-sandbox/fedcm/index.md
@@ -143,22 +143,12 @@ instructions.
 
 ### You're affected by the third-party cookie phase out {: #unaffected-by-3p-cookies }
 
-<figure class="float-right">
-{%
-   Img src="image/YLflGBAPWecgtKJLqCJHSzHqe2J2/GMv2zAgNt8dG62JnoSEC.png", alt="Simulate third-party cookie phase-out by configuring Chrome to block them", width="800", height="908"
-%}
-   <figcaption>Simulate third-party cookie phase-out by configuring Chrome to block them</figcaption>
-</figure>
-
 You should only use FedCM if your current integration is affected by the
 third-party cookie phase out.
 
 If you're unsure if your identity federation will continue to work after
-Chrome's third-party cookie phase out, you can test the effect on a website
-with your integration in [Incognito
-mode](https://support.google.com/chrome/answer/95464). Alternatively, you
-can block third-party cookies on desktop at `chrome://settings/cookies` or
-on mobile by navigating to **Settings** > **Site settings** > **Cookies**.
+Chrome's third-party cookie phase out, you can test the effect on a website by
+[blocking third-party cookies on Chrome](#block-third-party-cookies).
 
 If there is no discoverable impact on your identity federation without
 third-party cookies, you can continue using your current integration without
@@ -248,13 +238,6 @@ They can do the same for Chrome on desktop by going to
    width="800", height="678", class="screenshot"
 %}
 
-{% Aside 'caution' %}
-
-FedCM is temperarily disabled wherever third-party cookies are unavailable.
-For example, by default third-party cookies are blocked in incognito mode.
-Starting from Chrome 110, you can test FedCM without third-party cookies by
-enabling the Chrome flag: chrome://flags/#fedcm-without-third-party-cookies.
-
 ## Roadmap {: #roadmap}
 
 We are working on landing a number of changes on the FedCM.
@@ -342,6 +325,31 @@ forwarding](/docs/devtools/remote-debugging/local-server/).
 You can use DevTools on desktop to debug Chrome on Android by following the
 instructions at [Remote debug Android
 devices](/docs/devtools/remote-debugging/).
+
+### Block third-party cookies on Chrome {: #block-third-party-cookies}
+
+<figure class="float-right">
+{%
+   Img src="image/YLflGBAPWecgtKJLqCJHSzHqe2J2/GMv2zAgNt8dG62JnoSEC.png", alt="Simulate third-party cookie phase-out by configuring Chrome to block them", width="800", height="908"
+%}
+   <figcaption>Simulate third-party cookie phase-out by configuring Chrome to block them</figcaption>
+</figure>
+
+You can test how FedCM works without third-party cookies on Chrome before it's
+actually enforced.
+
+To block third-party cookies, use [Incognito
+mode](https://support.google.com/chrome/answer/95464), or block third-party
+cookies in settings on desktop at `chrome://settings/cookies` or on mobile by
+navigating to **Settings** > **Site settings** > **Cookies**.
+
+{% Aside 'caution' %}
+
+FedCM is temperarily disabled when third-party cookies are disabled. Starting
+from Chrome 110, you can force enabling it with the Chrome flag:
+`chrome://flags/#fedcm-without-third-party-cookies`.
+
+{% endAside %}
 
 ## Use the FedCM API {: #use-api }
 

--- a/site/en/docs/privacy-sandbox/fedcm/index.md
+++ b/site/en/docs/privacy-sandbox/fedcm/index.md
@@ -339,13 +339,13 @@ You can test how FedCM works without third-party cookies on Chrome before it's
 actually enforced.
 
 To block third-party cookies, use [Incognito
-mode](https://support.google.com/chrome/answer/95464), or block third-party
-cookies in settings on desktop at `chrome://settings/cookies` or on mobile by
-navigating to **Settings** > **Site settings** > **Cookies**.
+mode](https://support.google.com/chrome/answer/95464), or choose "Block
+third-party cookies" in settings on desktop at `chrome://settings/cookies` or on
+mobile by navigating to **Settings** > **Site settings** > **Cookies**.
 
 {% Aside 'caution' %}
 
-FedCM is temperarily disabled when third-party cookies are disabled. Starting
+FedCM is temperarily disabled when third-party cookies are blocked. Starting
 from Chrome 110, you can force enabling it with the Chrome flag:
 `chrome://flags/#fedcm-without-third-party-cookies`.
 

--- a/site/en/docs/privacy-sandbox/fedcm/index.md
+++ b/site/en/docs/privacy-sandbox/fedcm/index.md
@@ -147,7 +147,7 @@ You should only use FedCM if your current integration is affected by the
 third-party cookie phase out.
 
 If you're unsure if your identity federation will continue to work after
-Chrome's third-party cookie phase out, you can test the effect on a website by
+Chrome's third-party-cookie phase-out, you can test the effect on a website by
 [blocking third-party cookies on Chrome](#block-third-party-cookies).
 
 If there is no discoverable impact on your identity federation without
@@ -340,13 +340,13 @@ actually enforced.
 
 To block third-party cookies, use [Incognito
 mode](https://support.google.com/chrome/answer/95464), or choose "Block
-third-party cookies" in settings on desktop at `chrome://settings/cookies` or on
+third-party cookies" in your desktop settings at `chrome://settings/cookies` or on
 mobile by navigating to **Settings** > **Site settings** > **Cookies**.
 
 {% Aside 'caution' %}
 
 FedCM is temperarily disabled when third-party cookies are blocked. Starting
-from Chrome 110, you can force enabling it with the Chrome flag:
+from Chrome 110, you can force enable it with the Chrome flag:
 `chrome://flags/#fedcm-without-third-party-cookies`.
 
 {% endAside %}

--- a/site/en/docs/privacy-sandbox/fedcm/index.md
+++ b/site/en/docs/privacy-sandbox/fedcm/index.md
@@ -248,6 +248,13 @@ They can do the same for Chrome on desktop by going to
    width="800", height="678", class="screenshot"
 %}
 
+{% Aside 'caution' %}
+
+FedCM is temperarily disabled wherever third-party cookies are unavailable.
+For example, by default third-party cookies are blocked in incognito mode.
+Starting from Chrome 110, you can test FedCM without third-party cookies by
+enabling the Chrome flag: chrome://flags/#fedcm-without-third-party-cookies.
+
 ## Roadmap {: #roadmap}
 
 We are working on landing a number of changes on the FedCM.

--- a/site/en/docs/privacy-sandbox/fedcm/index.md
+++ b/site/en/docs/privacy-sandbox/fedcm/index.md
@@ -6,7 +6,7 @@ subhead: >
 description: >
   A web platform API that allows users to login to websites with their federated accounts in a manner compatible with improvements to browser privacy.
 date: 2022-04-25
-updated: 2022-11-28
+updated: 2023-02-09
 authors:
   - agektmr
 ---


### PR DESCRIPTION
Changes proposed in this pull request:

- adds a new section to clarify FedCM maybe disabled when 3PC are blocked and instruction about how to test it

@agektmr Do you think we should have this here or in the update doc? This could help to reduce confusion for IDPs when testing FedCM.