### PR TITLE
Cleanup of PS intro

### DIFF
--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -3,10 +3,11 @@
 - title: i18n.docs.privacy-sandbox.overview
   sections:
     - url: /docs/privacy-sandbox/overview
-    - url: /docs/privacy-sandbox/glossary
+    - url: /docs/privacy-sandbox/proposal-lifecycle
     - url: https://privacysandbox.com/timeline
       title: i18n.docs.privacy-sandbox.timeline
-    - url: /docs/privacy-sandbox/proposal-lifecycle
+    - url: /docs/privacy-sandbox/glossary
+      title: i18n.docs.privacy-sandbox.glossary
     - url: /docs/privacy-sandbox/events
     - url: /tags/privacy
       title: i18n.docs.privacy-sandbox.blog

--- a/site/_data/i18n/docs/privacy-sandbox.yml
+++ b/site/_data/i18n/docs/privacy-sandbox.yml
@@ -15,7 +15,7 @@ topics-api:
 topics-latest:
   en: 'Latest updates to the Topics API'
 glossary:
-  en: 'Privacy Sandbox glossary'
+  en: 'Glossary and key concepts'
   ja: 'プライバシー サンドボックスの用語集'
 guiding-principles:
   en: 'Guiding principles'

--- a/site/en/docs/privacy-sandbox/overview/index.md
+++ b/site/en/docs/privacy-sandbox/overview/index.md
@@ -24,6 +24,15 @@ The Privacy Sandbox has two core aims:
 	id='WnCKlNE52tc'
 %}
 
+The Privacy Sandbox APIs require web browsers to take on a new role. Rather 
+than working with limited tools and protections, the APIs allow a user's
+browser to act on the user's behalf—locally, on their device—to protect the
+user's identifying information as they navigate the web. This is a shift in
+direction for browsers.
+
+The Privacy Sandbox's vision of the future has browsers providing specific
+tools to satisfy specific use cases, while preserving user privacy.
+
 ## What are the Privacy Sandbox proposals?
 
 Chrome and other ecosystem stakeholders have offered more than 30 proposals to
@@ -100,10 +109,10 @@ Several key proposals are listed below.
 
 ## Who works on the Privacy Sandbox?
 
