### PR TITLE
Add rel=me to author social links

### DIFF
--- a/site/_includes/layouts/author-individual.njk
+++ b/site/_includes/layouts/author-individual.njk
@@ -27,32 +27,32 @@
       <div class="display-flex direction-column align-center">
         <div class="display-flex color-secondary-text gap-top-300 lg:gap-top-0">
           {% if paged.homepage %}
-            <a href="{{ paged.homepage }}" class="display-inline-flex color-secondary-text gap-left-200 gap-right-200 social-icon" aria-label="{{ 'i18n.common.website' | i18n(locale) }}">
+            <a rel="me" href="{{ paged.homepage }}" class="display-inline-flex color-secondary-text gap-left-200 gap-right-200 social-icon" aria-label="{{ 'i18n.common.website' | i18n(locale) }}">
               {{ icon('world', {hidden: true}) }}
             </a>
           {% endif %}
           {% if paged.twitter %}
-            <a href="https://twitter.com/{{ paged.twitter }}" class="display-inline-flex color-secondary-text gap-left-200 gap-right-200 social-icon" aria-label="Twitter">
+            <a rel="me" href="https://twitter.com/{{ paged.twitter }}" class="display-inline-flex color-secondary-text gap-left-200 gap-right-200 social-icon" aria-label="Twitter">
               {{ icon('twitter', {hidden: true}) }}
             </a>
           {% endif %}
           {% if paged.github %}
-            <a href="https://github.com/{{ paged.github }}" class="display-inline-flex color-secondary-text gap-left-200 gap-right-200 social-icon" aria-label="GitHub">
+            <a rel="me" href="https://github.com/{{ paged.github }}" class="display-inline-flex color-secondary-text gap-left-200 gap-right-200 social-icon" aria-label="GitHub">
               {{ icon('github', {hidden: true}) }}
             </a>
           {% endif %}
           {% if paged.glitch  %}
-            <a href="https://glitch.com/@{{ paged.glitch }}" class="display-inline-flex color-secondary-text gap-left-200 gap-right-200 social-icon" aria-label="Glitch">
+            <a rel="me" href="https://glitch.com/@{{ paged.glitch }}" class="display-inline-flex color-secondary-text gap-left-200 gap-right-200 social-icon" aria-label="Glitch">
               {{ icon('glitch', {hidden: true}) }}
             </a>
           {% endif %}
           {% if paged.mastodon  %}
-            <a href="{{ paged.mastodon }}" class="display-inline-flex color-secondary-text gap-left-200 gap-right-200 social-icon" aria-label="Mastodon">
+            <a rel="me" href="{{ paged.mastodon }}" class="display-inline-flex color-secondary-text gap-left-200 gap-right-200 social-icon" aria-label="Mastodon">
               {{ icon('mastodon', {hidden: true}) }}
             </a>
           {% endif %}
           {% if paged.linkedin  %}
-            <a href="{{ paged.linkedin }}" class="display-inline-flex color-secondary-text gap-left-200 gap-right-200 social-icon" aria-label="LinkedIn">
+            <a rel="me" href="{{ paged.linkedin }}" class="display-inline-flex color-secondary-text gap-left-200 gap-right-200 social-icon" aria-label="LinkedIn">
               {{ icon('linkedin', {hidden: true}) }}
             </a>
           {% endif %}

--- a/site/_includes/macros/post-author.njk
+++ b/site/_includes/macros/post-author.njk
@@ -31,22 +31,22 @@
       <!-- Start author social links -->
       <div class="post-authors-social">
         {% if author.homepage %}
-          <a href="{{ author.homepage }}" class="link">{{ 'i18n.common.website' | i18n(locale) }}</a>
+          <a rel="me" href="{{ author.homepage }}" class="link">{{ 'i18n.common.website' | i18n(locale) }}</a>
         {% endif %}
         {% if author.twitter %}
-          <a href="https://twitter.com/{{ author.twitter }}" class="link">Twitter</a>
+          <a rel="me" href="https://twitter.com/{{ author.twitter }}" class="link">Twitter</a>
         {% endif %}
         {% if author.github %}
-          <a href="https://github.com/{{ author.github }}" class="link">GitHub</a>
+          <a rel="me" href="https://github.com/{{ author.github }}" class="link">GitHub</a>
         {% endif %}
         {% if author.glitch %}
-          <a href="https://glitch.com/@{{ author.glitch }}" class="link">Glitch</a>
+          <a rel="me" href="https://glitch.com/@{{ author.glitch }}" class="link">Glitch</a>
         {% endif %}
         {% if author.mastodon %}
-          <a href="{{ author.mastodon }}" class="link">Mastodon</a>
+          <a rel="me" href="{{ author.mastodon }}" class="link">Mastodon</a>
         {% endif %}
         {% if author.linkedin %}
-          <a href="https://www.linkedin.com/in/{{ author.linkedin }}" class="link">LinkedIn</a>
+          <a rel="me" href="https://www.linkedin.com/in/{{ author.linkedin }}" class="link">LinkedIn</a>
         {% endif %}
       </div>
       <!-- End author social links -->


### PR DESCRIPTION
This PR adds `rel=me` to author social links as in the Google Search blog authors pages (ex: https://developers.google.com/search/blog/authors/daniel-waisberg)