### PR TITLE
[Privacy Sandbox] Redirect status page

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -51,6 +51,9 @@ redirects:
 - from: /docs/privacy-sandbox/attribution-reporting/summary-reports/
   to: /docs/privacy-sandbox/summary-reports/
 
+- from: /docs/privacy-sandbox/status
+  to: https://privacysandbox.com/open-web/#the-privacy-sandbox-timeline
+
 - from: /android
   to: /docs/android
 

--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -8,11 +8,11 @@
     - url: https://privacysandbox.com/timeline
       title: i18n.docs.privacy-sandbox.timeline
     - url: /docs/privacy-sandbox/glossary
+    - url: /docs/privacy-sandbox/proposal-lifecycle
     - url: /docs/privacy-sandbox/events
 - title: i18n.docs.privacy-sandbox.start
   sections:
     - url: /docs/privacy-sandbox/unified-origin-trial
-    - url: /docs/privacy-sandbox/proposal-lifecycle
     - url: /docs/privacy-sandbox/faq
     - url: /docs/privacy-sandbox/feedback
 - title: i18n.docs.privacy-sandbox.strengthen-boundaries

--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -7,12 +7,12 @@
       title: i18n.docs.privacy-sandbox.blog
     - url: https://privacysandbox.com/timeline
       title: i18n.docs.privacy-sandbox.timeline
+    - url: /docs/privacy-sandbox/glossary
     - url: /docs/privacy-sandbox/events
 - title: i18n.docs.privacy-sandbox.start
   sections:
     - url: /docs/privacy-sandbox/unified-origin-trial
     - url: /docs/privacy-sandbox/proposal-lifecycle
-    - url: /docs/privacy-sandbox/glossary
     - url: /docs/privacy-sandbox/faq
     - url: /docs/privacy-sandbox/feedback
 - title: i18n.docs.privacy-sandbox.strengthen-boundaries

--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -8,14 +8,13 @@
     - url: https://privacysandbox.com/timeline
       title: i18n.docs.privacy-sandbox.timeline
     - url: /docs/privacy-sandbox/events
-    - url: /docs/privacy-sandbox/proposal-lifecycle
 - title: i18n.docs.privacy-sandbox.start
   sections:
     - url: /docs/privacy-sandbox/unified-origin-trial
-    - url: /docs/privacy-sandbox/feedback
+    - url: /docs/privacy-sandbox/proposal-lifecycle
     - url: /docs/privacy-sandbox/glossary
-    - url: /docs/privacy-sandbox/status
     - url: /docs/privacy-sandbox/faq
+    - url: /docs/privacy-sandbox/feedback
 - title: i18n.docs.privacy-sandbox.strengthen-boundaries
   sections:
     - url: /docs/privacy-sandbox/first-party-sets


### PR DESCRIPTION
The status page is out-of-date, difficult to maintain, and repetitive of information across the sites. For the most part, if folks want a comprehensive update of a group of APIs, it will be relevant to the "Relevence and measurement" group or "anti-fraud" group rather than all possible PS APIs.

This does not delete the existing status page, which we could decide to rehab with partials from the APIs, grouped strategically.