### PR TITLE
Remove incorrectly applied tag

### DIFF
--- a/site/en/articles/css-nth-child-of-s/index.md
+++ b/site/en/articles/css-nth-child-of-s/index.md
@@ -12,7 +12,6 @@ hero: image/AeNB0cHNDkYPUYzDuv8gInYA9rY2/d3BZ8gLh8WkVPRfJf6mz.jpg
 alt: "Rows of green chairs in the Munich Olympic Stadium."
 tags:
   - css
-  - chrome-stable
   - chrome-111
 ---
 


### PR DESCRIPTION
111 is not stable right now (only beta). Furthermore the tag `chrome-stable` isn’t used all too often.