### PR TITLE
fix: Safari 15.3 layout issue

### DIFF
--- a/site/_includes/layouts/blog-post.njk
+++ b/site/_includes/layouts/blog-post.njk
@@ -13,7 +13,7 @@
   {% if hero %}
     <div class="display-flex justify-content-center lg:pad-left-400 lg:pad-right-400">
       {% Img
-        class="hero-image object-fit-cover",
+        class="hero-image object-fit-cover height-full",
         src=hero,
         alt=alt,
         width="960",


### PR DESCRIPTION
Fixes #2598

Changes proposed in this pull request:

- Adds height: 100% to the offending img element, tested and working in Safari 15.3
- Tested and working in various other browsers