-* 30+ Privacy Sandbox proposals offered by Chrome and others.
 * 400+ participants who joined W3C groups to provide input including the
   [Improving Web Advertising Business Group](https://www.w3.org/community/web-adv/participants)
   and the [Privacy Community Group](https://www.w3.org/community/privacycg/participants).
+* 30+ Privacy Sandbox proposals offered by Chrome and others.
 
 ## When will the APIs be implemented?
 
@@ -125,17 +134,9 @@ and the [Web Incubator Community Group](https://github.com/WICG).
 
 ## Find out more
 
-### Articles and videos for web developers
-
 * [Digging into the Privacy Sandbox](https://web.dev/digging-into-the-privacy-sandbox)
-* [SameSite cookies explained](https://web.dev/samesite-cookies-explained/)
-* [Getting started with Privacy State Tokens](https://web.dev/trust-tokens)
-
-### Principles and concepts behind the proposals
-
 * [A Potential Privacy Model for the Web](https://github.com/michaelkleber/privacy-model)
   sets out the core principles underlying the APIs.
-* [The Privacy Sandbox](https://www.chromium.org/Home/chromium-privacy/privacy-sandbox)
-* Privacy Sandbox overview: [Building a more private web](https://www.blog.google/products/chrome/building-a-more-private-web/)
+* Chromium's overview of [the Privacy Sandbox](https://www.chromium.org/Home/chromium-privacy/privacy-sandbox)
 * Google AI Blog: [Federated Learning: Collaborative Machine Learning without Centralized Training Data](https://ai.googleblog.com/2017/04/federated-learning-collaborative.html)
 * [The future of third-party cookies](https://blog.chromium.org/2019/10/developers-get-ready-for-new.html)

--- a/site/en/docs/privacy-sandbox/overview/index.md
+++ b/site/en/docs/privacy-sandbox/overview/index.md
@@ -11,7 +11,7 @@ authors:
   - samdutton
 ---
 
-The Privacy Sandbox is and initiative aims to create technologies that both
+The Privacy Sandbox initiative aims to create technologies that both
 protect people's privacy online and give companies and developers tools to
 build thriving digital businesses.
 

--- a/site/en/docs/privacy-sandbox/overview/index.md
+++ b/site/en/docs/privacy-sandbox/overview/index.md
@@ -59,12 +59,18 @@ Several key proposals are listed below.
   such as `localStorage` or cookies, to be double-keyed: by the top-level site
   as well as the origin of the resource being loaded, rather than a single
   origin or site.
-* [**Fenced Frames**](/docs/privacy-sandbox/fenced-frame): Securely embed content onto a page without sharing cross-site data.
+* [**Fenced Frames**](/docs/privacy-sandbox/fenced-frame): Securely embed
+  content onto a page without sharing cross-site data.
 * [**Network State Partitioning**](https://github.com/MattMenke2/Explainer---Partition-Network-State):
-  Prevent browser network resources being shared across first-party contexts, by ensuring that every request has a network partition key that must match in order for resources to be reused.
+  Prevent browser network resources being shared across first-party contexts,
+  by ensuring that every request has a network partition key that must match in
+  order for resources to be reused.
 * [**HTTP Cache Partitioning**](/blog/http-cache-partitioning): Improve
   security and privacy by partitioning the browser HTTP cache.
-* [**Federated Credential Management (FedCM)**](/docs/privacy-sandbox/fedcm/): Support federated identity without sharing the user's email address or other identifying information with a third-party service or website, unless the user explicitly agrees to do so.
+* [**Federated Credential Management (FedCM)**](/docs/privacy-sandbox/fedcm/):
+  Support federated identity without sharing the user's email address or other
+  identifying information with a third-party service or website, unless the
+  user explicitly agrees to do so.
 
 ### Show relevant content and ads
 
@@ -130,7 +136,7 @@ as APIs move from proposal to experiment to scaled availability.
 * **W3C**: Use cases can be discussed and industry feedback shared in the W3C [Improving Web Advertising Business Group](https://www.w3.org/community/web-adv/), the [Privacy Community Group](https://www.w3.org/community/privacycg/participants),
 and the [Web Incubator Community Group](https://github.com/WICG).
 * **Developer support**: Ask questions and join discussions on the
-[Privacy Sandbox Developer Support repo](https://github.com/GoogleChromeLabs/privacy-sandbox-dev-support).
+  [Privacy Sandbox Developer Support repo](https://github.com/GoogleChromeLabs/privacy-sandbox-dev-support).
 
 ## Find out more
 

--- a/site/en/docs/privacy-sandbox/overview/index.md
+++ b/site/en/docs/privacy-sandbox/overview/index.md
@@ -41,6 +41,13 @@ date, which can be found in the
 [public resources of W3C groups](https://github.com/w3c/web-advertising#ideas-and-proposals-links-outside-this-repo).
 These proposals cover a wide variety of use cases and requirements.
 
+Proposals have a lifecycle with up to three phases before becoming
+[web standards](https://www.w3.org/standards/): discussion, testing, and scaled
+adoption. It's critical we [receive feedback](/docs/privacy-sandbox/feedback/)
+from developers and industry leaders to ensure we create durable
+web features with broad utility and robust privacy protections for users.
+Read more about the [proposal lifecycle](/docs/privacy-sandbox/proposal-lifecycle/).
+
 Several key proposals are listed below.
 
 ### Strengthen cross-site privacy boundaries

--- a/site/en/docs/privacy-sandbox/overview/index.md
+++ b/site/en/docs/privacy-sandbox/overview/index.md
@@ -64,14 +64,17 @@ Several key proposals are listed below.
   across sites.
 * [**FLEDGE**](/docs/privacy-sandbox/fledge): Ad selection to serve remarketing
   and custom audience use cases, designed so that it cannot be used by third
-  parties to track user browsing behavior across sites.
+  parties to track user browsing behavior across sites. FLEDGE is the first
+  experiment to be implemented in Chromium from the
+  [TURTLEDOVE](https://github.com/WICG/turtledove) family of proposals.
 
 ### Measure digital ads
 
 * [**Attribution Reporting**](/docs/privacy-sandbox/attribution-reporting):
   Correlate ad clicks or ad views with conversions. Ad techs can generate
   event-level or [summary reports](/docs/privacy-sandbox/summary-reports).
-* [**Private Aggregation API**](/docs/privacy-sandbox/private-aggregation/): Generate noisy summary reports with cross-site data.
+* [**Private Aggregation API**](/docs/privacy-sandbox/private-aggregation/):
+  Generate noisy summary reports with cross-site data.
 
 ### Prevent covert tracking
 

--- a/site/en/docs/privacy-sandbox/overview/index.md
+++ b/site/en/docs/privacy-sandbox/overview/index.md
@@ -4,11 +4,12 @@ title: What is the Privacy Sandbox?
 subhead: >
   A series of proposals to satisfy cross-site use cases without
   third-party cookies or other tracking mechanisms.
-description: "What's in it, how to get involved, and what it's for."
+description: "What's in it, what's it for, and how to get involved."
 date: 2021-05-18
 updated: 2023-02-27
 authors:
   - samdutton
+  - alexandrawhite
 ---
 
 The Privacy Sandbox initiative aims to create technologies that both

--- a/site/en/docs/privacy-sandbox/overview/index.md
+++ b/site/en/docs/privacy-sandbox/overview/index.md
@@ -134,7 +134,7 @@ The [timeline](https://privacysandbox.com/open-web/#the-privacy-sandbox-timeline
 has the latest implementation status for the Privacy Sandbox on the web. Each
 API has an implementation status in their documentation.
 
-We'll make regular announcements on the [Chrome Developers blog](/tags/privacy/)
+We publish regular announcements on the [Chrome Developers blog](/tags/privacy/)
 as APIs move from proposal to experiment to scaled availability.
 
 ## Engage and share feedback

--- a/site/en/docs/privacy-sandbox/overview/index.md
+++ b/site/en/docs/privacy-sandbox/overview/index.md
@@ -1,125 +1,80 @@
 ---
 layout: layouts/doc-post.njk
 title: What is the Privacy Sandbox?
-subhead: The Privacy Sandbox is a series of proposals to satisfy cross-site use cases without third-party cookies or other tracking mechanisms.
+subhead: >
+  A series of proposals to satisfy cross-site use cases without
+  third-party cookies or other tracking mechanisms.
 description: "What's in it, how to get involved, and what it's for."
 date: 2021-05-18
-updated: 2021-01-25
+updated: 2023-02-27
 authors:
   - samdutton
 ---
 
+The Privacy Sandbox is and initiative aims to create technologies that both protect people's privacy online and give companies and developers tools to build thriving digital businesses.
+
+The Privacy Sandbox has two core aims:
+
+* Phase out support for third-party cookies when new solutions are in place.
+* Reduce cross-site and cross-app tracking while helping to keep online content and services free for all.
 
 {% YouTube
 	id='WnCKlNE52tc'
 %}
-
-
-## Why do we need the Privacy Sandbox?
-
-The Privacy Sandbox initiative has two core aims:
-* Develop replacement solutions to support web use cases and business models without enabling users
-to be tracked across sites, and avoiding cross-site tracking users aren't aware of.
-* Phase out support for third-party cookies when new solutions are in place.
-
 
 ## What are the Privacy Sandbox proposals?
 
 Chrome and other ecosystem stakeholders have offered more than 30 proposals to date, which can be
 found in the [public resources of W3C groups](https://github.com/w3c/web-advertising#ideas-and-proposals-links-outside-this-repo). These proposals cover a wide variety of use cases and requirements.
 
-The key proposals are listed below.
-
-{% Aside %}
-Some items below link to API explainers or other resources.
-
-Over the coming months, we'll add more posts within this site to summarize external content.
-{% endAside %}
-
+Several key proposals are listed below.
 
 ### Strengthen cross-site privacy boundaries
 
-* [**First-Party Sets**](/docs/privacy-sandbox/first-party-sets): Allow related domain names owned by
-the same entity to declare themselves as belonging to the same first party.
-* [**Shared Storage**](https://github.com/pythagoraskitty/shared-storage): Proposal for a
-general-purpose, low-level API that can serve a number of legitimate use cases that currently rely
-on unpartitioned storage (which is being deprecated).
-* [**CHIPS**](https://github.com/WICG/CHIPS): As with [First-Party Sets](/docs/privacy-sandbox/first-party-sets),
-this proposal addresses use cases around partitioning, and how cross-origin interactions and sharing
-might be enabled, where it makes sense, and how this can be kept safe. The core aim is to allow cookies
-to be set by a third-party service, but only read within the context of the top-level site where they
-were initially set. A partitioned third-party cookie is tied to the top-level site where it was initially
-set and cannot be accessed from elsewhere.
-* [**SameSite cookies**](https://web.dev/samesite-cookies-explained/): Secure sites by explicitly
-marking cross-site cookies.
-* [**Storage Partitioning**](https://github.com/privacycg/storage-partitioning): Enable all forms of
-[user agent state](https://github.com/privacycg/storage-partitioning#user-agent-state), such as
-`localStorage` or cookies, to be double-keyed: by the top-level site as well as the origin of
-the resource being loaded, rather than a single origin or site.
-* [**Fenced Frames**](https://github.com/shivanigithub/fenced-frame): Provide a type of frame element
-that can be used to display content (such as an advertisement) but can't interact with the page
-around it.
-* [**Network State Partitioning**](https://github.com/MattMenke2/Explainer---Partition-Network-State/blob/main/README.md):
-Partition network state to prevent browser network resources being shared across first-party
-contexts, by ensuring that every request has a network partition key that must match in order for
-resources to be reused.
-* [**HTTP Cache Partitioning**](/blog/http-cache-partitioning):
-Improve security and privacy by partitioning the browser HTTP cache.
-* [**Federated Credential Management**](https://github.com/wicg/fedcm):  Support federated identity (where a
-user can sign into a website through a third-party service) without sharing the user's email address
-or other identifying information with a third-party service or website, unless the user
-explicitly agrees to do so. WebID enables federated sign-in without the use of redirects, pop-ups or
-third-party cookies which can be used to identify and track users across sites.
-
+* [**First-Party Sets**](/docs/privacy-sandbox/first-party-sets): Allow related
+  domain names owned by the same entity to declare themselves as belonging to
+  the same first party.
+* [**Shared Storage**](/docs/privacy-sandbox/shared-storage/): Create a
+  general-purpose API which allows sites to store and access unpartitioned
+  cross-site data. This data must be read in a secure environment to prevent leakage.
+* [**CHIPS**](/docs/privacy-sandbox/chips/): Allow developers to opt-in a
+  cookie to "partitioned" storage, with a separate cookie jar per top-level site.
+* [**SameSite cookies**](https://web.dev/samesite-cookies-explained/): Secure
+  sites by explicitly marking cross-site cookies.
+* [**Storage Partitioning**](https://github.com/privacycg/storage-partitioning): Enable
+  all forms of [user agent state](https://github.com/privacycg/storage-partitioning#user-agent-state), such as `localStorage` or cookies, to be double-keyed: by the top-level site as well as the origin of the resource being loaded, rather than a single origin or site.
+* [**Fenced Frames**](/docs/privacy-sandbox/fenced-frame): Securely embed content onto a page without sharing cross-site data.
+* [**Network State Partitioning**](https://github.com/MattMenke2/Explainer---Partition-Network-State):
+  Prevent browser network resources being shared across first-party contexts, by ensuring that every request has a network partition key that must match in order for resources to be reused.
+* [**HTTP Cache Partitioning**](/blog/http-cache-partitioning): Improve
+  security and privacy by partitioning the browser HTTP cache.
+* [**Federated Credential Management (FedCM)**](/docs/privacy-sandbox/fedcm/): Support federated identity without sharing the user's email address or other identifying information with a third-party service or website, unless the user explicitly agrees to do so.
 
 ### Show relevant content and ads
 
-* [**Topics API**](/docs/privacy-sandbox/topics): Enable interest-based advertising. Designed so
-  that it doesn't require third-party cookies and cannot be used by third parties to track user
-  browsing behavior across sites. The Topics API proposes a mechanism to map website hostnames to
-  topics of interest, and provides a JavaScript API that returns coarse-grained topics a user
-  might currently be interested in, based on their recent browsing activity.
-* [**FLEDGE**](/docs/privacy-sandbox/fledge): Ad selection to serve remarketing and custom audience
-use cases, designed so that it cannot be used by third parties to track user browsing behavior across
-sites.  FLEDGE is the first experiment to be implemented in Chromium within the
-[TURTLEDOVE](https://github.com/WICG/turtledove) family of proposals.
-
+* [**Topics API**](/docs/privacy-sandbox/topics): Enable interest-based advertising without use of third-party cookies or tracking user behavior across sites.
+* [**FLEDGE**](/docs/privacy-sandbox/fledge): Ad selection to serve remarketing and custom audience use cases, designed so that it cannot be used by third parties to track user browsing behavior across sites.
 
 ### Measure digital ads
 
-* [**Core Attribution Reporting**](/docs/privacy-sandbox/attribution-reporting): Correlate ad clicks or ad
-views with conversions. Previously known as the Event Conversion Measurement API. Enables two types
-of reports: event-level and aggregate.
-
+* [**Attribution Reporting**](/docs/privacy-sandbox/attribution-reporting): Correlate ad clicks or ad views with conversions. Ad techs can generate event-level or summary reports.
+* [**Private Aggregation API**](/docs/privacy-sandbox/private-aggregation/): Generate noisy summary reports with cross-site data.
 
 ### Prevent covert tracking
 
-* [**User-Agent Client Hints**](https://web.dev/user-agent-client-hints/):
-The [User-Agent](https://developer.mozilla.org/docs/Web/HTTP/Headers/User-Agent) (UA) string
-is a significant passive [fingerprinting](https://w3c.github.io/fingerprinting-guidance/#passive)
-surface, as well as being difficult to process. Client Hints enable developers to actively
-request only the information they need about the user's device or conditions, rather than needing to
-parse this data from the User-Agent string.
-* [**DNS-over-HTTPS**](https://en.wikipedia.org/wiki/DNS_over_HTTPS): A protocol for
-[DNS resolution](https://www.cloudflare.com/en-gb/learning/dns/what-is-dns/) via the secure
-context of [HTTPS](https://www.cloudflare.com/en-gb/learning/ssl/what-is-https/).
-* [**IP Protection**](https://github.com/spanicker/ip-blindness): IP Protection proposes to anonymize the user's IP address, to help protect it from being used by third parties identified as potentially using IP addresses for web-wide cross-site tracking.
+* [**User-Agent reduction and User-Agent Client Hints**](/docs/privacy-sandbox/user-agent/): Limit passively shared browser data to reduce the volume of sensitive information which leads to fingerprinting. Client Hints allow developers to actively request only the information they need about the user's device or conditions.
+* [**IP Protection**](/docs/privacy-sandbox/ip-protection/): Improve user privacy by protecting their IP address from being used for tracking.
 * [**Bounce tracking mitigations**](/docs/privacy-sandbox/bounce-tracking-mitigations/): A proposal to reduce or eliminate the ability of bounce tracking to recognize people across contexts.
-* [**Privacy Budget**](https://www.youtube.com/watch?v=0STgfjSA6T8): Explore methods of quantifying
-the amount of information about a user's browser or device that are available to websites, and develop
-practical mechanisms to enable browser-based limits on the information a site can access.
-
+* [**Privacy Budget**](/docs/privacy-sandbox/privacy-budget/): Limit the amount of individual user data exposed to sites to prevent covert tracking.
 
 ### Fight spam and fraud on the web
 
-* [**Private State Tokens**](/docs/privacy-sandbox/trust-tokens): Enable a website to convey a limited amount of
-information from one browsing context to another (for example, across sites) to help combat fraud,
-without passive tracking.
-
+* [**Private State Tokens**](/docs/privacy-sandbox/trust-tokens): Allow websites to convey a limited amount of information from one browsing context to another (for example, across sites) to help combat fraud, without passive tracking.
 
 ## Who is working on the Privacy Sandbox?
 
 By early 2021 there were:
+
 * 30+ Privacy Sandbox proposals offered by Chrome and others.
 * 400+ participants who joined W3C groups to provide input including the
 [Improving Web Advertising Business Group](https://www.w3.org/community/web-adv/participants) and
@@ -129,47 +84,28 @@ the [Privacy Community Group](https://www.w3.org/community/privacycg/participant
 
 ## When will the APIs be implemented?
 
-The [implementation status](/docs/privacy-sandbox/status/) page on this site provides progress
-updates for individual APIs.
+The [timeline](https://privacysandbox.com/open-web/#the-privacy-sandbox-timeline)
+has the latest implementation status for the Privacy Sandbox on the web. Each
+API has an implementation status in their documentation.
 
----
-
+We'll make regular announcements on the [Chrome Developers blog](/tags/privacy/)
+as APIs move from proposal to experiment to scaled availability.
 
 ## Engage and share feedback
 
-* **GitHub**: read the explainer for the proposal on GitHub and raise questions or comments in the
-Issues tab for the explainer.
-[Links to explainers](#explainers) are provided below.
+* **GitHub**: read the explainers for the proposal on GitHub and raise questions or comments in the Issues tab for the explainer.
 * **W3C**: Use cases can be discussed and industry feedback shared in the W3C [Improving Web Advertising Business Group](https://www.w3.org/community/web-adv/), the [Privacy Community Group](https://www.w3.org/community/privacycg/participants),
 and the [Web Incubator Community Group](https://github.com/WICG).
 * **Developer support**: Ask questions and join discussions on the
 [Privacy Sandbox Developer Support repo](https://github.com/GoogleChromeLabs/privacy-sandbox-dev-support).
 
-
 ## Find out more
-
-### Privacy Sandbox proposal explainers {: #explainers }
-
-The API proposal explainers need feedback, in particular to suggest missing use cases and
-more-private ways to accomplish their goals. You can make comments or ask questions in the Issues
-tab for each explainer.
-
-* [Privacy Budget](https://github.com/bslassey/privacy-budget)
-* [Private State Tokens](https://github.com/dvorak42/trust-token-api)
-* [First-Party Sets](https://github.com/privacycg/first-party-sets)
-* [IP Protection](https://github.com/spanicker/ip-blindness)
-* [Aggregated Reporting API](https://github.com/csharrison/aggregate-reporting-api)
-* [Attribution Reporting](https://github.com/csharrison/conversion-measurement-api)
-* [Topics API](https://github.com/jkarlin/topics)
-* [FLEDGE](https://github.com/michaelkleber/turtledove)
 
 ### Articles and videos for web developers
 
 * [Digging into the Privacy Sandbox](https://web.dev/digging-into-the-privacy-sandbox)
 * [SameSite cookies explained](https://web.dev/samesite-cookies-explained/)
 * [Getting started with Privacy State Tokens](https://web.dev/trust-tokens)
-* [A more private way to measure ad conversions](https://web.dev/conversion-measurement/)
-* [Introducing the Privacy Budget](https://www.youtube.com/watch?v=0STgfjSA6T8)
 
 ### Principles and concepts behind the proposals
 

--- a/site/en/docs/privacy-sandbox/overview/index.md
+++ b/site/en/docs/privacy-sandbox/overview/index.md
@@ -11,7 +11,9 @@ authors:
   - samdutton
 ---
 
-The Privacy Sandbox is and initiative aims to create technologies that both protect people's privacy online and give companies and developers tools to build thriving digital businesses.
+The Privacy Sandbox is and initiative aims to create technologies that both
+protect people's privacy online and give companies and developers tools to
+build thriving digital businesses.
 
 The Privacy Sandbox has two core aims:
 
@@ -34,7 +36,7 @@ Several key proposals are listed below.
 ### Strengthen cross-site privacy boundaries
 
 * [**CHIPS**](/docs/privacy-sandbox/chips/): Allow developers to opt-in a
-  cookie to "partitioned" storage, with a separate cookie jar per top-level site.
+  cookie to partitioned storage, with a separate cookie jar per top-level site.
 * [**First-Party Sets**](/docs/privacy-sandbox/first-party-sets): Allow related
   domain names owned by the same entity to declare themselves as belonging to
   the same first party.
@@ -43,8 +45,11 @@ Several key proposals are listed below.
   cross-site data. This data must be read in a secure environment to prevent leakage.
 * [**SameSite cookies**](https://web.dev/samesite-cookies-explained/): Secure
   sites by explicitly marking cross-site cookies.
-* [**Storage Partitioning**](https://github.com/privacycg/storage-partitioning): Enable
-  all forms of [user agent state](https://github.com/privacycg/storage-partitioning#user-agent-state), such as `localStorage` or cookies, to be double-keyed: by the top-level site as well as the origin of the resource being loaded, rather than a single origin or site.
+* [**Storage Partitioning**](https://github.com/privacycg/storage-partitioning):
+  Enable all forms of [user agent state](https://github.com/privacycg/storage-partitioning#user-agent-state),
+  such as `localStorage` or cookies, to be double-keyed: by the top-level site
+  as well as the origin of the resource being loaded, rather than a single
+  origin or site.
 * [**Fenced Frames**](/docs/privacy-sandbox/fenced-frame): Securely embed content onto a page without sharing cross-site data.
 * [**Network State Partitioning**](https://github.com/MattMenke2/Explainer---Partition-Network-State):
   Prevent browser network resources being shared across first-party contexts, by ensuring that every request has a network partition key that must match in order for resources to be reused.
@@ -54,24 +59,41 @@ Several key proposals are listed below.
 
 ### Show relevant content and ads
 
-* [**Topics API**](/docs/privacy-sandbox/topics): Enable interest-based advertising without use of third-party cookies or tracking user behavior across sites.
-* [**FLEDGE**](/docs/privacy-sandbox/fledge): Ad selection to serve remarketing and custom audience use cases, designed so that it cannot be used by third parties to track user browsing behavior across sites.
+* [**Topics API**](/docs/privacy-sandbox/topics): Enable interest-based
+  advertising without use of third-party cookies or tracking user behavior
+  across sites.
+* [**FLEDGE**](/docs/privacy-sandbox/fledge): Ad selection to serve remarketing
+  and custom audience use cases, designed so that it cannot be used by third
+  parties to track user browsing behavior across sites.
 
 ### Measure digital ads
 
-* [**Attribution Reporting**](/docs/privacy-sandbox/attribution-reporting): Correlate ad clicks or ad views with conversions. Ad techs can generate event-level or [summary reports](/docs/privacy-sandbox/summary-reports).
+* [**Attribution Reporting**](/docs/privacy-sandbox/attribution-reporting):
+  Correlate ad clicks or ad views with conversions. Ad techs can generate
+  event-level or [summary reports](/docs/privacy-sandbox/summary-reports).
 * [**Private Aggregation API**](/docs/privacy-sandbox/private-aggregation/): Generate noisy summary reports with cross-site data.
 
 ### Prevent covert tracking
 
-* [**User-Agent reduction and User-Agent Client Hints**](/docs/privacy-sandbox/user-agent/): Limit passively shared browser data to reduce the volume of sensitive information which leads to fingerprinting. Client Hints allow developers to actively request only the information they need about the user's device or conditions.
-* [**IP Protection**](/docs/privacy-sandbox/ip-protection/): Improve user privacy by protecting their IP address from being used for tracking.
-* [**Bounce tracking mitigations**](/docs/privacy-sandbox/bounce-tracking-mitigations/): A proposal to reduce or eliminate the ability of bounce tracking to recognize people across contexts.
-* [**Privacy Budget**](/docs/privacy-sandbox/privacy-budget/): Limit the amount of individual user data exposed to sites to prevent covert tracking.
+* [**User-Agent reduction and User-Agent Client Hints**](/docs/privacy-sandbox/user-agent/):
+  Limit passively shared browser data to reduce the volume of sensitive
+  information which leads to fingerprinting. Client Hints allow developers to
+  actively request only the information they need about the user's device or
+  conditions.
+* [**IP Protection**](/docs/privacy-sandbox/ip-protection/): Improve user
+  privacy by protecting their IP address from being used for tracking.
+* [**Bounce tracking mitigations**](/docs/privacy-sandbox/bounce-tracking-mitigations/):
+  A proposal to reduce or eliminate the ability of bounce tracking to recognize
+  people across contexts.
+* [**Privacy Budget**](/docs/privacy-sandbox/privacy-budget/): Limit the amount
+  of individual user data exposed to sites to prevent covert tracking.
 
 ### Fight spam and fraud on the web
 
-* [**Private State Tokens**](/docs/privacy-sandbox/trust-tokens): Allow websites to convey a limited amount of information from one browsing context to another (for example, across sites) to help combat fraud, without passive tracking.
+* [**Private State Tokens**](/docs/privacy-sandbox/trust-tokens): Allow
+  websites to convey a limited amount of information from one browsing context
+  to another (for example, across sites) to help combat fraud, without passive
+  tracking.
 
 ## Who works on the Privacy Sandbox?
 
@@ -91,7 +113,8 @@ as APIs move from proposal to experiment to scaled availability.
 
 ## Engage and share feedback
 
-* **GitHub**: read the explainers for the proposal on GitHub and raise questions or comments in the Issues tab for the explainer.
+* **GitHub**: read the explainers on GitHub and raise questions or comments in
+  the Issues tab for each.
 * **W3C**: Use cases can be discussed and industry feedback shared in the W3C [Improving Web Advertising Business Group](https://www.w3.org/community/web-adv/), the [Privacy Community Group](https://www.w3.org/community/privacycg/participants),
 and the [Web Incubator Community Group](https://github.com/WICG).
 * **Developer support**: Ask questions and join discussions on the

--- a/site/en/docs/privacy-sandbox/overview/index.md
+++ b/site/en/docs/privacy-sandbox/overview/index.md
@@ -24,8 +24,10 @@ The Privacy Sandbox has two core aims:
 
 ## What are the Privacy Sandbox proposals?
 
-Chrome and other ecosystem stakeholders have offered more than 30 proposals to date, which can be
-found in the [public resources of W3C groups](https://github.com/w3c/web-advertising#ideas-and-proposals-links-outside-this-repo). These proposals cover a wide variety of use cases and requirements.
+Chrome and other ecosystem stakeholders have offered more than 30 proposals to
+date, which can be found in the
+[public resources of W3C groups](https://github.com/w3c/web-advertising#ideas-and-proposals-links-outside-this-repo).
+These proposals cover a wide variety of use cases and requirements.
 
 Several key proposals are listed below.
 

--- a/site/en/docs/privacy-sandbox/overview/index.md
+++ b/site/en/docs/privacy-sandbox/overview/index.md
@@ -31,14 +31,14 @@ Several key proposals are listed below.
 
 ### Strengthen cross-site privacy boundaries
 
+* [**CHIPS**](/docs/privacy-sandbox/chips/): Allow developers to opt-in a
+  cookie to "partitioned" storage, with a separate cookie jar per top-level site.
 * [**First-Party Sets**](/docs/privacy-sandbox/first-party-sets): Allow related
   domain names owned by the same entity to declare themselves as belonging to
   the same first party.
 * [**Shared Storage**](/docs/privacy-sandbox/shared-storage/): Create a
   general-purpose API which allows sites to store and access unpartitioned
   cross-site data. This data must be read in a secure environment to prevent leakage.
-* [**CHIPS**](/docs/privacy-sandbox/chips/): Allow developers to opt-in a
-  cookie to "partitioned" storage, with a separate cookie jar per top-level site.
 * [**SameSite cookies**](https://web.dev/samesite-cookies-explained/): Secure
   sites by explicitly marking cross-site cookies.
 * [**Storage Partitioning**](https://github.com/privacycg/storage-partitioning): Enable
@@ -57,7 +57,7 @@ Several key proposals are listed below.
 
 ### Measure digital ads
 
-* [**Attribution Reporting**](/docs/privacy-sandbox/attribution-reporting): Correlate ad clicks or ad views with conversions. Ad techs can generate event-level or summary reports.
+* [**Attribution Reporting**](/docs/privacy-sandbox/attribution-reporting): Correlate ad clicks or ad views with conversions. Ad techs can generate event-level or [summary reports](/docs/privacy-sandbox/summary-reports).
 * [**Private Aggregation API**](/docs/privacy-sandbox/private-aggregation/): Generate noisy summary reports with cross-site data.
 
 ### Prevent covert tracking
@@ -71,16 +71,12 @@ Several key proposals are listed below.
 
 * [**Private State Tokens**](/docs/privacy-sandbox/trust-tokens): Allow websites to convey a limited amount of information from one browsing context to another (for example, across sites) to help combat fraud, without passive tracking.
 
-## Who is working on the Privacy Sandbox?
-
-By early 2021 there were:
+## Who works on the Privacy Sandbox?
 
 * 30+ Privacy Sandbox proposals offered by Chrome and others.
 * 400+ participants who joined W3C groups to provide input including the
-[Improving Web Advertising Business Group](https://www.w3.org/community/web-adv/participants) and
-the [Privacy Community Group](https://www.w3.org/community/privacycg/participants).
-* Five API implementations available for testing in Chrome.
-
+  [Improving Web Advertising Business Group](https://www.w3.org/community/web-adv/participants)
+  and the [Privacy Community Group](https://www.w3.org/community/privacycg/participants).
 
 ## When will the APIs be implemented?
 
@@ -109,8 +105,8 @@ and the [Web Incubator Community Group](https://github.com/WICG).
 
 ### Principles and concepts behind the proposals
 
-* [A Potential Privacy Model for the Web](https://github.com/michaelkleber/privacy-model) sets out the
-core principles underlying the APIs.
+* [A Potential Privacy Model for the Web](https://github.com/michaelkleber/privacy-model)
+  sets out the core principles underlying the APIs.
 * [The Privacy Sandbox](https://www.chromium.org/Home/chromium-privacy/privacy-sandbox)
 * Privacy Sandbox overview: [Building a more private web](https://www.blog.google/products/chrome/building-a-more-private-web/)
 * Google AI Blog: [Federated Learning: Collaborative Machine Learning without Centralized Training Data](https://ai.googleblog.com/2017/04/federated-learning-collaborative.html)

--- a/site/en/docs/privacy-sandbox/proposal-lifecycle/index.md
+++ b/site/en/docs/privacy-sandbox/proposal-lifecycle/index.md
@@ -2,19 +2,16 @@
 layout: layouts/doc-post.njk
 title: Proposal lifecycle in the Privacy Sandbox
 subhead: >
-  How we collaborate with stakeholders to discuss, test, and adopt privacy-preserving technologies.
+  How we collaborate with stakeholders to discuss, test, and adopt
+  privacy-preserving technologies.
 description: >
-  How we collaborate with stakeholders to discuss, test, and adopt privacy-preserving technologies.
+  How we collaborate with stakeholders to discuss, test, and adopt
+  privacy-preserving technologies.
 date: 2022-03-30
 updated: 2022-05-17
 authors:
   - alexandrawhite
 ---
-
-_Much of this content was originally shared as a part of the [2021 Chrome
-Developer Summit recap](/docs/privacy-sandbox/cds21-update/)._
-
-## What is the goal of The Privacy Sandbox proposals?
 
 The Privacy Sandbox proposals are the first of many steps necessary in the
 creation of web standards.
@@ -80,16 +77,11 @@ meetings](https://github.com/WICG/turtledove/issues/88) to help refine the
 current version, plus over [200 online discussion
 threads](https://github.com/WICG/turtledove/issues).
 
-{% Img src="image/VbsHyyQopiec0718rMq2kTE1hke2/Rg4lEQVzb1v6CZTyzFTE.png",
-alt="In 2019 we proposed PIGIN, followed by TURTLEDOVE in 2020 and FLEDGE in
-2021.", width="800", height="169" %}
-
 There have also been more than half a dozen other proposals offered by other
 companies, in the same solution space. Through continued collaboration, we hope
-to define a path forward. 
+to define a path forward.
 
-At the same time, [developer testing](/blog/fledge-api/) for the initial version
-of FLEDGE is behind a Chrome flag so developers can get their hands on it.
+At the same time, [testing for FLEDGE](/docs/privacy-sandbox/fledge-experiment/) was made available behind a Chrome flag so developers can access it early.
 
 Not every proposal will go through such an intense incubation period as
 FLEDGE&mdash;some will move much more quickly&mdash;but there is a lot of
@@ -97,7 +89,6 @@ innovation happening. These are new ideas and it can take a lot of work to get
 them right.
 
 ### Developers test and share feedback {: #testing}
-
 
 Testing is critical because it provides an early opportunity to [provide
 feedback](/docs/privacy-sandbox/feedback/) on improvements or issues that
@@ -116,12 +107,10 @@ your opportunity to try the feature on production traffic and provide feedback
 on real-world experience.
 
 <figure>
-{% Img src="image/VWw0b3pM7jdugTkwI6Y81n6f5Yc2/gSDnOdAhjtUa5XnBFVI7.png",
-alt="Discussion starts with a proposal and an Intent to Prototype, Functional /
-technical / developer testing often includes a feature flag, Effectiveness /
-utility / scaled testing often includes an origin trial which is signalled with
-an Intent to Experiment. Finally an Intent to Ship signals to the transition to
-adoption / general availability", width="800", height="231" %}
+{% Img
+  src="image/VWw0b3pM7jdugTkwI6Y81n6f5Yc2/gSDnOdAhjtUa5XnBFVI7.png",
+  alt="Proposals move through discussion to functional testing, effectiveness and scaled testing, to general availability. At each stage, Chromium publishes Intent documents.", width="800", height="231"
+%}
 <figcaption>
 Features progress through a timeline of development and testing through to
 general availability. These individual phases are not hard boundaries, but
@@ -130,7 +119,6 @@ functionality through to testing real behavior in a browser. The diagram shows
 some terms and artefacts you will see through a proposal's progress.
 </figcaption>
 </figure>
-
 
 When a feature is initially made available for testing, the focus is generally
 on **functional or technical testing**. With new code, there is an expectation
@@ -159,17 +147,15 @@ reports](/docs/privacy-sandbox/feedback/#reports) as part of [our commitments
 agreed with the
 CMA](https://blog.google/around-the-globe/google-europe/path-forward-privacy-sandbox/).
 
+{% Aside 'example' %}
 
-{% Aside %}
-
-For example, Yahoo! JAPAN published a [detailed
+Yahoo! JAPAN published a [detailed
 analysis](https://github.com/WICG/conversion-measurement-api/issues/201) of
 their participation in the Attribution Reporting API origin trial. They
 highlighted areas for improvement like the need for a better way to deliver
 conversion reports, which has now been added to the API.
 
 {% endAside %}
-
 
 Whether you share your testing in public places like the W3C, feedback forms, or
 through direct partnership channels, [we hope to hear from
@@ -179,8 +165,7 @@ Testing in the browser, either through feature flags or origin trials, isn't the
 only way to explore how new technologies might work. Some companies are also
 building simulations based on Privacy Sandbox concepts.
 
-
-{% Aside %}
+{% Aside 'example' %}
 
 Advertising platform Criteo recently [ran a
 competition](https://medium.com/criteo-engineering/assessing-the-impacts-of-the-privacy-sandbox-piece-by-piece-1-bring-the-noise-624331e64a12)
@@ -205,13 +190,16 @@ provides a lot of information about the user's browser and device, making it a
 readily available surface for fingerprinting. It also has a format that can be a
 headache to parse.
 
+<figure>
 {% Img src="image/VbsHyyQopiec0718rMq2kTE1hke2/AVzbV9HF0T0bm3buFjV6.jpg",
-   alt="For example, 'User-Agent: Mozilla/5.0 (Linux; Android 10; Pixel 3)
+   alt="Full User-Agent string, highlighting the platform version, device model, and full chrome version.", width="800", height="464"
+%}
+<figcaption>For example, 'User-Agent: Mozilla/5.0 (Linux; Android 10; Pixel 3)
    AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4076.0 Mobile
    Safari/537.36' is very long and offers specific details used for
    fingerprinting, such as the exact device model, platform version, and full
-   Chrome version.", width="800", height="464"
-%}
+   Chrome version.</figcaption>
+</figure>
 
 The reduced User-Agent includes the browser's brand and a significant version,
 where the request came from (desktop or mobile), and the platform. In the
@@ -222,8 +210,10 @@ In other words, the User-Agent data is moving from an "available by default"
 model to an "on request" model. This is a good privacy practice today, and the
 pattern we want to set for the future.
 
-{% Img src="image/VbsHyyQopiec0718rMq2kTE1hke2/ZsumGF9jzVb5yYL4QD3i.png",
-alt="", width="800", height="338" %}
+{% Img
+  src="image/VbsHyyQopiec0718rMq2kTE1hke2/ZsumGF9jzVb5yYL4QD3i.png",
+  alt="", width="800", height="338"
+%}
 
 In April 2022, gradual UA string reduction will begin in Chrome. UA-CH launched
 and was ready for scaled adoption starting in March of 2021&mdash;you can begin
@@ -248,3 +238,6 @@ as we can, encourage your involvement, and hear your input.
    Twitter](https://twitter.com/ChromiumDev).
 *  Submit Issues to the [developer support
    repo](https://github.com/GoogleChromeLabs/privacy-sandbox-dev-support).
+
+_Much of this content was originally shared as a part of the [2021 Chrome
+Developer Summit recap](/docs/privacy-sandbox/cds21-update/)._


### PR DESCRIPTION
Primary goal is to remove outdated materials and clean up API descriptions.

- Reorganize top to introduce the Privacy Sandbox before the video.
- Add limited context from "Digging into the Privacy Sandbox"
- All PS APIs with documentation are now linked to, instead of older proposals.
- Shortened API explanations to match documentation.
- Remove duplicated explainers links. Each API either links to the explainer directly or to the docs which link to the explainers.
- Removed outdated reference as to who works on this project.
- Condense links and remove outdated info


https://pr-5467-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/overview/
https://pr-5467-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/proposal-lifecycle/
