### PR TITLE
Update soft navs doc for new flag

### DIFF
--- a/site/en/blog/soft-navigations-experiment/index.md
+++ b/site/en/blog/soft-navigations-experiment/index.md
@@ -8,7 +8,7 @@ authors:
  - tunetheweb
  - yoavweiss
 date: 2023-02-01
-#updated: 2023-02-01
+updated: 2023-02-11
 hero: image/W3z1f5ZkBJSgL1V1IfloTIctbIF3/ZJLD5QJvoFcWXkqF8m5P.jpg
 alt: A compass on top of some booklets labeled Field Notes
 tags:
@@ -70,7 +70,17 @@ Site owners can choose to include the origin trial on their pages for all, or fo
 
 ## How can I measure Core Web Vitals per soft navigation?
 
-Some considerations need to be taken into account when attempting to measure Core Web Vitals for soft navigations.
+To includes soft navigations you need to include `includeSoftNavigationObservations: true` in your performance observer's `observe` call:
+
+```js
+new PerformanceObserver((entryList) => {
+  for (const entry of entryList.getEntries()) {
+    console.log('LCP candidate:', entry.startTime, entry);
+  }
+}).observe({type: 'largest-contentful-paint', buffered: true, includeSoftNavigationObservations: true});
+```
+
+This extra flag on the `observe` method is needed in addition to [enabling the soft navigation functionality in Chrome](#how-do-i-enable-soft-navigations-in-chrome). This explicit opt-in at the performance observer level is to [ensure existing performance observers aren't surprised by these extra entries](https://github.com/WICG/soft-navigations/issues/11) as some considerations need to be taken into account when attempting to measure Core Web Vitals for soft navigations.
 
 Some metrics have traditionally been measured throughout the life of the page: LCP, for example, can change until an interaction occurs. CLS, FID and INP can be updated until the page is navigated away from. Therefore each “navigation” (including the original navigation) will need to finalize these metrics as each new soft navigation occurs.
 
@@ -90,7 +100,7 @@ You can use a `PerformanceObserver` to observe soft navigations. Below is an exa
 
 ```js
 const observer = new PerformanceObserver(console.log);
-observer.observe({ type: "soft-navigation", buffered: true });
+observer.observe({ type: "soft-navigation", buffered: true, includeSoftNavigationObservations: true });
 ```
 
 This can be used to finalize full-life page metrics for the previous navigation.


### PR DESCRIPTION
There's a [new flag needed on performance observers](https://github.com/WICG/soft-navigations/issues/11#issuecomment-1423909430), and looks like it's landed in Canary already as got a compliant it's not working anymore.

So updating doc to include that.

FYI @yoavweiss 