### PR TITLE
Fix a small typo: removing an extraneous  ']' in a link to #ad-auction.

### DIFF
--- a/site/en/blog/fledge-api/index.md
+++ b/site/en/blog/fledge-api/index.md
@@ -614,7 +614,7 @@ metadata that can be used at bidding time. For example:
 #### How do buyers make bids? {: #generatebid}
 
 The script at `biddingLogicUrl` provided by an interest group owner must include a `generateBid()`
-function. When [an ad-space seller calls `navigator.runAdAuction()`]](#ad-auction), the `generatedBid()`
+function. When [an ad-space seller calls `navigator.runAdAuction()](#ad-auction), the `generatedBid()`
 function is called once for each of the interest groups the browser is a member of, if the interest
 group's owner is invited to bid. In other words, `generateBid()` is called once for each candidate
 ad. The seller provides a `decisionLogicUrl` property on the auction configuration parameter passed


### PR DESCRIPTION
Changes proposed in this pull request:

- Fixes a small typo in https://github.com/GoogleChrome/developer.chrome.com/blob/main/site/en/blog/fledge-api/index.md#how-do-buyers-make-bids--generatebid (extraneous ']' breaking the intended link).
-
-