### PR TITLE
FIX content property in the blog chrome 110

### DIFF
--- a/site/en/blog/new-in-chrome-110/index.md
+++ b/site/en/blog/new-in-chrome-110/index.md
@@ -38,7 +38,7 @@ The snippet below shows how to use the picture-in-picture class to add a message
 #video-container:has(video:picture-in-picture)::before {
   bottom: 36px;
   color: #ddd;
-  content: 'Video is now playing in a Picture-in-Picture window';
+  content: '';
   position: absolute;
   right: 36px;
 }


### PR DESCRIPTION
I guess it's not the best way to put the text in the content property. Because you can't read them with the screen reader. I understand that you use it for educational purposes but I guess it can be improved without that anti-pattern