### PR TITLE
move subheads out of glossary partials

### DIFF
--- a/site/en/_partials/privacy-sandbox/glossary-entries/_README.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/_README.md
@@ -1,4 +1,4 @@
-# Using glossary partials
+## Using glossary partials
 
 These partials each contain one glossary term. If you use any and need a subhead for them, you'll need to include the subhead inline in your content before the include, like so
 

--- a/site/en/_partials/privacy-sandbox/glossary-entries/_README.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/_README.md
@@ -6,4 +6,4 @@ These partials each contain one glossary term. If you use any and need a subhead
 
     {% Partial 'privacy-sandbox/glossary-entries/ad-exchange.njk' %}
     
-These partials don't line have spacing before the content, thus the line space between the header and the partial reference is necessary, as above.
+These partials don't have line spacing before the content, thus the line space between the header and the partial reference is necessary, as above.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/_README.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/_README.md
@@ -6,4 +6,4 @@ These partials each contain one glossary term. If you use any and need a subhead
 
     {% Partial 'privacy-sandbox/glossary-entries/ad-exchange.njk' %}
     
-    These partials don't line have spacing before the content, thus the line space between the header and the partial reference is necessary, as above.
+These partials don't line have spacing before the content, thus the line space between the header and the partial reference is necessary, as above.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/_README.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/_README.md
@@ -1,0 +1,9 @@
+# Using glossary partials
+
+These partials each contain one glossary term. If you use any and need a subhead for them, you'll need to include the subhead inline in your content before the include, like so
+
+    ## Ad exchange
+
+    {% Partial 'privacy-sandbox/glossary-entries/ad-exchange.njk' %}
+    
+    These partials don't line have spacing before the content, thus the line space between the header and the partial reference is necessary, as above.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/_README.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/_README.md
@@ -2,8 +2,10 @@
 
 These partials each contain one glossary term. If you use any and need a subhead for them, you'll need to include the subhead inline in your content before the include, like so
 
-    ## Ad exchange
+```txt
+## Ad exchange
 
-    {% Partial 'privacy-sandbox/glossary-entries/ad-exchange.njk' %}
+{% Partial 'privacy-sandbox/glossary-entries/ad-exchange.njk' %}
+```
     
 These partials don't have line spacing before the content, thus the line space between the header and the partial reference is necessary, as above.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/ad-auction.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/ad-auction.md
