### PR TITLE
Improve documentation on offscreen document lifetime enforcement.

### DIFF
--- a/site/en/docs/extensions/reference/offscreen/index.md
+++ b/site/en/docs/extensions/reference/offscreen/index.md
@@ -23,7 +23,12 @@ Pages loaded as offscreen documents are handled differently from other types of 
 * An extension can only have one offscreen document open at a time. If the extension is running in split mode with an active incognito profile, both the normal and incognito profiles can each have one offscreen document. 
 
 ## Reasons
-Reasons, listed [below](/docs/extensions/reference/offscreen/#type-Reason), are set upon document creation to determine the document's lifespan. Currently, the `AUDIO_PLAYBACK` reason has specialized lifetime enforcement [`CreateAudioLifetimeEnforcer`][audio-lifetime-enforcer]. All others use generic idle detection [`CreateEmptyEnforcer`][empty-enforcer].
+Reasons, listed [below](/docs/extensions/reference/offscreen/#type-Reason), are set upon document creation to determine the document's lifespan.
+
+| Reason            | Offscreen Document Lifetime                    |
+|-------------------|------------------------------------------------|
+| AUDIO_PLAYBACK    | Closed after 30 seconds without audio playing. |
+| All other reasons | Not currently limited                          |
 
 ## Examples
 The following methods create and close an offscreen document. Only a single Document can be open at a time. 
@@ -37,6 +42,3 @@ chrome.offscreen.createDocument({
 
 chrome.offscreen.closeDocument()
 ```
-
-[audio-lifetime-enforcer]: https://source.chromium.org/chromium/chromium/src/+/main:extensions/browser/api/offscreen/audio_lifetime_enforcer.h
-[empty-enforcer]: https://source.chromium.org/chromium/chromium/src/+/main:extensions/browser/api/offscreen/lifetime_enforcer_factories.cc


### PR DESCRIPTION
Explicitly document the lifetime enforcement for an offscreen document based on the specified reason.

Fixes #5019
Fixes #5095