### PR TITLE
Document additional CDP namespaces available in debugger API.

### DIFF
--- a/site/en/docs/extensions/reference/debugger/index.md
+++ b/site/en/docs/extensions/reference/debugger/index.md
@@ -6,10 +6,15 @@ has_warning: This permission <a href="/docs/extensions/mv3/permission_warnings/#
 ## Note
 
 For security reasons, the `chrome.debugger` API does not provide access to all Chrome DevTools
-Protocol Domains. The available domains are: [Audits][1], [DOM][2], [Emulation][3], [Fetch][4],
-[IO][5], [Input][6], [Inspector][7], [Log][8], [Network][9], [Overlay][10], [Page][11],
-[Storage][12], [Target][13], [Tracing][14] and [WebAuthn][15].
-
+Protocol Domains. The available domains are: [Accessibility][accessibility],
+[Audits][audits], [CacheStorage][cache-storage], [Console][console],
+[CSS][css], [Database][database], [Debugger][debugger], [DOM][dom],
+[DOMDebugger][dom-debugger], [DOMSnapshot][dom-snapshot],
+[Emulation][emulation], [Fetch][fetch], [IO][io], [Input][input],
+[Inspector][inspector], [Log][log], [Network][network], [Overlay][overlay],
+[Page][page], [Performance][performance], [Profiler][profiler],
+[Runtime][runtime], [Storage][storage], [Target][target], [Tracing][tracing],
+[WebAudio][web-audio], and [WebAuthn][webauthn].
 
 ## Manifest
 
@@ -28,21 +33,33 @@ You must declare the "debugger" permission in your extension's manifest to use t
 
 ## Examples
 
-You can find samples of this API in [Samples][16].
+You can find samples of this API in [Samples][debugger-samples].
 
-[1]: https://chromedevtools.github.io/devtools-protocol/tot/Audits
-[2]: https://chromedevtools.github.io/devtools-protocol/tot/DOM
-[3]: https://chromedevtools.github.io/devtools-protocol/tot/Emulation
-[4]: https://chromedevtools.github.io/devtools-protocol/tot/Fetch
-[5]: https://chromedevtools.github.io/devtools-protocol/tot/IO
-[6]: https://chromedevtools.github.io/devtools-protocol/tot/Input
-[7]: https://chromedevtools.github.io/devtools-protocol/tot/Inspector
-[8]: https://chromedevtools.github.io/devtools-protocol/tot/Log
-[9]: https://chromedevtools.github.io/devtools-protocol/tot/Network
-[10]: https://chromedevtools.github.io/devtools-protocol/tot/Overlay
-[11]: https://chromedevtools.github.io/devtools-protocol/tot/Page
-[12]: https://chromedevtools.github.io/devtools-protocol/tot/Storage
-[13]: https://chromedevtools.github.io/devtools-protocol/tot/Target
-[14]: https://chromedevtools.github.io/devtools-protocol/tot/Tracing
-[15]: https://chromedevtools.github.io/devtools-protocol/tot/WebAuthn
-[16]: /docs/extensions/mv2/samples#search:debugger
+[audits]: https://chromedevtools.github.io/devtools-protocol/tot/Audits
+[dom]: https://chromedevtools.github.io/devtools-protocol/tot/DOM
+[emulation]: https://chromedevtools.github.io/devtools-protocol/tot/Emulation
+[fetch]: https://chromedevtools.github.io/devtools-protocol/tot/Fetch
+[io]: https://chromedevtools.github.io/devtools-protocol/tot/IO
+[input]: https://chromedevtools.github.io/devtools-protocol/tot/Input
+[inspector]: https://chromedevtools.github.io/devtools-protocol/tot/Inspector
+[log]: https://chromedevtools.github.io/devtools-protocol/tot/Log
+[network]: https://chromedevtools.github.io/devtools-protocol/tot/Network
+[overlay]: https://chromedevtools.github.io/devtools-protocol/tot/Overlay
+[page]: https://chromedevtools.github.io/devtools-protocol/tot/Page
+[storage]: https://chromedevtools.github.io/devtools-protocol/tot/Storage
+[target]: https://chromedevtools.github.io/devtools-protocol/tot/Target
+[tracing]: https://chromedevtools.github.io/devtools-protocol/tot/Tracing
+[webauthn]: https://chromedevtools.github.io/devtools-protocol/tot/WebAuthn
+[debugger-samples]: /docs/extensions/mv3/samples#search:debugger
+[css]: https://chromedevtools.github.io/devtools-protocol/tot/css
+[cache-storage]: https://chromedevtools.github.io/devtools-protocol/tot/CacheStorage
+[dom-debugger]: https://chromedevtools.github.io/devtools-protocol/tot/DOMDebugger
+[dom-snapshot]: https://chromedevtools.github.io/devtools-protocol/tot/DOMSnapshot
+[database]: https://chromedevtools.github.io/devtools-protocol/tot/Database
+[performance]: https://chromedevtools.github.io/devtools-protocol/tot/Performance
+[web-audio]: https://chromedevtools.github.io/devtools-protocol/tot/WebAudio
+[runtime]: https://chromedevtools.github.io/devtools-protocol/tot/Runtime
+[debugger]: https://chromedevtools.github.io/devtools-protocol/tot/Debugger
+[console]: https://chromedevtools.github.io/devtools-protocol/tot/Console
+[profiler]: https://chromedevtools.github.io/devtools-protocol/tot/Profiler
+[accessibility]: https://chromedevtools.github.io/devtools-protocol/tot/Accessibility


### PR DESCRIPTION
The list of available domains in the `chrome.debugger` API was incomplete. I've gone through and added the missing ones.