### PR TITLE
separate glossary entries b/265335974

### DIFF
--- a/site/en/_partials/privacy-sandbox/glossary-entries/ad-auction.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/ad-auction.md
@@ -1,0 +1,6 @@
+## Ad auction (FLEDGE)
+
+In FLEDGE, an ad auction is run by a seller (ikely to be an [SSP](#ssp) or maybe the publisher itself), in JavaScript code in the browser on the
+user's device, to sell ad space on a site that displays ads.
+
+{: #creative}

--- a/site/en/_partials/privacy-sandbox/glossary-entries/ad-creative.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/ad-creative.md
@@ -1,0 +1,5 @@
+## Ad creative, creative {: #ad-creative}
+
+The contents of the ad served to users. Creatives can be images, videos, audio,
+and other formats. Creatives live within an ad space, and are served by adtech
+within line items.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/ad-exchange.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/ad-exchange.md
@@ -1,0 +1,6 @@
+## Ad exchange
+
+A platform to automate buying and selling of ad inventory from multiple ad
+networks.
+
+{: #ad-space }

--- a/site/en/_partials/privacy-sandbox/glossary-entries/ad-inventory-space.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/ad-inventory-space.md
@@ -1,0 +1,5 @@
+{: #ad-space }
+
+## Ad inventory, ad space {: #ad-inventory }
+
+The spaces for ads that are available from a site that sells ad space.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/ad-platform.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/ad-platform.md
@@ -1,0 +1,3 @@
+## Ad platform (Adtech) {: #adtech }
+
+A company that provides services to deliver ads.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/advertiser.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/advertiser.md
@@ -1,0 +1,3 @@
+## Advertiser {: #advertiser }
+
+A company that pays to advertise its products.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/aggregatable-reports.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/aggregatable-reports.md
@@ -1,0 +1,7 @@
+## Aggregatable reports
+
+Encrypted reports sent from individual user devices. These reports contain
+data about cross-site user behavior and conversions. Conversions (sometimes
+called attribution trigger events) and associated metrics are defined by the
+advertiser or adtech. Each report is encrypted to prevent various parties
+from accessing the underlying data.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/attestation.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/attestation.md
@@ -1,0 +1,7 @@
+## Attestation
+
+A mechanism to authenticate software identity, usually with [cryptographic
+hashes](https://en.wikipedia.org/wiki/Cryptographic_hash_function) or
+signatures. For the aggregation service proposal, attestation matches the
+code running in the adtech-operated aggregation service with the open
+source code.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/attribution.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/attribution.md
@@ -1,0 +1,5 @@
+## Attribution {: #attribution }
+
+Identification of user actions that contribute to an outcome.
+
+For example, a correlation of ad clicks or views with [conversions](#conversion).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/blink.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/blink.md
@@ -1,0 +1,4 @@
+## Blink {: #blink }
+
+The [rendering engine](https://en.wikipedia.org/wiki/Browser_engine) used by
+Chrome, developed as part of the [Chromium](#chromium) project.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/buyer.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/buyer.md
@@ -1,0 +1,7 @@
+## Buyer
+
+A party bidding for ad space in an [ad auction](#ad-auction), likely to be a
+[DSP](#DSP), or maybe the advertiser itself. Ad space buyers own and manage
+interest groups. 
+
+Learn about [ad space buyers in FLEDGE](/docs/privacy-sandbox/fledge/#buyer-detail).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/chromium.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/chromium.md
@@ -1,0 +1,4 @@
+## Chromium {: #chromium }
+
+An open-source web browser project. Chrome, Microsoft Edge, Opera and other
+browsers are based on Chromium.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/clickthrough-conversion.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/clickthrough-conversion.md
@@ -1,0 +1,3 @@
+## Click-through-conversion (CTC) {: #ctc }
+
+A conversion attributed to an ad that was 'clicked'.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/clickthrough-rate.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/clickthrough-rate.md
@@ -1,0 +1,5 @@
+## Click-through rate (CTR) {: #ctr }
+
+The ratio of users who click on an ad, having seen it.
+
+See also [impression](#impression).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/conversion.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/conversion.md
@@ -1,0 +1,6 @@
+## Conversion
+
+The completion of some desired goal following action by a user.
+
+For example, a conversion may occur with the purchase of a product or sign-up
+for a newsletter after clicking an ad that links to the advertiser's site.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/cookie.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/cookie.md
@@ -1,0 +1,11 @@
+## Cookie
+
+A small piece of textual data that websites can store on a user's browser.
+Cookies can be used by a website to save information associated with a user
+(or a reference to data stored on the website's backend servers) as the user
+moves across the web.
+
+For example, an online store can retain shopping cart details even if a user is
+not logged in, or the site could record the user's browsing activity on their
+site. See [First-party cookie](#first-party-cookie) and
+[Third-party cookie](#third-party-cookie).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/coordinator.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/coordinator.md
@@ -1,0 +1,3 @@
+## Coordinator
+
+An entity responsible for key management and aggregatable report accounting. The coordinator maintains a list of hashes of approved aggregation service configurations and configures access to decryption keys.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/course-data.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/course-data.md
@@ -1,0 +1,6 @@
+## Coarse data
+
+Limited information provided by Attribution Reporting API event-level reports.
+This is limited to 3 pieces of conversion data for clicks and 1 piece for
+views. Specific, granular conversion data (such as specific prices of items
+and timestamps)  are not included.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/data-management-platform.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/data-management-platform.md
@@ -1,0 +1,7 @@
+## Data management platform (DMP) {: #dmp }
+
+A software used to collect and manage data relevant for advertisers. These
+platforms help advertisers and publishers identify audience segments, which can
+then be used for campaign targeting.
+
+Learn more about [DMPs](https://en.wikipedia.org/wiki/Data_management_platform).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/demand-side-platform.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/demand-side-platform.md
@@ -1,0 +1,8 @@
+## Demand-side platform (DSP) {: #dsp }
+
+An adtech service used to automate ad purchasing. DSPs are used by advertisers
+to buy [ad impressions](https://en.wikipedia.org/wiki/Impression_(online_media))
+across a range of publisher sites. Publishers put their
+[ad inventory](#ad-inventory) up for sale through marketplaces called ad
+exchanges, and DSPs decide programmatically which available ad impression makes
+most sense for an advertiser to buy.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/differential-privacy.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/differential-privacy.md
@@ -1,0 +1,5 @@
+## Differential privacy {: #differential-privacy }
+
+Techniques to allow sharing of information about a dataset to reveal patterns
+of behaviour without revealing private information about individuals or whether
+they belong to the dataset.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/domain.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/domain.md
@@ -1,0 +1,3 @@
+## Domain
+
+See [Top-Level Domain](#tld) and [eTLD](#etld).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/entropy.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/entropy.md
@@ -1,0 +1,10 @@
+## Entropy
+
+A measure of how much an item of data reveals individual identity.
+
+Data entropy is measured in bits. The more that data reveals identity, the higher its entropy value.
+
+Data can be combined to identify an individual, but it can be difficult to work
+out whether new data adds to entropy. For example, knowing a person is from
+Australia doesn't reduce entropy if you already know the person is from
+Kangaroo Island.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/etld-etld1.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/etld-etld1.md
@@ -1,0 +1,18 @@
+## eTLD, eTLD+1 {: #etld }
+
+Stands for effective top-level domains (TLD), which are defined by the
+[Public Suffix List](https://publicsuffix.org/list/).
+
+For example:
+
+```text
+co.uk 
+github.io 
+glitch.me
+``` 
+
+Effective TLDs are what allow `foo.appspot.com` to be a different site from
+`bar.appspot.com`. The eTLD in this case is `appspot.com`, and the whole
+site name (`foo.appspot.com`, `bar.appspot.com`) is known as the eTLD+1.
+
+See also [Top-Level Domain](#tld).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/federated-credential-management.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/federated-credential-management.md
@@ -1,0 +1,9 @@
+## Federated Credential Management API (FedCM) {: #fedcm }
+
+Federated Credential Management API is a proposal for a privacy-preserving
+approach to federated identity services. This will allow users to log into
+sites without sharing their personal information with the identity service or
+the site.
+
+FedCM was previously known as WebID, and is still
+[in development in the W3C](https://github.com/wicg/fedcm).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/federated-identity.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/federated-identity.md
@@ -1,0 +1,4 @@
+## Federated identity (federated login) {: #federated-identity }
+
+A third-party platform to allow a user to sign in to a website, without
+requiring the site to implement their own identity service.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/feedback-aside.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/feedback-aside.md
@@ -1,0 +1,8 @@
+{% Aside %}
+The API is a work in progress and will evolve over time, dependent on
+ecosystem feedback and input. Your input helps ensure that solutions to various
+use cases are discussed.
+
+This API is being incubated and developed in the open. [Consider participating](/docs/privacy-sandbox/attribution-reporting-introduction/#participate)
+in the discussion.
+{% endAside %}

--- a/site/en/_partials/privacy-sandbox/glossary-entries/fenced-frame.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/fenced-frame.md
@@ -1,0 +1,11 @@
+## Fenced frame
+
+A (`<fencedframe>`) is a proposed HTML element for embedded content, similar to
+an [iframe](https://developer.mozilla.org/docs/Web/HTML/Element/iframe). Unlike
+iframes, a fenced frame restricts communication with its embedding context to
+allow the frame access to cross-site data without sharing it with the embedding
+context.
+
+Some Privacy Sandbox APIs may require select documents to render within a
+fenced frame. Learn more about the
+[Fenced Frames proposal](/docs/privacy-sandbox/fenced-frame/).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/fingerprinting-surface.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/fingerprinting-surface.md
@@ -1,0 +1,8 @@
+## Fingerprinting surface {: #fingerprinting-surface }
+
+Something that can be used (probably in combination with other surfaces) to
+identify a particular user or device.
+
+For example, the `navigator.userAgent()` JavaScript method and the `User-Agent`
+HTTP request header provide access to a fingerprinting surface (the User-Agent
+string).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/fingerprinting.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/fingerprinting.md
@@ -1,0 +1,8 @@
+## Fingerprinting {: #fingerprinting }
+
+Techniques to identify and track the behaviour of individual users.
+
+Fingerprinting uses mechanisms that users aren't aware of and can't control. 
+Sites such as [Panopticlick](https://panopticlick.eff.org) and
+[amiunique.org](https://amiunique.org/) show how fingerprint data can be
+combined to identify you as an individual.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/first-party-cookie.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/first-party-cookie.md
@@ -1,0 +1,7 @@
+## First-party cookie {: #first-party-cookie } 
+
+[Cookie](#cookie) stored by a website while a user is on the site itself.
+
+For example, an online store might ask a browser to store a cookie in order to
+retain shopping cart details for a user who is not logged in. See also
+[Third-party cookies](#third-party-cookie).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/first-party.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/first-party.md
@@ -1,0 +1,11 @@
+## First-party {: #first-party }
+
+Resources from the site you're visiting.
+
+For example, the page you're reading is on the site `developer.chrome.com` and
+includes resources requested from this site. Requests for those first-party
+resources are called 'first-party requests'. [Cookies](#cookie) from
+`developer.chrome.com` stored while you're on this site are called
+[first-party cookies](#first-party-cookie).
+
+See also [Third-party](#third-party).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/i2e.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/i2e.md
@@ -1,0 +1,5 @@
+## I2E {: #i2e }
+
+Intent to Experiment. Announcement of a plan to make a new [Blink](#blink)
+feature available to users for testing, typically through an [origin
+trial](#origin-trial).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/i2ee.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/i2ee.md
@@ -1,0 +1,4 @@
+## I2EE {: #i2ee }
+
+Intent to Extend Experiment. Announcement of a plan to extend the duration of an
+[origin trial](#origin-trial).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/i2p.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/i2p.md
@@ -1,0 +1,7 @@
+## I2P {: #i2p }
+
+Intent to Prototype. The first stage in
+[developing a new feature](/blog/progress-in-the-privacy-sandbox-2021-12/#chromium-development-process)
+in [Blink](#blink). The announcement is posted to the [blink-dev mailing
+list](https://groups.google.com/a/chromium.org/g/blink-dev) with a link to the
+proposal for discussion.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/i2s.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/i2s.md
@@ -1,0 +1,4 @@
+## I2S {: #i2s }
+
+Intent to Ship. Announcement of a plan to make a new feature of [Blink](#blink)
+available to users in stable versions of Chrome.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/impression.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/impression.md
@@ -1,0 +1,7 @@
+## Impression {: #impression }
+
+Could refer to either:
+
+*  View of an ad. See also [click-through rate](#ctr).
+*  An ad slot: the HTML markup (usually `<div>` tags) on a web page where an ad
+   can be displayed. Ad slots constitute [inventory](#inventory).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/inventory.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/inventory.md
@@ -1,0 +1,4 @@
+## Inventory {: #inventory}
+
+The ad slots available on a site. Ad slots are the HTML markup (usually `<div>`
+tags) where ads can be displayed.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/k-anonymity.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/k-anonymity.md
@@ -1,0 +1,5 @@
+## k-anonymity
+
+A measure of anonymity within a data set. If you have _k_ anonymity, you can't
+be distinguished from _k-1_ other individuals in the data set. In other words,
+_k_ individuals have the same information (including you).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/nonce.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/nonce.md
@@ -1,0 +1,3 @@
+## Nonce 
+
+Arbitrary number used once only in cryptographic communication.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/origin-trial.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/origin-trial.md
@@ -1,0 +1,14 @@
+## Origin trial {: #origin-trial}
+
+Trials provide access to a new or experimental feature, to make it possible to
+build functions that users can try out for a limited time before the feature is made available to everyone.
+
+When Chrome offers an origin trial for a feature, an [origin](#origin) can be
+registered for the trial to allow the feature for all users on that origin,
+without requiring users to toggle flags or switch to an alternative build of
+Chrome (though they may need to upgrade). Origin trials allow developers to
+build demos and prototypes using new features. The trials help Chrome engineers
+understand how new features are used, and how they may interact with other web technologies.
+
+Find out more: 
+[Getting started with Chrome's origin trials](https://web.dev/origin-trials/).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/origin.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/origin.md
@@ -1,0 +1,5 @@
+## Origin 
+
+Defined by the scheme (protocol), hostname (domain), and port of the URL used to access it.
+
+For example: `https://developer.chrome.com`

--- a/site/en/_partials/privacy-sandbox/glossary-entries/passive-surface.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/passive-surface.md
@@ -1,0 +1,12 @@
+## Passive surface {: #passive-surface }
+
+Some [fingerprinting surfaces](#fingerprinting-surface)&mdash;such as 
+User-Agent strings, IP addresses, and Accept-Language headers&mdash;that are
+available to every website, whether the site asks for them or not.
+
+Passive surfaces can easily consume a site's privacy budget.
+
+The Privacy Sandbox initiative proposes replacing passive surfaces with active
+ways to get specific information, for example using Client Hints a single time
+to get the user's language rather than having an Accept-Language header for
+every response to every server.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/publisher.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/publisher.md
@@ -1,0 +1,4 @@
+## Publisher
+
+In the Privacy Sandbox context, a site with ad space that is paid to display
+ads.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/reach.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/reach.md
@@ -1,0 +1,4 @@
+## Reach
+
+The total number of people who see an ad or who visit a web page that displays
+the ad.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/real-time-bidding.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/real-time-bidding.md
@@ -1,0 +1,4 @@
+## Real-time bidding (RTB) {: #rtb}
+
+An automated auction for buying and selling ad impressions on websites,
+completed during page load.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/remarketing.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/remarketing.md
@@ -1,0 +1,6 @@
+## Remarketing
+
+Advertising to people who've already visited your site on other sites.
+
+For example, an online store could show ads for a toy sale to people who
+previously viewed toys on their site.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/reporting-origin.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/reporting-origin.md
@@ -1,0 +1,6 @@
+## Reporting origin
+
+The entity that receives aggregatable reports&mdash;in other words, the adtech
+that called the Attribution Reporting API. Aggregatable reports are sent from
+user devices to a [well-known](#well-known) URL associated with the reporting
+origin.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/seller.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/seller.md
@@ -1,0 +1,4 @@
+## Seller
+
+The party running an ad auction, likely to be an [SSP](#ssp) or maybe the
+publisher itself.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/site.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/site.md
@@ -1,0 +1,3 @@
+## Site
+
+See [Top-Level Domain](#tld) and [eTLD](#etld).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/summary-report.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/summary-report.md
@@ -1,0 +1,9 @@
+## Summary report {: #aggregate-report}
+
+An Attribution Reporting API and Private Aggregation API report type. A [summary
+report](/docs/privacy-sandbox/attribution-reporting/summary-reports/) includes
+aggregated user data and detailed conversion data, resulting from noisy
+aggregation applied to aggregatable reports. The summary
+includes aggregated user data and detailed conversion data.
+
+Summary reports were formerly known as aggregate reports.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/supply-side-platform.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/supply-side-platform.md
@@ -1,0 +1,6 @@
+## Supply-side platform, Sell-side platform {: #ssp}
+
+An adtech service used to automate selling ad inventory. SSPs allow publishers
+to offer their inventory (empty rectangles where ads will go) to multiple ad
+exchanges, [DSPs](#DSP), and networks. This enables a wide range of potential
+buyers to bid for ad space.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/surface.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/surface.md
@@ -1,0 +1,4 @@
+## Surface
+
+See [Fingerprinting surface](#fingerprinting-surface) and
+[Passive surface](#passive-surface).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/third-party-cookie.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/third-party-cookie.md
@@ -1,0 +1,9 @@
+## Third-party cookie {: #third-party-cookie}
+
+[Cookie](#cookie) stored by a third-party service.
+
+For example, a video website might include a **Watch Later** button in their
+embedded player to allow a user to add a video to their wishlist without
+forcing them to navigate to the video site.
+
+See also [First-party cookie](#first-party-cookie).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/third-party.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/third-party.md
@@ -1,0 +1,9 @@
+## Third-party {: #third-party }
+
+Resources served from a domain that's different from the website you're
+visiting.
+
+For example, a website `foo.com` might use analytics code from
+`google-analytics.com` (via JavaScript), fonts from
+`use.typekit.net` (via a link element) and a video from `vimeo.com` (in an
+iframe). See also [First-party](#first-party).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/top-level-domain.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/top-level-domain.md
@@ -1,0 +1,7 @@
+## Top-level domain (TLD) {: #tld }
+
+Top-level domains such as .com and .org are listed in the
+[Root Zone Database](https://www.iana.org/domains/root/db).
+
+Note that some 'sites' are actually just subdomains. For example,
+`translate.google.com` and `maps.google.com` are subdomains of `google.com`. These subdomains are [eTLD + 1](#etld).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/trusted-execution-environment.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/trusted-execution-environment.md
@@ -1,0 +1,11 @@
+## Trusted Execution Environment (TEE) {: #tee }
+
+A special configuration of computer hardware and software that allows external
+parties to verify the exact versions of software running on the computer. TEEs
+allow external parties to verify that the software does exactly what the
+software manufacturer claims it does—nothing more or less.
+
+To learn more about TEEs used for the Privacy Sandbox proposals, read the
+[FLEDGE services explainer](https://github.com/privacysandbox/fledge-docs/blob/main/trusted_services_overview.md#trusted-execution-environment)
+and the
+[Aggregation Service explainer](https://github.com/WICG/attribution-reporting-api/blob/main/AGGREGATION_SERVICE_TEE.md).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/user-agent-client-hints.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/user-agent-client-hints.md
@@ -1,0 +1,7 @@
+## User-Agent Client Hints (UA-CH) {: #ua-ch }
+
+Provide specific pieces of the User-Agent string on explicit request. This
+helps reduce [passive surfaces](#passive-surface) in the User-Agent string
+which may lead to user identification or covert tracking.
+
+UA-CH is sometimes referred to as "Client Hints."

--- a/site/en/_partials/privacy-sandbox/glossary-entries/user-agent-string.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/user-agent-string.md
@@ -1,0 +1,8 @@
+## User-Agent string {: #user-agent }
+
+An HTTP header used by servers and network peers to request indentifying
+information about an application, operating system, vendor, or version of a
+user agent. The User-Agent string broadcasts a large string of data, which is
+problematic for user privacy. [User-Agent
+reduction](/docs/privacy-sandbox/user-agent/) is proposed to remove sensitive
+information and reduce passive fingerprinting.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/well-known.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/well-known.md
@@ -1,0 +1,16 @@
+## .well-known {: #well-known }
+
+A file used to add redirects to a website from standardized URLs.
+
+For example, password managers can make it easier for users to update passwords
+if a website sets a redirect from `/.well-known/change-password` to the change
+password page of the site.
+
+In addition, it can be useful to access policy or other information about a
+host _before_ making a request. For example, `robots.txt` tells web crawlers
+which pages to visit and which pages to ignore. IETF
+[RFC8615](https://tools.ietf.org/html/rfc8615) outlines a standardized way
+to make site-wide metadata accessible in standard locations in a `/.well-known/` subdirectory.
+
+See a list of recommendations for `.well-known` at
+[iana.org/assignments/well-known-uris/well-known-uris.xhtml](https://www.iana.org/assignments/well-known-uris/well-known-uris.xhtml).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/worklet.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/worklet.md
@@ -1,0 +1,6 @@
+## Worklet
+
+A [worklet](https://developer.mozilla.org/docs/Web/API/Worklet) allows
+you to run specific JavaScript functions and return information back to the
+requester. Within a worklet, you can execute JavaScript but you cannot interact
+or communicate with the outside page.

--- a/site/en/docs/privacy-sandbox/glossary/index.md
+++ b/site/en/docs/privacy-sandbox/glossary/index.md
@@ -12,463 +12,134 @@ authors:
 ---
 
 
+
 {% Aside %}
 [Let us know](https://github.com/GoogleChrome/developer.chrome.com/issues/new?assignees=&labels=feature+request&template=feature_request.md&title=)
 if something is missing!
 {% endAside %}
 
-## Ad auction (FLEDGE)
+{% Partial 'privacy-sandbox/glossary-entries/ad-auction.njk' %}
 
-In FLEDGE, an ad auction is run by a seller (ikely to be an [SSP](#ssp) or maybe the publisher itself), in JavaScript code in the browser on the
-user's device, to sell ad space on a site that displays ads.
 
-{: #creative}
+{% Partial 'privacy-sandbox/glossary-entries/ad-creative.njk' %}
 
-## Ad creative, creative {: #ad-creative}
 
-The contents of the ad served to users. Creatives can be images, videos, audio,
-and other formats. Creatives live within an ad space, and are served by adtech
-within line items.
+{% Partial 'privacy-sandbox/glossary-entries/ad-exchange.njk' %}
 
-## Ad exchange
 
-A platform to automate buying and selling of ad inventory from multiple ad
-networks.
+{% Partial 'privacy-sandbox/glossary-entries/ad-inventory-space.njk' %}
 
-{: #ad-space }
 
-## Ad inventory, ad space {: #ad-inventory }
+{% Partial 'privacy-sandbox/glossary-entries/ad-platform.njk' %}
 
-The spaces for ads that are available from a site that sells ad space.
 
-## Ad platform (Adtech) {: #adtech }
+{% Partial 'privacy-sandbox/glossary-entries/advertiser.njk' %}
 
-A company that provides services to deliver ads.
 
-## Advertiser {: #advertiser }
+{% Partial 'privacy-sandbox/glossary-entries/aggregatable-reports.njk' %}
 
-A company that pays to advertise its products.
+{% Partial 'privacy-sandbox/glossary-entries/attestation.njk' %}
 
-## Aggregatable reports
+{% Partial 'privacy-sandbox/glossary-entries/attribution.njk' %}
 
-Encrypted reports sent from individual user devices. These reports contain
-data about cross-site user behavior and conversions. Conversions (sometimes
-called attribution trigger events) and associated metrics are defined by the
-advertiser or adtech. Each report is encrypted to prevent various parties
-from accessing the underlying data.
+{% Partial 'privacy-sandbox/glossary-entries/blink.njk' %}
 
-## Attestation
+{% Partial 'privacy-sandbox/glossary-entries/buyer.njk' %}
 
-A mechanism to authenticate software identity, usually with [cryptographic
-hashes](https://en.wikipedia.org/wiki/Cryptographic_hash_function) or
-signatures. For the aggregation service proposal, attestation matches the
-code running in the adtech-operated aggregation service with the open
-source code.
+{% Partial 'privacy-sandbox/glossary-entries/chromium.njk' %}
 
-## Attribution {: #attribution }
+{% Partial 'privacy-sandbox/glossary-entries/clickthrough-rate.njk' %}
 
-Identification of user actions that contribute to an outcome.
+{% Partial 'privacy-sandbox/glossary-entries/clickthrough-conversion.njk' %}
 
-For example, a correlation of ad clicks or views with [conversions](#conversion).
+{% Partial 'privacy-sandbox/glossary-entries/course-data.njk' %}
 
-## Blink {: #blink }
+{% Partial 'privacy-sandbox/glossary-entries/conversion.njk' %}
 
-The [rendering engine](https://en.wikipedia.org/wiki/Browser_engine) used by
-Chrome, developed as part of the [Chromium](#chromium) project.
+{% Partial 'privacy-sandbox/glossary-entries/cookie.njk' %}
 
-## Buyer
+{% Partial 'privacy-sandbox/glossary-entries/coordinator.njk' %}
 
-A party bidding for ad space in an [ad auction](#ad-auction), likely to be a
-[DSP](#DSP), or maybe the advertiser itself. Ad space buyers own and manage
-interest groups. 
+{% Partial 'privacy-sandbox/glossary-entries/data-management-platform.njk' %}
 
-Learn about [ad space buyers in FLEDGE](/docs/privacy-sandbox/fledge/#buyer-detail).
+{% Partial 'privacy-sandbox/glossary-entries/demand-side-platform.njk' %}
 
-## Chromium {: #chromium }
+{% Partial 'privacy-sandbox/glossary-entries/differential-privacy.njk' %}
 
-An open-source web browser project. Chrome, Microsoft Edge, Opera and other
-browsers are based on Chromium.
+{% Partial 'privacy-sandbox/glossary-entries/domain.njk' %}
 
-## Click-through rate (CTR) {: #ctr }
+{% Partial 'privacy-sandbox/glossary-entries/etld-etld1.njk' %}
 
-The ratio of users who click on an ad, having seen it.
+{% Partial 'privacy-sandbox/glossary-entries/entropy.njk' %}
 
-See also [impression](#impression).
+{% Partial 'privacy-sandbox/glossary-entries/federated-identity.njk' %}
 
-## Click-through-conversion (CTC) {: #ctc }
+{% Partial 'privacy-sandbox/glossary-entries/federated-credential-management.njk' %}
 
-A conversion attributed to an ad that was 'clicked'.
+{% Partial 'privacy-sandbox/glossary-entries/fenced-frame.njk' %}
 
-## Coarse data
+{% Partial 'privacy-sandbox/glossary-entries/fingerprinting.njk' %}
 
-Limited information provided by Attribution Reporting API event-level reports.
-This is limited to 3 pieces of conversion data for clicks and 1 piece for
-views. Specific, granular conversion data (such as specific prices of items
-and timestamps)  are not included.
+{% Partial 'privacy-sandbox/glossary-entries/fingerprinting-surface.njk' %}
 
-## Conversion
+{% Partial 'privacy-sandbox/glossary-entries/first-party.njk' %}
 
-The completion of some desired goal following action by a user.
+{% Partial 'privacy-sandbox/glossary-entries/first-party-cookie.njk' %}
 
-For example, a conversion may occur with the purchase of a product or sign-up
-for a newsletter after clicking an ad that links to the advertiser's site.
+{% Partial 'privacy-sandbox/glossary-entries/i2p.njk' %}
 
-## Cookie
+{% Partial 'privacy-sandbox/glossary-entries/i2e.njk' %}
 
-A small piece of textual data that websites can store on a user's browser.
-Cookies can be used by a website to save information associated with a user
-(or a reference to data stored on the website's backend servers) as the user
-moves across the web.
+{% Partial 'privacy-sandbox/glossary-entries/i2ee.njk' %}
 
-For example, an online store can retain shopping cart details even if a user is
-not logged in, or the site could record the user's browsing activity on their
-site. See [First-party cookie](#first-party-cookie) and
-[Third-party cookie](#third-party-cookie).
+{% Partial 'privacy-sandbox/glossary-entries/i2s.njk' %}
 
-## Coordinator
+{% Partial 'privacy-sandbox/glossary-entries/impression.njk' %}
 
-An entity responsible for key management and aggregatable report accounting. The coordinator maintains a list of hashes of approved aggregation service configurations and configures access to decryption keys.
+{% Partial 'privacy-sandbox/glossary-entries/inventory.njk' %}
 
-## Data management platform (DMP) {: #dmp }
+{% Partial 'privacy-sandbox/glossary-entries/k-anonymity.njk' %}
 
-A software used to collect and manage data relevant for advertisers. These
-platforms help advertisers and publishers identify audience segments, which can
-then be used for campaign targeting.
+{% Partial 'privacy-sandbox/glossary-entries/nonce.njk' %}
 
-Learn more about [DMPs](https://en.wikipedia.org/wiki/Data_management_platform).
+{% Partial 'privacy-sandbox/glossary-entries/origin.njk' %}
 
-## Demand-side platform (DSP) {: #dsp }
+{% Partial 'privacy-sandbox/glossary-entries/origin-trial.njk' %}
 
-An adtech service used to automate ad purchasing. DSPs are used by advertisers
-to buy [ad impressions](https://en.wikipedia.org/wiki/Impression_(online_media))
-across a range of publisher sites. Publishers put their
-[ad inventory](#ad-inventory) up for sale through marketplaces called ad
-exchanges, and DSPs decide programmatically which available ad impression makes
-most sense for an advertiser to buy.
+{% Partial 'privacy-sandbox/glossary-entries/passive-surface.njk' %}
 
-## Differential privacy {: #differential-privacy }
+{% Partial 'privacy-sandbox/glossary-entries/publisher.njk' %}
 
-Techniques to allow sharing of information about a dataset to reveal patterns
-of behaviour without revealing private information about individuals or whether
-they belong to the dataset.
+{% Partial 'privacy-sandbox/glossary-entries/reach.njk' %}
 
-## Domain
+{% Partial 'privacy-sandbox/glossary-entries/real-time-bidding.njk' %}
 
-See [Top-Level Domain](#tld) and [eTLD](#etld).
+{% Partial 'privacy-sandbox/glossary-entries/remarketing.njk' %}
 
-## eTLD, eTLD+1 {: #etld }
+{% Partial 'privacy-sandbox/glossary-entries/reporting-origin.njk' %}
 
-Stands for effective top-level domains (TLD), which are defined by the
-[Public Suffix List](https://publicsuffix.org/list/).
+{% Partial 'privacy-sandbox/glossary-entries/seller.njk' %}
 
-For example:
+{% Partial 'privacy-sandbox/glossary-entries/site.njk' %}
 
-```text
-co.uk 
-github.io 
-glitch.me
-``` 
+{% Partial 'privacy-sandbox/glossary-entries/summary-report.njk' %}
 
-Effective TLDs are what allow `foo.appspot.com` to be a different site from
-`bar.appspot.com`. The eTLD in this case is `appspot.com`, and the whole
-site name (`foo.appspot.com`, `bar.appspot.com`) is known as the eTLD+1.
+{% Partial 'privacy-sandbox/glossary-entries/supply-side-platform.njk' %}
 
-See also [Top-Level Domain](#tld).
+{% Partial 'privacy-sandbox/glossary-entries/surface.njk' %}
 
-## Entropy
+{% Partial 'privacy-sandbox/glossary-entries/third-party.njk' %}
 
-A measure of how much an item of data reveals individual identity.
+{% Partial 'privacy-sandbox/glossary-entries/third-party-cookie.njk' %}
 
-Data entropy is measured in bits. The more that data reveals identity, the higher its entropy value.
+{% Partial 'privacy-sandbox/glossary-entries/top-level-domain.njk' %}
 
-Data can be combined to identify an individual, but it can be difficult to work
-out whether new data adds to entropy. For example, knowing a person is from
-Australia doesn't reduce entropy if you already know the person is from
-Kangaroo Island.
+{% Partial 'privacy-sandbox/glossary-entries/trusted-execution-environment.njk' %}
 
-## Federated identity (federated login) {: #federated-identity }
+{% Partial 'privacy-sandbox/glossary-entries/user-agent-string.njk' %}
 
-A third-party platform to allow a user to sign in to a website, without
-requiring the site to implement their own identity service.
+{% Partial 'privacy-sandbox/glossary-entries/user-agent-client-hints.njk' %}
 
-## Federated Credential Management API (FedCM) {: #fedcm }
+{% Partial 'privacy-sandbox/glossary-entries/well-known.njk' %}
 
-Federated Credential Management API is a proposal for a privacy-preserving
-approach to federated identity services. This will allow users to log into
-sites without sharing their personal information with the identity service or
-the site.
-
-FedCM was previously known as WebID, and is still
-[in development in the W3C](https://github.com/wicg/fedcm).
-
-## Fenced frame
-
-A (`<fencedframe>`) is a proposed HTML element for embedded content, similar to
-an [iframe](https://developer.mozilla.org/docs/Web/HTML/Element/iframe). Unlike
-iframes, a fenced frame restricts communication with its embedding context to
-allow the frame access to cross-site data without sharing it with the embedding
-context.
-
-Some Privacy Sandbox APIs may require select documents to render within a
-fenced frame. Learn more about the
-[Fenced Frames proposal](/docs/privacy-sandbox/fenced-frame/).
-
-## Fingerprinting {: #fingerprinting }
-
-Techniques to identify and track the behaviour of individual users.
-
-Fingerprinting uses mechanisms that users aren't aware of and can't control. 
-Sites such as [Panopticlick](https://panopticlick.eff.org) and
-[amiunique.org](https://amiunique.org/) show how fingerprint data can be
-combined to identify you as an individual.
-
-## Fingerprinting surface {: #fingerprinting-surface }
-
-Something that can be used (probably in combination with other surfaces) to
-identify a particular user or device.
-
-For example, the `navigator.userAgent()` JavaScript method and the `User-Agent`
-HTTP request header provide access to a fingerprinting surface (the User-Agent
-string).
-
-## First-party {: #first-party }
-
-Resources from the site you're visiting.
-
-For example, the page you're reading is on the site `developer.chrome.com` and
-includes resources requested from this site. Requests for those first-party
-resources are called 'first-party requests'. [Cookies](#cookie) from
-`developer.chrome.com` stored while you're on this site are called
-[first-party cookies](#first-party-cookie).
-
-See also [Third-party](#third-party).
-
-## First-party cookie {: #first-party-cookie } 
-
-[Cookie](#cookie) stored by a website while a user is on the site itself.
-
-For example, an online store might ask a browser to store a cookie in order to
-retain shopping cart details for a user who is not logged in. See also
-[Third-party cookies](#third-party-cookie). 
-
-## I2P {: #i2p }
-
-Intent to Prototype. The first stage in
-[developing a new feature](/blog/progress-in-the-privacy-sandbox-2021-12/#chromium-development-process)
-in [Blink](#blink). The announcement is posted to the [blink-dev mailing
-list](https://groups.google.com/a/chromium.org/g/blink-dev) with a link to the
-proposal for discussion.
-
-## I2E {: #i2e }
-
-Intent to Experiment. Announcement of a plan to make a new [Blink](#blink)
-feature available to users for testing, typically through an [origin
-trial](#origin-trial).
-
-## I2EE {: #i2ee }
-
-Intent to Extend Experiment. Announcement of a plan to extend the duration of an
-[origin trial](#origin-trial).
-
-## I2S {: #i2s }
-
-Intent to Ship. Announcement of a plan to make a new feature of [Blink](#blink)
-available to users in stable versions of Chrome.
-
-## Impression {: #impression }
-
-Could refer to either:
-
-*  View of an ad. See also [click-through rate](#ctr).
-*  An ad slot: the HTML markup (usually `<div>` tags) on a web page where an ad
-   can be displayed. Ad slots constitute [inventory](#inventory).
-
-## Inventory {: #inventory}
-
-The ad slots available on a site. Ad slots are the HTML markup (usually `<div>`
-tags) where ads can be displayed.
-
-## k-anonymity
-
-A measure of anonymity within a data set. If you have _k_ anonymity, you can't
-be distinguished from _k-1_ other individuals in the data set. In other words,
-_k_ individuals have the same information (including you).
-
-## Nonce 
-
-Arbitrary number used once only in cryptographic communication.
-
-## Origin 
-
-Defined by the scheme (protocol), hostname (domain), and port of the URL used to access it.
-
-For example: `https://developer.chrome.com`
-
-## Origin trial {: #origin-trial}
-
-Trials provide access to a new or experimental feature, to make it possible to
-build functions that users can try out for a limited time before the feature is made available to everyone.
-
-When Chrome offers an origin trial for a feature, an [origin](#origin) can be
-registered for the trial to allow the feature for all users on that origin,
-without requiring users to toggle flags or switch to an alternative build of
-Chrome (though they may need to upgrade). Origin trials allow developers to
-build demos and prototypes using new features. The trials help Chrome engineers
-understand how new features are used, and how they may interact with other web technologies.
-
-Find out more: 
-[Getting started with Chrome's origin trials](https://web.dev/origin-trials/).
-
-## Passive surface {: #passive-surface }
-
-Some [fingerprinting surfaces](#fingerprinting-surface)&mdash;such as 
-User-Agent strings, IP addresses, and Accept-Language headers&mdash;that are
-available to every website, whether the site asks for them or not.
-
-Passive surfaces can easily consume a site's privacy budget.
-
-The Privacy Sandbox initiative proposes replacing passive surfaces with active
-ways to get specific information, for example using Client Hints a single time
-to get the user's language rather than having an Accept-Language header for
-every response to every server.
-
-## Publisher
-
-In the Privacy Sandbox context, a site with ad space that is paid to display
-ads.
-
-## Reach
-
-The total number of people who see an ad or who visit a web page that displays
-the ad.
-
-## Real-time bidding (RTB) {: #rtb}
-
-An automated auction for buying and selling ad impressions on websites,
-completed during page load.
-
-## Remarketing
-
-Advertising to people who've already visited your site on other sites.
-
-For example, an online store could show ads for a toy sale to people who
-previously viewed toys on their site.
-
-## Reporting origin
-
-The entity that receives aggregatable reports&mdash;in other words, the adtech
-that called the Attribution Reporting API. Aggregatable reports are sent from
-user devices to a [well-known](#well-known) URL associated with the reporting
-origin.
-
-## Seller
-
-The party running an ad auction, likely to be an [SSP](#ssp) or maybe the
-publisher itself.
-
-## Site
-
-See [Top-Level Domain](#tld) and [eTLD](#etld).
-
-## Summary report {: #aggregate-report}
-
-An Attribution Reporting API and Private Aggregation API report type. A [summary
-report](/docs/privacy-sandbox/attribution-reporting/summary-reports/) includes
-aggregated user data and detailed conversion data, resulting from noisy
-aggregation applied to aggregatable reports. The summary
-includes aggregated user data and detailed conversion data.
-
-Summary reports were formerly known as aggregate reports.
-
-## Supply-side platform, Sell-side platform {: #ssp}
-
-An adtech service used to automate selling ad inventory. SSPs allow publishers
-to offer their inventory (empty rectangles where ads will go) to multiple ad
-exchanges, [DSPs](#DSP), and networks. This enables a wide range of potential
-buyers to bid for ad space.
-
-## Surface
-
-See [Fingerprinting surface](#fingerprinting-surface) and
-[Passive surface](#passive-surface).
-
-## Third-party {: #third-party }
-
-Resources served from a domain that's different from the website you're
-visiting.
-
-For example, a website `foo.com` might use analytics code from
-`google-analytics.com` (via JavaScript), fonts from
-`use.typekit.net` (via a link element) and a video from `vimeo.com` (in an
-iframe). See also [First-party](#first-party).
-
-## Third-party cookie {: #third-party-cookie}
-
-[Cookie](#cookie) stored by a third-party service.
-
-For example, a video website might include a **Watch Later** button in their
-embedded player to allow a user to add a video to their wishlist without
-forcing them to navigate to the video site.
-
-See also [First-party cookie](#first-party-cookie).
-
-## Top-level domain (TLD) {: #tld }
-
-Top-level domains such as .com and .org are listed in the
-[Root Zone Database](https://www.iana.org/domains/root/db).
-
-Note that some 'sites' are actually just subdomains. For example,
-`translate.google.com` and `maps.google.com` are subdomains of `google.com`. These subdomains are [eTLD + 1](#etld).
-
-## Trusted Execution Environment (TEE) {: #tee }
-
-A special configuration of computer hardware and software that allows external
-parties to verify the exact versions of software running on the computer. TEEs
-allow external parties to verify that the software does exactly what the
-software manufacturer claims it does—nothing more or less.
-
-To learn more about TEEs used for the Privacy Sandbox proposals, read the
-[FLEDGE services explainer](https://github.com/privacysandbox/fledge-docs/blob/main/trusted_services_overview.md#trusted-execution-environment)
-and the
-[Aggregation Service explainer](https://github.com/WICG/attribution-reporting-api/blob/main/AGGREGATION_SERVICE_TEE.md).
-
-## User-Agent string {: #user-agent }
-
-An HTTP header used by servers and network peers to request indentifying
-information about an application, operating system, vendor, or version of a
-user agent. The User-Agent string broadcasts a large string of data, which is
-problematic for user privacy. [User-Agent
-reduction](/docs/privacy-sandbox/user-agent/) is proposed to remove sensitive
-information and reduce passive fingerprinting.
-
-## User-Agent Client Hints (UA-CH) {: #ua-ch }
-
-Provide specific pieces of the User-Agent string on explicit request. This
-helps reduce [passive surfaces](#passive-surface) in the User-Agent string
-which may lead to user identification or covert tracking.
-
-UA-CH is sometimes referred to as "Client Hints."
-
-## .well-known {: #well-known }
-
-A file used to add redirects to a website from standardized URLs.
-
-For example, password managers can make it easier for users to update passwords
-if a website sets a redirect from `/.well-known/change-password` to the change
-password page of the site.
-
-In addition, it can be useful to access policy or other information about a
-host _before_ making a request. For example, `robots.txt` tells web crawlers
-which pages to visit and which pages to ignore. IETF
-[RFC8615](https://tools.ietf.org/html/rfc8615) outlines a standardized way
-to make site-wide metadata accessible in standard locations in a `/.well-known/` subdirectory.
-
-See a list of recommendations for `.well-known` at
-[iana.org/assignments/well-known-uris/well-known-uris.xhtml](https://www.iana.org/assignments/well-known-uris/well-known-uris.xhtml).
-
-## Worklet
-
-A [worklet](https://developer.mozilla.org/docs/Web/API/Worklet) allows
-you to run specific JavaScript functions and return information back to the
-requester. Within a worklet, you can execute JavaScript but you cannot interact
-or communicate with the outside page.
+{% Partial 'privacy-sandbox/glossary-entries/worklet.njk' %}


### PR DESCRIPTION
Fixes b/265335974

Take glossary entries out of main glossary index page, put each into its own partial, and add only partials refs to the glossary index.md

staging: https://pr-5226-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/glossary/
live page: https://developer.chrome.com/docs/privacy-sandbox/glossary/