@@ -1,5 +1,3 @@
-## Ad auction (FLEDGE)
-
 In FLEDGE, an ad auction is run by a seller (likely to be an [SSP](#ssp) or maybe the publisher itself), in JavaScript code in the browser on the
 user's device, to sell ad space on a site that displays ads.
 

--- a/site/en/_partials/privacy-sandbox/glossary-entries/ad-creative.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/ad-creative.md
@@ -1,5 +1,3 @@
-## Ad creative, creative {: #ad-creative}
-
 The contents of the ad served to users. Creatives can be images, videos, audio,
 and other formats. Creatives live within an ad space, and are served by ad tech
 within line items.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/ad-creative.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/ad-creative.md
@@ -1,3 +1,3 @@
-The contents of the ad served to users. Creatives can be images, videos, audio,
+Ad creative refers to the contents of the ad served to users. Creatives can be images, videos, audio,
 and other formats. Creatives live within an ad space, and are served by ad tech
 within line items.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/ad-exchange.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/ad-exchange.md
@@ -1,4 +1,4 @@
-A platform to automate buying and selling of ad inventory from multiple ad
+An ad exchange is a platform to automate buying and selling of ad inventory from multiple ad
 networks.
 
 {: #ad-space }

--- a/site/en/_partials/privacy-sandbox/glossary-entries/ad-exchange.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/ad-exchange.md
@@ -1,5 +1,3 @@
-## Ad exchange
-
 A platform to automate buying and selling of ad inventory from multiple ad
 networks.
 

--- a/site/en/_partials/privacy-sandbox/glossary-entries/ad-inventory-space.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/ad-inventory-space.md
@@ -1,1 +1,1 @@
-The spaces for ads that are available from a site that sells ad space.
+Ad inventory space is the space or spaces for ads that are available from a site that sells ad space.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/ad-inventory-space.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/ad-inventory-space.md
@@ -1,5 +1,1 @@
-{: #ad-space }
-
-## Ad inventory, ad space {: #ad-inventory }
-
 The spaces for ads that are available from a site that sells ad space.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/ad-platform.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/ad-platform.md
@@ -1,1 +1,1 @@
-A company that provides services to deliver ads.
+An ad platform is a company that provides services to deliver ads.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/ad-platform.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/ad-platform.md
@@ -1,3 +1,1 @@
-## Ad platform (Ad tech) {: #adtech }
-
 A company that provides services to deliver ads.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/advertiser.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/advertiser.md
@@ -1,3 +1,1 @@
-## Advertiser {: #advertiser }
-
 A company that pays to advertise its products.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/advertiser.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/advertiser.md
@@ -1,1 +1,1 @@
-A company that pays to advertise its products.
+An advertiser is a company that pays to advertise its products.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/aggregatable-reports.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/aggregatable-reports.md
@@ -1,5 +1,3 @@
-## Aggregatable reports
-
 Encrypted reports sent from individual user devices. These reports contain
 data about cross-site user behavior and conversions. Conversions (sometimes
 called attribution trigger events) and associated metrics are defined by the

--- a/site/en/_partials/privacy-sandbox/glossary-entries/aggregatable-reports.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/aggregatable-reports.md
@@ -1,4 +1,4 @@
-Encrypted reports sent from individual user devices. These reports contain
+Aggregatable reports are encrypted reports sent from individual user devices. These reports contain
 data about cross-site user behavior and conversions. Conversions (sometimes
 called attribution trigger events) and associated metrics are defined by the
 advertiser or ad tech. Each report is encrypted to prevent various parties

--- a/site/en/_partials/privacy-sandbox/glossary-entries/attestation.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/attestation.md
@@ -1,4 +1,4 @@
-A mechanism to authenticate software identity, usually with [cryptographic
+Attestation is a mechanism to authenticate software identity, usually with [cryptographic
 hashes](https://en.wikipedia.org/wiki/Cryptographic_hash_function) or
 signatures. For the aggregation service proposal, attestation matches the
 code running in the ad tech-operated aggregation service with the open

--- a/site/en/_partials/privacy-sandbox/glossary-entries/attestation.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/attestation.md
@@ -1,5 +1,3 @@
-## Attestation
-
 A mechanism to authenticate software identity, usually with [cryptographic
 hashes](https://en.wikipedia.org/wiki/Cryptographic_hash_function) or
 signatures. For the aggregation service proposal, attestation matches the

--- a/site/en/_partials/privacy-sandbox/glossary-entries/attribution.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/attribution.md
@@ -1,5 +1,3 @@
-## Attribution {: #attribution }
-
 Identification of user actions that contribute to an outcome.
 
 For example, a correlation of ad clicks or views with [conversions](#conversion).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/attribution.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/attribution.md
@@ -1,3 +1,3 @@
-Identification of user actions that contribute to an outcome.
+Attribution refers to the identification of user actions that contribute to an outcome.
 
 For example, a correlation of ad clicks or views with [conversions](#conversion).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/blink.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/blink.md
@@ -1,2 +1,2 @@
-The [rendering engine](https://en.wikipedia.org/wiki/Browser_engine) used by
+Blink is the [rendering engine](https://en.wikipedia.org/wiki/Browser_engine) used by
 Chrome, developed as part of the [Chromium](#chromium) project.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/blink.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/blink.md
@@ -1,4 +1,2 @@
-## Blink {: #blink }
-
 The [rendering engine](https://en.wikipedia.org/wiki/Browser_engine) used by
 Chrome, developed as part of the [Chromium](#chromium) project.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/buyer.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/buyer.md
@@ -1,5 +1,3 @@
-## Buyer
-
 A party bidding for ad space in an [ad auction](#ad-auction), likely to be a
 [DSP](#DSP), or maybe the advertiser itself. Ad space buyers own and manage
 interest groups. 

--- a/site/en/_partials/privacy-sandbox/glossary-entries/buyer.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/buyer.md
@@ -1,4 +1,4 @@
-A party bidding for ad space in an [ad auction](#ad-auction), likely to be a
+A buyer  is a party bidding for ad space in an [ad auction](#ad-auction), likely to be a
 [DSP](#DSP), or maybe the advertiser itself. Ad space buyers own and manage
 interest groups. 
 

--- a/site/en/_partials/privacy-sandbox/glossary-entries/chromium.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/chromium.md
@@ -1,4 +1,2 @@
-## Chromium {: #chromium }
-
 An open-source web browser project. Chrome, Microsoft Edge, Opera and other
 browsers are based on Chromium.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/chromium.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/chromium.md
@@ -1,2 +1,2 @@
-An open-source web browser project. Chrome, Microsoft Edge, Opera and other
+Chromium is an open-source web browser project. Chrome, Microsoft Edge, Opera and other
 browsers are based on Chromium.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/clickthrough-conversion.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/clickthrough-conversion.md
@@ -1,1 +1,1 @@
-A click-through conversion is a conversion attributed to an ad that was 'clicked'.
+A click-through conversion is a conversion attributed to an ad that was 'clicked.'

--- a/site/en/_partials/privacy-sandbox/glossary-entries/clickthrough-conversion.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/clickthrough-conversion.md
@@ -1,3 +1,1 @@
-## Click-through-conversion (CTC) {: #ctc }
-
 A conversion attributed to an ad that was 'clicked'.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/clickthrough-conversion.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/clickthrough-conversion.md
@@ -1,1 +1,1 @@
-A click-through conversion is a conversion attributed to an ad that was 'clicked.'
+A click-through conversion is a conversion attributed to an ad that was clicked.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/clickthrough-conversion.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/clickthrough-conversion.md
@@ -1,1 +1,1 @@
-A conversion attributed to an ad that was 'clicked'.
+A click-through conversion is a conversion attributed to an ad that was 'clicked'.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/clickthrough-rate.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/clickthrough-rate.md
@@ -1,5 +1,3 @@
-## Click-through rate (CTR) {: #ctr }
-
 The ratio of users who click on an ad, having seen it.
 
 See also [impression](#impression).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/clickthrough-rate.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/clickthrough-rate.md
@@ -1,3 +1,3 @@
-The ratio of users who click on an ad, having seen it.
+The click-through rate is the ratio of users who click on an ad, having seen it.
 
 See also [impression](#impression).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/conversion.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/conversion.md
@@ -1,4 +1,4 @@
-The completion of some desired goal following action by a user.
+A conversion is the completion of some desired goal following action by a user.
 
 For example, a conversion may occur with the purchase of a product or sign-up
 for a newsletter after clicking an ad that links to the advertiser's site.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/conversion.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/conversion.md
@@ -1,5 +1,3 @@
-## Conversion
-
 The completion of some desired goal following action by a user.
 
 For example, a conversion may occur with the purchase of a product or sign-up

--- a/site/en/_partials/privacy-sandbox/glossary-entries/cookie.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/cookie.md
@@ -1,5 +1,3 @@
-## Cookie
-
 A small piece of textual data that websites can store on a user's browser.
 Cookies can be used by a website to save information associated with a user
 (or a reference to data stored on the website's backend servers) as the user

--- a/site/en/_partials/privacy-sandbox/glossary-entries/cookie.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/cookie.md
@@ -1,4 +1,4 @@
-A small piece of textual data that websites can store on a user's browser.
+A cookie is a small piece of textual data that websites can store on a user's browser.
 Cookies can be used by a website to save information associated with a user
 (or a reference to data stored on the website's backend servers) as the user
 moves across the web.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/coordinator.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/coordinator.md
@@ -1,1 +1,1 @@
-An entity responsible for key management and aggregatable report accounting. The coordinator maintains a list of hashes of approved aggregation service configurations and configures access to decryption keys.
+A coordinator is an entity responsible for key management and aggregatable report accounting. The coordinator maintains a list of hashes of approved aggregation service configurations and configures access to decryption keys.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/coordinator.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/coordinator.md
@@ -1,3 +1,1 @@
-## Coordinator
-
 An entity responsible for key management and aggregatable report accounting. The coordinator maintains a list of hashes of approved aggregation service configurations and configures access to decryption keys.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/course-data.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/course-data.md
@@ -1,5 +1,3 @@
-## Coarse data
-
 Limited information provided by Attribution Reporting API event-level reports.
 This is limited to 3 pieces of conversion data for clicks and 1 piece for
 views. Specific, granular conversion data (such as specific prices of items

--- a/site/en/_partials/privacy-sandbox/glossary-entries/course-data.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/course-data.md
@@ -1,4 +1,4 @@
-Limited information provided by Attribution Reporting API event-level reports.
+Course data refers to limited information provided by Attribution Reporting API event-level reports.
 This is limited to 3 pieces of conversion data for clicks and 1 piece for
 views. Specific, granular conversion data (such as specific prices of items
 and timestamps)  are not included.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/data-management-platform.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/data-management-platform.md
@@ -1,4 +1,4 @@
-A software used to collect and manage data relevant for advertisers. These
+A data management platform is software used to collect and manage data relevant for advertisers. These
 platforms help advertisers and publishers identify audience segments, which can
 then be used for campaign targeting.
 

--- a/site/en/_partials/privacy-sandbox/glossary-entries/data-management-platform.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/data-management-platform.md
@@ -1,5 +1,3 @@
-## Data management platform (DMP) {: #dmp }
-
 A software used to collect and manage data relevant for advertisers. These
 platforms help advertisers and publishers identify audience segments, which can
 then be used for campaign targeting.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/demand-side-platform.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/demand-side-platform.md
@@ -1,4 +1,4 @@
-An adtech service used to automate ad purchasing. DSPs are used by advertisers
+An ad tech service used to automate ad purchasing. DSPs are used by advertisers
 to buy [ad impressions](https://en.wikipedia.org/wiki/Impression_(online_media))
 across a range of publisher sites. Publishers put their
 [ad inventory](#ad-inventory) up for sale through marketplaces called ad

--- a/site/en/_partials/privacy-sandbox/glossary-entries/demand-side-platform.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/demand-side-platform.md
@@ -1,4 +1,4 @@
-An ad tech service used to automate ad purchasing. DSPs are used by advertisers
+A demand-side platform is an ad tech service used to automate ad purchasing. DSPs are used by advertisers
 to buy [ad impressions](https://en.wikipedia.org/wiki/Impression_(online_media))
 across a range of publisher sites. Publishers put their
 [ad inventory](#ad-inventory) up for sale through marketplaces called ad

--- a/site/en/_partials/privacy-sandbox/glossary-entries/demand-side-platform.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/demand-side-platform.md
@@ -1,5 +1,3 @@
-## Demand-side platform (DSP) {: #dsp }
-
 An adtech service used to automate ad purchasing. DSPs are used by advertisers
 to buy [ad impressions](https://en.wikipedia.org/wiki/Impression_(online_media))
 across a range of publisher sites. Publishers put their

--- a/site/en/_partials/privacy-sandbox/glossary-entries/differential-privacy.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/differential-privacy.md
@@ -1,5 +1,3 @@
-## Differential privacy {: #differential-privacy }
-
 Techniques to allow sharing of information about a dataset to reveal patterns
 of behaviour without revealing private information about individuals or whether
 they belong to the dataset.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/differential-privacy.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/differential-privacy.md
@@ -1,3 +1,3 @@
-Techniques to allow sharing of information about a dataset to reveal patterns
+Differential privacy refers to techniques to allow sharing of information about a dataset to reveal patterns
 of behaviour without revealing private information about individuals or whether
 they belong to the dataset.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/domain.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/domain.md
@@ -1,1 +1,1 @@
-See [Top-Level Domain](#tld) and [eTLD](#etld).
+Domain. See [Top-Level Domain](#tld) and [eTLD](#etld).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/domain.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/domain.md
@@ -1,3 +1,1 @@
-## Domain
-
 See [Top-Level Domain](#tld) and [eTLD](#etld).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/entropy.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/entropy.md
@@ -1,4 +1,4 @@
-A measure of how much an item of data reveals individual identity.
+Entropy, in the privacy domain, is a measure of how much an item of data reveals individual identity.
 
 Data entropy is measured in bits. The more that data reveals identity, the higher its entropy value.
 

--- a/site/en/_partials/privacy-sandbox/glossary-entries/entropy.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/entropy.md
@@ -1,5 +1,3 @@
-## Entropy
-
 A measure of how much an item of data reveals individual identity.
 
 Data entropy is measured in bits. The more that data reveals identity, the higher its entropy value.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/etld-etld1.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/etld-etld1.md
@@ -1,4 +1,4 @@
-Stands for effective top-level domains (TLD), which are defined by the
+eLTDs are effective top-level domains (TLD), which are defined by the
 [Public Suffix List](https://publicsuffix.org/list/).
 
 For example:

--- a/site/en/_partials/privacy-sandbox/glossary-entries/etld-etld1.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/etld-etld1.md
@@ -1,4 +1,4 @@
-eLTDs are effective top-level domains (TLD), which are defined by the
+eTLDs are effective top-level domains (TLD), which are defined by the
 [Public Suffix List](https://publicsuffix.org/list/).
 
 For example:

--- a/site/en/_partials/privacy-sandbox/glossary-entries/etld-etld1.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/etld-etld1.md
@@ -1,5 +1,3 @@
-## eTLD, eTLD+1 {: #etld }
-
 Stands for effective top-level domains (TLD), which are defined by the
 [Public Suffix List](https://publicsuffix.org/list/).
 

--- a/site/en/_partials/privacy-sandbox/glossary-entries/federated-credential-management.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/federated-credential-management.md
@@ -1,5 +1,3 @@
-## Federated Credential Management API (FedCM) {: #fedcm }
-
 Federated Credential Management API is a proposal for a privacy-preserving
 approach to federated identity services. This will allow users to log into
 sites without sharing their personal information with the identity service or

--- a/site/en/_partials/privacy-sandbox/glossary-entries/federated-identity.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/federated-identity.md
@@ -1,2 +1,2 @@
-A third-party platform to allow a user to sign in to a website, without
+Fderated identity is a third-party platform to allow a user to sign in to a website, without
 requiring the site to implement their own identity service.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/federated-identity.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/federated-identity.md
@@ -1,4 +1,2 @@
-## Federated identity (federated login) {: #federated-identity }
-
 A third-party platform to allow a user to sign in to a website, without
 requiring the site to implement their own identity service.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/fenced-frame.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/fenced-frame.md
@@ -1,5 +1,3 @@
-## Fenced frame
-
 A (`<fencedframe>`) is a proposed HTML element for embedded content, similar to
 an [iframe](https://developer.mozilla.org/docs/Web/HTML/Element/iframe). Unlike
 iframes, a fenced frame restricts communication with its embedding context to

--- a/site/en/_partials/privacy-sandbox/glossary-entries/fingerprinting-surface.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/fingerprinting-surface.md
@@ -1,5 +1,3 @@
-## Fingerprinting surface {: #fingerprinting-surface }
-
 Something that can be used (probably in combination with other surfaces) to
 identify a particular user or device.
 

--- a/site/en/_partials/privacy-sandbox/glossary-entries/fingerprinting-surface.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/fingerprinting-surface.md
@@ -1,4 +1,4 @@
-A fingerprinting surface is Something that can be used (probably in combination with other surfaces) to
+A fingerprinting surface is something that can be used (probably in combination with other surfaces) to
 identify a particular user or device.
 
 For example, the `navigator.userAgent()` JavaScript method and the `User-Agent`

--- a/site/en/_partials/privacy-sandbox/glossary-entries/fingerprinting-surface.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/fingerprinting-surface.md
@@ -1,4 +1,4 @@
-Something that can be used (probably in combination with other surfaces) to
+A fingerprinting surface is Something that can be used (probably in combination with other surfaces) to
 identify a particular user or device.
 
 For example, the `navigator.userAgent()` JavaScript method and the `User-Agent`

--- a/site/en/_partials/privacy-sandbox/glossary-entries/fingerprinting.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/fingerprinting.md
@@ -1,5 +1,3 @@
-## Fingerprinting {: #fingerprinting }
-
 Techniques to identify and track the behaviour of individual users.
 
 Fingerprinting uses mechanisms that users aren't aware of and can't control. 

--- a/site/en/_partials/privacy-sandbox/glossary-entries/fingerprinting.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/fingerprinting.md
@@ -1,4 +1,4 @@
-Techniques to identify and track the behaviour of individual users.
+Fingerprinting encompasses techniques to identify and track the behaviour of individual users.
 
 Fingerprinting uses mechanisms that users aren't aware of and can't control. 
 Sites such as [Panopticlick](https://panopticlick.eff.org) and

--- a/site/en/_partials/privacy-sandbox/glossary-entries/first-party-cookie.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/first-party-cookie.md
@@ -1,5 +1,3 @@
-## First-party cookie {: #first-party-cookie } 
-
 [Cookie](#cookie) stored by a website while a user is on the site itself.
 
 For example, an online store might ask a browser to store a cookie in order to

--- a/site/en/_partials/privacy-sandbox/glossary-entries/first-party-cookie.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/first-party-cookie.md
@@ -1,4 +1,4 @@
-[Cookie](#cookie) stored by a website while a user is on the site itself.
+A first-party [cookie](#cookie) is a cookie stored by a website while a user is on the site itself.
 
 For example, an online store might ask a browser to store a cookie in order to
 retain shopping cart details for a user who is not logged in. See also

--- a/site/en/_partials/privacy-sandbox/glossary-entries/first-party.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/first-party.md
@@ -1,5 +1,3 @@
-## First-party {: #first-party }
-
 Resources from the site you're visiting.
 
 For example, the page you're reading is on the site `developer.chrome.com` and

--- a/site/en/_partials/privacy-sandbox/glossary-entries/first-party.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/first-party.md
@@ -1,4 +1,4 @@
-Resources from the site you're visiting.
+First party refers to resources from the site you're visiting.
 
 For example, the page you're reading is on the site `developer.chrome.com` and
 includes resources requested from this site. Requests for those first-party

--- a/site/en/_partials/privacy-sandbox/glossary-entries/i2e.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/i2e.md
@@ -1,3 +1,3 @@
-Intent to Experiment. Announcement of a plan to make a new [Blink](#blink)
+Intent to Experiment (I2E) is the announcement of a plan to make a new [Blink](#blink)
 feature available to users for testing, typically through an [origin
 trial](#origin-trial).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/i2e.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/i2e.md
@@ -1,5 +1,3 @@
-## I2E {: #i2e }
-
 Intent to Experiment. Announcement of a plan to make a new [Blink](#blink)
 feature available to users for testing, typically through an [origin
 trial](#origin-trial).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/i2ee.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/i2ee.md
@@ -1,2 +1,2 @@
-Intent to Extend Experiment. Announcement of a plan to extend the duration of an
+Intent to Extend Experiment (I2EE) is an announcement of a plan to extend the duration of an
 [origin trial](#origin-trial).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/i2ee.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/i2ee.md
@@ -1,4 +1,2 @@
-## I2EE {: #i2ee }
-
 Intent to Extend Experiment. Announcement of a plan to extend the duration of an
 [origin trial](#origin-trial).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/i2p.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/i2p.md
@@ -1,4 +1,4 @@
-Intent to Prototype. The first stage in
+Intent to Prototype (I2P) is the first stage in
 [developing a new feature](/blog/progress-in-the-privacy-sandbox-2021-12/#chromium-development-process)
 in [Blink](#blink). The announcement is posted to the [blink-dev mailing
 list](https://groups.google.com/a/chromium.org/g/blink-dev) with a link to the

--- a/site/en/_partials/privacy-sandbox/glossary-entries/i2p.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/i2p.md
@@ -1,5 +1,3 @@
-## I2P {: #i2p }
-
 Intent to Prototype. The first stage in
 [developing a new feature](/blog/progress-in-the-privacy-sandbox-2021-12/#chromium-development-process)
 in [Blink](#blink). The announcement is posted to the [blink-dev mailing

--- a/site/en/_partials/privacy-sandbox/glossary-entries/i2s.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/i2s.md
@@ -1,2 +1,2 @@
-Intent to Ship. Announcement of a plan to make a new feature of [Blink](#blink)
+Intent to Ship (I2S) is an announcement of a plan to make a new feature of [Blink](#blink)
 available to users in stable versions of Chrome.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/i2s.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/i2s.md
@@ -1,4 +1,2 @@
-## I2S {: #i2s }
-
 Intent to Ship. Announcement of a plan to make a new feature of [Blink](#blink)
 available to users in stable versions of Chrome.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/impression.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/impression.md
@@ -1,4 +1,4 @@
-Could refer to either:
+Impression could refer to either:
 
 *  View of an ad. See also [click-through rate](#ctr).
 *  An ad slot: the HTML markup (usually `<div>` tags) on a web page where an ad

--- a/site/en/_partials/privacy-sandbox/glossary-entries/impression.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/impression.md
@@ -1,5 +1,3 @@
-## Impression {: #impression }
-
 Could refer to either:
 
 *  View of an ad. See also [click-through rate](#ctr).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/inventory.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/inventory.md
@@ -1,2 +1,2 @@
-The ad slots available on a site. Ad slots are the HTML markup (usually `<div>`
+Inventory is the ad slots available on a site. Ad slots are the HTML markup (usually `<div>`
 tags) where ads can be displayed.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/inventory.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/inventory.md
@@ -1,4 +1,2 @@
-## Inventory {: #inventory}
-
 The ad slots available on a site. Ad slots are the HTML markup (usually `<div>`
 tags) where ads can be displayed.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/k-anonymity.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/k-anonymity.md
@@ -1,3 +1,3 @@
-A measure of anonymity within a data set. If you have _k_ anonymity, you can't
+K-anonymity is the measure of anonymity within a data set. If you have _k_ anonymity, you can't
 be distinguished from _k-1_ other individuals in the data set. In other words,
 _k_ individuals have the same information (including you).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/k-anonymity.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/k-anonymity.md
@@ -1,5 +1,3 @@
-## k-anonymity
-
 A measure of anonymity within a data set. If you have _k_ anonymity, you can't
 be distinguished from _k-1_ other individuals in the data set. In other words,
 _k_ individuals have the same information (including you).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/nonce.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/nonce.md
@@ -1,1 +1,1 @@
-Arbitrary number used once only in cryptographic communication.
+A nonce is an arbitrary number used only once in cryptographic communication.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/nonce.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/nonce.md
@@ -1,3 +1,1 @@
-## Nonce 
-
 Arbitrary number used once only in cryptographic communication.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/origin-trial.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/origin-trial.md
@@ -1,4 +1,4 @@
-Trials provide access to a new or experimental feature, to make it possible to
+Origin trials are trials that provide access to a new or experimental feature, to make it possible to
 build functions that users can try out for a limited time before the feature is made available to everyone.
 
 When Chrome offers an origin trial for a feature, an [origin](#origin) can be

--- a/site/en/_partials/privacy-sandbox/glossary-entries/origin-trial.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/origin-trial.md
@@ -1,5 +1,3 @@
-## Origin trial {: #origin-trial}
-
 Trials provide access to a new or experimental feature, to make it possible to
 build functions that users can try out for a limited time before the feature is made available to everyone.
 

--- a/site/en/_partials/privacy-sandbox/glossary-entries/origin.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/origin.md
@@ -1,5 +1,3 @@
-## Origin 
-
 Defined by the scheme (protocol), hostname (domain), and port of the URL used to access it.
 
 For example: `https://developer.chrome.com`

--- a/site/en/_partials/privacy-sandbox/glossary-entries/origin.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/origin.md
@@ -1,3 +1,3 @@
-Defined by the scheme (protocol), hostname (domain), and port of the URL used to access it.
+An origin is defined by the scheme (protocol), hostname (domain), and port of the URL used to access it.
 
 For example: `https://developer.chrome.com`

--- a/site/en/_partials/privacy-sandbox/glossary-entries/passive-surface.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/passive-surface.md
@@ -1,5 +1,3 @@
-## Passive surface {: #passive-surface }
-
 Some [fingerprinting surfaces](#fingerprinting-surface)&mdash;such as 
 User-Agent strings, IP addresses, and Accept-Language headers&mdash;that are
 available to every website, whether the site asks for them or not.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/passive-surface.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/passive-surface.md
@@ -1,4 +1,4 @@
-Some [fingerprinting surfaces](#fingerprinting-surface)&mdash;such as 
+Passive surfaces are [fingerprinting surfaces](#fingerprinting-surface)&mdash;such as 
 User-Agent strings, IP addresses, and Accept-Language headers&mdash;that are
 available to every website, whether the site asks for them or not.
 

--- a/site/en/_partials/privacy-sandbox/glossary-entries/publisher.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/publisher.md
@@ -1,4 +1,2 @@
-## Publisher
-
 In the Privacy Sandbox context, a site with ad space that is paid to display
 ads.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/publisher.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/publisher.md
@@ -1,2 +1,2 @@
-In the Privacy Sandbox context, a site with ad space that is paid to display
+In the Privacy Sandbox context, a publisher is a site with ad space that is paid to display
 ads.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/reach.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/reach.md
@@ -1,4 +1,2 @@
-## Reach
-
 The total number of people who see an ad or who visit a web page that displays
 the ad.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/reach.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/reach.md
@@ -1,2 +1,2 @@
-The total number of people who see an ad or who visit a web page that displays
+Reach represents the total number of people who see an ad or who visit a web page that displays
 the ad.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/real-time-bidding.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/real-time-bidding.md
@@ -1,4 +1,2 @@
-## Real-time bidding (RTB) {: #rtb}
-
 An automated auction for buying and selling ad impressions on websites,
 completed during page load.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/real-time-bidding.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/real-time-bidding.md
@@ -1,2 +1,2 @@
-An automated auction for buying and selling ad impressions on websites,
+Real-time bidding refers to an automated auction for buying and selling ad impressions on websites,
 completed during page load.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/remarketing.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/remarketing.md
@@ -1,5 +1,3 @@
-## Remarketing
-
 Advertising to people who've already visited your site on other sites.
 
 For example, an online store could show ads for a toy sale to people who

--- a/site/en/_partials/privacy-sandbox/glossary-entries/remarketing.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/remarketing.md
@@ -1,4 +1,4 @@
-Advertising to people who've already visited your site on other sites.
+Remarketing is the practice of advertising to people who've already visited your site on other sites.
 
 For example, an online store could show ads for a toy sale to people who
 previously viewed toys on their site.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/reporting-origin.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/reporting-origin.md
@@ -1,4 +1,4 @@
-The entity that receives aggregatable reports&mdash;in other words, the ad tech
+The reporting origin is the entity that receives aggregatable reports&mdash;in other words, the ad tech
 that called the Attribution Reporting API. Aggregatable reports are sent from
 user devices to a [well-known](#well-known) URL associated with the reporting
 origin.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/reporting-origin.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/reporting-origin.md
@@ -1,5 +1,3 @@
-## Reporting origin
-
 The entity that receives aggregatable reports&mdash;in other words, the ad tech
 that called the Attribution Reporting API. Aggregatable reports are sent from
 user devices to a [well-known](#well-known) URL associated with the reporting

--- a/site/en/_partials/privacy-sandbox/glossary-entries/seller.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/seller.md
@@ -1,2 +1,2 @@
-The party running an ad auction, likely to be an [SSP](#ssp) or maybe the
+A seller is the party running an ad auction, likely to be an [SSP](#ssp) or maybe the
 publisher itself.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/seller.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/seller.md
@@ -1,4 +1,2 @@
-## Seller
-
 The party running an ad auction, likely to be an [SSP](#ssp) or maybe the
 publisher itself.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/site.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/site.md
@@ -1,3 +1,1 @@
-## Site
-
 See [Top-Level Domain](#tld) and [eTLD](#etld).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/site.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/site.md
@@ -1,1 +1,1 @@
-See [Top-Level Domain](#tld) and [eTLD](#etld).
+Site. See [Top-Level Domain](#tld) and [eTLD](#etld).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/summary-report.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/summary-report.md
@@ -1,4 +1,4 @@
-An Attribution Reporting API and Private Aggregation API report type. A [summary
+A summary report is an Attribution Reporting API and Private Aggregation API report type. A [summary
 report](/docs/privacy-sandbox/attribution-reporting/summary-reports/) includes
 aggregated user data and detailed conversion data, resulting from noisy
 aggregation applied to aggregatable reports. The summary

--- a/site/en/_partials/privacy-sandbox/glossary-entries/summary-report.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/summary-report.md
@@ -1,5 +1,3 @@
-## Summary report {: #aggregate-report}
-
 An Attribution Reporting API and Private Aggregation API report type. A [summary
 report](/docs/privacy-sandbox/attribution-reporting/summary-reports/) includes
 aggregated user data and detailed conversion data, resulting from noisy

--- a/site/en/_partials/privacy-sandbox/glossary-entries/supply-side-platform.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/supply-side-platform.md
@@ -1,5 +1,3 @@
-## Supply-side platform, Sell-side platform {: #ssp}
-
 An ad tech service used to automate selling ad inventory. SSPs allow publishers
 to offer their inventory (empty rectangles where ads will go) to multiple ad
 exchanges, [DSPs](#DSP), and networks. This enables a wide range of potential

--- a/site/en/_partials/privacy-sandbox/glossary-entries/supply-side-platform.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/supply-side-platform.md
@@ -1,4 +1,4 @@
-An ad tech service used to automate selling ad inventory. SSPs allow publishers
+A supply-side platform is an ad tech service used to automate selling ad inventory. SSPs allow publishers
 to offer their inventory (empty rectangles where ads will go) to multiple ad
 exchanges, [DSPs](#DSP), and networks. This enables a wide range of potential
 buyers to bid for ad space.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/surface.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/surface.md
@@ -1,4 +1,2 @@
-## Surface
-
 See [Fingerprinting surface](#fingerprinting-surface) and
 [Passive surface](#passive-surface).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/surface.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/surface.md
@@ -1,2 +1,2 @@
-See [Fingerprinting surface](#fingerprinting-surface) and
+Surface. See [Fingerprinting surface](#fingerprinting-surface) and
 [Passive surface](#passive-surface).

--- a/site/en/_partials/privacy-sandbox/glossary-entries/third-party-cookie.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/third-party-cookie.md
@@ -1,4 +1,4 @@
-[Cookie](#cookie) stored by a third-party service.
+A third-party [cookie](#cookie) is a cookie stored by a third-party service.
 
 For example, a video website might include a **Watch Later** button in their
 embedded player to allow a user to add a video to their wishlist without

--- a/site/en/_partials/privacy-sandbox/glossary-entries/third-party-cookie.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/third-party-cookie.md
@@ -1,5 +1,3 @@
-## Third-party cookie {: #third-party-cookie}
-
 [Cookie](#cookie) stored by a third-party service.
 
 For example, a video website might include a **Watch Later** button in their

--- a/site/en/_partials/privacy-sandbox/glossary-entries/third-party.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/third-party.md
@@ -1,4 +1,4 @@
-Resources served from a domain that's different from the website you're
+Third party refers to resources served from a domain that's different from the website you're
 visiting.
 
 For example, a website `foo.com` might use analytics code from

--- a/site/en/_partials/privacy-sandbox/glossary-entries/third-party.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/third-party.md
@@ -1,5 +1,3 @@
-## Third-party {: #third-party }
-
 Resources served from a domain that's different from the website you're
 visiting.
 

--- a/site/en/_partials/privacy-sandbox/glossary-entries/top-level-domain.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/top-level-domain.md
@@ -1,5 +1,3 @@
-## Top-level domain (TLD) {: #tld }
-
 Top-level domains such as .com and .org are listed in the
 [Root Zone Database](https://www.iana.org/domains/root/db).
 

--- a/site/en/_partials/privacy-sandbox/glossary-entries/trusted-execution-environment.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/trusted-execution-environment.md
@@ -1,4 +1,4 @@
-A special configuration of computer hardware and software that allows external
+A trusted execution environment is a special configuration of computer hardware and software that allows external
 parties to verify the exact versions of software running on the computer. TEEs
 allow external parties to verify that the software does exactly what the
 software manufacturer claims it does—nothing more or less.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/trusted-execution-environment.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/trusted-execution-environment.md
@@ -1,5 +1,3 @@
-## Trusted Execution Environment (TEE) {: #tee }
-
 A special configuration of computer hardware and software that allows external
 parties to verify the exact versions of software running on the computer. TEEs
 allow external parties to verify that the software does exactly what the

--- a/site/en/_partials/privacy-sandbox/glossary-entries/user-agent-client-hints.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/user-agent-client-hints.md
@@ -1,5 +1,3 @@
-## User-Agent Client Hints (UA-CH) {: #ua-ch }
-
 Provide specific pieces of the User-Agent string on explicit request. This
 helps reduce [passive surfaces](#passive-surface) in the User-Agent string
 which may lead to user identification or covert tracking.

--- a/site/en/_partials/privacy-sandbox/glossary-entries/user-agent-client-hints.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/user-agent-client-hints.md
@@ -1,4 +1,4 @@
-Provide specific pieces of the User-Agent string on explicit request. This
+User-agent client hints provide specific pieces of the User-Agent string on explicit request. This
 helps reduce [passive surfaces](#passive-surface) in the User-Agent string
 which may lead to user identification or covert tracking.
 

--- a/site/en/_partials/privacy-sandbox/glossary-entries/user-agent-string.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/user-agent-string.md
@@ -1,4 +1,4 @@
-An HTTP header used by servers and network peers to request identifying
+A user-agent string is an HTTP header used by servers and network peers to request identifying
 information about an application, operating system, vendor, or version of a
 user agent. The User-Agent string broadcasts a large string of data, which is
 problematic for user privacy. [User-Agent

--- a/site/en/_partials/privacy-sandbox/glossary-entries/user-agent-string.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/user-agent-string.md
@@ -1,5 +1,3 @@
-## User-Agent string {: #user-agent }
-
 An HTTP header used by servers and network peers to request identifying
 information about an application, operating system, vendor, or version of a
 user agent. The User-Agent string broadcasts a large string of data, which is

--- a/site/en/_partials/privacy-sandbox/glossary-entries/well-known.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/well-known.md
@@ -1,5 +1,3 @@
-## .well-known {: #well-known }
-
 A file used to add redirects to a website from standardized URLs.
 
 For example, password managers can make it easier for users to update passwords

--- a/site/en/_partials/privacy-sandbox/glossary-entries/well-known.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/well-known.md
@@ -1,4 +1,4 @@
-A file used to add redirects to a website from standardized URLs.
+.well-known is a file used to add redirects to a website from standardized URLs.
 
 For example, password managers can make it easier for users to update passwords
 if a website sets a redirect from `/.well-known/change-password` to the change

--- a/site/en/_partials/privacy-sandbox/glossary-entries/worklet.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/worklet.md
@@ -1,5 +1,3 @@
-## Worklet
-
 A [worklet](https://developer.mozilla.org/docs/Web/API/Worklet) allows you to run specific JavaScript functions and return information back to the requester. Within a worklet, you can execute JavaScript but you cannot interact or communicate with the outside page.
 
 Worklets are used to store and extract data with the [Shared Storage API](/docs/privacy-sandbox/shared-storage/).

--- a/site/en/docs/privacy-sandbox/glossary/index.md
+++ b/site/en/docs/privacy-sandbox/glossary/index.md
@@ -68,13 +68,13 @@ if something is missing!
 
 {% Partial 'privacy-sandbox/glossary-entries/chromium.njk' %}
 
+## Click-through conversion (CTC) {: #ctc }
+
+{% Partial 'privacy-sandbox/glossary-entries/clickthrough-conversion.njk' %}
+
 ## Click-through rate (CTR) {: #ctr }
 
 {% Partial 'privacy-sandbox/glossary-entries/clickthrough-rate.njk' %}
-
-## Click-through-conversion (CTC) {: #ctc }
-
-{% Partial 'privacy-sandbox/glossary-entries/clickthrough-conversion.njk' %}
 
 ## Conversion
 

--- a/site/en/docs/privacy-sandbox/glossary/index.md
+++ b/site/en/docs/privacy-sandbox/glossary/index.md
@@ -18,128 +18,245 @@ authors:
 if something is missing!
 {% endAside %}
 
+## Ad auction (FLEDGE)
+
 {% Partial 'privacy-sandbox/glossary-entries/ad-auction.njk' %}
 
+## Ad creative, creative {: #ad-creative}
 
 {% Partial 'privacy-sandbox/glossary-entries/ad-creative.njk' %}
 
+## Ad exchange
 
 {% Partial 'privacy-sandbox/glossary-entries/ad-exchange.njk' %}
 
+{: #ad-space }
+
+## Ad inventory, ad space {: #ad-inventory }
 
 {% Partial 'privacy-sandbox/glossary-entries/ad-inventory-space.njk' %}
 
+## Ad platform (Ad tech) {: #adtech }
 
 {% Partial 'privacy-sandbox/glossary-entries/ad-platform.njk' %}
 
+## Advertiser {: #advertiser }
 
 {% Partial 'privacy-sandbox/glossary-entries/advertiser.njk' %}
 
+## Aggregatable reports
 
 {% Partial 'privacy-sandbox/glossary-entries/aggregatable-reports.njk' %}
 
+## Attestation
+
 {% Partial 'privacy-sandbox/glossary-entries/attestation.njk' %}
+
+## Attribution {: #attribution }
 
 {% Partial 'privacy-sandbox/glossary-entries/attribution.njk' %}
 
+## Blink {: #blink }
+
 {% Partial 'privacy-sandbox/glossary-entries/blink.njk' %}
+
+## Buyer
 
 {% Partial 'privacy-sandbox/glossary-entries/buyer.njk' %}
 
+## Chromium {: #chromium }
+
 {% Partial 'privacy-sandbox/glossary-entries/chromium.njk' %}
+
+## Click-through rate (CTR) {: #ctr }
 
 {% Partial 'privacy-sandbox/glossary-entries/clickthrough-rate.njk' %}
 
+## Click-through-conversion (CTC) {: #ctc }
+
 {% Partial 'privacy-sandbox/glossary-entries/clickthrough-conversion.njk' %}
 
-{% Partial 'privacy-sandbox/glossary-entries/course-data.njk' %}
+## Conversion
 
-{% Partial 'privacy-sandbox/glossary-entries/conversion.njk' %}
+{% Partial 'privacy-sandbox/glossary-entries/conversion.njk' %} 
+
+## Cookie
 
 {% Partial 'privacy-sandbox/glossary-entries/cookie.njk' %}
 
+## Coordinator
+
 {% Partial 'privacy-sandbox/glossary-entries/coordinator.njk' %}
+
+## Coarse data
+
+{% Partial 'privacy-sandbox/glossary-entries/course-data.njk' %}
+
+## Data management platform (DMP) {: #dmp }
 
 {% Partial 'privacy-sandbox/glossary-entries/data-management-platform.njk' %}
 
+## Demand-side platform (DSP) {: #dsp }
+
 {% Partial 'privacy-sandbox/glossary-entries/demand-side-platform.njk' %}
+
+## Differential privacy {: #differential-privacy }
 
 {% Partial 'privacy-sandbox/glossary-entries/differential-privacy.njk' %}
 
+## Domain
+
 {% Partial 'privacy-sandbox/glossary-entries/domain.njk' %}
 
-{% Partial 'privacy-sandbox/glossary-entries/etld-etld1.njk' %}
+## Entropy
 
 {% Partial 'privacy-sandbox/glossary-entries/entropy.njk' %}
 
-{% Partial 'privacy-sandbox/glossary-entries/federated-identity.njk' %}
+## eTLD, eTLD+1 {: #etld }
+
+{% Partial 'privacy-sandbox/glossary-entries/etld-etld1.njk' %}
+
+## Federated Credential Management API (FedCM) {: #fedcm }
 
 {% Partial 'privacy-sandbox/glossary-entries/federated-credential-management.njk' %}
 
+## Federated identity (federated login) {: #federated-identity }
+
+{% Partial 'privacy-sandbox/glossary-entries/federated-identity.njk' %}
+
+## Fenced frame
+
 {% Partial 'privacy-sandbox/glossary-entries/fenced-frame.njk' %}
+
+## Fingerprinting {: #fingerprinting }
 
 {% Partial 'privacy-sandbox/glossary-entries/fingerprinting.njk' %}
 
+## Fingerprinting surface {: #fingerprinting-surface }
+
 {% Partial 'privacy-sandbox/glossary-entries/fingerprinting-surface.njk' %}
+
+## First-party {: #first-party }
 
 {% Partial 'privacy-sandbox/glossary-entries/first-party.njk' %}
 
+## First-party cookie {: #first-party-cookie } 
+
 {% Partial 'privacy-sandbox/glossary-entries/first-party-cookie.njk' %}
 
-{% Partial 'privacy-sandbox/glossary-entries/i2p.njk' %}
+
+## I2E {: #i2e }
 
 {% Partial 'privacy-sandbox/glossary-entries/i2e.njk' %}
 
+## I2EE {: #i2ee }
+
 {% Partial 'privacy-sandbox/glossary-entries/i2ee.njk' %}
+
+## I2P {: #i2p }
+
+{% Partial 'privacy-sandbox/glossary-entries/i2p.njk' %}
+
+## I2S {: #i2s }
 
 {% Partial 'privacy-sandbox/glossary-entries/i2s.njk' %}
 
+## Impression {: #impression }
+
 {% Partial 'privacy-sandbox/glossary-entries/impression.njk' %}
+
+## Inventory {: #inventory}
 
 {% Partial 'privacy-sandbox/glossary-entries/inventory.njk' %}
 
+## k-anonymity
+
 {% Partial 'privacy-sandbox/glossary-entries/k-anonymity.njk' %}
+
+## Nonce 
 
 {% Partial 'privacy-sandbox/glossary-entries/nonce.njk' %}
 
+## Origin 
+
 {% Partial 'privacy-sandbox/glossary-entries/origin.njk' %}
+
+## Origin trial {: #origin-trial}
 
 {% Partial 'privacy-sandbox/glossary-entries/origin-trial.njk' %}
 
+## Passive surface {: #passive-surface }
+
 {% Partial 'privacy-sandbox/glossary-entries/passive-surface.njk' %}
+
+## Publisher
 
 {% Partial 'privacy-sandbox/glossary-entries/publisher.njk' %}
 
+## Reach
+
 {% Partial 'privacy-sandbox/glossary-entries/reach.njk' %}
+
+## Real-time bidding (RTB) {: #rtb}
 
 {% Partial 'privacy-sandbox/glossary-entries/real-time-bidding.njk' %}
 
+## Remarketing
+
 {% Partial 'privacy-sandbox/glossary-entries/remarketing.njk' %}
+
+## Reporting origin
 
 {% Partial 'privacy-sandbox/glossary-entries/reporting-origin.njk' %}
 
+## Seller
+
 {% Partial 'privacy-sandbox/glossary-entries/seller.njk' %}
+
+## Site
 
 {% Partial 'privacy-sandbox/glossary-entries/site.njk' %}
 
+## Summary report {: #aggregate-report}
+
 {% Partial 'privacy-sandbox/glossary-entries/summary-report.njk' %}
+
+## Supply-side platform, Sell-side platform {: #ssp}
 
 {% Partial 'privacy-sandbox/glossary-entries/supply-side-platform.njk' %}
 
+## Surface
+
 {% Partial 'privacy-sandbox/glossary-entries/surface.njk' %}
+
+## Third-party {: #third-party }
 
 {% Partial 'privacy-sandbox/glossary-entries/third-party.njk' %}
 
+## Third-party cookie {: #third-party-cookie}
+
 {% Partial 'privacy-sandbox/glossary-entries/third-party-cookie.njk' %}
+
+## Top-level domain (TLD) {: #tld }
 
 {% Partial 'privacy-sandbox/glossary-entries/top-level-domain.njk' %}
 
+## Trusted Execution Environment (TEE) {: #tee }
+
 {% Partial 'privacy-sandbox/glossary-entries/trusted-execution-environment.njk' %}
 
-{% Partial 'privacy-sandbox/glossary-entries/user-agent-string.njk' %}
+## User-Agent Client Hints (UA-CH) {: #ua-ch }
 
 {% Partial 'privacy-sandbox/glossary-entries/user-agent-client-hints.njk' %}
 
+## User-Agent string {: #user-agent }
+
+{% Partial 'privacy-sandbox/glossary-entries/user-agent-string.njk' %}
+
+## .well-known {: #well-known }
+
 {% Partial 'privacy-sandbox/glossary-entries/well-known.njk' %}
+
+## Worklet
 
 {% Partial 'privacy-sandbox/glossary-entries/worklet.njk' %}


### PR DESCRIPTION
fixes: b/270137366
Changes proposed in this pull request:
move subheads out of glossary partials and put them in the glossary index file so heads don't show up in other text/docs when used

https://deploy-preview-5391--developer-chrome-com.netlify.app/docs/privacy-sandbox/glossary/