### PR TITLE
recognize falsy values in .env ignoring variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ ELEVENTY_IGNORE_WORKBOX=true
 ELEVENTY_IGNORE_BLOG=true
 ```
 
+To build only a specific component, start with the above `.env` file and change the value for the
+component you wish to build. You can comment it out, or set it to `0` or `false`.
+
 ### Start a local server to preview the site
 
 ```bash

--- a/tools/eleventyignore/index.js
+++ b/tools/eleventyignore/index.js
@@ -46,8 +46,13 @@ const isCI = process.env.CI;
 
 // Only use ignore environment variables during dev and CI builds.
 if (!isProduction || isCI) {
+  const isTruthy = value => {
+    if (value === '0' || value === 'false') return false;
+    return !!value;
+  };
+
   // Ignore translated documents
-  if (!process.env.ELEVENTY_INCLUDE_TRANSLATED) {
+  if (!isTruthy(process.env.ELEVENTY_INCLUDE_TRANSLATED)) {
     console.log(warning('Ignoring TRANSLATED docs.'));
     const translated = locales
       .filter(locale => locale !== 'en')
@@ -56,85 +61,85 @@ if (!isProduction || isCI) {
   }
 
   // Ignore /blog/
-  if (process.env.ELEVENTY_IGNORE_BLOG) {
+  if (isTruthy(process.env.ELEVENTY_IGNORE_BLOG)) {
     console.log(warning('Ignoring BLOG.'));
     ignores.push('site/**/blog/**/*');
   }
 
   // Ignore /docs/
-  if (process.env.ELEVENTY_IGNORE_DOCS) {
+  if (isTruthy(process.env.ELEVENTY_IGNORE_DOCS)) {
     console.log(warning('Ignoring ALL docs.'));
     ignores.push('site/**/docs/**/*');
   }
 
   // Ignore /docs/android/
-  if (process.env.ELEVENTY_IGNORE_ANDROID) {
+  if (isTruthy(process.env.ELEVENTY_IGNORE_ANDROID)) {
     console.log(warning('Ignoring android docs.'));
     ignores.push('site/**/docs/android/**/*');
   }
 
   // Ignore /docs/apps/
-  if (process.env.ELEVENTY_IGNORE_APPS) {
+  if (isTruthy(process.env.ELEVENTY_IGNORE_APPS)) {
     console.log(warning('Ignoring apps docs.'));
     ignores.push('site/**/docs/apps/**/*');
   }
 
   // Ignore /docs/devtools/
-  if (process.env.ELEVENTY_IGNORE_DEVTOOLS) {
+  if (isTruthy(process.env.ELEVENTY_IGNORE_DEVTOOLS)) {
     console.log(warning('Ignoring devtools docs.'));
     ignores.push('site/**/docs/devtools/**/*');
   }
 
   // Ignore /docs/extensions/
-  if (process.env.ELEVENTY_IGNORE_EXTENSIONS) {
+  if (isTruthy(process.env.ELEVENTY_IGNORE_EXTENSIONS)) {
     console.log(warning('Ignoring extensions docs.'));
     ignores.push('site/**/docs/extensions/**/*');
   }
 
   // Ignore /docs/handbook/
-  if (process.env.ELEVENTY_IGNORE_HANDBOOK) {
+  if (isTruthy(process.env.ELEVENTY_IGNORE_HANDBOOK)) {
     console.log(warning('Ignoring handbook docs.'));
     ignores.push('site/**/docs/handbook/**/*');
   }
 
   // Ignore /docs/lighthouse/
-  if (process.env.ELEVENTY_IGNORE_LIGHTHOUSE) {
+  if (isTruthy(process.env.ELEVENTY_IGNORE_LIGHTHOUSE)) {
     console.log(warning('Ignoring lighthouse docs.'));
     ignores.push('site/**/docs/lighthouse/**/*');
   }
 
   // Ignore /docs/multidevice/
-  if (process.env.ELEVENTY_IGNORE_MULTIDEVICE) {
+  if (isTruthy(process.env.ELEVENTY_IGNORE_MULTIDEVICE)) {
     console.log(warning('Ignoring multidevice docs.'));
     ignores.push('site/**/docs/multidevice/**/*');
   }
 
   // Ignore /docs/native-client/
-  if (process.env.ELEVENTY_IGNORE_NACL) {
+  if (isTruthy(process.env.ELEVENTY_IGNORE_NACL)) {
     console.log(warning('Ignoring native-client docs.'));
     ignores.push('site/**/docs/native-client/**/*');
   }
 
   // Ignore /docs/privacy-sandbox/
-  if (process.env.ELEVENTY_IGNORE_PRIVACY_SANDBOX) {
+  if (isTruthy(process.env.ELEVENTY_IGNORE_PRIVACY_SANDBOX)) {
     console.log(warning('Ignoring privacy-sandbox docs.'));
     ignores.push('site/**/docs/privacy-sandbox/**/*');
   }
 
   // Ignore /docs/versionhistory/
-  if (process.env.ELEVENTY_IGNORE_VERSIONHISTORY) {
+  if (isTruthy(process.env.ELEVENTY_IGNORE_VERSIONHISTORY)) {
     console.log(warning('Ignoring versionhistory docs.'));
     ignores.push('site/**/docs/versionhistory/**/*');
   }
 
   // Ignore /docs/webstore/
-  if (process.env.ELEVENTY_IGNORE_WEBSTORE) {
+  if (isTruthy(process.env.ELEVENTY_IGNORE_WEBSTORE)) {
     console.log(warning('Ignoring webstore docs.'));
     ignores.push('site/**/docs/webstore/**/*');
   }
 
   // Ignore /docs/workbox/
-  if (process.env.ELEVENTY_IGNORE_WORKBOX) {
+  if (isTruthy(process.env.ELEVENTY_IGNORE_WORKBOX)) {
     console.log(warning('Ignoring workbox docs.'));
     ignores.push('site/**/docs/workbox/**/*');
   }


### PR DESCRIPTION
This is a minor improvement, but it would have saved me a few minutes of confusion (not yet being familiar with how to build the site).