### PR TITLE
Stay quiet for missing href/links in dom-transformer

### DIFF
--- a/site/_transforms/pretty-urls.js
+++ b/site/_transforms/pretty-urls.js
@@ -76,14 +76,7 @@ const prettyUrls = ($, outputPath, locale) => {
 
     const href = $link.attr('href');
     if (!href && !$link.attr('id')) {
-      // Only warn in non-production builds, as this is a common occurrence and might
-      // be confusing when debugging build errors.
-      if (process.env.ELEVENTY_ENV !== 'production') {
-        console.warn(
-          `Found <a> in ${outputPath} with no href/id (text=\`${$link.text()}\`)`
-        );
-      }
-
+      // Early-exit if a link has no href and no id.
       return;
     }
 


### PR DESCRIPTION
Wanted to do this for sometime. Opinions might clash on this, but I vote to remove this log. It regularly causes confusion for contributors dealing with build errors. For example see https://github.com/GoogleChrome/developer.chrome.com/pull/5046.

Also for me that seems to be the wrong approach on this. A warning with no consequences is usually ignored. So it either breaks the build which is bad author UX for different reasons, or is surfaced during linting and blocks PRs where a new error is introduced - that would be ideal. For this I'll reference this PR in https://github.com/GoogleChrome/webdev-infra/issues/53.

For more context. This log currently pollutes build output with this:

```
Found <a> in dist/en/docs/apps/offline_storage/index.html with no href/id (text=`TEMPORARY`)
Found <a> in dist/en/docs/apps/offline_storage/index.html with no href/id (text=`PERSISTENT`)
Found <a> in dist/en/docs/privacy-sandbox/fedcm/index.html with no href/id (text=``)
Found <a> in dist/en/docs/web-platform/webgpu/index.html with no href/id (text=`Request a token`)
Found <a> in dist/es/docs/web-platform/webgpu/index.html with no href/id (text=`Request a token`)
Found <a> in dist/ja/docs/privacy-sandbox/fledge/index.html with no href/id (text=`拡大表示`)
Found <a> in dist/ja/docs/privacy-sandbox/fledge-api/index.html with no href/id (text=`広告オークションを実行`)
Found <a> in dist/ja/docs/privacy-sandbox/fedcm/index.html with no href/id (text=``)
Found <a> in dist/ja/docs/privacy-sandbox/fledge-api/index.html with no href/id (text=`広告枠`)
Found <a> in dist/ja/docs/privacy-sandbox/fledge-api/index.html with no href/id (text=`リアルタイム入札`)
Found <a> in dist/ja/docs/privacy-sandbox/fledge-api/index.html with no href/id (text=`TURTLEDOVE`)
Found <a> in dist/pt/docs/web-platform/webgpu/index.html with no href/id (text=`Request a token`)
Found <a> in dist/es/docs/lighthouse/performance/font-display/index.html with no href/id (text=``)
Found <a> in dist/es/docs/lighthouse/performance/font-display/index.html with no href/id (text=``)
Found <a> in dist/pt/docs/lighthouse/performance/font-display/index.html with no href/id (text=`parâmetro`)
Found <a> in dist/en/docs/workbox/faster-multipage-applications-with-streams/index.html with no href/id (text=`effective connection type`)
Found <a> in dist/ko/articles/contact-picker/index.html with no href/id (text=`완료`)
Found <a> in dist/ko/articles/local-fonts/index.html with no href/id (text=`완료`)
Found <a> in dist/ko/articles/file-handling/index.html with no href/id (text=`@ChromiumDev`)
Found <a> in dist/pt/articles/contact-picker/index.html with no href/id (text=`Concluído`)
Found <a> in dist/ko/articles/web-otp/index.html with no href/id (text=`@ChromiumDev`)
Found <a> in dist/ru/articles/serial/index.html with no href/id (text=`Завершен`)
Found <a> in dist/ru/articles/contact-picker/index.html with no href/id (text=`Готово`)
Found <a> in dist/zh/articles/local-fonts/index.html with no href/id (text=`完成`)
Found <a> in dist/zh/articles/contact-picker/index.html with no href/id (text=`标签向@ChromiumDev`)
Found <a> in dist/zh/articles/web-otp/index.html with no href/id (text=`@ChromiumDev`)
Found <a> in dist/zh/articles/websocketstream/index.html with no href/id (text=` 向 @ChromiumDev`)
Found <a> in dist/en/articles/reporting-api/index.html with no href/id (text=` and follow the instructions to generate example reports.`)
Found <a> in dist/en/blog/chrome-109-beta/index.html with no href/id (text=`Register for the Private Network Access preflight requests for subresources origin trial`)
Found <a> in dist/en/blog/chrome-68-deps-rems/index.html with no href/id (text=`Intent to Remove`)
Found <a> in dist/en/blog/chrome-80-deps-rems/index.html with no href/id (text=`Disallowing synchronous
XMLHTTPRequest() during page dismissal`)
Found <a> in dist/en/blog/chrome-68-deps-rems/index.html with no href/id (text=`Chromium Bug`)
Found <a> in dist/en/blog/chrome-77-deps-rems/index.html with no href/id (text=`Intent to Remove`)
Found <a> in dist/en/blog/chrome-85-deps-rems/index.html with no href/id (text=`Intent to Remove`)
Found <a> in dist/en/blog/chrome-ux-report-api/index.html with no href/id (text=`CrUXApiUtil`)
Found <a> in dist/en/blog/hpkp-reporting-with-chrome-46/index.html with no href/id (text=`https://developers.google.com`)
Found <a> in dist/en/blog/push-notifications-on-the-open-web/index.html with no href/id (text=`https://console.firebase.google.com/`)
Found <a> in dist/en/blog/sxg-desktop/index.html with no href/id (text=``)
Found <a> in dist/ja/blog/fledge-api/index.html with no href/id (text=`TURTLEDOVE`)
Found <a> in dist/en/docs/handbook/content-types/blog-landing/2/index.html with no href/id (text=`
      This is the 8th post

    `)
Found <a> in dist/en/docs/handbook/content-types/blog-landing/index.html with no href/id (text=`
      A post without a thumbnail

    `)
Found <a> in dist/en/docs/handbook/content-types/blog-landing/index.html with no href/id (text=`

      `)
Found <a> in dist/en/docs/handbook/content-types/blog-landing/index.html with no href/id (text=`
      If a post has a thumbnail then it will use this layout

    `)
Found <a> in dist/en/docs/handbook/content-types/blog-landing/index.html with no href/id (text=`

      `)
Found <a> in dist/en/docs/handbook/content-types/blog-landing/index.html with no href/id (text=`
      This is what a post looks like with a single author

    `)
Found <a> in dist/en/docs/handbook/content-types/blog-landing/index.html with no href/id (text=`

      `)
Found <a> in dist/en/docs/handbook/content-types/blog-landing/index.html with no href/id (text=`
      This is what a post looks like with two authors

    `)
Found <a> in dist/en/docs/handbook/content-types/blog-landing/index.html with no href/id (text=`

      `)
Found <a> in dist/en/docs/handbook/content-types/blog-landing/index.html with no href/id (text=`
      This is what a post looks like with more than two authors

    `)
Found <a> in dist/en/docs/handbook/content-types/blog-landing/index.html with no href/id (text=`

      `)
Found <a> in dist/en/docs/handbook/content-types/blog-landing/index.html with no href/id (text=`
      This is what a post looks like with a single tag

    `)
Found <a> in dist/en/docs/handbook/content-types/blog-landing/index.html with no href/id (text=`

      `)
Found <a> in dist/en/docs/handbook/content-types/blog-landing/index.html with no href/id (text=`
      This is what a post looks like multiple  tags

    `)
[11ty] Copied 721 files / Wrote 4520 files in 95.93 seconds (21.2ms each, v1.0.2)
```