### PR TITLE
Update "Hardware APIs" capabilities section

### DIFF
--- a/site/_includes/macros/landing-deco.njk
+++ b/site/_includes/macros/landing-deco.njk
@@ -2,7 +2,8 @@
   <div class="landing-deco pad-300 md:pad-500 masonry:pad-500 width-full bg-{{color}}-lightest">
     <div class="landing-deco__inner">
       <div>
-        <h2 class="type--h3 color-{{color}}-darkest">
+        {% set titleSlug = title | slugify %}
+        <h2 id="{{ titleSlug }}" class="type--h3 color-{{color}}-darkest">
           {% if smallImgSrc %}
           <span class="sm-only landing-deco__icon">{% Img
             src=smallImgSrc,
@@ -12,6 +13,7 @@
           %}</span>
           {% endif %}
           <span>
+            <a class="heading-link" href="#{{ titleSlug }}">#</a>
             {{ title | md | safe }}
           </span>
         </h2>

--- a/site/en/capabilities/index.njk
+++ b/site/en/capabilities/index.njk
@@ -47,6 +47,9 @@ sections:
       title: Integrate with the OS sharing UI with the Web Share API
       description: Web apps can use the same system-provided share capabilities as platform-specific apps.
   hardware:
+    - url: https://web.dev/devices-introduction/
+      title: Accessing hardware devices on the web
+      description: Pick the appropriate API to communicate with a hardware device of your choice.
     - url: https://developer.chrome.com/articles/hid/
       title: Connecting to uncommon HID devices
       description: The WebHID API allows websites to access alternative auxiliary keyboards and exotic gamepads.
@@ -59,6 +62,12 @@ sections:
     - url: https://developer.chrome.com/articles/usb/
       title: Access USB Devices on the Web
       description: The WebUSB API makes USB safer and easier to use by bringing it to the Web.
+    - url: https://developer.chrome.com/articles/build-for-webusb/
+      title: Building a device for WebUSB
+      description: Build a device to take full advantage of the WebUSB API.
+    - url: https://developer.chrome.com/articles/nfc/
+      title: Interact with NFC devices on Chrome for Android
+      description: Reading and writing to NFC tags is now possible.
     - url: https://web.dev/gamepad/
       title: Play the Chrome dino game with your gamepad
       description: Learn how to use the Gamepad API to push your web games to the next level.
@@ -146,9 +155,9 @@ sections:
   'Learn about the hardware APIs we work on in the context of Project Fugu that allow you to access physical devices from the web.',
   sections.hardware,
   'yellow',
-  'left',
+  'top-3',
   true,
-  'image/8WbTDNrhLsU0El80frMBGE4eMCD3/AZza6zt6XdpzWKySovAb.jpg',
+  'image/vvhSqZboQoZZN9wBvoXq72wzGAf1/qYR7nkwL7cWGOnFb1mPG.jpg',
   'Arduino board and many electronic components.',
   400,
   600,


### PR DESCRIPTION
Here are the changes to the "Hardware APIs" capabilities section:
- Add NFC and Build for WebUSB dcc articles [recently migrated](https://github.com/GoogleChrome/developer.chrome.com/pull/5217)
- Insert "Accessing hardware devices on the web" introduction web.dev article
- Update layout
- Rotate hero image

I also took the liberty to add anchors so that we can link directly to the "Hardware APIs" capabilities section