### PR TITLE
Correct typos in snippet

### DIFF
--- a/site/en/blog/soft-navigations-experiment/index.md
+++ b/site/en/blog/soft-navigations-experiment/index.md
@@ -113,7 +113,7 @@ The `navigationID` attribute of the appropriate `PerformanceEntry` can be used t
 
 ```js
 pageUrl =
-  performance.getEntriesByType('soft-navigation')[navigationId - 2]?.name
+  performance.getEntriesByType('soft-navigation')['navigationId' - 2]?.name
   || performance.getEntriesByType('navigation')[0]?.name
 ```
 
@@ -131,7 +131,7 @@ The navigation start time can be obtained in a similar manner:
 
 ```js
 startTime =
-  performance.getEntriesByType('soft-navigation')[navigationId - 2]?.startTime
+  performance.getEntriesByType('soft-navigation')['navigationId' - 2]?.startTime
   || performance.getEntriesByType('navigation')[0]?.startTime
 ```
 


### PR DESCRIPTION
The line `performance.getEntriesByType('soft-navigation')[navigationId - 2]?.startTime` resulted in a reference error ("`navigationId` is not defined").  I just added single quotes around `navigationID` to make it work.

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

-
-
-