### PR TITLE
[Fugu API Showcase] Add Electron.js label

### DIFF
--- a/site/_data/i18n/common.yml
+++ b/site/_data/i18n/common.yml
@@ -200,6 +200,9 @@ featured:
 launch_app:
   en: 'Launch app'
 
+download_app:
+  en: 'Download app'
+
 view_source:
   en: 'View source'
 

--- a/site/_includes/partials/showcase-card.njk
+++ b/site/_includes/partials/showcase-card.njk
@@ -29,7 +29,11 @@
     {% if item.appURL %}
       <a class="display-flex align-center color-primary type--small" href="{{ item.appURL }}" rel="noopener" target="_blank">
         {{ icon('external-link') }}
-        {{ 'i18n.common.launch_app' | i18n(locale) }}
+        {% if item.isElectronApp %}
+          {{ 'i18n.common.download_app' | i18n(locale) }}
+        {% else %}
+          {{ 'i18n.common.launch_app' | i18n(locale) }}
+        {% endif %}
       </a>
     {% endif %}
     {% if item.isElectronApp %}

--- a/site/_includes/partials/showcase-card.njk
+++ b/site/_includes/partials/showcase-card.njk
@@ -32,6 +32,9 @@
         {{ 'i18n.common.launch_app' | i18n(locale) }}
       </a>
     {% endif %}
+    {% if item.isElectronApp %}
+      <span class="type--xsmall">(Electron.js)</span>
+    {% endif %}
     {% if item.sourceURL %}
       <a class="display-flex align-center color-primary type--small" href="{{ item.sourceURL }}" rel="noopener" target="_blank">
         {{ icon('code') }}

--- a/site/_scss/blocks/_fugu-showcase.scss
+++ b/site/_scss/blocks/_fugu-showcase.scss
@@ -42,9 +42,9 @@
   }
 
   .blog-card__actions {
+    align-items: center;
     border-bottom: 1px solid var(--color-hairline);
     justify-content: space-between;
-    align-items: center;
     width: 100%;
 
     a {

--- a/site/_scss/blocks/_fugu-showcase.scss
+++ b/site/_scss/blocks/_fugu-showcase.scss
@@ -37,7 +37,6 @@
     color: var(--color-primary);
   }
 
-
   .blog-grid {
     justify-content: space-evenly;
   }
@@ -45,6 +44,7 @@
   .blog-card__actions {
     border-bottom: 1px solid var(--color-hairline);
     justify-content: space-between;
+    align-items: center;
     width: 100%;
 
     a {


### PR DESCRIPTION
Changes proposed in this pull request:

- Add Electron.js label 

<img width="407" alt="Screenshot 2023-02-10 at 16 48 12" src="https://user-images.githubusercontent.com/145676/218135401-a3bf8940-d8c6-42a0-b813-a306471f5dd7.png">
