### PR TITLE
fix code sample links

### DIFF
--- a/site/en/docs/privacy-sandbox/shared-storage/ab-testing/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/ab-testing/index.md
@@ -81,7 +81,7 @@ async function injectContent() {
 injectContent();
 ```
 
-**[ab-testing-worklet.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/advertiser/ab-testing-worklet.js)**
+**[ab-testing-worklet.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/content-producer/url-selection/ab-testing-worklet.js)**
 
 ```js
 class SelectURLOperation {

--- a/site/en/docs/privacy-sandbox/shared-storage/ab-testing/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/ab-testing/index.md
@@ -48,7 +48,7 @@ In this example:
 *   `ab-testing.js` should be embedded in a frame, which maps a control and two experiment contents. The script calls the shared storage worklet for the experiment.
 *   `ab-testing-worklet.js`  is the shared storage worklet that returns which group the user is assigned to, determining which ad is shown.
 
-**[ab-testing.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/advertiser/ab-testing.js)**
+**[ab-testing.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/content-producer/url-selection/ab-testing.js)**
 
 ```js
 // Randomly assigns a user to a group 0 or 1

--- a/site/en/docs/privacy-sandbox/shared-storage/creative-rotation/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/creative-rotation/index.md
@@ -47,7 +47,7 @@ In this example:
 *   `creative-rotation.js` is embedded in a frame. This script sets which ads are the most important ( weight), and calls to the worklet to determine which content should be displayed.
 *   `creative-rotation-worklet.js`  is the shared storage worklet that determines the weighted distribution for the contents and returns which should be displayed.
 
-**[creative-rotation.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/advertiser/creative-rotation.js)**
+**[creative-rotation.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/content-producer/url-selection/creative-rotation.js)**
 
 ```js
 // Ad config with the URL of the content, a probability weight for rotation, and the clickthrough rate.
@@ -95,7 +95,7 @@ async function injectAd() {
 injectAd();
 ```
 
-**[creative-rotation-worklet.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/advertiser/creative-rotation-worklet.js)**
+**[creative-rotation-worklet.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/content-producer/url-selection/creative-rotation-worklet.js)**
 
 ```js
 class SelectURLOperation {

--- a/site/en/docs/privacy-sandbox/shared-storage/frequency-control/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/frequency-control/index.md
@@ -70,7 +70,7 @@ In this example:
 *  `frequency-cap-worklet.js` is the shared storage worklet that reads the
    frequency cap count value to determine which URL is returned for the ad creative.
 
-**[frequency-cap.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/advertiser/frequency-cap.js)**
+**[frequency-cap.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/content-producer/url-selection/frequency-cap.js)**
 
 ```javascript
 // The first URL is the default ad to be rendered when the frequency cap is reached
@@ -98,7 +98,7 @@ async function injectAd() {
 injectAd();
 ```
 
-**[frequency-cap-worklet.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/advertiser/frequency-cap-worklet.js)**
+**[frequency-cap-worklet.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/content-producer/url-selection/frequency-cap-worklet.js)**
 
 ```javascript
 class SelectURLOperation {

--- a/site/en/docs/privacy-sandbox/shared-storage/k-freq-reach/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/k-freq-reach/index.md
@@ -41,8 +41,8 @@ You may want to measure the number of users who have seen your content K or more
 
 In this example:
 
-*   [`k-frequency-measurement.js`](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/advertiser/private-aggregation/k-freq-measurement.js) is loaded via a frame, and is responsible for loading the shared storage worklet.
-*   [`k-frequency-measurement-worklet.js`](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/advertiser/private-aggregation/k-freq-measurement-worklet.js) is the shared storage worklet that reads the impression count in shared storage and sends a report via the Private Aggregation API.
+*   [`k-frequency-measurement.js`](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/content-producer/private-aggregation/k-freq-measurement.js) is loaded via a frame, and is responsible for loading the shared storage worklet.
+*   [`k-frequency-measurement-worklet.js`](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/content-producer/private-aggregation/k-freq-measurement-worklet.js) is the shared storage worklet that reads the impression count in shared storage and sends a report via the Private Aggregation API.
 
 **`k-frequency-measurement.js`**
 

--- a/site/en/docs/privacy-sandbox/shared-storage/known-customer/index.md
+++ b/site/en/docs/privacy-sandbox/shared-storage/known-customer/index.md
@@ -50,7 +50,7 @@ In this example:
 *   `known-customer.js` is embedded in a frame. This script sets the options for which button should be displayed on a site, “Register” or “Buy now.”
 *   `known-customer-worklet.js`  is the shared storage worklet that determines if the user is known. If the user is known, the information is returned. If the user is unknown, that information is returned to display the “Register” button and the user is marked as known for the future.
 
-**[known-customer.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/advertiser/known-customer.js)**
+**[known-customer.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/content-producer/url-selection/known-customer.js)**
 
 ```js
 // The first URL for the "register" button is rendered for unknown users.
@@ -78,7 +78,7 @@ async function injectButton() {
 injectButton();
 ```
 
-**[known-customer-worklet.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/advertiser/known-customer-worklet.js)**
+**[known-customer-worklet.js](https://github.com/GoogleChromeLabs/shared-storage-demo/blob/main/sites/content-producer/url-selection/known-customer-worklet.js)**
 
 ```js
 class SelectURLOperation {


### PR DESCRIPTION
Fixes b/271154209

Changes proposed in this pull request:

- Fix shared storage code sample links---new location in github
- staging links: 
- https://pr-5484-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/shared-storage/ab-testing/#:~:text=ad%20is%20shown.-,ab%2Dtesting.js,-//%20Randomly%20assigns%20a
- https://pr-5484-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/shared-storage/ab-testing/#:~:text=()%3B-,ab%2Dtesting%2Dworklet.js,-class%20SelectURLOperation%20%7B
- https://pr-5484-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/shared-storage/creative-rotation/#:~:text=should%20be%20displayed.-,creative%2Drotation.js,-//%20Ad%20config%20with
- https://pr-5484-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/shared-storage/creative-rotation/#:~:text=()%3B-,creative%2Drotation%2Dworklet.js,-class%20SelectURLOperation%20%7B
- https://pr-5484-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/shared-storage/k-freq-reach/#:~:text=In%20this%20example%3A-,k%2Dfrequency%2Dmeasurement.js,-is%20loaded%20via
- https://pr-5484-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/shared-storage/known-customer/#:~:text=for%20the%20future.-,known%2Dcustomer.js,-//%20The%20first%20URL
- https://pr-5484-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/shared-storage/known-customer/#:~:text=()%3B-,known%2Dcustomer%2Dworklet.js,-class%20SelectURLOperation%20%7B
- https://pr-5484-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/shared-storage/frequency-control/#:~:text=the%20ad%20creative.-,frequency%2Dcap.js,-//%20The%20first%20URL
- https://pr-5484-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/shared-storage/frequency-control/#:~:text=()%3B-,frequency%2Dcap%2Dworklet.js,-class%20SelectURLOperation%20%7B
