### PR TITLE
Remove "the" before Apple

### DIFF
--- a/site/en/docs/privacy-sandbox/fedcm/index.md
+++ b/site/en/docs/privacy-sandbox/fedcm/index.md
@@ -21,7 +21,7 @@ Credential Management API (FedCM).
 *  FedCM is shipped in Chrome 108.
 *  FedCM isn't supported in other browsers yet, but Mozilla is [implementing a
    prototype](https://bugzilla.mozilla.org/show_bug.cgi?id=1782066) to Firefox,
-   while the [Apple has expressed general
+   while [Apple has expressed general
    support](https://lists.webkit.org/pipermail/webkit-dev/2022-March/032162.html)
    and interest in working together on the FedCM proposal.
 *  [Chrome Platform Status](https://chromestatus.com/feature/6438627087220736)


### PR DESCRIPTION
Changes proposed in this pull request:

- Remove "the" before Apple on FedCM page