### PR TITLE
Run npm init before creating temporary package with workbox dependencies for build-external script

### DIFF
--- a/external/build/workbox-types.js
+++ b/external/build/workbox-types.js
@@ -37,6 +37,7 @@ async function fetchAndPrepare(packages, targetDir) {
   /** @type {childProcess.ExecFileSyncOptions} */
   const options = {cwd: targetDir, stdio: 'inherit'};
 
+  childProcess.execFileSync('npm', ['init', '--yes'], options);
   childProcess.execFileSync('npm', ['install', ...packages], options);
 
   const versionData = Object.fromEntries(


### PR DESCRIPTION
Fixes #5461

It looks like the new TS version does not like the fact, that the temporary package create from Workbox dependencies did not have a name.

I added an npm init call to fix it. It works locally, we need to merge to main to test on prod.