### PR TITLE
Add developer mailing list for Shared Storage

### DIFF
--- a/site/en/_partials/privacy-sandbox/shared-storage-engage.md
+++ b/site/en/_partials/privacy-sandbox/shared-storage-engage.md
@@ -4,6 +4,7 @@ The Shared Storage proposal is under active discussion and subject to change
 in the future. If you try this API and have feedback, we'd love to hear it.
 
 -  **GitHub**: Read the
-   [proposal](https://github.com/pythagoraskitty/shared-storage), [raise questions and participate in discussion](https://github.com/pythagoraskitty/shared-storage/issues).
+   [proposal](https://github.com/WICG/shared-storage), [raise questions and participate in discussion](https://github.com/WICG/shared-storage/issues).
+-  **Shared Storage API announcements**: Join or view the mailing list at: https://groups.google.com/a/chromium.org/g/shared-storage-api-announcements
 -  **Developer support**: Ask questions and join discussions on the
    [Privacy Sandbox Developer Support repo](https://github.com/GoogleChromeLabs/privacy-sandbox-dev-support).

--- a/site/en/_partials/privacy-sandbox/shared-storage-engage.md
+++ b/site/en/_partials/privacy-sandbox/shared-storage-engage.md
@@ -5,6 +5,6 @@ in the future. If you try this API and have feedback, we'd love to hear it.
 
 -  **GitHub**: Read the
    [proposal](https://github.com/WICG/shared-storage), [raise questions and participate in discussion](https://github.com/WICG/shared-storage/issues).
--  **Shared Storage API announcements**: Join or view the mailing list at: https://groups.google.com/a/chromium.org/g/shared-storage-api-announcements
+-  **Shared Storage API announcements**: Join or view past announcements on our [mailing list](https://groups.google.com/a/chromium.org/g/shared-storage-api-announcements)
 -  **Developer support**: Ask questions and join discussions on the
    [Privacy Sandbox Developer Support repo](https://github.com/GoogleChromeLabs/privacy-sandbox-dev-support).


### PR DESCRIPTION
Changes:
- Add link to the developer mailing list for Shared Storage
- Update proposal repository link to WICG/shared-storage