### PR TITLE
fix(5442): fix typo in blog article

### DIFF
--- a/site/en/blog/style-queries/index.md
+++ b/site/en/blog/style-queries/index.md
@@ -49,7 +49,7 @@ Unlike with style queries, you don’t need to apply containment using the `cont
 To directly query a parent, you can write:
 
 ```css
-/* styling .card based on the value of --myVar on .card-container */
+/* styling .card based on the value of --theme on .card-container */
 @container style(--theme: warm) {
   .card {
     background-color: wheat;


### PR DESCRIPTION
Fixes a typo in the article [Getting Started with Style Queries](https://developer.chrome.com/blog/style-queries/).

Fixes #5442

Google Individual CLA
flauns04