### PR TITLE
fix: show non-article/blog/docs pages in search

### DIFF
--- a/site/_js/web-components/search-box.js
+++ b/site/_js/web-components/search-box.js
@@ -70,7 +70,7 @@ export class SearchBox extends BaseElement {
     this._active = false;
     this.buttonLabel = 'open search';
     this.docsLabel = 'Documentation';
-    this.otherLabel = 'Other';
+    this.overviewLabel = 'Overview';
     this.articlesLabel = 'Articles';
     this.blogLabel = 'Blog';
     this.locale = 'en';
@@ -341,6 +341,7 @@ export class SearchBox extends BaseElement {
       };
 
       this.categorisedResults = {
+        [this.overviewLabel]: [],
         [this.docsLabel]: mutableResults.filterMutate(r => r.type === 'doc'),
         [this.articlesLabel]: mutableResults.filterMutate(
           r => r.type === 'article'
@@ -348,8 +349,9 @@ export class SearchBox extends BaseElement {
         [this.blogLabel]: mutableResults.filterMutate(
           r => r.type === 'blogPost'
         ),
-        [this.otherLabel]: mutableResults,
       };
+
+      this.categorisedResults[this.overviewLabel] = mutableResults;
     } catch (err) {
       console.error(err);
       console.error(/** @type {any} */ (err).debugData);

--- a/site/_js/web-components/search-box.js
+++ b/site/_js/web-components/search-box.js
@@ -70,6 +70,7 @@ export class SearchBox extends BaseElement {
     this._active = false;
     this.buttonLabel = 'open search';
     this.docsLabel = 'Documentation';
+    this.otherLabel = 'Other';
     this.articlesLabel = 'Articles';
     this.blogLabel = 'Blog';
     this.locale = 'en';
@@ -77,10 +78,8 @@ export class SearchBox extends BaseElement {
     this.query = '';
     /** @type AlgoliaCollectionItem[] */
     this.results = [];
-    /** @type AlgoliaCollectionItem[] */
-    this.docsResults = [];
-    /** @type AlgoliaCollectionItem[] */
-    this.blogResults = [];
+    /** @type {Object<string, AlgoliaCollectionItem[]>} */
+    this.categorisedResults = {};
     // Used when rendering categorized results. The counter helps ensure that
     // each result has a unique id that corresponds to its rendered order in
     // the list.
@@ -283,8 +282,7 @@ export class SearchBox extends BaseElement {
     this.query = query.trim();
     if (this.query === '') {
       this.results = [];
-      this.docsResults = [];
-      this.blogResults = [];
+      this.categorisedResults = {};
       return;
     }
 
@@ -322,10 +320,36 @@ export class SearchBox extends BaseElement {
         return r;
       });
 
-      // Further categorize results into docs and blog posts.
-      this.docsResults = this.results.filter(r => r.type === 'doc');
-      this.articlesResults = this.results.filter(r => r.type === 'article');
-      this.blogResults = this.results.filter(r => r.type === 'blogPost');
+      // Further categorize results into docs, articles, blog and the remaining posts.
+      /** @type {AlgoliaCollectionItem[] & {
+       *   filterMutate?: (predicate: (item: AlgoliaCollectionItem) => boolean) => AlgoliaCollectionItem[]
+       * }}
+       */
+      const mutableResults = [...this.results];
+      mutableResults.filterMutate = predicate => {
+        const results = [];
+        let i = 0;
+        while (i < mutableResults.length) {
+          if (predicate(mutableResults[i])) {
+            results.push(mutableResults.splice(i, 1)[0]);
+          } else {
+            i++;
+          }
+        }
+
+        return results;
+      };
+
+      this.categorisedResults = {
+        [this.docsLabel]: mutableResults.filterMutate(r => r.type === 'doc'),
+        [this.articlesLabel]: mutableResults.filterMutate(
+          r => r.type === 'article'
+        ),
+        [this.blogLabel]: mutableResults.filterMutate(
+          r => r.type === 'blogPost'
+        ),
+        [this.otherLabel]: mutableResults,
+      };
     } catch (err) {
       console.error(err);
       console.error(/** @type {any} */ (err).debugData);
@@ -402,9 +426,6 @@ export class SearchBox extends BaseElement {
       return;
     }
 
-    this.blogResults = this.blogResults || [];
-    this.docsResults = this.docsResults || [];
-
     this.resultsCounter = -1;
     return html`
       <div
@@ -413,30 +434,16 @@ export class SearchBox extends BaseElement {
         role="listbox"
         aria-label="${this.placeholder}"
       >
-        ${this.blogResults.length
-          ? html`
-              <div class="search-box__result-heading type--label">
-                ${this.blogLabel.toUpperCase()}
-              </div>
-              ${this.blogResults.map(this.renderResult)}
-            `
-          : ''}
-        ${this.articlesResults?.length
-          ? html`
-              <div class="search-box__result-heading type--label">
-                ${this.articlesLabel.toUpperCase()}
-              </div>
-              ${this.articlesResults.map(this.renderResult)}
-            `
-          : ''}
-        ${this.docsResults.length
-          ? html`
-              <div class="search-box__result-heading type--label">
-                ${this.docsLabel.toUpperCase()}
-              </div>
-              ${this.docsResults.map(this.renderResult)}
-            `
-          : ''}
+        ${Object.entries(this.categorisedResults).map(([label, results]) =>
+          results.length
+            ? html`
+                <div class="search-box__result-heading type--label">
+                  ${label.toUpperCase()}
+                </div>
+                ${results.map(this.renderResult)}
+              `
+            : ''
+        )}
       </div>
     `;
   }


### PR DESCRIPTION
Fixes #5309 

Changes proposed in this pull request:

- Adds a new "other" category to search results which contains previously missing results
- Refactors/cleans up existing code

Screenshot:
<img width="896" alt="Screenshot 2023-02-20 at 12 39 38" src="https://user-images.githubusercontent.com/42349493/220124545-8f4a430b-ab59-4196-8cb2-b3013dacfb8f.png">

