### PR TITLE
Maskable icon link fix

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -24,6 +24,9 @@ redirects:
 - from: /blog/navigation-preload/
   to: https://web.dev/navigation-preload/
 
+- from: /maskable-icon/
+  to: https://web.dev/maskable-icon/
+
 - from: /activeTab
   to: /docs/extensions/reference/activeTab
 

--- a/site/en/docs/lighthouse/pwa/maskable-icon-audit/index.md
+++ b/site/en/docs/lighthouse/pwa/maskable-icon-audit/index.md
@@ -67,7 +67,7 @@ In order to pass the audit:
 - [Add a web app manifest][manifest]
 - [The `icons` property on MDN](https://developer.mozilla.org/docs/Web/Manifest/icons)
 
-[guide]: /maskable-icon/
+[guide]: https://web.dev/maskable-icon/
 [editor]: https://maskable.app/editor
 [manifest]: /add-manifest/
 [values]: https://developer.mozilla.org/docs/Web/Manifest/icons#Values


### PR DESCRIPTION
https://twitter.com/maboa/status/1628699412921819136

https://developer.chrome.com/docs/lighthouse/pwa/maskable-icon-audit/ links to https://developer.chrome.com/maskable-icon/ which is a 404.

Not sure if a redirect is needed. Happy to drop it from the PR.