### PR TITLE
Fix `enhanced-select` on iOS and improve styling

### DIFF
--- a/site/_js/web-components/enhanced-select.js
+++ b/site/_js/web-components/enhanced-select.js
@@ -35,8 +35,12 @@ export class EnhancedSelect extends BaseElement {
   constructor() {
     super();
 
-    // @ts-ignore
-    this.internals = this.attachInternals();
+    try {
+      // @ts-ignore
+      this.internals = this.attachInternals();
+    } catch (e) {
+      console.warn('ElementInternals not supported');
+    }
 
     this.handleLabelClick = this.handleLabelClick.bind(this);
     this.handleLabelKeydown = this.handleLabelKeydown.bind(this);
@@ -123,7 +127,12 @@ export class EnhancedSelect extends BaseElement {
 
     value.forEach(value => data.append(this.name, value));
 
-    this.internals.setFormValue(data);
+    // ElementInternals are not yet supported in Safari, but would
+    // also only be used in a <form> context, where we currently
+    // don't use it.
+    if (this.internals) {
+      this.internals.setFormValue(data);
+    }
 
     this.dispatchEvent(new Event('change', {bubbles: true, cancelable: true}));
   }

--- a/site/_scss/blocks/_enhanced-select.scss
+++ b/site/_scss/blocks/_enhanced-select.scss
@@ -45,8 +45,8 @@
       font-family: 'Google Sans', sans-serif;
       font-size: 0.875rem;
       font-weight: 500;
-      line-height: 3rem;
-      padding: 0 2.75rem;
+      line-height: 1.2rem;
+      padding: 1rem 2.75rem;
       text-align: left;
     }
 

--- a/site/_scss/blocks/_enhanced-select.scss
+++ b/site/_scss/blocks/_enhanced-select.scss
@@ -93,9 +93,13 @@
 
 enhanced-select {
   align-items: center;
-  display: inline-flex;
+  display: none;
   height: 2.5rem;
   position: relative;
+
+  &:defined {
+    display: inline-flex;
+  }
 
   select {
     max-height: 100%;


### PR DESCRIPTION
Fixes #5186 and fixes #5236.

Technically there is a [polyfill](https://www.npmjs.com/package/element-internals-polyfill) for `ElementInternals` but I think it's not really worth it bringing it in, since we are not using the element in form contexts.