### PR TITLE
Make devguide overview more usable.

### DIFF
--- a/site/en/docs/extensions/mv3/devguide/index.md
+++ b/site/en/docs/extensions/mv3/devguide/index.md
@@ -67,7 +67,7 @@ functionality.
 [Browsing data](/docs/extensions/reference/browsingData)
 : Remove browsing data from a user's local profile.
 
-[Downloads](/docs/extensions/reference/downloads
+[Downloads](/docs/extensions/reference/downloads)
 : Programmatically initiate, monitor, manipulate, and search for downloads.
 
 [Settings](/docs/extensions/reference/fontSettings)
@@ -77,7 +77,7 @@ functionality.
 : Interact with the browser's record of visited pages.
 
 [Privacy](/docs/extensions/reference/privacy)
-: Control Chrome privacy features
+: Control Chrome privacy features.
 
 [Proxy](/docs/extensions/reference/proxy)
 : Manage Chrome's proxy settings.

--- a/site/en/docs/extensions/mv3/devguide/index.md
+++ b/site/en/docs/extensions/mv3/devguide/index.md
@@ -10,221 +10,143 @@ description: An overview of Chrome Extension capabilities and components.
 After reading the [Getting Started][doc-getstarted] guides and [Architecture Overview][doc-arch], use this guide as an outline of extension components and their capabilities in Manifest V3. You are encouraged to explore and expand extension
 functionality.
 
-<table class="width-full">
-  <tbody>
-    <tr>
-      <th colspan="2"><strong>Customize extension user interface</strong></th>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/action">Action</a></td>
-      <td>Control the display of an extension's icon in the toolbar.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/commands">Commands</a></td>
-      <td>Add keyboard shortcuts that trigger actions.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/contextMenus">Context&nbsp;Menus</a></td>
-      <td>Add items to Google Chrome's context menu.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/omnibox">Omnibox</a></td>
-      <td>Add keyword functionality to the address bar.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/mv3/override">Override&nbsp;Pages</a></td>
-      <td>Create a version of the New Tab, Bookmark, or History page.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/pageAction">Page&nbsp;Actions</a></td>
-      <td>Dynamically display icons in the toolbar.</td>
-    </tr>
-  </tbody>
-</table>
+## Customize the user interface
 
-<table class="width-full">
-  <tbody>
-    <tr>
-      <th colspan="2"><strong>Build extension utilities</strong></th>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/mv3/a11y">Accessibility (a11y)</a></td>
-      <td>Make an extension accessible to people with disabilities.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/mv3/migrating_to_service_workers">Service Workers</a></td>
-      <td>Detect and react when something interesting happens.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/i18n">Internationalization</a></td>
-      <td>Work with language and locale.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/identity">Identity</a></td>
-      <td>Get OAuth2 access tokens.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/management">Management</a></td>
-      <td>Manage extensions that are installed and running.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/mv3/messaging">Message&nbsp;Passing</a></td>
-      <td>Communicate from a content script to its parent extension, or vice versa.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/mv3/options">Options&nbsp;Pages</a></td>
-      <td>Let users customize an extension.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/permissions">Permissions</a></td>
-      <td>Modify an extension's permissions.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/storage">Storage</a></td>
-      <td>Store and retrieve data.</td>
-    </tr>
-  </tbody>
-</table>
+[Action](/docs/extensions/reference/action)
+: Control the display of an extension's icon in the toolbar.
 
-<table class="width-full">
-  <tbody>
-    <tr>
-      <th colspan="2"><strong>Modify and observe the Chrome Browser</strong></th>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/bookmarks">Bookmarks</a></td>
-      <td>Create, organize, and manipulate bookmark behavior.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/browsingData">Browsing&nbsp;Data</a></td>
-      <td>Remove browsing data from a user's local profile.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/downloads">Downloads</a></td>
-      <td>Programmatically initiate, monitor, manipulate, and search for downloads.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/fontSettings">Font&nbsp;Settings</a></td>
-      <td>Manage Chrome's font settings.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/history">History</a></td>
-      <td>Interact with the browser's record of visited pages.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/privacy">Privacy</a></td>
-      <td>Control Chrome privacy features.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/proxy">Proxy</a></td>
-      <td>Manage Chrome's proxy settings.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/sessions">Sessions</a></td>
-      <td>Query and restore tabs and windows from a browsing session.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/tabs">Tabs</a></td>
-      <td>Create, modify, and rearrange tabs in the browser.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/topSites">Top&nbsp;Sites</a></td>
-      <td>Access users most visited URLs.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/mv3/themes">Themes</a></td>
-      <td>Change the overall appearance of the browser.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/windows">Windows</a></td>
-      <td>Create, modify, and rearrange windows in the browser.</td>
-    </tr>
-  </tbody>
-</table>
+[Commands](/docs/extensions/reference/commands)
+: Add keyboard shortcuts that trigger actions.
 
-<table class="width-full">
-  <tbody>
-    <tr>
-      <th colspan="2"><strong>Modify and observe the web</strong></th>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/mv3/manifest/activeTab">Active&nbsp;Tab</a></td>
-      <td>Securely access websites by removing most needs for <code>&lt;all_urls&gt;</code> host permission.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/contentSettings">Content&nbsp;Settings</a></td>
-      <td>Customize websites features such as cookies, JavaScript, and plugins.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/mv3/content_scripts">Content&nbsp;Scripts</a></td>
-      <td>Run JavaScript code in the context of web pages.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/cookies">Cookies</a></td>
-      <td>Explore and modify the browser's cookie system.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/mv3/xhr">Cross-Origin&nbsp;XHR</a></td>
-      <td>Use XMLHttpRequest to send and receive data from remote servers.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/declarativeContent">Declarative&nbsp;Content</a></td>
-      <td>Perform actions on the content of a page without requiring permission.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/desktopCapture">Desktop&nbsp;Capture</a></td>
-      <td>Capture content of screen, individual windows or tabs.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/pageCapture">Page&nbsp;Capture</a></td>
-      <td>Save a tab's source information as MHTML.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/tabCapture">Tab&nbsp;Capture</a></td>
-      <td>Interact with tab media streams.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/webNavigation">Web&nbsp;Navigation</a></td>
-      <td>Status updates of navigation requests in-flight.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/declarativeNetRequest">Declarative&nbsp;Net&nbsp;Request</a></td>
-      <td>Provide rules that tell Chrome how to intercept, block, or modify requests in-flight.</td>
-    </tr>
-  </tbody>
-</table>
+[Menus](/docs/extensions/reference/contextMenus)
+: Add items to Google Chrome's context menu.
 
-<table class="width-full">
-  <tbody>
-    <tr>
-      <th colspan="2"><strong>Package, deploy and update</strong></th>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/mv3/hosting">Chrome Web Store</a></td>
-      <td>Hosting and updating extensions with the Chrome Web Store.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/mv3/external_extensions">Other&nbsp;Deployment&nbsp;Options</a></td>
-      <td>Distribute extensions on a designated network or with other software.</td>
-    </tr>
-  </tbody>
-</table>
+[Omnibox](/docs/extensions/reference/omnibox">Omnibox)
+: Add keyword functionality to the address bar.
 
-<table class="width-full">
-  <tbody>
-    <tr>
-      <th colspan="2"><strong>Expand Chrome DevTools</strong></th>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/reference/debugger">Debugger</a></td>
-      <td>Instrument network interaction, debug JavaScript, mutate the DOM and CSS.</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/extensions/mv3/devtools">Devtools</a></td>
-      <td>Add features to Chrome Developer Tools.</td>
-    </tr>
-  </tbody>
-</table>
+[Pages](/docs/extensions/mv3/override)
+: Create a version of the New Tab, Bookmark, or History page.
+
+[Actions](/docs/extensions/reference/pageAction)
+: Dynamically display icons in the toolbar.</td>
+
+## Build extension utilities
+
+[Accessibility](/docs/extensions/mv3/a11y)
+: Make an extension accessible to people with disabilities.
+
+[Service workers](/docs/extensions/mv3/migrating_to_service_workers)
+: Detect and react when something interesting happens.
+
+[Internationalization](/docs/extensions/reference/i18n)
+: Work with language and locale.
+
+[Identity](/docs/extensions/reference/identity)
+: Get OAuth2 access tokens.
+
+[Management](/docs/extensions/reference/management)
+: Manage extensions that are installed and running.
+
+[Message passing](/docs/extensions/mv3/messaging)
+: Communicate from a content script to its parent extension, or vice versa.
+
+[Options page](/docs/extensions/mv3/options)
+: Let users customize an extension.
+
+[Permissions](/docs/extensions/reference/permissions)
+: Modify an extension's permissions.
+
+[Storage](/docs/extensions/reference/storage)
+: Store and retrieve data.
+
+## Modify and observe the Chrome browser
+
+[Bookmarks](/docs/extensions/reference/bookmarks)
+: Create, organize, and manipulate bookmark behavior.
+
+[Browsing data](/docs/extensions/reference/browsingData)
+: Remove browsing data from a user's local profile.
+
+[Downloads](/docs/extensions/reference/downloads
+: Programmatically initiate, monitor, manipulate, and search for downloads.
+
+[Settings](/docs/extensions/reference/fontSettings)
+: Manage Chrome's font settings.
+
+[History](/docs/extensions/reference/history)
+: Interact with the browser's record of visited pages.
+
+[Privacy](/docs/extensions/reference/privacy)
+: Control Chrome privacy features
+
+[Proxy](/docs/extensions/reference/proxy)
+: Manage Chrome's proxy settings.
+
+[Sessions](/docs/extensions/reference/sessions)
+: Query and restore tabs and windows from a browsing session.
+
+[Tabs](/docs/extensions/reference/tabs)
+: Create, modify, and rearrange tabs in the browser.
+
+[Top sites](/docs/extensions/reference/topSites)
+: Access users most visited URLs.
+
+[Themes](/docs/extensions/mv3/themes)
+: Change the overall appearance of the browser.
+
+[Windows](/docs/extensions/reference/windows)
+: Create, modify, and rearrange windows in the browser.
+
+## Modify and observe the web
+
+[Active tab](/docs/extensions/mv3/manifest/activeTab)
+: Securely access websites by removing most needs for <code>&lt;all_urls&gt;</code> host permission.
+
+[Content settings](/docs/extensions/reference/contentSettings)
+: Customize websites features such as cookies, JavaScript, and plugins.
+
+[Content scripts](/docs/extensions/mv3/content_scripts)
+: Run JavaScript code in the context of web pages.
+
+[Cookies](/docs/extensions/reference/cookies)
+: Explore and modify the browser's cookie system.
+
+[Cross-origin XMLHttpRequest](/docs/extensions/mv3/xhr)
+: Use XMLHttpRequest to send and receive data from remote servers.
+
+[Declarative content](/docs/extensions/reference/declarativeContent)
+: Perform actions on the content of a page without requiring permission.
+
+[Desktop capture](docs/extensions/reference/desktopCapture)
+: Capture content of screen, individual windows or tabs.
+
+[Page capture](/docs/extensions/reference/pageCapture)
+: Save a tab's source information as MHTML.
+
+[Tab capture](/docs/extensions/reference/tabCapture)
+: Interact with tab media streams.
+
+[Web navigation](/docs/extensions/reference/webNavigation)
+: Status updates of navigation requests in-flight.
+
+[Declarative net request](/docs/extensions/reference/declarativeNetRequest)
+: Provide rules that tell Chrome how to intercept, block, or modify requests in-flight.
+
+## Package, deploy, and update
+
+[Chrome Web Store](/docs/extensions/mv3/hosting)
+: Hosting and updating extensions with the Chrome Web Store.
+
+[Other deployment options](/docs/extensions/mv3/external_extensions)
+: Distribute extensions on a designated network or with other software.
+
+## Expand Chrome DevTools
+
+[Debugger](/docs/extensions/reference/debugger)
+: Instrument network interaction, debug JavaScript, mutate the DOM and CSS.
+
+[Devtools](/docs/extensions/mv3/devtools)
+: Add features to Chrome Developer Tools.
 
 [doc-getstarted]: /docs/extensions/mv3/getstarted
 [doc-arch]: /docs/extensions/mv3/architecture-overview/


### PR DESCRIPTION
Does the following
- Replaces tables with definition lists to avoid horizontal scrolling on small screens.
- Replaces table headings with actual headings so that the page has a table of contents.
- Applies corporate standard capitalization to headings.