### PR TITLE
Migrate NFC and Build for WebUSB articles

### DIFF
--- a/site/_data/authorsData.json
+++ b/site/_data/authorsData.json
@@ -499,6 +499,11 @@
     "github": "beaufortfrancois",
     "image": "image/sQ51XsLqKMgSQMCZjIN0B7hlBO02/8SV7KI2QNVXph2L5Cga2.jpeg"
   },
+  "reillyg": {
+    "twitter": "reillyeon",
+    "github": "reillyeon",
+    "image": "image/admin/C7kO2T8Q8jSZxU9xj3AC.jpg"
+  },
   "cwallez": {
     "country": "FR",
     "twitter": "DaKangz",

--- a/site/_data/i18n/authors.yaml
+++ b/site/_data/i18n/authors.yaml
@@ -560,6 +560,23 @@ beaufortfrancois:
     en: 'François Beaufort'
   description:
     en: 'Dives into Chromium source code'
+reillyg:
+  title:
+    en: Reilly Grant
+    es: Reilly Grant
+    ja: Reilly Grant
+    ko: Reilly Grant
+    pt: Reilly Grant
+    ru: Reilly Grant
+    zh: Reilly Grant
+  description:
+    en: Software Engineer on Google Chrome focusing on hardware APIs
+    es: Ingeniero de software en Google Chrome centrado en las API de hardware
+    ja: ハードウェア API に関心を持つ Google Chrome のソフトウェアエンジニア
+    ko: 하드웨어 API에 중점을 둔 Chrome의 소프트웨어 엔지니어
+    pt: Engenheiro de software no Google Chrome com foco em APIs de hardware
+    ru: Инженер-программист в команде Google Chrome, специализирующийся на API для работы с устройствами
+    zh: 专注于硬件 API 的 Google Chrome 软件工程师
 cwallez:
   title:
     en: Corentin Wallez

--- a/site/en/articles/build-for-webusb/index.md
+++ b/site/en/articles/build-for-webusb/index.md
@@ -1,0 +1,1025 @@
+---
+layout: 'layouts/blog-post.njk'
+title: Building a device for WebUSB
+subhead: |
+  Build a device to take full advantage of the WebUSB API.
+authors:
+  - reillyg
+date: 2018-12-20
+updated: 2020-12-03
+tags:
+  - capabilities
+  - devices
+stack_overflow_tag: webusb
+---
+
+This article explains how to build a device to take full advantage of the
+[WebUSB API]. For a brief introduction to the API itself, see [Access USB Devices
+on the Web].
+
+## Background
+
+The Universal Serial Bus (USB) has become the most common physical interface for
+connecting peripherals to desktop and mobile computing devices. In addition to
+defining the electrical characteristics of the bus and a general model for
+communicating with a device, USB specifications include a set of device class
+specifications. These are general models for particular classes of devices such
+as storage, audio, video, networking, etc. that device manufacturers can
+implement. The advantage of these device class specifications is that an
+operating system vendor can implement a single driver based on the class
+specification (a "class driver") and any device implementing that class will be
+supported. This was a great improvement over every manufacturer needing to write
+their own device drivers.
+
+Some devices however don't fit into one of these standardized device classes. A
+manufacturer may instead choose to label their device as implementing the
+vendor-specific class. In this case the operating system chooses which device
+driver to load based on information provided in the vendor's driver package,
+typically a set of vendor and product IDs which are known to implement a
+particular vendor-specific protocol.
+
+Another feature of the USB is that devices may provide multiple interfaces to
+the host they are connected to. Each interface can implement either a
+standardized class or be vendor-specific. When an operating system chooses the
+right drivers to handle the device each interface can be claimed by a different
+driver. For example, a USB webcam typically provides two interfaces, one
+implementing the USB video class (for the camera) and one implementing the USB
+audio class (for the microphone). The operating system does not load a single
+"webcam driver" but instead loads independent video and audio class drivers
+which take responsibility for the separate functions of the device. This
+composition of interface classes provides for greater flexibility.
+
+## API basics
+
+Many of the standard USB classes have corresponding web APIs. For example, a
+page can capture video from a video class device using [`getUserMedia()`]
+or receive input events from a human interface (HID) class device by listening
+for [KeyboardEvents] or [PointerEvents], or by using the [Gamepad] or the
+[WebHID] API.
+Just as not all devices implement a standardized class definition, not all
+devices implement features that correspond to existing web platform APIs. When
+this is the case the WebUSB API can fill that gap by providing a way for sites
+to claim a vendor-specific interface and implement support for it from directly
+within their page.
+
+The specific requirements for a device to be accessible via WebUSB vary slightly
+from platform to platform due to differences in how operating systems manage USB
+devices but the basic requirement is that a device should not already have a
+driver claiming the interface the page wants to control. This could be either a
+generic class driver provided by the OS vendor or a device driver provided by
+the vendor. As USB devices can provide multiple interfaces, each of which may
+have its own driver, it is possible to build a device for which some interfaces
+are claimed by a driver and others are left accessible to the browser.
+
+For example, a high-end USB keyboard may provide an HID class interface that
+will be claimed by the operating system's input subsystem and a vendor-specific
+interface that remains available to WebUSB for use by a configuration tool. This
+tool can be served on the manufacturer's website allowing the user to change
+aspects of the device's behavior such as macro keys and lighting effects without
+installing any platform-specific software. Such a device's configuration descriptor would
+look something like this:
+
+{% Aside  %}
+Values in this and other tables in this document are presented in hexadecimal or
+binary, whichever is more readable. The USB is a little-endian bus and so any
+integer value larger than 1 byte should be sent least-significant byte first.
+{% endAside %}
+
+<div>
+  <table>
+    <tr>
+    <th>Value</th>
+    <th>Field</th>
+    <th>Description</th>
+    </tr>
+    <tr>
+    <td colspan="3">Configuration descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x09</code></td>
+    <td>bLength</td>
+    <td>Size of this descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x02</code></td>
+    <td>bDescriptorType</td>
+    <td>Configuration descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x0039</code></td>
+    <td>wTotalLength</td>
+    <td>Total length of this series of descriptors</td>
+    </tr>
+    <tr>
+    <td><code>0x02</code></td>
+    <td>bNumInterfaces</td>
+    <td>Number of interfaces</td>
+    </tr>
+    <tr>
+    <td><code>0x01</code></td>
+    <td>bConfigurationValue</td>
+    <td>Configuration 1</td>
+    </tr>
+    <tr>
+    <td><code>0x00</code></td>
+    <td>iConfiguration</td>
+    <td>Configuration name (none)</td>
+    </tr>
+    <tr>
+    <td><code>0b1010000</code></td>
+    <td>bmAttributes</td>
+    <td>Self-powered device with remote wakeup</td>
+    </tr>
+    <tr>
+    <td><code>0x32</code></td>
+    <td>bMaxPower</td>
+    <td>Max Power is expressed in 2 mA increments</td>
+    </tr>
+    <tr>
+    <td colspan="3">Interface descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x09</code></td>
+    <td>bLength</td>
+    <td>Size of this descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x04</code></td>
+    <td>bDescriptorType</td>
+    <td>Interface descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x00</code></td>
+    <td>bInterfaceNumber</td>
+    <td>Interface 0</td>
+    </tr>
+    <tr>
+    <td><code>0x00</code></td>
+    <td>bAlternateSetting</td>
+    <td>Alternate setting 0 (default)</td>
+    </tr>
+    <tr>
+    <td><code>0x01</code></td>
+    <td>bNumEndpoints</td>
+    <td>1 endpoint</td>
+    </tr>
+    <tr>
+    <td><code>0x03</code></td>
+    <td>bInterfaceClass</td>
+    <td>HID interface class</td>
+    </tr>
+    <tr>
+    <td><code>0x01</code></td>
+    <td>bInterfaceSubClass</td>
+    <td>Boot interface subclass</td>
+    </tr>
+    <tr>
+    <td><code>0x01</code></td>
+    <td>bInterfaceProtocol</td>
+    <td>Keyboard</td>
+    </tr>
+    <tr>
+    <td><code>0x00</code></td>
+    <td>iInterface</td>
+    <td>Interface name (none)</td>
+    </tr>
+    <tr>
+    <td colspan="3">HID descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x09</code></td>
+    <td>bLength</td>
+    <td>Size of this descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x21</code></td>
+    <td>bDescriptorType</td>
+    <td>HID descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x0101</code></td>
+    <td>bcdHID</td>
+    <td>HID version 1.1</td>
+    </tr>
+    <tr>
+    <td><code>0x00</code></td>
+    <td>bCountryCode</td>
+    <td>Hardware target country</td>
+    </tr>
+    <tr>
+    <td><code>0x01</code></td>
+    <td>bNumDescriptors</td>
+    <td>Number of HID class descriptors to follow</td>
+    </tr>
+    <tr>
+    <td><code>0x22</code></td>
+    <td>bDescriptorType</td>
+    <td>Report descriptor type</td>
+    </tr>
+    <tr>
+    <td><code>0x003F</code></td>
+    <td>wDescriptorLength</td>
+    <td>Total length of the Report descriptor</td>
+    </tr>
+    <tr>
+    <td colspan="3">Endpoint descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x07</code></td>
+    <td>bLength</td>
+    <td>Size of this descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x05</code></td>
+    <td>bDescriptorType</td>
+    <td>Endpoint descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0b10000001</code></td>
+    <td>bEndpointAddress</td>
+    <td>Endpoint 1 (IN)</td>
+    </tr>
+    <tr>
+    <td><code>0b00000011</code></td>
+    <td>bmAttributes</td>
+    <td>Interrupt</td>
+    </tr>
+    <tr>
+    <td><code>0x0008</code></td>
+    <td>wMaxPacketSize</td>
+    <td>8 byte packets</td>
+    </tr>
+    <tr>
+    <td><code>0x0A</code></td>
+    <td>bInterval</td>
+    <td>10ms interval</td>
+    </tr>
+    <tr>
+    <td colspan="3">Interface descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x09</code></td>
+    <td>bLength</td>
+    <td>Size of this descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x04</code></td>
+    <td>bDescriptorType</td>
+    <td>Interface descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x01</code></td>
+    <td>bInterfaceNumber</td>
+    <td>Interface 1</td>
+    </tr>
+    <tr>
+    <td><code>0x00</code></td>
+    <td>bAlternateSetting</td>
+    <td>Alternate setting 0 (default)</td>
+    </tr>
+    <tr>
+    <td><code>0x02</code></td>
+    <td>bNumEndpoints</td>
+    <td>2 endpoints</td>
+    </tr>
+    <tr>
+    <td><code>0xFF</code></td>
+    <td>bInterfaceClass</td>
+    <td>Vendor-specific interface class</td>
+    </tr>
+    <tr>
+    <td><code>0x00</code></td>
+    <td>bInterfaceSubClass</td>
+    <td></td>
+    </tr>
+    <tr>
+    <td><code>0x00</code></td>
+    <td>bInterfaceProtocol</td>
+    <td></td>
+    </tr>
+    <tr>
+    <td><code>0x00</code></td>
+    <td>iInterface</td>
+    <td>Interface name (none)</td>
+    </tr>
+    <tr>
+    <td colspan="3">Endpoint descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x07</code></td>
+    <td>bLength</td>
+    <td>Size of this descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x05</code></td>
+    <td>bDescriptorType</td>
+    <td>Endpoint descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0b10000010</code></td>
+    <td>bEndpointAddress</td>
+    <td>Endpoint 1 (IN)</td>
+    </tr>
+    <tr>
+    <td><code>0b00000010</code></td>
+    <td>bmAttributes</td>
+    <td>Bulk</td>
+    </tr>
+    <tr>
+    <td><code>0x0040</code></td>
+    <td>wMaxPacketSize</td>
+    <td>64 byte packets</td>
+    </tr>
+    <tr>
+    <td><code>0x00</code></td>
+    <td>bInterval</td>
+    <td>N/A for bulk endpoints</td>
+    </tr>
+    <tr>
+    <td colspan="3">Endpoint descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x07</code></td>
+    <td>bLength</td>
+    <td>Size of this descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x05</code></td>
+    <td>bDescriptorType</td>
+    <td>Endpoint descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0b00000011</code></td>
+    <td>bEndpointAddress</td>
+    <td>Endpoint 3 (OUT)</td>
+    </tr>
+    <tr>
+    <td><code>0b00000010</code></td>
+    <td>bmAttributes</td>
+    <td>Bulk</td>
+    </tr>
+    <tr>
+    <td><code>0x0040</code></td>
+    <td>wMaxPacketSize</td>
+    <td>64 byte packets</td>
+    </tr>
+    <tr>
+    <td><code>0x00</code></td>
+    <td>bInterval</td>
+    <td>N/A for bulk endpoints</td>
+    </tr>
+  </table>
+</div>
+
+The configuration descriptor consists of multiple descriptors concatenated
+together. Each begins with `bLength` and `bDescriptorType` fields so that they
+can be identified. The first interface is an HID interface with an associated
+HID descriptor and a single endpoint used to deliver input events to the
+operating system. The second interface is a vendor-specific interface with two
+endpoints that can be used to send commands to the device and receive responses
+in return.
+
+## WebUSB descriptors
+
+While WebUSB can work with many devices without firmware modifications,
+additional functionality is enabled by marking the device with specific
+descriptors indicating support for WebUSB. For example, you can specify a
+landing page URL that the browser can direct the user to when your device is
+plugged in.
+
+<figure>
+  {% Img src="image/admin/KBZaQNlDcishHiu3XkPU.png", alt="Screenshot of the WebUSB notification in Chrome", width="800", height="450" %}
+  <figcaption>WebUSB notification.</figcaption>
+</figure>
+
+The Binary device Object Store (BOS) is a concept introduced in USB 3.0 but has
+also been backported to USB 2.0 devices as part of version 2.1. Declaring
+support for WebUSB starts with including the following Platform Capability
+Descriptor in the BOS descriptor:
+
+<div>
+  <table>
+    <tr>
+    <th style="width: 33%">Value</th>
+    <th style="width: 33%">Field</th>
+    <th style="width: 33%">Description</th>
+    </tr>
+    <tr>
+    <td colspan="3">Binary device Object Store descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x05</code></td>
+    <td>bLength</td>
+    <td>Size of this descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x0F</code></td>
+    <td>bDescriptorType</td>
+    <td>Binary device Object Store descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x001D</code></td>
+    <td>wTotalLength</td>
+    <td>Total length of this series of descriptors</td>
+    </tr>
+    <tr>
+    <td><code>0x01</code></td>
+    <td>bNumDeviceCaps</td>
+    <td>Number of device capability descriptors in the BOS</td>
+    </tr>
+    <tr>
+    <td colspan="3">WebUSB platform capability descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x18</code></td>
+    <td>bLength</td>
+    <td>Size of this descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x10</code></td>
+    <td>bDescriptorType</td>
+    <td>Device capability descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x05</code></td>
+    <td>bDevCapabilityType</td>
+    <td>Platform capability descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x00</code></td>
+    <td>bReserved</td>
+    <td></td>
+    </tr>
+    <tr>
+    <td><code>{0x38, 0xB6, 0x08, 0x34, 0xA9, 0x09, 0xA0, 0x47, 0x8B, 0xFD, 0xA0, 0x76, 0x88, 0x15, 0xB6, 0x65}</code></td>
+    <td>PlatformCapablityUUID</td>
+    <td>WebUSB platform capability descriptor GUID in little-endian format</td>
+    </tr>
+    <tr>
+    <td><code>0x0100</code></td>
+    <td>bcdVersion</td>
+    <td>WebUSB descriptor version 1.0</td>
+    </tr>
+    <tr>
+    <td><code>0x01</code></td>
+    <td>bVendorCode</td>
+    <td>bRequest value for WebUSB</td>
+    </tr>
+    <tr>
+    <td><code>0x01</code></td>
+    <td>iLandingPage</td>
+    <td>URL for landing page</td>
+    </tr>
+  </table>
+</div>
+
+{% Aside %}
+The UUID above would be written as `{3408b638-09a9-47a0-8bfd-a0768815b665}`;
+however, when sent as part of a USB descriptor its component fields must be sent
+in little-endian order. This transformation is complex so the proper encoding is
+given here for reference. See [RFC4122](https://tools.ietf.org/html/rfc4122).
+{% endAside %}
+
+The platform capability UUID identifies this as a [WebUSB Platform Capability
+descriptor], which provides basic information about the device. For the browser
+to fetch more information about the device it uses the `bVendorCode` value to
+issue additional requests to the device. The only request currently specified is
+`GET_URL` which returns a [URL descriptor]. These are similar to string
+descriptors but are designed to encode URLs in the fewest bytes. A URL
+descriptor for `"https://google.com"` would look like this:
+
+<div>
+  <table>
+    <tr>
+    <th>Value</th>
+    <th>Field</th>
+    <th>Description</th>
+    </tr>
+    <tr>
+    <td colspan="3">URL descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x0D</code></td>
+    <td>bLength</td>
+    <td>Size of this descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x03</code></td>
+    <td>bDescriptorType</td>
+    <td>URL descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x01</code></td>
+    <td>bScheme</td>
+    <td>https://</td>
+    </tr>
+    <tr>
+    <td><code>"google.com"</code></td>
+    <td>URL</td>
+    <td>UTF-8 encoded URL content</td>
+    </tr>
+  </table>
+</div>
+
+When your device is first plugged in the browser reads the BOS descriptor by
+issuing this standard `GET_DESCRIPTOR` control transfer:
+
+<div>
+  <table>
+    <tr>
+    <th>bmRequestType</th>
+    <th>bRequest</th>
+    <th>wValue</th>
+    <th>wIndex</th>
+    <th>wLength</th>
+    <th>Data (response)</th>
+    </tr>
+    <tr>
+    <td><code>0b10000000</code></td>
+    <td><code>0x06</code></td>
+    <td><code>0x0F00</code></td>
+    <td><code>0x0000</code></td>
+    <td>*</td>
+    <td>The BOS descriptor</td>
+    </tr>
+  </table>
+</div>
+
+This request is usually made twice, the first time with a large enough `wLength`
+so that the host finds out the value of the `wTotalLength` field without
+committing to a large transfer and then again when the full descriptor length is
+known.
+
+If the WebUSB Platform Capability descriptor has the `iLandingPage` field set to
+a non-zero value the browser then performs a WebUSB-specific `GET_URL` request
+by issuing a control transfer with the `bRequest` set to the `bVendorCode` value
+from the platform capability descriptor and `wValue` set to the `iLandingPage`
+value. The request code for `GET_URL` (`0x02`) goes in `wIndex`:
+
+<div>
+  <table>
+    <tr>
+    <th>bmRequestType</th>
+    <th>bRequest</th>
+    <th>wValue</th>
+    <th>wIndex</th>
+    <th>wLength</th>
+    <th>Data (response)</th>
+    </tr>
+    <tr>
+    <td><code>0b11000000</code></td>
+    <td><code>0x01</code></td>
+    <td><code>0x0001</code></td>
+    <td><code>0x0002</code></td>
+    <td>*</td>
+    <td>The URL descriptor</td>
+    </tr>
+  </table>
+</div>
+
+Again, this request may be issued twice in order to first probe for the length
+of the descriptor being read.
+
+{% Aside %}
+Support for displaying a notification when a USB device is plugged in is not
+available yet on Android.
+{% endAside %}
+
+## Platform-specific considerations
+
+While the WebUSB API attempts to provide a consistent interface for accessing
+USB devices developers should still be aware of requirements imposed on
+applications such as a web browsers requirements in order to access devices.
+
+### macOS
+
+Nothing special is necessary for macOS. A website using WebUSB can connect to
+the device and claim any interfaces that aren't claimed by a kernel driver or
+another application.
+
+### Linux
+
+Linux is like macOS but by default most distributions do not set up user
+accounts with permission to open USB devices. A system daemon called udev is
+responsible for assigning the user and group allowed to access a device. A rule
+such as this will assign ownership of a device matching the given vendor and
+product IDs to the `plugdev` group which is a common group for users with access
+to peripherals:
+
+```vim
+SUBSYSTEM=="usb", ATTR{idVendor}=="XXXX", ATTR{idProduct}=="XXXX", GROUP="plugdev"
+```
+
+Replace `XXXX` with the hexadecimal vendor and product IDs for your device,
+e.g. `ATTR{idVendor}=="18d1", ATTR{idProduct}=="4e11"` would match a Nexus One
+phone. These must be written without the usual "0x" prefix and all lowercase
+to be recognized correctly. To find the IDs for your device run the command line
+tool `lsusb`.
+
+This rule should be placed in a file in the `/etc/udev/rules.d` directory and
+takes effect as soon as the device is plugged in. There is no need to restart
+udev.
+
+### Android
+
+The Android platform is based on Linux but does not require any modification to
+system configuration. By default any device that does not have a driver built
+into the operating system is available to the browser. Developers should be
+aware however that users will encounter an additional step when connecting to
+the device. Once a user selects a device in response to a call to
+[`requestDevice()`], Android will display a prompt asking whether to allow
+Chrome to access it. This prompt also reappears if a user returns to a website
+that already has permission to connect to a device and the website calls
+[`open()`].
+
+In addition more devices will be accessible on Android than on desktop Linux
+because fewer drivers are included by default. A notable omission, for example,
+is the USB CDC-ACM class commonly implemented by USB-to-serial adapters as there
+is no API in the Android SDK for communicating with a serial device.
+
+### ChromeOS
+
+ChromeOS is based on Linux as well and also does not require any modification
+to system configuration. The permission_broker service controls access to USB
+devices and will allow the browser to access them as long as there is at least
+one unclaimed interface.
+
+### Windows
+
+The Windows driver model introduces an additional requirement. Unlike the
+platforms above the ability to open a USB device from a user application is not
+the default, even if there is no driver loaded. Instead there is a special
+driver, WinUSB, that needs to be loaded in order to provide the interface
+applications use to access the device. This can be done with either a custom
+driver information file (INF) installed on the system or by modifying the device
+firmware to provide the Microsoft OS Compatibility Descriptors during
+enumeration.
+
+#### Driver Information File (INF)
+
+A driver information file tells Windows what to do when encountering a device
+for the first time. Since the user's system already includes the WinUSB driver
+all that's necessary is for the INF file to associate your vendor and product ID
+with this new installation rule. The file below is a basic example. Save it to a
+file with the `.inf` extension, change the sections marked with "X", then right
+click on it and choose "Install" from the context menu.
+
+```ini
+[Version]
+Signature   = "$Windows NT$"
+Class       = USBDevice
+ClassGUID   = {88BAE032-5A81-49f0-BC3D-A4FF138216D6}
+Provider    = %ManufacturerName%
+CatalogFile = WinUSBInstallation.cat
+DriverVer   = 09/04/2012,13.54.20.543
+
+; ========== Manufacturer/Models sections ===========
+
+[Manufacturer]
+%ManufacturerName% = Standard,NTx86,NTia64,NTamd64
+
+[Standard.NTx86]
+%USB\MyCustomDevice.DeviceDesc% = USB_Install,USB\VID_XXXX&PID_XXXX
+
+[Standard.NTia64]
+%USB\MyCustomDevice.DeviceDesc% = USB_Install,USB\VID_XXXX&PID_XXXX
+
+[Standard.NTamd64]
+%USB\MyCustomDevice.DeviceDesc% = USB_Install,USB\VID_XXXX&PID_XXXX
+
+; ========== Class definition ===========
+
+[ClassInstall32]
+AddReg = ClassInstall_AddReg
+
+[ClassInstall_AddReg]
+HKR,,,,%ClassName%
+HKR,,NoInstallClass,,1
+HKR,,IconPath,%REG_MULTI_SZ%,"%systemroot%\system32\setupapi.dll,-20"
+HKR,,LowerLogoVersion,,5.2
+
+; =================== Installation ===================
+
+[USB_Install]
+Include = winusb.inf
+Needs   = WINUSB.NT
+
+[USB_Install.Services]
+Include = winusb.inf
+Needs   = WINUSB.NT.Services
+
+[USB_Install.HW]
+AddReg = Dev_AddReg
+
+[Dev_AddReg]
+HKR,,DeviceInterfaceGUIDs,0x10000,"{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}"
+
+; =================== Strings ===================
+
+[Strings]
+ManufacturerName              = "Your Company Name Here"
+ClassName                     = "Your Company Devices"
+USB\MyCustomDevice.DeviceDesc = "Your Device Name Here"
+```
+
+The `[Dev_AddReg]` section configures the set of DeviceInterfaceGUIDs for the
+device. Every device interface must have a GUID in order for an application to
+find and connect to it through the Windows API. Use the `New-Guid` PowerShell
+cmdlet or an online tool to generate a random GUID.
+
+For development purposes the [Zadig tool] provides an easy interface for
+replacing the driver loaded for a USB interface with the WinUSB driver.
+
+#### Microsoft OS compatibility descriptors
+
+The INF file approach above is cumbersome because it requires configuring every
+user's machine ahead of time. Windows 8.1 and higher offers an alternative
+through the use of custom USB descriptors. These descriptors provide information
+to the Windows operating system when the device is first plugged in that would
+normally be included in the INF file.
+
+Once you have WebUSB descriptors set up it is easy to add Microsoft's OS
+compatibility descriptors as well. First extend the BOS descriptor with this
+additional platform capability descriptor. Make sure to update `wTotalLength`
+and `bNumDeviceCaps` to account for it.
+
+<div>
+  <table>
+    <tr>
+    <th style="width: 33%">Value</th>
+    <th style="width: 33%">Field</th>
+    <th style="width: 33%">Description</th>
+    </tr>
+    <tr>
+    <td colspan="3">Microsoft OS 2.0 platform capability descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x1C</code></td>
+    <td>bLength</td>
+    <td>Size of this descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x10</code></td>
+    <td>bDescriptorType</td>
+    <td>Device capability descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x05</code></td>
+    <td>bDevCapabilityType</td>
+    <td>Platform capability descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x00</code></td>
+    <td>bReserved</td>
+    <td></td>
+    </tr>
+    <tr>
+    <td><code>{0xDF, 0x60, 0xDD, 0xD8, 0x89, 0x45, 0xC7, 0x4C, 0x9C, 0xD2, 0x65, 0x9D, 0x9E, 0x64, 0x8A, 0x9F}</code></td>
+    <td>PlatformCapablityUUID</td>
+    <td>Microsoft OS 2.0 platform compatibility descriptor GUID in little-endian format</td>
+    </tr>
+    <tr>
+    <td><code>0x06030000</code></td>
+    <td>dwWindowsVersion</td>
+    <td>Minimum compatible Windows version (Windows 8.1)</td>
+    </tr>
+    <tr>
+    <td><code>0x00B2</code></td>
+    <td>wMSOSDescriptorSetTotalLength</td>
+    <td>Total length of the descriptor set</td>
+    </tr>
+    <tr>
+    <td><code>0x02</code></td>
+    <td>bMS_VendorCode</td>
+    <td>bRequest value for retrieving further Microsoft descriptors </td>
+    </tr>
+    <tr>
+    <td><code>0x00</code></td>
+    <td>bAltEnumCode</td>
+    <td>Device does not support alternate enumeration</td>
+    </tr>
+  </table>
+</div>
+
+As with the WebUSB descriptors you have to pick a `bRequest` value to be used by
+control transfers related to these descriptors. In this example I've picked
+`0x02`. `0x07`, placed in `wIndex`, is the command to retrieve the Microsoft OS
+2.0 Descriptor Set from the device.
+
+<div>
+  <table>
+    <tr>
+    <th>bmRequestType</th>
+    <th>bRequest</th>
+    <th>wValue</th>
+    <th>wIndex</th>
+    <th>wLength</th>
+    <th>Data (response)</th>
+    </tr>
+    <tr>
+    <td><code>0b11000000</code></td>
+    <td><code>0x02</code></td>
+    <td><code>0x0000</code></td>
+    <td><code>0x0007</code></td>
+    <td>*</td>
+    <td>MS OS 2.0 Descriptor Set</td>
+    </tr>
+  </table>
+</div>
+
+A USB device can have multiple functions and so the first part of the descriptor
+set describes which function the properties that follow are associated with. The
+example below configures interface 1 of a composite device. The descriptor gives
+the OS two important pieces of information about this interface. The compatible
+ID descriptor tells Windows that this device is compatible with the WinUSB
+driver. The registry property descriptor functions similarly to the
+`[Dev_AddReg]` section of the INF example above, setting a registry property to
+assign this function a device interface GUID.
+
+<div>
+  <table>
+    <tr>
+    <th style="width: 33%">Value</th>
+    <th style="width: 33%">Field</th>
+    <th style="width: 33%">Description</th>
+    </tr>
+    <tr>
+    <td colspan="3">Microsoft OS 2.0 descriptor set header</td>
+    </tr>
+    <tr>
+    <td><code>0x000A</code></td>
+    <td>wLength</td>
+    <td>Size of this descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x0000</code></td>
+    <td>wDescriptorType</td>
+    <td>Descriptor set header descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x06030000</code></td>
+    <td>dwWindowsVersion</td>
+    <td>Minimum compatible Windows version (Windows 8.1)</td>
+    </tr>
+    <tr>
+    <td><code>0x00B2</code></td>
+    <td>wTotalLength</td>
+    <td>Total length of the descriptor set</td>
+    </tr>
+    <tr>
+    <td colspan="3">Microsoft OS 2.0 configuration subset header</td>
+    </tr>
+    <tr>
+    <td><code>0x0008</code></td>
+    <td>wLength</td>
+    <td>Size of this descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x0001</code></td>
+    <td>wDescriptorType</td>
+    <td>Configuration subset header desc.</td>
+    </tr>
+    <tr>
+    <td><code>0x00</code></td>
+    <td>bConfigurationValue</td>
+    <td>
+      Applies to configuration 1 (indexed from 0 despite configurations
+      normally indexed from 1)
+    </td>
+    </tr>
+    <tr>
+    <td><code>0x00</code></td>
+    <td>bReserved</td>
+    <td>Must be set to 0</td>
+    </tr>
+    <tr>
+    <td><code>0x00A8</code></td>
+    <td>wTotalLength</td>
+    <td>Total length of the subset including this header</td>
+    </tr>
+    <tr>
+    <td colspan="3">Microsoft OS 2.0 function subset header</td>
+    </tr>
+    <tr>
+    <td><code>0x0008</code></td>
+    <td>wLength</td>
+    <td>Size of this descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x0002</code></td>
+    <td>wDescriptorType</td>
+    <td>Function subset header descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x01</code></td>
+    <td>bFirstInterface</td>
+    <td>First interface of the function</td>
+    </tr>
+    <tr>
+    <td><code>0x00</code></td>
+    <td>bReserved</td>
+    <td>Must be set to 0</td>
+    </tr>
+    <tr>
+    <td><code>0x00A0</code></td>
+    <td>wSubsetLength</td>
+    <td>Total length of the subset including this header</td>
+    </tr>
+    <tr>
+    <td colspan="3">Microsoft OS 2.0 compatible ID descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x0014</code></td>
+    <td>wLength</td>
+    <td>Size of this descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x0003</code></td>
+    <td>wDescriptorType</td>
+    <td>Compatible ID descriptor</td>
+    </tr>
+    <tr>
+    <td><code>"WINUSB\0\0"</code></td>
+    <td>CompatibileID</td>
+    <td>ASCII string padded to 8 bytes</td>
+    </tr>
+    <tr>
+    <td><code>"\0\0\0\0\0\0\0\0"</codE></td>
+    <td>SubCompatibleID</td>
+    <td>ASCII string padded to 8 bytes</td>
+    </tr>
+    <tr>
+    <td colspan="3">Microsoft OS 2.0 registry property descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x0084</code></td>
+    <td>wLength</td>
+    <td>Size of this descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x0004</code></td>
+    <td>wDescriptorType</td>
+    <td>Registry property descriptor</td>
+    </tr>
+    <tr>
+    <td><code>0x0007</code></td>
+    <td>wPropertyDataType</td>
+    <td>REG_MULTI_SZ</td>
+    </tr>
+    <tr>
+    <td><code>0x002A</code></td>
+    <td>wPropertyNameLength</td>
+    <td>Length of the property name</td>
+    </tr>
+    <tr>
+    <td><code>"DeviceInterfaceGUIDs\0"</code></td>
+    <td>PropertyName</td>
+    <td>Property name with null terminator encoded in UTF-16LE</td>
+    </tr>
+    <tr>
+    <td><code>0x0050</code></td>
+    <td>wPropertyDataLength</td>
+    <td>Length of the property value</td>
+    </tr>
+    <tr>
+    <td><code>"{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}\0\0"</code></td>
+    <td>PropertyData</td>
+    <td>GUID plus two null terminators encoded in UTF-16LE</td>
+    </tr>
+  </table>
+</div>
+
+Windows will only query the device for this information once. If the device does
+not respond with valid descriptors it will not ask again the next time the
+device is connected. Microsoft has provided [a list of USB Device Registry
+Entries] describing the registry entries created when enumerating a device. When
+testing delete the entries created for a device for force Windows to try to read
+the descriptors again.
+
+For more information check out Microsoft's [blog post] on how to use these
+descriptors.
+
+## Examples
+
+Example code implementing WebUSB-aware devices that include both WebUSB
+descriptors and Microsoft OS descriptors can be found in these projects:
+
+ * [WebLight]
+ * [WebUSB Arduino Library]
+
+[webusb api]: https://wicg.github.io/webusb
+[access usb devices on the web]: /articles/usb
+[`getusermedia()`]: https://html5rocks.com/en/tutorials/getusermedia/intro/
+[keyboardevents]: https://developer.mozilla.org/docs/Web/API/KeyboardEvent
+[pointerevents]: https://developer.mozilla.org/docs/Web/API/Pointer_events
+[gamepad]: https://web.dev/gamepad/
+[webhid]: /articles/hid/
+[webusb platform capability descriptor]: https://wicg.github.io/webusb/#webusb-platform-capability-descriptor
+[url descriptor]: https://wicg.github.io/webusb/#url-descriptor
+[zadig tool]: https://zadig.akeo.ie/
+[`requestdevice()`]: https://wicg.github.io/webusb/#dom-usb-requestdevice
+[`open()`]: https://wicg.github.io/webusb/#dom-usbdevice-open
+[a list of usb device registry entries]: https://docs.microsoft.com/en-us/windows-hardware/drivers/usbcon/usb-device-specific-registry-settings
+[blog post]: https://techcommunity.microsoft.com/t5/microsoft-usb-blog/how-to-install-winusb-sys-without-a-custom-inf/ba-p/270769
+[weblight]: https://github.com/sowbug/weblight
+[webusb arduino library]: https://github.com/webusb/arduino

--- a/site/en/articles/nfc/index.md
+++ b/site/en/articles/nfc/index.md
@@ -1,0 +1,887 @@
+---
+layout: 'layouts/blog-post.njk'
+title: Interact with NFC devices on Chrome for Android
+subhead: Reading and writing to NFC tags is now possible.
+authors:
+  - beaufortfrancois
+date: 2020-02-12
+updated: 2022-01-27
+hero: image/admin/TqG3qb5MiLGNTnAgKtqO.jpg
+thumbnail: image/admin/8tWkeYbKLxSd2YgTUSGv.jpg
+alt: A photo of NFC tags
+description: |
+  Reading and writing to NFC tags is now possible on Chrome for Android.
+tags:
+  - capabilities
+  - devices
+feedback:
+  - api
+stack_overflow_tag: webnfc
+---
+
+{% Aside 'success' %}
+Web NFC, part of the [capabilities project](/blog/fugu-status/), launched in
+Chrome&nbsp;89 for Android.
+{% endAside %}
+
+## What is Web NFC? {: #what }
+
+NFC stands for Near Field Communications, a short-range wireless technology
+operating at 13.56 MHz that enables communication between devices at a distance
+less than 10 cm and a transmission rate of up to 424 kbit/s.
+
+Web NFC provides sites the ability to read and write to NFC tags when they are
+in close proximity to the user's device (usually 5-10 cm, 2-4 inches).
+The current scope is limited to NFC Data Exchange Format (NDEF), a lightweight
+binary message format that works across different tag formats.
+
+<figure>
+  {% Img src="image/admin/jWmCabXZCB6zNwQIR90I.png", alt="Phone powering up an NFC tag to exchange data", width="800", height="489" %}
+  <figcaption>Diagram of an NFC operation</figcaption>
+</figure>
+
+## Suggested use cases {: #use-cases }
+
+Web NFC is limited to NDEF because the security properties of reading and
+writing NDEF data are more easily quantifiable. Low-level I/O operations (e.g.
+ISO-DEP, NFC-A/B, NFC-F), Peer-to-Peer communication mode and Host-based Card
+Emulation (HCE) are not supported.
+
+Examples of sites that may use Web NFC include:
+- Museums and art galleries can display additional information about a display
+  when the user touches their device to an NFC card near the exhibit.
+- Inventory management sites can read or write data to the NFC tag on a
+  container to update information on its contents.
+- Conference sites can use it to scan NFC badges during the event and make sure
+  they are locked to prevent further changes to the information written on them.
+- Sites can use it for sharing initial secrets needed for device or service
+  provisioning scenarios and also to deploy configuration data in operational
+  mode.
+
+<figure>
+  {% Img src="image/admin/zTEXhIx9nDWtbKrIPN0x.png", alt="Phone scanning several NFC tags", width="800", height="383" %}
+  <figcaption>NFC inventory management illustrated</figcaption>
+</figure>
+
+## Current status {: #status }
+
+<div>
+
+| Step                                       | Status                       |
+| ------------------------------------------ | ---------------------------- |
+| 1. Create explainer                        | [Complete][explainer]        |
+| 2. Create initial draft of specification   | [Complete][spec]             |
+| 3. Gather feedback & iterate on design     | [Complete](#feedback)        |
+| 4. Origin trial                            | [Complete][ot]               |
+| **5. Launch**                              | **Complete**                 |
+
+</div>
+
+## Using Web NFC {: #use }
+
+### Feature detection {: #feature-detection }
+
+Feature detection for hardware is different from what you're probably used to.
+The presence of `NDEFReader` tells you that the browser supports Web NFC, but
+not whether the required hardware is present. In particular, if the hardware is
+missing, the promise returned by certain calls will reject. I'll provide
+details when I describe `NDEFReader`.
+
+```js
+if ('NDEFReader' in window) { /* Scan and write NFC tags */ }
+```
+
+### Terminology {: #terminology }
+
+An NFC tag is a passive NFC device, meaning that is powered by magnetic
+induction when an active NFC device (.e.g a phone) is in proximity. NFC tags
+come in many forms and fashions, as stickers, credit cards, arm wrists, etc.
+
+<figure>
+  {% Img src="image/admin/uUBxSkSc3MJBG8Lw52fV.jpg", alt="Photo of a transparent NFC tag", width="800", height="450" %}
+  <figcaption>A transparent NFC tag</figcaption>
+</figure>
+
+The `NDEFReader` object is the entry point in Web NFC that exposes functionality
+for preparing reading and/or writing actions that are fulfilled when an NDEF tag
+comes in proximity. The `NDEF` in `NDEFReader` stands for NFC Data Exchange
+Format, a lightweight binary message format standardized by the [NFC Forum].
+
+The `NDEFReader` object is for acting on incoming NDEF messages from NFC tags
+and for writing NDEF messages to NFC tags within range.
+
+An NFC tag that supports NDEF is like a post-it note. Anyone can read it, and
+unless it is read-only, anyone can write to it. It contains a single NDEF
+message which encapsulates one or more NDEF records. Each NDEF record is a
+binary structure that contains a data payload, and associated type information.
+Web NFC supports the following NFC Forum standardized record types: empty, text,
+URL, smart poster, MIME type, absolute URL, external type, unknown, and local
+type.
+
+<figure>
+  {% Img src="image/admin/50clBWSJbKkyumsxrioB.png", alt="Diagram of an NDEF message", width="800", height="243" %}
+  <figcaption>Diagram of an NDEF message</figcaption>
+</figure>
+
+### Scan NFC tags {: #scan }
+
+To scan NFC tags, first instantiate a new `NDEFReader` object. Calling `scan()`
+returns a promise. The [user may be prompted] if access was not previously
+granted. The promise will resolve if the following conditions are all met:
+
+- It was only called in response to a user gesture such as a touch gesture or
+  mouse click.
+- The user has allowed the website to interact with NFC devices.
+- The user's phone supports NFC.
+- The user has enabled NFC on their phone.
+
+Once the promise is resolved, incoming NDEF messages are available by
+subscribing to `reading` events via an event listener. You should also subscribe
+to `readingerror` events to be notified when incompatible NFC tags are in
+proximity.
+
+```js
+const ndef = new NDEFReader();
+ndef.scan().then(() => {
+  console.log("Scan started successfully.");
+  ndef.onreadingerror = () => {
+    console.log("Cannot read data from the NFC tag. Try another one?");
+  };
+  ndef.onreading = event => {
+    console.log("NDEF message read.");
+  };
+}).catch(error => {
+  console.log(`Error! Scan failed to start: ${error}.`);
+});
+```
+
+When an NFC tag is in proximity, a `NDEFReadingEvent` event is fired. It
+contains two properties unique to it:
+
+- `serialNumber` represents the serial number of the device (.e.g
+  00-11-22-33-44-55-66), or an empty string if none is available.
+- `message` represents the NDEF message stored in the NFC tag.
+
+To read the content of the NDEF message, loop through `message.records` and
+process their `data` members [appropriately] based on their `recordType`.
+The `data` member is exposed as a <code>[DataView]</code> as it allows handling
+cases where data is encoded in UTF-16.
+
+```js
+ndef.onreading = event => {
+  const message = event.message;
+  for (const record of message.records) {
+    console.log("Record type:  " + record.recordType);
+    console.log("MIME type:    " + record.mediaType);
+    console.log("Record id:    " + record.id);
+    switch (record.recordType) {
+      case "text":
+        // TODO: Read text record with record data, lang, and encoding.
+        break;
+      case "url":
+        // TODO: Read URL record with record data.
+        break;
+      default:
+        // TODO: Handle other records with record data.
+    }
+  }
+};
+```
+
+{% Aside %}
+The [cookbook](#cookbook) contains many examples of how to read NDEF records based on
+their types.
+{% endAside %}
+
+### Write NFC tags {: #write }
+
+To write NFC tags, first instantiate a new `NDEFReader` object. Calling
+`write()` returns a promise. The [user may be prompted] if access was not
+previously granted. At this point, an NDEF message is "prepared" and promise
+will resolve if the following conditions are all met:
+
+- It was only called in response to a user gesture such as a touch gesture or
+  mouse click.
+- The user has allowed the website to interact with NFC devices.
+- The user's phone supports NFC.
+- The user has enabled NFC on their phone.
+- User has tapped an NFC tag and an NDEF message has been successfully written.
+
+To write text to an NFC tag, pass a string to the `write()` method.
+
+```js
+const ndef = new NDEFReader();
+ndef.write(
+  "Hello World"
+).then(() => {
+  console.log("Message written.");
+}).catch(error => {
+  console.log(`Write failed :-( try again: ${error}.`);
+});
+```
+
+To write a URL record to an NFC tag, pass a dictionary that represents an NDEF
+message to `write()`. In the example below, the NDEF message is a dictionary
+with a `records` key. Its value is an array of records - in this case, a URL
+record defined as an object with a `recordType` key set to `"url"` and a `data`
+key set to the URL string.
+
+```js
+const ndef = new NDEFReader();
+ndef.write({
+  records: [{ recordType: "url", data: "https://w3c.github.io/web-nfc/" }]
+}).then(() => {
+  console.log("Message written.");
+}).catch(error => {
+  console.log(`Write failed :-( try again: ${error}.`);
+});
+```
+
+It is also possible to write multiple records to an NFC tag.
+
+```js
+const ndef = new NDEFReader();
+ndef.write({ records: [
+    { recordType: "url", data: "https://w3c.github.io/web-nfc/" },
+    { recordType: "url", data: "https://web.dev/nfc/" }
+]}).then(() => {
+  console.log("Message written.");
+}).catch(error => {
+  console.log(`Write failed :-( try again: ${error}.`);
+});
+```
+
+{% Aside %}
+The [cookbook](#cookbook) contains many examples of how to write other types of
+NDEF records.
+{% endAside %}
+
+If the NFC tag contains an NDEF message that is not meant to be overwritten, set
+the `overwrite` property to `false` in the options passed to the `write()`
+method. In that case, the returned promise will reject if an NDEF message is
+already stored in the NFC tag.
+
+```js
+const ndef = new NDEFReader();
+ndef.write("Writing data on an empty NFC tag is fun!", { overwrite: false })
+.then(() => {
+  console.log("Message written.");
+}).catch(error => {
+  console.log(`Write failed :-( try again: ${error}.`);
+});
+```
+
+### Make NFC tags read-only {: #make-read-only }
+
+To prevent malicious users from overwriting an NFC tag's content, it is possible to
+make NFC tags permanently read-only. This operation is a one-way process and
+cannot be reversed. Once an NFC tag has been made read-only, it can't be written
+to anymore.
+
+To make NFC tags read-only, first instantiate a new `NDEFReader` object. Calling
+`makeReadOnly()` returns a promise. The [user may be prompted] if access was not
+previously granted. The promise will resolve if the following conditions are all
+met:
+
+- It was only called in response to a user gesture such as a touch gesture or
+  mouse click.
+- The user has allowed the website to interact with NFC devices.
+- The user's phone supports NFC.
+- The user has enabled NFC on their phone.
+- The user has tapped an NFC tag and the NFC tag has been successfully made read-only.
+
+```js
+const ndef = new NDEFReader();
+ndef.makeReadOnly()
+.then(() => {
+  console.log("NFC tag has been made permanently read-only.");
+}).catch(error => {
+  console.log(`Operation failed: ${error}`);
+});
+```
+
+Here's how to make an NFC tag permanently read-only after writing to it.
+
+```js
+const ndef = new NDEFReader();
+try {
+  await ndef.write("Hello world");
+  console.log("Message written.");
+  await ndef.makeReadOnly();
+  console.log("NFC tag has been made permanently read-only after writing to it.");
+} catch (error) {
+  console.log(`Operation failed: ${error}`);
+}
+```
+
+As `makeReadOnly()` is available on Android in Chrome&nbsp;100 or later, check
+if this feature is supported with the following:
+
+```js
+if ("NDEFReader" in window && "makeReadOnly" in NDEFReader.prototype) {
+  // makeReadOnly() is supported.
+}
+```
+
+### Security and permissions {: #security-and-permissions }
+
+The Chrome team has designed and implemented Web NFC using the core principles
+defined in [Controlling Access to Powerful Web Platform
+Features][powerful-apis], including user control, transparency, and ergonomics.
+
+Because NFC expands the domain of information potentially available to malicious
+websites, the availability of NFC is restricted to maximize users' awareness and
+control over NFC use.
+
+<figure>
+  {% Img src="image/admin/PjUcOk4zbtOFJLXfSeSD.png", alt="Screenshot of a Web NFC prompt on a website", width="800", height="407" %}
+  <figcaption>Web NFC user prompt</figcaption>
+</figure>
+
+Web NFC is only available to top-level frames and secure browsing contexts (HTTPS
+only). Origins must first request the `"nfc"` [permission] while handling a
+user gesture (e.g a button click). The `NDEFReader` `scan()`, `write()`, and
+`makeReadOnly()` methods trigger a user prompt, if access was not previously
+granted.
+
+```js
+  document.querySelector("#scanButton").onclick = async () => {
+    const ndef = new NDEFReader();
+    // Prompt user to allow website to interact with NFC devices.
+    await ndef.scan();
+    ndef.onreading = event => {
+      // TODO: Handle incoming NDEF messages.
+    };
+  };
+```
+
+The combination of a user-initiated permission prompt and real-world, physical
+movement of bringing the device over a target NFC tag mirrors the chooser
+pattern found in the other file and device-access APIs.
+
+To perform a scan or write, the web page must be visible when the user touches
+an NFC tag with their device. The browser uses haptic feedback to indicate a
+tap. Access to the NFC radio is blocked if the display is off or the device is
+locked. For non visible web pages, receiving and pushing NFC content are
+suspended, and resumed when a web page becomes visible again.
+
+Thanks to the [Page Visibility API], it is possible to track when document
+visibility changes.
+
+```js
+document.onvisibilitychange = event => {
+  if (document.hidden) {
+    // All NFC operations are automatically suspended when document is hidden.
+  } else {
+    // All NFC operations are resumed, if needed.
+  }
+};
+```
+
+## Cookbook {: #cookbook }
+
+Here's some code samples to get you started.
+
+### Check for permission
+
+The [Permissions API] allows checking whether the `"nfc"` permission was
+granted. This example shows how to scan NFC tags without user interaction if
+access was previously granted, or show a button otherwise. Note that the same
+mechanism works for writing NFC tags as it uses the same permission under the
+hood.
+
+```js
+const ndef = new NDEFReader();
+
+async function startScanning() {
+  await ndef.scan();
+  ndef.onreading = event => {
+    /* handle NDEF messages */
+  };
+}
+
+const nfcPermissionStatus = await navigator.permissions.query({ name: "nfc" });
+if (nfcPermissionStatus.state === "granted") {
+  // NFC access was previously granted, so we can start NFC scanning now.
+  startScanning();
+} else {
+  // Show a "scan" button.
+  document.querySelector("#scanButton").style.display = "block";
+  document.querySelector("#scanButton").onclick = event => {
+    // Prompt user to allow UA to send and receive info when they tap NFC devices.
+    startScanning();
+  };
+}
+```
+
+### Abort NFC operations
+
+Using the <code>[AbortController]</code> primitive makes it easy to abort NFC
+operations. The example below shows you how to pass the `signal` of an
+`AbortController` through the options of NDEFReader `scan()`, `makeReadOnly()`,
+`write()` methods and abort both NFC operations at the same time.
+
+```js
+const abortController = new AbortController();
+abortController.signal.onabort = event => {
+  // All NFC operations have been aborted.
+};
+
+const ndef = new NDEFReader();
+await ndef.scan({ signal: abortController.signal });
+
+await ndef.write("Hello world", { signal: abortController.signal });
+await ndef.makeReadOnly({ signal: abortController.signal });
+
+document.querySelector("#abortButton").onclick = event => {
+  abortController.abort();
+};
+```
+
+### Read and write a text record
+
+The text record `data` can be decoded with a `TextDecoder` instantiated with the
+record `encoding` property. Note that the language of the text record is
+available through its `lang` property.
+
+```js
+function readTextRecord(record) {
+  console.assert(record.recordType === "text");
+  const textDecoder = new TextDecoder(record.encoding);
+  console.log(`Text: ${textDecoder.decode(record.data)} (${record.lang})`);
+}
+```
+
+To write a simple text record, pass a string to the NDEFReader `write()` method.
+
+```js
+const ndef = new NDEFReader();
+await ndef.write("Hello World");
+```
+
+Text records are UTF-8 by default and assume the current document's language but
+both properties (`encoding` and `lang`) can be specified using the full syntax
+for creating a custom NDEF record.
+
+```js
+function a2utf16(string) {
+  let result = new Uint16Array(string.length);
+  for (let i = 0; i < string.length; i++) {
+    result[i] = string.codePointAt(i);
+  }
+  return result;
+}
+
+const textRecord = {
+  recordType: "text",
+  lang: "fr",
+  encoding: "utf-16",
+  data: a2utf16("Bonjour, François !")
+};
+
+const ndef = new NDEFReader();
+await ndef.write({ records: [textRecord] });
+```
+
+### Read and write a URL record
+
+Use `TextDecoder` to decode the record's `data`.
+
+```js
+function readUrlRecord(record) {
+  console.assert(record.recordType === "url");
+  const textDecoder = new TextDecoder();
+  console.log(`URL: ${textDecoder.decode(record.data)}`);
+}
+```
+
+To write a URL record, pass an NDEF message dictionary to the NDEFReader
+`write()` method. The URL record contained in the NDEF message is defined as an
+object with a `recordType` key set to `"url"` and a `data` key set to the URL
+string.
+
+```js
+const urlRecord = {
+  recordType: "url",
+  data:"https://w3c.github.io/web-nfc/"
+};
+
+const ndef = new NDEFReader();
+await ndef.write({ records: [urlRecord] });
+```
+
+### Read and write a MIME type record
+
+The `mediaType` property of a MIME type record represents the MIME type of the
+NDEF record payload so that `data` can be properly decoded. For instance, use
+`JSON.parse` to decode JSON text and an Image element to decode image data.
+
+```js
+function readMimeRecord(record) {
+  console.assert(record.recordType === "mime");
+  if (record.mediaType === "application/json") {
+    const textDecoder = new TextDecoder();
+    console.log(`JSON: ${JSON.parse(decoder.decode(record.data))}`);
+  }
+  else if (record.mediaType.startsWith('image/')) {
+    const blob = new Blob([record.data], { type: record.mediaType });
+    const img = new Image();
+    img.src = URL.createObjectURL(blob);
+    document.body.appendChild(img);
+  }
+  else {
+    // TODO: Handle other MIME types.
+  }
+}
+```
+
+To write a MIME type record, pass an NDEF message dictionary to the NDEFReader
+`write()` method. The MIME type record contained in the NDEF message is defined
+as an object with a `recordType` key set to `"mime"`, a `mediaType` key set to
+the actual MIME type of the content, and a `data` key set to an object that can
+be either an `ArrayBuffer` or provides a view on to an `ArrayBuffer` (e.g.
+`Uint8Array`, `DataView`).
+
+```js
+const encoder = new TextEncoder();
+const data = {
+  firstname: "François",
+  lastname: "Beaufort"
+};
+const jsonRecord = {
+  recordType: "mime",
+  mediaType: "application/json",
+  data: encoder.encode(JSON.stringify(data))
+};
+
+const imageRecord = {
+  recordType: "mime",
+  mediaType: "image/png",
+  data: await (await fetch("icon1.png")).arrayBuffer()
+};
+
+const ndef = new NDEFReader();
+await ndef.write({ records: [jsonRecord, imageRecord] });
+```
+
+### Read and write an absolute-URL record
+
+The absolute-URL record `data` can be decoded with a simple `TextDecoder`.
+
+```js
+function readAbsoluteUrlRecord(record) {
+  console.assert(record.recordType === "absolute-url");
+  const textDecoder = new TextDecoder();
+  console.log(`Absolute URL: ${textDecoder.decode(record.data)}`);
+}
+```
+
+To write an absolute URL record, pass an NDEF message dictionary to the
+NDEFReader `write()` method. The absolute-URL record contained in the NDEF
+message is defined as an object with a `recordType` key set to `"absolute-url"`
+and a `data` key set to the URL string.
+
+```js
+const absoluteUrlRecord = {
+  recordType: "absolute-url",
+  data:"https://w3c.github.io/web-nfc/"
+};
+
+const ndef = new NDEFReader();
+await ndef.write({ records: [absoluteUrlRecord] });
+```
+
+### Read and write a smart poster record
+
+A smart poster record (used in magazine advertisements, fliers, billboards,
+etc.), describes some web content as an NDEF record that contains an NDEF
+message as its payload. Call `record.toRecords()` to transform `data` to a list
+of records contained in the smart poster record. It should have a URL record, a
+text record for the title, a MIME type record for the image, and some [custom
+local type records] such as `":t"`, `":act"`, and `":s"` respectively for the
+type, action, and size of the smart poster record.
+
+Local type records are unique only within the local context of the containing
+NDEF record. Use them when the meaning of the types doesn't matter outside
+of the local context of the containing record and when storage usage is a hard
+constraint. Local type record names always start with `:` in Web NFC (e.g.
+`":t"`, `":s"`, `":act"`). This is to differentiate a text record from a local
+type text record for instance.
+
+```js
+function readSmartPosterRecord(smartPosterRecord) {
+  console.assert(record.recordType === "smart-poster");
+  let action, text, url;
+
+  for (const record of smartPosterRecord.toRecords()) {
+    if (record.recordType == "text") {
+      const decoder = new TextDecoder(record.encoding);
+      text = decoder.decode(record.data);
+    } else if (record.recordType == "url") {
+      const decoder = new TextDecoder();
+      url = decoder.decode(record.data);
+    } else if (record.recordType == ":act") {
+      action = record.data.getUint8(0);
+    } else {
+      // TODO: Handle other type of records such as `:t`, `:s`.
+    }
+  }
+
+  switch (action) {
+    case 0:
+      // Do the action
+      break;
+    case 1:
+      // Save for later
+      break;
+    case 2:
+      // Open for editing
+      break;
+  }
+}
+```
+
+To write a smart poster record, pass an NDEF message to the NDEFReader `write()`
+method. The smart poster record contained in the NDEF message is defined as an
+object with a `recordType` key set to `"smart-poster"` and a `data` key set to
+an object that represents (once again) an NDEF message contained in the
+smart poster record.
+
+```js
+const encoder = new TextEncoder();
+const smartPosterRecord = {
+  recordType: "smart-poster",
+  data: {
+    records: [
+      {
+        recordType: "url", // URL record for smart poster content
+        data: "https://my.org/content/19911"
+      },
+      {
+        recordType: "text", // title record for smart poster content
+        data: "Funny dance"
+      },
+      {
+        recordType: ":t", // type record, a local type to smart poster
+        data: encoder.encode("image/gif") // MIME type of smart poster content
+      },
+      {
+        recordType: ":s", // size record, a local type to smart poster
+        data: new Uint32Array([4096]) // byte size of smart poster content
+      },
+      {
+        recordType: ":act", // action record, a local type to smart poster
+        // do the action, in this case open in the browser
+        data: new Uint8Array([0])
+      },
+      {
+        recordType: "mime", // icon record, a MIME type record
+        mediaType: "image/png",
+        data: await (await fetch("icon1.png")).arrayBuffer()
+      },
+      {
+        recordType: "mime", // another icon record
+        mediaType: "image/jpg",
+        data: await (await fetch("icon2.jpg")).arrayBuffer()
+      }
+    ]
+  }
+};
+
+const ndef = new NDEFReader();
+await ndef.write({ records: [smartPosterRecord] });
+```
+
+### Read and write an external type record
+
+To create application defined records, use external type records. These may
+contain an NDEF message as payload that is accessible with `toRecords()`. Their
+name contains the domain name of the issuing organization, a colon and a type
+name that is at least one character long, for instance `"example.com:foo"`.
+
+```js
+function readExternalTypeRecord(externalTypeRecord) {
+  for (const record of externalTypeRecord.toRecords()) {
+    if (record.recordType == "text") {
+      const decoder = new TextDecoder(record.encoding);
+      console.log(`Text: ${textDecoder.decode(record.data)} (${record.lang})`);
+    } else if (record.recordType == "url") {
+      const decoder = new TextDecoder();
+      console.log(`URL: ${decoder.decode(record.data)}`);
+    } else {
+      // TODO: Handle other type of records.
+    }
+  }
+}
+```
+
+To write an external type record, pass an NDEF message dictionary to the
+NDEFReader `write()` method. The external type record contained in the NDEF
+message is defined as an object with a `recordType` key set to the name of the
+external type and a `data` key set to an object that represents an NDEF message
+contained in the external type record. Note that the `data` key can also be
+either an `ArrayBuffer` or provides a view on to an `ArrayBuffer` (e.g.
+`Uint8Array`, `DataView`).
+
+```js
+const externalTypeRecord = {
+  recordType: "example.game:a",
+  data: {
+    records: [
+      {
+        recordType: "url",
+        data: "https://example.game/42"
+      },
+      {
+        recordType: "text",
+        data: "Game context given here"
+      },
+      {
+        recordType: "mime",
+        mediaType: "image/png",
+        data: await (await fetch("image.png")).arrayBuffer()
+      }
+    ]
+  }
+};
+
+const ndef = new NDEFReader();
+ndef.write({ records: [externalTypeRecord] });
+```
+
+### Read and write an empty record
+
+An empty record has no payload.
+
+To write an empty record, pass an NDEF message dictionary to the NDEFReader
+`write()` method. The empty record contained in the NDEF message is defined as
+an object with a `recordType` key set to `"empty"`.
+
+```js
+const emptyRecord = {
+  recordType: "empty"
+};
+
+const ndef = new NDEFReader();
+await ndef.write({ records: [emptyRecord] });
+```
+
+## Browser support {: #browser-support }
+
+Web NFC is available on Android in Chrome 89.
+
+## Dev Tips
+
+Here's a list of things I wish I had known when I started playing with Web NFC:
+
+- Android handles NFC tags at the OS-level before Web NFC is operational.
+- You can find an NFC icon on [material.io].
+- Use NDEF record `id` to easily identifying a record when needed.
+- An unformatted NFC tag that supports NDEF contains a single record of the empty type.
+- Writing an [android application record] is easy, as shown below.
+
+```js
+const encoder = new TextEncoder();
+const aarRecord = {
+  recordType: "android.com:pkg",
+  data: encoder.encode("com.example.myapp")
+};
+
+const ndef = new NDEFReader();
+await ndef.write({ records: [aarRecord] });
+```
+
+## Demos {: #demos }
+
+Try out the [official sample] and check out some cool Web NFC demos:
+- [Cards demo]
+- [Grocery Demo]
+- [Intel RSP Sensor NFC]
+- [Media MEMO]
+
+<figure>
+  <video controls autoplay loop muted>
+    <source src="https://storage.googleapis.com/webfundamentals-assets/videos/web-nfc-cards-demo.mp4">
+  </video>
+  <figcaption>
+    Web NFC cards demo at Chrome Dev Summit 2019
+  </figcaption>
+</figure>
+
+## Feedback {: #feedback }
+
+The [Web NFC Community Group](https://www.w3.org/community/web-nfc/) and the
+Chrome team would love to hear about your thoughts and experiences with Web NFC.
+
+### Tell us about the API design
+
+Is there something about the API that doesn't work as expected? Or are there
+missing methods or properties that you need to implement your idea?
+
+File a spec issue on the [Web NFC GitHub repo][issues] or add your thoughts to
+an existing issue.
+
+### Report a problem with the implementation
+
+Did you find a bug with Chrome's implementation? Or is the implementation
+different from the spec?
+
+File a bug at [https://new.crbug.com][new-bug]. Be sure to include as much
+detail as you can, provide simple instructions for reproducing the bug, and have
+*Components* set to `Blink>NFC`. [Glitch](https://glitch.com) works great for
+sharing quick and easy repros.
+
+### Show support
+
+Are you planning to use Web NFC? Your public support helps the Chrome team
+prioritize features and shows other browser vendors how critical it is to
+support them.
+
+Send a tweet to [@ChromiumDev][cr-dev-twitter] using the hashtag
+[`#WebNFC`](https://twitter.com/search?q=%23WebNFC&src=typed_query&f=live)
+and let us know where and how you're using it.
+
+## Helpful links {: #helpful }
+
+* [Specification][spec]
+* [Web NFC Demo][demo] | [Web NFC Demo source][demo-source]
+* [Tracking bug][cr-bug]
+* [ChromeStatus.com entry][cr-status]
+* Blink Component: [`Blink>NFC`](https://chromestatus.com/features#component%3ABlink%3ENFC)
+
+## Acknowledgements
+
+Big thanks to the [folks at Intel] for implementing Web NFC. Google Chrome
+depends on a community of committers working together to move the Chromium
+project forward. Not every Chromium committer is a Googler, and these
+contributors deserve special recognition!
+
+[explainer]: https://github.com/w3c/web-nfc/blob/gh-pages/EXPLAINER.md#web-nfc-explained
+[spec]: https://w3c.github.io/web-nfc/
+[ot]: /origintrials/#/view_trial/236438980436951041
+[issues]: https://github.com/w3c/web-nfc/issues
+[demo]: https://web-nfc-demo.glitch.me/
+[demo-source]: https://glitch.com/edit/#!/web-nfc-demo?path=script.js:1:0
+[new-bug]: https://bugs.chromium.org/p/chromium/issues/entry?components=Blink%3ENFC
+[cr-dev-twitter]: https://twitter.com/chromiumdev
+[cr-bug]: https://bugs.chromium.org/p/chromium/issues/detail?id=520391
+[cr-status]: https://www.chromestatus.com/feature/6261030015467520
+[powerful-apis]: https://chromium.googlesource.com/chromium/src/+/main/docs/security/permissions-for-powerful-web-platform-features.md
+[permissions api]: https://www.w3.org/TR/permissions/
+[abortcontroller]: https://developer.mozilla.org/docs/Web/API/AbortController
+[page visibility api]: https://developer.mozilla.org/docs/Web/API/Page_Visibility_API
+[user may be prompted]: #security-and-permissions
+[permission]: https://w3c.github.io/permissions/
+[folks at intel]: https://github.com/w3c/web-nfc/graphs/contributors
+[android application record]: https://developer.android.com/guide/topics/connectivity/nfc/nfc#aar
+[nfc forum]: https://nfc-forum.org/
+[android application record]: https://developer.android.com/guide/topics/connectivity/nfc/nfc#aar
+[official sample]: https://googlechrome.github.io/samples/web-nfc/
+[cards demo]: https://web-nfc-demo.glitch.me
+[grocery demo]: https://kenchris.github.io/webnfc-groceries
+[media memo]: https://webnfc-media-memo.netlify.com/
+[intel rsp sensor nfc]: https://kenchris.github.io/webnfc-rsp/
+[material.io]: https://material.io/resources/icons/?icon=nfc&style=baseline
+[appropriately]: https://w3c.github.io/web-nfc/#data-mapping
+[custom local type records]: https://w3c.github.io/web-nfc/#smart-poster-record
+[dataview]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView


### PR DESCRIPTION
Changes proposed in this pull request:

web.dev/nfc -> developer.chrome.com/articles/nfc
web.dev/build-for-webusb -> developer.chrome.com/articles/build-for-webusb

See https://github.com/GoogleChrome/web.dev/pull/9543