### PR TITLE
Fix supernest on landing page

### DIFF
--- a/site/_includes/macros/project-sections.njk
+++ b/site/_includes/macros/project-sections.njk
@@ -14,6 +14,8 @@ have been defined in the _data/docs/*.yml file for this project.
   {% set type = 'column' %}
 {% elif previousType === 'column' %}
   {% set type = 'nested-column' %}
+{% elif previousType === 'nested-column' %}
+  {% set type = 'nested-column' %}
 {% endif %}
 
 <ul class="project-sections__{{type}} stack flow-space-300 pad-left-0 gap-top-0" role="list">


### PR DESCRIPTION
Fixes re-opened #4195

Adds 'nested-column' style for anything that lives in a nested column.

The design could still be improved but is no longer a squished version of a document.