### PR TITLE
Add FLEDGE+ARA testing availability info

### DIFF
--- a/site/en/docs/privacy-sandbox/fledge-api/feature-status/index.md
+++ b/site/en/docs/privacy-sandbox/fledge-api/feature-status/index.md
@@ -62,7 +62,7 @@ As we move [FLEDGE](/docs/privacy-sandbox/fledge/) closer to general availabilit
    </td>
    <td>2023 Q2
    </td>
-   <td>In development. 
+   <td>Will be available for testing in Chrome Stable M112+.
    </td>
   </tr>
   <tr>
@@ -103,7 +103,7 @@ The temporary `navigator.deprecatedURNToURL()` will be removed by third-party co
 
 Recently, challenges have been [pointed out](https://github.com/WICG/turtledove/issues/281) around the integration of the [Attribution Reporting API](/docs/privacy-sandbox/attribution-reporting/) and FLEDGE, especially in the situation where fenced frames are involved. 
 
-For event-level attribution reporting with FLEDGE, we have a proposed set of initial improvements to make this integration easier which you can learn more about in the [explainer](https://github.com/WICG/turtledove/blob/main/Fenced_Frames_Ads_Reporting.md#support-for-attribution-reporting). The integration will be available in both Fenced Frames and iFrames. 
+For event-level attribution reporting with FLEDGE, we have a proposed set of initial improvements to make this integration easier which you can learn more about in the [explainer](https://github.com/WICG/turtledove/blob/main/Fenced_Frames_Ads_Reporting.md#support-for-attribution-reporting). The integration will be available in both Fenced Frames and iFrames. Event-level attribution reporting will be available for testing in Chrome Stable M112+.
 
 For those who need [aggregate attribution reporting with FLEDGE](https://github.com/WICG/turtledove/issues/289), we are working on more flexible solutions to capture more bidding signals with aggregate reporting, and we will publish a proposal once it is ready. 
 

--- a/site/en/docs/privacy-sandbox/fledge-api/feature-status/index.md
+++ b/site/en/docs/privacy-sandbox/fledge-api/feature-status/index.md
@@ -62,7 +62,7 @@ As we move [FLEDGE](/docs/privacy-sandbox/fledge/) closer to general availabilit
    </td>
    <td>2023 Q2
    </td>
-   <td>Will be available for testing in Chrome Stable M112+.
+   <td>Available for testing in Chrome Stable M112+.
    </td>
   </tr>
   <tr>
@@ -103,7 +103,7 @@ The temporary `navigator.deprecatedURNToURL()` will be removed by third-party co
 
 Recently, challenges have been [pointed out](https://github.com/WICG/turtledove/issues/281) around the integration of the [Attribution Reporting API](/docs/privacy-sandbox/attribution-reporting/) and FLEDGE, especially in the situation where fenced frames are involved. 
 
-For event-level attribution reporting with FLEDGE, we have a proposed set of initial improvements to make this integration easier which you can learn more about in the [explainer](https://github.com/WICG/turtledove/blob/main/Fenced_Frames_Ads_Reporting.md#support-for-attribution-reporting). The integration will be available in both Fenced Frames and iFrames. Event-level attribution reporting will be available for testing in Chrome Stable M112+.
+For event-level reporting with FLEDGE, we have a proposed set of initial improvements to make this integration easier which you can learn more about in the [explainer](https://github.com/WICG/turtledove/blob/main/Fenced_Frames_Ads_Reporting.md#support-for-attribution-reporting). The integration will be available for both fenced frames and iFrames. Event-level reporting will be available for testing in Chrome Stable M112+.
 
 For those who need [aggregate attribution reporting with FLEDGE](https://github.com/WICG/turtledove/issues/289), we are working on more flexible solutions to capture more bidding signals with aggregate reporting, and we will publish a proposal once it is ready. 
 


### PR DESCRIPTION
This PR adds the testing availability information for FLEDGE+ARA integration to the FLEDGE status page. 

Preview link: https://deploy-preview-5439--developer-chrome-com.netlify.app/en/docs/privacy-sandbox/fledge-api/feature-status/#improved-fledge-attribution-reporting-integration