### PR TITLE
Update storage.session API quota.

### DIFF
--- a/site/en/docs/extensions/mv3/known-issues/index.md
+++ b/site/en/docs/extensions/mv3/known-issues/index.md
@@ -56,7 +56,7 @@ This section lists major features that will be added to the Manifest V3 platform
 
 **Summary:** When it was introduced, the `session` storage area had an intentionally conservative maximum quota of 1 MB. This limit is being increased to 10 MB.
 
-**Estimated timeline**: This will be available in Chrome 112.
+**Estimated timeline**: This will be available in Chrome 112. Chrome 112 beta is planned around March 9, with a stable release around the beginning of April.
 
 ## Bugs {: #bugs }
 

--- a/site/en/docs/extensions/mv3/known-issues/index.md
+++ b/site/en/docs/extensions/mv3/known-issues/index.md
@@ -54,9 +54,9 @@ This section lists major features that will be added to the Manifest V3 platform
 
 ### Increased quota for session storage in the Storage API {: #increased-session-storage-quota }
 
-**Summary:** When it was introduced, the `session` storage area had an intentionally conservative maximum quota of 1 MB. We are planning to increase this limit, but have not yet settled on a new value.
+**Summary:** When it was introduced, the `session` storage area had an intentionally conservative maximum quota of 1 MB. This limit is being increased to 10 MB.
 
-**Estimated timeline**: Targeting Canary support in the first quarter of 2023.
+**Estimated timeline**: This will be available in Chrome 112.
 
 ## Bugs {: #bugs }
 

--- a/site/en/docs/extensions/reference/storage/index.md
+++ b/site/en/docs/extensions/reference/storage/index.md
@@ -44,7 +44,13 @@ Local and sync storage areas should not store confidential user data because the
 {% endAside %}
 
 [storage.session][prop-session]
-: Holds data in memory for the duration of a browser session. By default, it's not exposed to content scripts, but this behavior can be changed by setting [`chrome.storage.session.setAccessLevel()`][method-access-level]. The quota limitation is 1 MB approx. Consider using it to store global variables across service worker runs.
+: Holds data in memory for the duration of a browser session. By default, it's not exposed to content scripts, but this behavior can be changed by setting [`chrome.storage.session.setAccessLevel()`][method-access-level]. The quota limitation is approximately 10 MB. Consider using it to store global variables across service worker runs.
+
+{% Aside 'warning' %}
+
+Before Chrome 112, the quota was approximately 1 MB.
+
+{% endAside %}
 
 [storage.managed][prop-managed]
 : Administrator can use a [schema][manifest-storage] and enterprise policies to configure a supporting extension's settings in a managed environment. This storage area is read-only.

--- a/site/en/docs/extensions/reference/storage/index.md
+++ b/site/en/docs/extensions/reference/storage/index.md
@@ -38,18 +38,14 @@ The Storage API is divided into the following four buckets ("storage areas"):
 
 
 {% Aside 'warning' %}
-
 Local and sync storage areas should not store confidential user data because they are not encrypted. When working with sensitive data, consider using the `session` storage area to hold values in memory until the browser is shut down.
-
 {% endAside %}
 
 [storage.session][prop-session]
 : Holds data in memory for the duration of a browser session. By default, it's not exposed to content scripts, but this behavior can be changed by setting [`chrome.storage.session.setAccessLevel()`][method-access-level]. The quota limitation is approximately 10 MB. Consider using it to store global variables across service worker runs.
 
 {% Aside 'warning' %}
-
 Before Chrome 112, the quota was approximately 1 MB.
-
 {% endAside %}
 
 [storage.managed][prop-managed]

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -16,6 +16,12 @@ tags:
 Check this page often to learn about changes to the Chrome extensions platform, its documentation,
 and related policy or other changes. You'll find other notices posted on the [Extensions Google Group](https://groups.google.com/a/chromium.org/g/chromium-extensions). The [Extensions News](/tags/extensions-news/) tag lists articles about many of the topics listed here. (It even has [an RSS feed](/feeds/extensions-news.xml).)
 
+### Chrome 112: Increased storage.session quota {: #m112-storage-session-quota}
+
+March 1, 2023
+
+From Chrome 112, the quota for the [`storage.session`](/docs/extensions/reference/storage/#property-session) API has been increased to approximately 10 MB. This was discussed in the Web Extensions Community Group: [https://github.com/w3c/webextensions/issues/350](https://github.com/w3c/webextensions/issues/350)
+
 ### Chrome 109: Is an exension enabled {: #m110-action }
 
 January 12, 2023

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -20,7 +20,7 @@ and related policy or other changes. You'll find other notices posted on the [Ex
 
 March 3, 2023
 
-From Chrome 112, the quota for the [`storage.session`](/docs/extensions/reference/storage/#property-session) property has been increased to approximately 10 MB. This was discussed in the Web Extensions Community Group: [https://github.com/w3c/webextensions/issues/350](https://github.com/w3c/webextensions/issues/350)
+From Chrome 112, the quota for the [`storage.session`](/docs/extensions/reference/storage/#property-session) property has been increased to approximately 10 MB. This was agreed in the Web Extensions Community Group: [https://github.com/w3c/webextensions/issues/350](https://github.com/w3c/webextensions/issues/350)
 
 ### Chrome 109: Is an exension enabled {: #m110-action }
 

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -18,9 +18,9 @@ and related policy or other changes. You'll find other notices posted on the [Ex
 
 ### Chrome 112: Increased storage.session quota {: #m112-storage-session-quota}
 
-March 1, 2023
+March 3, 2023
 
-From Chrome 112, the quota for the [`storage.session`](/docs/extensions/reference/storage/#property-session) API has been increased to approximately 10 MB. This was discussed in the Web Extensions Community Group: [https://github.com/w3c/webextensions/issues/350](https://github.com/w3c/webextensions/issues/350)
+From Chrome 112, the quota for the [`storage.session`](/docs/extensions/reference/storage/#property-session) property has been increased to approximately 10 MB. This was discussed in the Web Extensions Community Group: [https://github.com/w3c/webextensions/issues/350](https://github.com/w3c/webextensions/issues/350)
 
 ### Chrome 109: Is an exension enabled {: #m110-action }
 


### PR DESCRIPTION
Updates our documentation to reflect that the storage.session quota has been increased to 10 MB.