### PR TITLE
Expose IDs on landing page section macros

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -14,6 +14,7 @@ const {githubLink} = require('./site/_filters/github-link');
 const {namespaceToPath} = require('./site/_filters/namespace');
 const mdFilters = require('./site/_filters/md');
 const {slugify} = require('./site/_filters/slugify');
+const {ensureUniqueHref} = require('./site/_filters/ensureUniqueHref');
 const {toc} = require('./site/_filters/toc');
 const {updateSvgForInclude} = require('webdev-infra/filters/svg');
 const {minifyHtml} = require('webdev-infra/filters/minifyHtml');
@@ -126,6 +127,7 @@ module.exports = eleventyConfig => {
   eleventyConfig.addFilter('updateSvgForInclude', updateSvgForInclude);
   eleventyConfig.addFilter('slugify', slugify);
   eleventyConfig.addFilter('toc', toc);
+  eleventyConfig.addFilter('ensureUniqueHref', ensureUniqueHref);
   eleventyConfig.addFilter('typeof', x => typeof x);
   eleventyConfig.addNunjucksAsyncFilter('minifyHtml', minifyHtml);
 

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -14,7 +14,7 @@ const {githubLink} = require('./site/_filters/github-link');
 const {namespaceToPath} = require('./site/_filters/namespace');
 const mdFilters = require('./site/_filters/md');
 const {slugify} = require('./site/_filters/slugify');
-const {ensureUniqueHref} = require('./site/_filters/ensureUniqueHref');
+const {ensureUniqueHrefInProduction} = require('./site/_filters/ensureUniqueHrefInProduction');
 const {toc} = require('./site/_filters/toc');
 const {updateSvgForInclude} = require('webdev-infra/filters/svg');
 const {minifyHtml} = require('webdev-infra/filters/minifyHtml');
@@ -127,7 +127,7 @@ module.exports = eleventyConfig => {
   eleventyConfig.addFilter('updateSvgForInclude', updateSvgForInclude);
   eleventyConfig.addFilter('slugify', slugify);
   eleventyConfig.addFilter('toc', toc);
-  eleventyConfig.addFilter('ensureUniqueHref', ensureUniqueHref);
+  eleventyConfig.addFilter('ensureUniqueHrefInProduction', ensureUniqueHrefInProduction);
   eleventyConfig.addFilter('typeof', x => typeof x);
   eleventyConfig.addNunjucksAsyncFilter('minifyHtml', minifyHtml);
 

--- a/site/_filters/ensureUniqueHref.js
+++ b/site/_filters/ensureUniqueHref.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const pageIds = new Set();
+
+/**
+ * Builds a key from the given id and the page URL and verifies
+ * it is unique across the page for a production build
+ * @param {string} id of the section
+ * @this {any} The eleventy context
+ * @return {string} unique id for the section
+ */
+function ensureUniqueHref(id) {
+  // Incremental builds (e.g. `npm run dev`) can not check for uniqueness
+  // as they create the same ID for every run which would trigger an error.
+  if (process.env.ELEVENTY_ENV !== 'production') {
+    return id;
+  }
+
+  const key = `${this.ctx.page.url}#${id}`;
+
+  if (!pageIds.has(key)) {
+    pageIds.add(key);
+
+    return id;
+  }
+
+  throw new Error(
+    `There is another element with the ID ${id} on the page ${this.ctx.page.url}. Please make sure all IDs are unique.`
+  );
+}
+
+module.exports = {
+  ensureUniqueHref,
+};

--- a/site/_filters/ensureUniqueHrefInProduction.js
+++ b/site/_filters/ensureUniqueHrefInProduction.js
@@ -23,7 +23,7 @@ const pageIds = new Set();
  * @this {any} The eleventy context
  * @return {string} unique id for the section
  */
-function ensureUniqueHref(id) {
+function ensureUniqueHrefInProduction(id) {
   // Incremental builds (e.g. `npm run dev`) can not check for uniqueness
   // as they create the same ID for every run which would trigger an error.
   if (process.env.ELEVENTY_ENV !== 'production') {
@@ -44,5 +44,5 @@ function ensureUniqueHref(id) {
 }
 
 module.exports = {
-  ensureUniqueHref,
+  ensureUniqueHrefInProduction,
 };

--- a/site/_includes/macros/landing-section-expanded.njk
+++ b/site/_includes/macros/landing-section-expanded.njk
@@ -8,7 +8,7 @@
 <section
   class="landing-section landing-section--{{type}} {% if ordered %} landing-section--ordered {% endif %} hairline rounded-lg width-full display-grid gap-top-400"
   style="--number-color: var(--color-{{ color }}-medium); --dot-color: var(--color-{{ color }}-lighter);"
-  id="{{sectionId | slugify | ensureUniqueHref }}">
+  id="{{sectionId | slugify | ensureUniqueHrefInProduction }}">
 
   {{ landingDeco(title, desc, color, imgSrc, imgAlt, imgWidth, imgHeight, smallImgSrc) }}
   <div class="gap-top-200 gap-left-200 gap-right-200">

--- a/site/_includes/macros/landing-section-expanded.njk
+++ b/site/_includes/macros/landing-section-expanded.njk
@@ -2,14 +2,15 @@
 {% from 'macros/landing-deco.njk' import landingDeco with context %}
 {% from 'macros/related-articles.njk' import relatedArticles with context %}
 
-{% macro landingSectionExpanded(title, desc, items, color, type, ordered, imgSrc, imgAlt, imgWidth, imgHeight, smallImgSrc, relatedTitle, relatedItems) %}
+{% macro landingSectionExpanded(title, desc, items, color, type, ordered, imgSrc, imgAlt, imgWidth, imgHeight, smallImgSrc, relatedTitle, relatedItems, customId) %}
+{% set sectionId = customId if customId else title %}
 
 <section
   class="landing-section landing-section--{{type}} {% if ordered %} landing-section--ordered {% endif %} hairline rounded-lg width-full display-grid gap-top-400"
-  style="--number-color: var(--color-{{ color }}-medium); --dot-color: var(--color-{{ color }}-lighter);">
+  style="--number-color: var(--color-{{ color }}-medium); --dot-color: var(--color-{{ color }}-lighter);"
+  id="{{sectionId | slugify | ensureUniqueHref }}">
 
   {{ landingDeco(title, desc, color, imgSrc, imgAlt, imgWidth, imgHeight, smallImgSrc) }}
-
   <div class="gap-top-200 gap-left-200 gap-right-200">
     <div class="landing-section__links">
       {% for item in items %}

--- a/site/_includes/macros/landing-section-usecases.njk
+++ b/site/_includes/macros/landing-section-usecases.njk
@@ -2,10 +2,13 @@
 {% from 'macros/landing-deco.njk' import landingDeco with context %}
 {% from 'macros/related-articles.njk' import relatedArticles with context %}
 
-{% macro landingSectionUseCases(title, desc, useCase1Title, useCase1items, useCase2Title, useCase2items, items, color, type, ordered, imgSrc, imgAlt, imgWidth, imgHeight, smallImgSrc, learnMore, moreDocuments1, moreDocuments2) %}
+{% macro landingSectionUseCases(title, desc, useCase1Title, useCase1items, useCase2Title, useCase2items, items, color, type, ordered, imgSrc, imgAlt, imgWidth, imgHeight, smallImgSrc, customId) %}
+{% set sectionId = customId if customId else title %}
+
 <section
   class="landing-section landing-section--{{type}} {% if ordered %} landing-section--ordered {% endif %} hairline rounded-lg width-full display-grid gap-top-400"
-  style="--number-color: var(--color-{{ color }}-medium); --dot-color: var(--color-{{ color }}-lighter);">
+  style="--number-color: var(--color-{{ color }}-medium); --dot-color: var(--color-{{ color }}-lighter);"
+  id="{{sectionId | slugify | ensureUniqueHref}}">
 
   {{ landingDeco(title, desc, color, imgSrc, imgAlt, imgWidth, imgHeight, smallImgSrc, learnMore) }}
 

--- a/site/_includes/macros/landing-section-usecases.njk
+++ b/site/_includes/macros/landing-section-usecases.njk
@@ -8,7 +8,7 @@
 <section
   class="landing-section landing-section--{{type}} {% if ordered %} landing-section--ordered {% endif %} hairline rounded-lg width-full display-grid gap-top-400"
   style="--number-color: var(--color-{{ color }}-medium); --dot-color: var(--color-{{ color }}-lighter);"
-  id="{{sectionId | slugify | ensureUniqueHref}}">
+  id="{{sectionId | slugify | ensureUniqueHrefInProduction}}">
 
   {{ landingDeco(title, desc, color, imgSrc, imgAlt, imgWidth, imgHeight, smallImgSrc, learnMore) }}
 

--- a/site/_includes/macros/landing-section.njk
+++ b/site/_includes/macros/landing-section.njk
@@ -6,7 +6,7 @@
 <section
   class="landing-section landing-section--{{type}} {% if ordered %} landing-section--ordered {% endif %} hairline rounded-lg width-full display-grid gap-top-400"
   style="--number-color: var(--color-{{ color }}-medium); --dot-color: var(--color-{{ color }}-lighter);"
-  id="{{sectionId | slugify | ensureUniqueHref}}">
+  id="{{sectionId | slugify | ensureUniqueHrefInProduction}}">
 
   {{ landingDeco(title, desc, color, imgSrc, imgAlt, imgWidth, imgHeight, smallImgSrc) }}
 

--- a/site/_includes/macros/landing-section.njk
+++ b/site/_includes/macros/landing-section.njk
@@ -1,9 +1,12 @@
 {% from 'macros/landing-deco.njk' import landingDeco with context %}
 
-{% macro landingSection(title, desc, items, color, type, ordered, imgSrc, imgAlt, imgWidth, imgHeight, smallImgSrc) %}
+{% macro landingSection(title, desc, items, color, type, ordered, imgSrc, imgAlt, imgWidth, imgHeight, smallImgSrc, customId) %}
+{% set sectionId = customId if customId else title %}
+
 <section
   class="landing-section landing-section--{{type}} {% if ordered %} landing-section--ordered {% endif %} hairline rounded-lg width-full display-grid gap-top-400"
-  style="--number-color: var(--color-{{ color }}-medium); --dot-color: var(--color-{{ color }}-lighter);">
+  style="--number-color: var(--color-{{ color }}-medium); --dot-color: var(--color-{{ color }}-lighter);"
+  id="{{sectionId | slugify | ensureUniqueHref}}">
 
   {{ landingDeco(title, desc, color, imgSrc, imgAlt, imgWidth, imgHeight, smallImgSrc) }}
 

--- a/site/en/docs/handbook/content-types/landing/index.njk
+++ b/site/en/docs/handbook/content-types/landing/index.njk
@@ -160,7 +160,8 @@ useCaseLandingSection:
   '',
   333,
   165,
-  'image/jxu1OdD7LKOGIDU7jURMpSH2lyK2/kdPhkPXy7R0mmcJaKyoi.svg'
+  'image/jxu1OdD7LKOGIDU7jURMpSH2lyK2/kdPhkPXy7R0mmcJaKyoi.svg',
+  'section-id'
   )
 }}
 


### PR DESCRIPTION
Follow-up to #5016, including Sim's original changes. I needed to revert the PR last night as it broke the watch build.

This is due to a flaw in the original PR: incremental builds will of course create the same IDs, causing false-positive errors. So we can only check for unique IDs in prod builds, which is fair I think as they would make GitHub checks fail.