### PR TITLE
Fix bug in social media links caused by unnecessary URL

### DIFF
--- a/site/_data/authorsData.json
+++ b/site/_data/authorsData.json
@@ -300,7 +300,7 @@
   },
   "justinschuh": {
     "country": "US",
-    "github": "https://github.com/jschuh",
+    "github": "jschuh",
     "twitter": "justinschuh",
     "image": "image/80mq7dk16vVEg8BBhsVe42n6zn82/Cv4qmh8vnXhcHPgCzbpb.jpg"
   },
@@ -739,8 +739,8 @@
   "jarhar": {
     "country": "US",
     "image": "image/kheDArv5csY6rvQUJDbWRscckLr1/xHYktxBPGfDHbzmEufy9.jpeg",
-    "github": "https://github.com/josepharhar",
-    "twitter": "https://twitter.com/josepharhar"
+    "github": "josepharhar",
+    "twitter": "josepharhar"
   },
   "emmatwersky": {
     "country": "US",


### PR DESCRIPTION
This pull request addresses a bug in the display of certain social media links. Currently, the links were showing up with an unnecessary URL, such as "https://twitter.com/https://twitter.com/username", instead of the intended format "https://twitter.com/username".

Changes proposed in this pull request:

- Remove the unnecessary URL from affected social media links.

![image](https://user-images.githubusercontent.com/122186255/217686634-1dacbb7e-4588-437d-87b0-9c5e63279802.png)

https://developer.chrome.com/articles/hidden-until-found/

