### PR TITLE
DevTools 111: HD Colors

### DIFF
--- a/site/_data/docs/devtools/toc.yml
+++ b/site/_data/docs/devtools/toc.yml
@@ -23,6 +23,7 @@
       sections:
         - url: /docs/devtools/css/
         - url: /docs/devtools/css/issues/
+        - url: /docs/devtools/css/color/
         - url: /docs/devtools/css/grid/
         - url: /docs/devtools/css/flexbox/
         - url: /docs/devtools/css/container-queries/

--- a/site/en/docs/devtools/css/color/index.md
+++ b/site/en/docs/devtools/css/color/index.md
@@ -12,34 +12,34 @@ tags:
   - css
 ---
 
-{% Aside %}
-This video was made before Chrome version 112 that introduced HD color support in DevTools.
-{% endAside %}
+The **Color Picker** provides a GUI for changing `color` and `*-color` declarations and lets you create, convert, and debug non-HD and [HD colors](/articles/high-definition-css-color-guide/) with a click.
 
 {% YouTube id='TuR27BxCRVk' %}
 
-The **Color Picker** provides a GUI for changing `color` and `*-color` declarations and lets you create, convert, and debug [HD color](/articles/high-definition-css-color-guide/) with a click.
-
-{% Aside 'gotchas' %}
-Starting with version 112, the **Styles** pane supports:
+{% Aside "important" %}
+This video shows Chrome DevTools version earlier than 112. In later versions, the **Styles** pane supports:
 
 - 12 new color spaces and 7 new gamuts from the [CSS Color Level 4](https://www.w3.org/TR/css-color-4/) specification.
 - The [`color-mix()`](/blog/css-color-mix) function from [CSS Color Level 5](https://www.w3.org/TR/css-color-5/#color-mix).
 {% endAside %}
 
-## Change colors with the Color Picker {: #change-colors }
+For a deep dive on the new color spaces, see [High Definition CSS Color Guide](/articles/high-definition-css-color-guide/).
 
-Use the **Color Picker** to change and debug color values:
+## Open the Color Picker and change colors {: #change-colors }
 
-1.  [Select an element][24] in the **Elements** panel.
-2.  In the **Styles** pane, find the `color` or `*-color` declaration that you want to
-    change.
+Use the **Color Picker** to change color values with a click:
 
-    To the left of each `color` or `*-color` value, there is a small square icon with a preview of that color.
+1. [Select an element](/docs/devtools/css/reference/#select) in the **Elements** panel.
+1. In the **Styles** pane, find the `color` or `*-color` declaration you want to change.
 
-    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/UbGGOVBV5ZCxcPT3JCZk.png", alt="Color preview.", width="600", height="400" %}
+   To the left of each `color` or `*-color` value, there is a small square icon with a preview of that color.
 
-3.  Click the preview to open the **Color Picker**.
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/UbGGOVBV5ZCxcPT3JCZk.png", alt="Color preview.", width="600", height="400" %}
+
+1. Click the preview to open the **Color Picker**.
+1. To change the color, use any of the UI elements of the **Color Picker**.
+
+## Color Picker elements {: #color-picker-elements }
 
 Here's a description of each of the UI elements of the **Color Picker**:
 
@@ -48,26 +48,88 @@ Here's a description of each of the UI elements of the **Color Picker**:
 1. **Shades**.
 1. **Eyedropper**. See [Sample a color anywhere with the Eyedropper](#eyedropper).
 1. **Copy to clipboard**. Copy the **Display value** to your clipboard.
-1. **Display value**. The parameter values of the chosen color space.
-1. **Contrast**. The difference between `color` and `background-color`. See [Color and contrast accessibility](https://web.dev/color-and-contrast-accessibility/).
-1. **Color palette**. Click one of these squares to change the color to that of the square.
-1. **Gamut boundary**. This boundary is for the new color spaces and [`color()`](/articles/high-definition-css-color-guide/#the-color-function) function. They can produce both HD and non-HD colors. The boundary lets you distinguish between them at a glance.
-1. **Color circle**. Drag this circle to change the display value.  
-1. **Hue** slider.
-1. **Opacity** slider.
-1. **Display value switcher**. Pick a color space from the drop-down list. See [Conver colors](#convert-colors)
+1. **Display value**. Arguments of the chosen color space.
+1. **Contrast ratio**. Available only for `color` values. It's the difference between `color` and `background-color`. 
+1. **Color palette**. Click a square to change the color to that of the square.
+1. **Gamut boundary**. This line is available only for the new color spaces and the [`color()`](/articles/high-definition-css-color-guide/#the-color-function) function. They can produce both HD and non-HD colors. The line lets you distinguish between HD and non-HD.
+1. **Color circle**. Drag this circle across the shades to change the display value.
+1. **Hue slider**.
+1. **Opacity slider**.
+1. **Display value switcher**. Pick a color space from the drop-down list. See [Convert colors](#convert-colors).
    {% Aside %}
-   **Note**: Alternatively, to open the drop-down menu directly, hold down <kbd>Shift</kbd> and click on the color preview icon next to the color value.
+   Alternatively, to open the drop-down menu directly, hold down <kbd>Shift</kbd> and click on the color preview icon next to the color value.
    {% endAside %}
-1. **Color palette switcher**. Toggle between the [Material Design palette][26], a custom palette,
-   or a page colors palette. DevTools generates the page color palette based on the colors that it
-   finds in your stylesheets.
+1. **Expand contrast ratio**. Opens the corresponding section that lets you [Fix contrast](#fix-contrast).
+1. **Color palette switcher**. Click it to toggle between:
 
-## Convert colors {: #convert-colors }
+   - [**Material** Design palette](https://m2.material.io/design/color/the-color-system.html#color-usage-and-palettes).
+   - **Custom** palette. To manually add the current color to this palette, click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/eY8MaTQqlXF3oiT6STmy.svg", alt="Add.", width="20", height="20" %}.
+   - **CSS Variables** palette. Lists all custom CSS variables (appended with `--`) on your page.
+   - **Page colors** palette. To generate this palette, DevTools looks for all the colors in your stylesheets.
 
-Toggle between the [RGBA][29], [HSLA][30], [HWBA][31], and [Hex][32] representations of the current color.
+## Choose a color space {: #choose-color-space }
 
-## Fix contrast issues {: # }
+To choose a color space:
+
+1. <kbd>Shift-click</kbd> the preview icon next a color value. A drop-down list opens.
+
+   {% Aside %}
+   Alternatively, click the **Display value switcher** in the **Color Picker**.
+   {% endAside %}
+
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/VDuxFzZRnRkSWsSfTlhx.png", alt="The drop-down list with all the supported color spaces.", width="800", height="838" %}
+
+1. Choose one of the following color spaces:
+
+   - [`#<hex-color>`](https://developer.mozilla.org/docs/Web/CSS/hex-color)
+   - [`rgb(X X X / .X)`](https://developer.mozilla.org/docs/Web/CSS/color_value/rgb).
+   - [`hsl(X X X / X)`](https://developer.mozilla.org/docs/Web/CSS/color_value/hsl).
+   - [`hwb(X X X / .X)`](https://developer.mozilla.org/docs/Web/CSS/color_value/hwb).
+   
+   Or one of the experimental ones:
+   - [`lch(X X X / .X)`](https://developer.mozilla.org/docs/Web/CSS/color_value/lch)
+   - [`oklch(X X X / .X)`](https://developer.mozilla.org/docs/Web/CSS/color_value/oklch)
+   - [`lab(X X X / .X)`](https://developer.mozilla.org/docs/Web/CSS/color_value/lab)
+   - [`oklab(X X X / .X)`](https://developer.mozilla.org/docs/Web/CSS/color_value/oklab)
+
+   Or one defined by the [`color(<color_space> X X X)`](/articles/high-definition-css-color-guide/#the-color-function) function.
+
+### Convert colors {: #convert-colors }
+
+When you switch between color spaces with the **Display value switcher**, DevTools automatically converts the values.
+
+{% Aside 'caution' %}
+When converting from HD to non-HD, DevTools clips gamuts to fit the space and marks clipped values with {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/hJxGejygnlBfMvhMtcCX.svg", alt="Warning.", width="24", height="24" %} warning icons. Hover over the icon to see the original value.
+
+{% Img src="image/vS06HQ1YTsbMKSFTIPl2iogUQP73/gKaBwo9xmgtONghzOdZr.png", alt="A warning icon indicating a gamut clipping and a tooltip with the original value.", width="400", height="204", class="screenshot" %}
+{% endAside %}
+
+{% Video src="video/vS06HQ1YTsbMKSFTIPl2iogUQP73/wsWrvMTPYM0a5tmNdzlQ.mp4", controls="true", loop="true", muted="true", class="screenshot" %}
+
+## Fix contrast {: #fix-contrast }
+
+{% Aside 'important' %}
+The **Color Picker** calculates contrast ratios only for the `color` values and relative to the respective `background-color` values. So, only the `color` values have **Contrast ratio** sections.
+{% endAside %}
+
+To fix a contrast issue for a `color` declaration:
+
+1. Open the **Color Picker** next to the `color` value.
+1. Expand the **Contrast ratio** {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/1UTR0tiSxiKD0YSwAc1g.svg", alt="Expand.", width="24", height="24" %} section.
+1. Use the suggested color that complies with a guideline:
+
+   - Click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/5sHRUwsqWoQHF2BiEwlm.png", alt="Use suggested color.", width="23", height="20" %} next to the guideline.
+   - In the **Shades** preview at the top, drag the **Color circle** below the corresponding line.
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/1OBcwQNbZivVFL4vbC47.png", alt="The expanded contrast ratio section with WebAIM or APCA guidelines.", width="800", height="518" %}
+
+{% Aside %}
+By default, the **Color Picker** suggests you to follow the [WebAIM guidelines](https://webaim.org/standards/wcag/). Alternatively, you can set it to suggest values compliant with [APCA](https://web.dev/color-and-contrast-accessibility/#advanced-perceptual-contrast-algorithm-apca):
+
+In {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/9gzXiTYY0nZzBxGI6KrV.svg", alt="Settings.", width="24", height="24" %} [**Settings** > **Experiments**](/docs/devtools/settings/experiments/), check {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/hmp8j3HiLMCcqPArD9yt.svg", alt="Checkbox.", width="22", height="22" %} **Enable new Advanced Perceptual Contrast Algorithm (APCA)...**
+{% endAside %}
+
+To get a list of all contrast issues in one go, follow the [Make your website more readable](/docs/devtools/accessibility/contrast/) guide.
 
 ## Sample a color anywhere with the Eyedropper {: #eyedropper }
 
@@ -78,10 +140,11 @@ The **Eyedropper** {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/WKeaXT922ot9wQ
 
 To pick a color from anywhere on the screen:
 
-1.  Hover over the target color.
-1.  Click to confirm.
+1. Select a color space with the [**Display value switcher**](#convert-colors).
+1. Hover over the target color.
+1. Click to confirm.
 
-    <div class="elevation--4" style="margin-top: 20px; margin-bottom: 20px;">
-    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/8Omn8AauWoiknzjzjlGA.png", alt="Using the Eyedropper anywhere on the screen.", width="800", height="450" %}</div>
+  <div class="elevation--4" style="margin-top: 20px; margin-bottom: 20px;">
+  {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/8Omn8AauWoiknzjzjlGA.png", alt="Using the Eyedropper anywhere on the screen.", width="800", height="450" %}</div>
 
-In the example above, the **Color Picker** shows a current color value of `rgb(224 255 255 / 15%)`. This color changes to pink once you click it.
+In this, the **Color Picker** shows a current color value of `rgb(224 255 255 / 15%)`. This color changes to pink once you click it.

--- a/site/en/docs/devtools/css/color/index.md
+++ b/site/en/docs/devtools/css/color/index.md
@@ -1,0 +1,87 @@
+---
+layout: "layouts/doc-post.njk"
+title: "Inspect and debug HD and non-HD colors with the Color Picker"
+authors:
+  - jecelynyeen
+  - sofiayem
+date: 2023-03-07
+#updated: YYYY-MM-DD
+description: "Learn how to use the Color Picker in Elements > Styles to inspect and debug HD and non-HD colors."
+tags:
+  - prototype-fixes
+  - css
+---
+
+{% Aside %}
+This video was made before Chrome version 112 that introduced HD color support in DevTools.
+{% endAside %}
+
+{% YouTube id='TuR27BxCRVk' %}
+
+The **Color Picker** provides a GUI for changing `color` and `*-color` declarations and lets you create, convert, and debug [HD color](/articles/high-definition-css-color-guide/) with a click.
+
+{% Aside 'gotchas' %}
+Starting with version 112, the **Styles** pane supports:
+
+- 12 new color spaces and 7 new gamuts from the [CSS Color Level 4](https://www.w3.org/TR/css-color-4/) specification.
+- The [`color-mix()`](/blog/css-color-mix) function from [CSS Color Level 5](https://www.w3.org/TR/css-color-5/#color-mix).
+{% endAside %}
+
+## Change colors with the Color Picker {: #change-colors }
+
+Use the **Color Picker** to change and debug color values:
+
+1.  [Select an element][24] in the **Elements** panel.
+2.  In the **Styles** pane, find the `color` or `*-color` declaration that you want to
+    change.
+
+    To the left of each `color` or `*-color` value, there is a small square icon with a preview of that color.
+
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/UbGGOVBV5ZCxcPT3JCZk.png", alt="Color preview.", width="600", height="400" %}
+
+3.  Click the preview to open the **Color Picker**.
+
+Here's a description of each of the UI elements of the **Color Picker**:
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/AzrBlIl6iPByojkmoU4y.png", alt="The Color Picker, annotated.", width="800", height="908" %}
+
+1. **Shades**.
+1. **Eyedropper**. See [Sample a color anywhere with the Eyedropper](#eyedropper).
+1. **Copy to clipboard**. Copy the **Display value** to your clipboard.
+1. **Display value**. The parameter values of the chosen color space.
+1. **Contrast**. The difference between `color` and `background-color`. See [Color and contrast accessibility](https://web.dev/color-and-contrast-accessibility/).
+1. **Color palette**. Click one of these squares to change the color to that of the square.
+1. **Gamut boundary**. This boundary is for the new color spaces and [`color()`](/articles/high-definition-css-color-guide/#the-color-function) function. They can produce both HD and non-HD colors. The boundary lets you distinguish between them at a glance.
+1. **Color circle**. Drag this circle to change the display value.  
+1. **Hue** slider.
+1. **Opacity** slider.
+1. **Display value switcher**. Pick a color space from the drop-down list. See [Conver colors](#convert-colors)
+   {% Aside %}
+   **Note**: Alternatively, to open the drop-down menu directly, hold down <kbd>Shift</kbd> and click on the color preview icon next to the color value.
+   {% endAside %}
+1. **Color palette switcher**. Toggle between the [Material Design palette][26], a custom palette,
+   or a page colors palette. DevTools generates the page color palette based on the colors that it
+   finds in your stylesheets.
+
+## Convert colors {: #convert-colors }
+
+Toggle between the [RGBA][29], [HSLA][30], [HWBA][31], and [Hex][32] representations of the current color.
+
+## Fix contrast issues {: # }
+
+## Sample a color anywhere with the Eyedropper {: #eyedropper }
+
+When you open the **Color Picker**, the **Eyedropper**
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/WKeaXT922ot9wQjtvwcZ.svg", alt="Eyedropper.", width="20", height="20" %} is on by default.
+
+The **Eyedropper** {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/WKeaXT922ot9wQjtvwcZ.svg", alt="Eyedropper.", width="20", height="20" %} can sample colors both from the page and from anywhere on the screen:
+
+To pick a color from anywhere on the screen:
+
+1.  Hover over the target color.
+1.  Click to confirm.
+
+    <div class="elevation--4" style="margin-top: 20px; margin-bottom: 20px;">
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/8Omn8AauWoiknzjzjlGA.png", alt="Using the Eyedropper anywhere on the screen.", width="800", height="450" %}</div>
+
+In the example above, the **Color Picker** shows a current color value of `rgb(224 255 255 / 15%)`. This color changes to pink once you click it.

--- a/site/en/docs/devtools/css/color/index.md
+++ b/site/en/docs/devtools/css/color/index.md
@@ -93,13 +93,13 @@ To choose a color space:
    - [`hsl(X X X / X)`](https://developer.mozilla.org/docs/Web/CSS/color_value/hsl).
    - [`hwb(X X X / .X)`](https://developer.mozilla.org/docs/Web/CSS/color_value/hwb).
    
-   Or one of the experimental ones:
+   Or one of the new spaces:
    - [`lch(X X X / .X)`](https://developer.mozilla.org/docs/Web/CSS/color_value/lch)
    - [`oklch(X X X / .X)`](https://developer.mozilla.org/docs/Web/CSS/color_value/oklch)
    - [`lab(X X X / .X)`](https://developer.mozilla.org/docs/Web/CSS/color_value/lab)
    - [`oklab(X X X / .X)`](https://developer.mozilla.org/docs/Web/CSS/color_value/oklab)
 
-   Or one defined by the [`color(<color_space> X X X)`](/articles/high-definition-css-color-guide/#the-color-function) function.
+   Or a space defined by the [`color(<color_space> X X X)`](/articles/high-definition-css-color-guide/#the-color-function) function.
 
 ### Convert colors {: #convert-colors }
 
@@ -140,18 +140,20 @@ To get a list of all contrast issues in one go, follow the [Make your website mo
 
 ## Sample a color anywhere with the Eyedropper {: #eyedropper }
 
-When you open the **Color Picker**, the **Eyedropper**
-{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/WKeaXT922ot9wQjtvwcZ.svg", alt="Eyedropper.", width="20", height="20" %} is on by default.
-
-The **Eyedropper** {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/WKeaXT922ot9wQjtvwcZ.svg", alt="Eyedropper.", width="20", height="20" %} can sample colors both from the page and from anywhere on the screen:
+The {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/WKeaXT922ot9wQjtvwcZ.svg", alt="Eyedropper.", width="20", height="20" %} **Eyedropper** can sample colors both from the page and from anywhere on the screen.
 
 To pick a color from anywhere on the screen:
 
-1. Select a color space with the [**Display value switcher**](#convert-colors).
-1. Hover over the target color.
-1. Click to confirm.
+1. [Open the **Color Picker**](#change-colors) and do one of the following:
+   - Click the {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/WKeaXT922ot9wQjtvwcZ.svg", alt="Eyedropper.", width="20", height="20" %} button.
+   - Press <kbd>C</kbd> to activate the **Eyedropper**. To deactivate, press <kbd>Escape</kbd>.
+1. With the **Eyedropper** active, hover over the target color and click to sample.
+
+{% Aside %}
+The **Eyedropper** samples colors only in the sRGB color space. When you sample outside this space, the **Eyedropper** clips the color to the closest one. See [Convert colors](#convert-colors).
+{% endAside %}
 
   <div class="elevation--4" style="margin-top: 20px; margin-bottom: 20px;">
   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/8Omn8AauWoiknzjzjlGA.png", alt="Using the Eyedropper anywhere on the screen.", width="800", height="450" %}</div>
 
-In this, the **Color Picker** shows a current color value of `rgb(224 255 255 / 15%)`. This color changes to pink once you click it.
+In this example, the **Color Picker** shows a current color value of `rgb(224 255 255 / 15%)`. This color changes to pink once you click outside Chrome.

--- a/site/en/docs/devtools/css/color/index.md
+++ b/site/en/docs/devtools/css/color/index.md
@@ -36,7 +36,14 @@ Use the **Color Picker** to change color values with a click:
 
    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/UbGGOVBV5ZCxcPT3JCZk.png", alt="Color preview.", width="600", height="400" %}
 
-1. Click the preview to open the **Color Picker**.
+   {% Aside %}
+   This example shows two intersected circles next to the [`color-mix()`](https://developer.mozilla.org/docs/Web/CSS/color_value/color-mix) function: {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/NxzOQosIfXPQDL5gi566.png", alt="Color-mix preview.", width="24", height="24" %}. The intersection is a preview of the resulting color.
+
+   To inspect the computed value, [use the **Computed** pane](/docs/devtools/css/issues/#computed).
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/V3DUCujgQV8OQDzR0f4h.png", alt="The computed value of color-mix().", width="400", height="204", class="screenshot", style="margin-top: 20px;" %}
+   {% endAside %}
+
+1. Click the preview square next to a color to open the **Color Picker**.
 1. To change the color, use any of the UI elements of the **Color Picker**.
 
 ## Color Picker elements {: #color-picker-elements }

--- a/site/en/docs/devtools/css/reference/index.md
+++ b/site/en/docs/devtools/css/reference/index.md
@@ -717,10 +717,6 @@ Additionally, you can [track changes](/docs/devtools/changes/) you make with the
 [26]: https://material.io/design/color/the-color-system.html#color-usage-and-palettes
 [27]: #select
 [28]: /docs/devtools/shortcuts#styles
-[29]: https://drafts.csswg.org/css-color/#rgb-functions
-[30]: https://drafts.csswg.org/css-color/#the-hsl-notation
-[31]: https://drafts.csswg.org/css-color/#the-hwb-notation
-[32]: https://drafts.csswg.org/css-color/#hex-notation
 [33]: https://developer.mozilla.org/docs/Web/CSS/Pseudo-elements
 [34]: /blog/auto-dark-theme/
 [35]: https://web.dev/prefers-color-scheme/

--- a/site/en/docs/devtools/css/reference/index.md
+++ b/site/en/docs/devtools/css/reference/index.md
@@ -508,62 +508,7 @@ See the corresponding [section in Inspect CSS grid](/docs/devtools/css/grid/#gri
 
 ### Change colors with the Color Picker {: #color-picker }
 
-{% YouTube id='TuR27BxCRVk' %}
-
-The **Color Picker** provides a GUI for changing `color` and `background-color` declarations.
-
-To open the **Color Picker**:
-
-1.  [Select an element][24].
-2.  In the **Styles** pane, find the `color` or `background-color` declaration that you want to
-    change. To the left of the `color` or `background-color` value, there is a small square which is
-    a preview of the color.
-
-    {% Img src="image/admin/SuJ1WT25iaaOgt8iWQzj.png", alt="Color preview.", width="800", height="517" %}
-
-    The small blue square to the left of `rgb(123, 170, 247)` is a preview of that
-    color.
-
-3.  Click the preview to open the **Color Picker**.
-
-    {% Img src="image/admin/i8pU9ALTZwhbvrhlXGm7.png", alt="The Color Picker.", width="800", height="624" %}
-
-Here's a description of each of the UI elements of the **Color Picker**:
-
-{% Img src="image/admin/kAtu8Uoi2x8IFvaX561h.svg", alt="The Color Picker, annotated.", width="800", height="548" %}
-
-1.  **Shades**.
-2.  **Eyedropper**. See [Sample a color anywhere with the Eyedropper][25].
-3.  **Copy To Clipboard**. Copy the **Display Value** to your clipboard.
-4.  **Display Value**. The [RGBA][29], [HSLA][30], [HWBA][31], or [Hex][32] representation of the color.
-5.  **Color Palette**. Click one of these squares to change the color to that square.
-6.  **Hue**.
-7.  **Opacity**.
-8.  **Display Value Switcher**. Toggle between the [RGBA][29], [HSLA][30], [HWBA][31], and [Hex][32] representations of the
-    current color.
-    {% Aside %}
-    **Note**: Alternatively, to toggle between color representations, hold down <kbd>Shift</kbd> and click on the color preview button.
-    {% endAside %}
-9.  **Color Palette Switcher**. Toggle between the [Material Design palette][26], a custom palette,
-    or a page colors palette. DevTools generates the page color palette based on the colors that it
-    finds in your stylesheets.
-
-#### Sample a color anywhere with the Eyedropper {: #eyedropper }
-
-When you open the **Color Picker**, the **Eyedropper**
-{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/WKeaXT922ot9wQjtvwcZ.svg", alt="Eyedropper.", width="20", height="20" %} is on by default.
-
-The **Eyedropper** {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/WKeaXT922ot9wQjtvwcZ.svg", alt="Eyedropper.", width="20", height="20" %} can sample colors both from the page and from anywhere on the screen:
-
-To pick a color from anywhere on the screen:
-
-1.  Hover over the target color.
-1.  Click to confirm.
-
-    <div class="elevation--4" style="margin-top: 20px; margin-bottom: 20px;">
-    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/8Omn8AauWoiknzjzjlGA.png", alt="Using the Eyedropper anywhere on the screen.", width="800", height="450" %}</div>
-
-In the example above, the **Color Picker** shows a current color value of `rgb(224 255 255 / 15%)`. This color changes to pink once you click it.
+See [Inspect and debug HD and non-HD colors with the Color Picker](/docs/devtools/css/color).
 
 ### Change angle value with the Angle Clock {: #angle-clock }
 

--- a/site/en/docs/devtools/settings/preferences/index.md
+++ b/site/en/docs/devtools/settings/preferences/index.md
@@ -14,7 +14,13 @@ To set preferences, open {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/9gzXiTYY
 
 {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/IFH59J9W2RT4nDN2miTU.png", alt="The Appearance section in the Preferences tab.", width="800", height="812" %}
 
-To find out what each setting does, search this page for the setting's name and expand its description. Some options are checkboxes indicated by {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/hmp8j3HiLMCcqPArD9yt.svg", alt="Checkbox.", width="22", height="22" %} icons, others are drop-down lists indicated by {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/VPpFJAIWgNSaTmnYrqNP.svg", alt="Drop-down.", width="24", height="24" %} icons.
+To find out what each setting does, search this page for the setting's name and expand its description.
+
+This reference indicates different settings with the following icons:
+
+- {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/hmp8j3HiLMCcqPArD9yt.svg", alt="Checkbox.", width="22", height="22" %} Checkboxes
+- Drop-down lists {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/VPpFJAIWgNSaTmnYrqNP.svg", alt="Drop-down.", width="24", height="24" %}
+- {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/E7duEXTRnleJ5OOJ0f0C.svg", alt="Deprecated.", width="24", height="24" %} Deprecated
 
 To restore default preferences, scroll down to the end of the **Preferences** tab and click **Restore defaults and reload**.
 
@@ -60,11 +66,19 @@ Affects **Elements** > **Styles** and sister tabs, and the **Sources** > **Debug
 </fieldset>
 {% endDetails %}
 
+
 {% Details %}
 
+
 {% DetailsSummary %}
-**Color format** {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/VPpFJAIWgNSaTmnYrqNP.svg", alt="Drop-down.", width="24", height="24" %} sets the format of CSS color values in **Elements** > **Styles**.
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/E7duEXTRnleJ5OOJ0f0C.svg", alt="Deprecated.", width="24", height="24" %} **Color format** {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/VPpFJAIWgNSaTmnYrqNP.svg", alt="Drop-down.", width="24", height="24" %} sets the format of CSS color values in **Elements** > **Styles**.
 {% endDetailsSummary %}
+
+{% Aside %}
+**Deprecated**: This settings is disabled to make room for [HD color spaces](/docs/devtools/css/color/).
+
+To re-enable it, clear the {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/9gzXiTYY0nZzBxGI6KrV.svg", alt="Settings.", width="24", height="24" %} [**Settings** > **Experiments**](/docs/devtools/settings/experiments/) > {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/hmp8j3HiLMCcqPArD9yt.svg", alt="Checkbox.", width="22", height="22" %} **Disable the deprecated Color Format setting** checkbox.
+{% endAside %}
 
 DevTools automatically converts any valid color value to the chosen format.
 


### PR DESCRIPTION
Moved the color picker section into a separate doc because it gained sophistication.

LMK if you think we should remove the video from the doc altogether because it's now outdated.

Publish on March 7.