### PR TITLE
Add approvals config for spanish translations

### DIFF
--- a/.github/chrome-devrel-bot.json
+++ b/.github/chrome-devrel-bot.json
@@ -17,7 +17,8 @@
           "amysteam"
         ],
         "paths" : [
-          "site/**/*.md"
+          "site/**/*.md",
+          "!site/es/**/*.md"
         ]
       },
       {
@@ -61,6 +62,16 @@
           "site/_data/**.yaml",
           "site/_data/**.json",
           "redirects.yaml"
+        ]
+      },
+      {
+        "check_name" : "Content (es) team approval",
+        "teams" : [],
+        "users" : [
+          "tropicadri"
+        ],
+        "paths" : [
+          "site/es/**/*.md"
         ]
       }
     ]


### PR DESCRIPTION
This alters the approvals config to not require an approval from the content team for any markdown document published in the `es` language folder, but instead requires one from @tropicadri.