### PR TITLE
Add prerender origin trial

### DIFF
--- a/site/_includes/layouts/base.njk
+++ b/site/_includes/layouts/base.njk
@@ -36,7 +36,7 @@
     <script>{% include 'partials/script.js' %}</script>
 
     {# Some articles may have previously used lists with anchors for their
-    content (like FAQs) which may have evolved into their own articles by now. 
+    content (like FAQs) which may have evolved into their own articles by now.
     Such anchors should be able to link to those new articles #}
     {% if anchorRedirects %}
     <script>
@@ -60,6 +60,23 @@
       })();
     </script>
     {% endif %}
+
+    {# Dogfood automatic prerender origin trial #}
+    <!-- deploy-preview-9532--web-dev-staging.netlify.app origin trial token - for testing only, remove before merging -->
+    <meta http-equiv="origin-trial" content="AhaT7AdLUbVk3M0VorYLzXSY8Km9PJZlzg3Xkv6KT2QMZ4zyqA5BfdTJLCj1TVnGhryWtQH66HWQEsIbZDUrsAwAAABseyJvcmlnaW4iOiJodHRwczovL2RldmVsb3Blci5jaHJvbWUuY29tOjQ0MyIsImZlYXR1cmUiOiJTcGVjdWxhdGlvblJ1bGVzUHJlZmV0Y2hGdXR1cmUiLCJleHBpcnkiOjE2OTQxMzExOTl9">
+    <!-- developer.chrome.com origin trial token - valid until 23 Mar 2023 -->
+    <meta http-equiv="origin-trial" content="AhaT7AdLUbVk3M0VorYLzXSY8Km9PJZlzg3Xkv6KT2QMZ4zyqA5BfdTJLCj1TVnGhryWtQH66HWQEsIbZDUrsAwAAABseyJvcmlnaW4iOiJodHRwczovL2RldmVsb3Blci5jaHJvbWUuY29tOjQ0MyIsImZlYXR1cmUiOiJTcGVjdWxhdGlvblJ1bGVzUHJlZmV0Y2hGdXR1cmUiLCJleHBpcnkiOjE2OTQxMzExOTl9">
+    {# Exlude the /articles/ section as a control #}
+    <script type="speculationrules">
+    {"prerender": [
+      {"source": "document",
+        "where": {"and": [
+          {"href_matches": "/*\\?*", "relative_to": "document"},
+          {"not": {"href_matches": "/articles/*\\?*", "relative_to": "document"}}
+        ]}}
+    ]}
+    </script>
+
   </head>
   <body>
     <div class="scaffold">


### PR DESCRIPTION
Changes proposed in this pull request:

- Add automatic prerendering on hovering of internal links, via [this origin trial](https://developer.chrome.com/origintrials/#/view_trial/705939241590325249). We want to test out this feature on our own site and collect feedback for a blog post on this feature.

