### PR TITLE
Fix "Launch a partial Custom Tab via startActivityForResult" sample code

### DIFF
--- a/site/en/docs/android/custom-tabs/integration-guide/index.md
+++ b/site/en/docs/android/custom-tabs/integration-guide/index.md
@@ -124,7 +124,8 @@ public void onCreate(@Nullable Bundle savedInstanceState) {
     selectButton.setOnClickListener(new OnClickListener() {
         @Override
         public void onClick(View view) {
-            mCustomTabLauncher.launch(customTabsIntent.intent);
+            String url = "https://google.com/";
+            mCustomTabLauncher.launch(url);
         }
     });
 }


### PR DESCRIPTION
Changes proposed in this pull request:

- https://developer.chrome.com/docs/android/custom-tabs/integration-guide/#launch-a-partial-custom-tab-via-startactivityforresult this sample code for CustomTab was not working properly, so I fix it.