### PR TITLE
Add native messaging to sidebar.

### DIFF
--- a/site/_data/docs/extensions/toc.yml
+++ b/site/_data/docs/extensions/toc.yml
@@ -59,6 +59,7 @@
     - url: /docs/extensions/mv3/tut_oauth
     - url: /docs/extensions/mv3/override
     - url: /docs/extensions/mv3/richNotifications
+    - url: /docs/extensions/mv3/nativeMessaging
 - title: i18n.docs.extensions.quality
   sections:
     - url: /docs/extensions/mv3/user_privacy


### PR DESCRIPTION
I noticed that in a previous PR, I didn't add native messaging to the TOC, so it was rendering under the "Welcome" section:

<img width="1067" alt="Screenshot 2023-03-01 at 10 30 48" src="https://user-images.githubusercontent.com/6097064/222113880-60f18732-4b46-42c5-bcf3-38fa264973e5.png">

This fixes that.