### PR TITLE
update Lighthouse perf ToC and scoring for 10.0 release

### DIFF
--- a/site/_data/docs/lighthouse/performance/toc.yml
+++ b/site/_data/docs/lighthouse/performance/toc.yml
@@ -4,13 +4,12 @@
 - title: i18n.docs.performance.topics.metrics
   sections:
     - url: /docs/lighthouse/performance/first-contentful-paint/
-    - url: /docs/lighthouse/performance/first-meaningful-paint/
     - url: /docs/lighthouse/performance/speed-index/
-    - url: /docs/lighthouse/performance/first-cpu-idle/
-    - url: /docs/lighthouse/performance/interactive/
-    - url: /docs/lighthouse/performance/lighthouse-max-potential-fid/
     - url: /docs/lighthouse/performance/lighthouse-total-blocking-time/
     - url: /docs/lighthouse/performance/lighthouse-largest-contentful-paint/
+    - url: https://web.dev/cls/
+      title: i18n.docs.performance.topics.cls
+      description: i18n.docs.performance.topics.cls_description
 - title: i18n.docs.performance.topics.opportunities
   sections:
     - url: /docs/lighthouse/performance/render-blocking-resources/
@@ -42,3 +41,9 @@
     - url: /docs/lighthouse/performance/font-display/
     - url: /docs/lighthouse/performance/resource-summary/
     - url: /docs/lighthouse/performance/bf-cache/
+- title: i18n.docs.performance.topics.retired_metrics
+  sections:
+    - url: /docs/lighthouse/performance/interactive/
+    - url: /docs/lighthouse/performance/first-meaningful-paint/
+    - url: /docs/lighthouse/performance/first-cpu-idle/
+    - url: /docs/lighthouse/performance/lighthouse-max-potential-fid/

--- a/site/_data/i18n/docs/performance.yml
+++ b/site/_data/i18n/docs/performance.yml
@@ -55,3 +55,9 @@ topics:
     pt: Diagnóstico
     ru: Диагностика
     zh: 诊断
+  cls:
+    en: Cumulative Layout Shift
+  cls_description:
+    en: Learn about the Cumulative Layout Shift (CLS) metric and how to optimize for it.
+  retired_metrics:
+    en: Retired metrics

--- a/site/en/docs/lighthouse/performance/first-cpu-idle/index.md
+++ b/site/en/docs/lighthouse/performance/first-cpu-idle/index.md
@@ -2,7 +2,7 @@
 layout: 'layouts/doc-post.njk'
 title: First CPU Idle
 description: |
-  Learn about Lighthouse's First CPU Idle metric and how to optimize it.
+  Learn about Lighthouse's deprecated First CPU Idle metric and how to optimize it.
 date: 2019-05-02
 updated: 2019-11-05
 ---

--- a/site/en/docs/lighthouse/performance/first-meaningful-paint/index.md
+++ b/site/en/docs/lighthouse/performance/first-meaningful-paint/index.md
@@ -2,7 +2,7 @@
 layout: 'layouts/doc-post.njk'
 title: First Meaningful Paint
 description: |
-  Learn about Lighthouse's First Meaningful Paint metric and
+  Learn about Lighthouse's deprecated First Meaningful Paint metric and
   how to measure and optimize it.
 date: 2019-05-02
 updated: 2019-11-05

--- a/site/en/docs/lighthouse/performance/lighthouse-max-potential-fid/index.md
+++ b/site/en/docs/lighthouse/performance/lighthouse-max-potential-fid/index.md
@@ -2,11 +2,15 @@
 layout: 'layouts/doc-post.njk'
 title: Max Potential First Input Delay
 description: |
-  Learn about Lighthouse's Max Potential First Input Delay metric and
+  Learn about Lighthouse's deprecated Max Potential First Input Delay metric and
   how to measure and optimize it.
 date: 2019-05-02
 updated: 2019-10-16
 ---
+
+{% Aside 'caution' %}
+Max Potential First Input Delay was deprecated in Lighthouse 6.0. Moving forward, consider using [Total Blocking Time](https://web.dev/lcp/) in the lab and [First Input Delay](https://web.dev/fid/) and [Interaction to Next Paint](https://web.dev/inp/) in the field.
+{% endAside %}
 
 Max Potential First Input Delay (FID) is one of the metrics
 tracked in the **Performance** section of the Lighthouse report.

--- a/site/en/docs/lighthouse/performance/performance-scoring/index.md
+++ b/site/en/docs/lighthouse/performance/performance-scoring/index.md
@@ -5,7 +5,7 @@ description: |
   Learn how Lighthouse generates the overall Performance score for your page.
 subhead: How Lighthouse calculates your overall Performance score
 date: 2019-09-19
-updated: 2021-06-04
+updated: 2023-02-09
 ---
 
 In general, only [metrics](/docs/lighthouse/performance/#metrics)
@@ -53,10 +53,45 @@ impact on user-perceived performance.
   </figcaption>
 </figure>
 
+### Lighthouse 10
+
+<div class="table-wrapper">
+  <table class="with-heading-tint">
+    <thead>
+      <tr>
+        <th>Audit</th>
+        <th>Weight</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a href="/first-contentful-paint/">First Contentful Paint</a></td>
+        <td>10%</td>
+      </tr>
+      <tr>
+        <td><a href="/speed-index/">Speed Index</a></td>
+        <td>10%</td>
+      </tr>
+      <tr>
+        <td><a href="/lcp/">Largest Contentful Paint</a></td>
+        <td>25%</td>
+      </tr>
+      <tr>
+        <td><a href="/lighthouse-total-blocking-time/">Total Blocking Time</a></td>
+        <td>30%</td>
+      </tr>
+      <tr>
+        <td><a href="/cls/">Cumulative Layout Shift</a></td>
+        <td>25%</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
 ### Lighthouse 8
 
 <div class="table-wrapper">
-  <table>
+  <table class="with-heading-tint">
     <thead>
       <tr>
         <th>Audit</th>
@@ -87,45 +122,6 @@ impact on user-perceived performance.
       <tr>
         <td><a href="/cls/">Cumulative Layout Shift</a></td>
         <td>15%</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-
-### Lighthouse 6
-
-<div class="table-wrapper">
-  <table>
-    <thead>
-      <tr>
-        <th>Audit</th>
-        <th>Weight</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a href="/first-contentful-paint/">First Contentful Paint</a></td>
-        <td>15%</td>
-      </tr>
-      <tr>
-        <td><a href="/speed-index/">Speed Index</a></td>
-        <td>15%</td>
-      </tr>
-      <tr>
-        <td><a href="/lcp/">Largest Contentful Paint</a></td>
-        <td>25%</td>
-      </tr>
-      <tr>
-        <td><a href="/interactive/">Time to Interactive</a></td>
-        <td>15%</td>
-      </tr>
-      <tr>
-        <td><a href="/lighthouse-total-blocking-time/">Total Blocking Time</a></td>
-        <td>25%</td>
-      </tr>
-      <tr>
-        <td><a href="/cls/">Cumulative Layout Shift</a></td>
-        <td>5%</td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
In the imminent Lighthouse 10 release, TTI is bumped from the main scored metrics and score weight are adjusted accordingly.

Also makes a "retired metrics" section so the docs are still accessible but clearer that they're no longer part of the current tool.