### PR TITLE
Add FLEDGE ramp up and isolated origin trial experiment info

### DIFF
--- a/site/en/docs/privacy-sandbox/unified-origin-trial/index.md
+++ b/site/en/docs/privacy-sandbox/unified-origin-trial/index.md
@@ -11,6 +11,7 @@ date: 2022-09-08
 updated: 2022-11-04
 authors:
   - anusmitaray
+  - kevinkiklee
   - rowan_m
 ---
 
@@ -29,6 +30,175 @@ through the configuration steps to access the APIs, tells you how to validate
 your configuration, and provides further resources for testing against the APIs.
 
 ## Check the status of the origin trial {: #status}
+
+### March 2023
+
+#### FLEDGE 1% ramp back up
+
+Last month, we [temporarily reduced FLEDGE origin trial traffic](/docs/privacy-sandbox/unified-origin-trial/#january-2023) from 5% to 4% of Chrome stable for testing. The initial testing has concluded, and we plan to ramp FLEDGE back up to 5% from 4% for the unified experiment on Monday, March 13, 2023.
+
+The ramped-up users will be the same set of users that were ramped down. However, their previous interest groups have expired, since more than 30 days have passed since the ramp-down. 
+
+#### Isolated experiments
+
+To improve our testing process and continue observing the metrics of origin trial APIs, we're creating isolated experiments for each API, in addition to the existing unified experiment. New experiments will be created for Attribution Reporting, Topics, a combination of FLEDGE and Fenced Frames, and a combination of Shared Storage’s URL Selection operation and Fenced Frames. In each isolated experiment, only the assigned APIs will be available for the users in that group.
+
+<table>
+  <tr>
+   <td><strong>API</strong>
+   </td>
+   <td><strong>Isolated experiment<br>traffic allocation</strong>
+   </td>
+  </tr>
+  <tr>
+   <td>Attribution Reporting 
+   </td>
+   <td>1%
+   </td>
+  </tr>
+  <tr>
+   <td>FLEDGE + Fenced Frames
+   </td>
+   <td>1%
+   </td>
+  </tr>
+  <tr>
+   <td>Shared Storage (URL selection) + Fenced Frames
+   </td>
+   <td>1%
+   </td>
+  </tr>
+  <tr>
+   <td>Topics
+   </td>
+   <td>1%
+   </td>
+  </tr>
+</table>
+
+Starting Monday, March 13, you will begin to receive an additional 1% of the Chrome Stable traffic for the APIs listed above, on top of the 5% traffic you are receiving from the existing unified experiment. New users will be allocated to each experiment.
+
+#### Traffic allocation
+
+The current unified origin trials traffic allocation as of Tuesday, February 28, is as follows:
+
+<table>
+  <tr>
+   <td><strong>API</strong>
+   </td>
+   <td><strong>Current unified experiment<br>traffic allocation</strong>
+   </td>
+  </tr>
+  <tr>
+   <td>Attribution Reporting 
+   </td>
+   <td>5%
+   </td>
+  </tr>
+  <tr>
+   <td>Fenced Frames
+   </td>
+   <td>5%
+   </td>
+  </tr>
+  <tr>
+   <td>FLEDGE
+   </td>
+   <td>4%
+   </td>
+  </tr>
+  <tr>
+   <td>Shared Storage (URL selection)
+   </td>
+   <td>5%
+   </td>
+  </tr>
+  <tr>
+   <td>Topics
+   </td>
+   <td>5%
+   </td>
+  </tr>
+</table>
+
+The traffic allocation will look like the following starting on Monday, March 13, after FLEDGE is ramped back up, and the new isolated experiments begin:
+
+<table>
+  <tr>
+   <td><strong>API</strong>
+   </td>
+   <td><strong>New traffic allocation</strong>
+   </td>
+   <td><strong>Status</strong>
+   </td>
+  </tr>
+  <tr>
+   <td rowspan="2">Attribution Reporting 
+   </td>
+   <td style="border-left: 1px solid var(--color-hairline);border-right: 1px solid var(--color-hairline);">Unified - 5%
+   </td>
+   <td rowspan="2">6% of the Stable traffic starting from March 13, 2023
+   </td>
+  </tr>
+  <tr>
+   <td style="border-left: 1px solid var(--color-hairline);border-right: 1px solid var(--color-hairline);">Isolated - 1% - ARA only
+   </td>
+  </tr>
+  <tr>
+   <td rowspan="3">Fenced Frames
+   </td>
+   <td style="border-left: 1px solid var(--color-hairline);border-right: 1px solid var(--color-hairline);">Unified - 5%
+   </td>
+   <td rowspan="3">7% of the Stable traffic starting from March 13, 2023
+   </td>
+  </tr>
+  <tr>
+   <td style="border-left: 1px solid var(--color-hairline);border-right: 1px solid var(--color-hairline);">Isolated - 1% - Shared Storage (URL Selection) + Fenced Frames only
+   </td>
+  </tr>
+  <tr>
+   <td style="border-left: 1px solid var(--color-hairline);border-right: 1px solid var(--color-hairline);">Isolated - 1% - FLEDGE + Fenced Frames only
+   </td>
+  </tr>
+  <tr>
+   <td rowspan="2">FLEDGE 
+   </td>
+   <td style="border-left: 1px solid var(--color-hairline);border-right: 1px solid var(--color-hairline);">Unified - 5% (4% current allocation + 1% ramp back up)
+   </td>
+   <td rowspan="2">6% of the Stable traffic starting from March 13, 2023
+   </td>
+  </tr>
+  <tr>
+   <td style="border-left: 1px solid var(--color-hairline);border-right: 1px solid var(--color-hairline);">Isolated - 1% - FLEDGE + Fenced Frames only
+   </td>
+  </tr>
+  <tr>
+   <td rowspan="2">Shared Storage <br>(URL Selection)
+   </td>
+   <td style="border-left: 1px solid var(--color-hairline);border-right: 1px solid var(--color-hairline);">Unified - 5%
+   </td>
+   <td rowspan="2">6% of the Stable traffic starting from March 13, 2023
+   </td>
+  </tr>
+  <tr>
+   <td style="border-left: 1px solid var(--color-hairline);border-right: 1px solid var(--color-hairline);">Isolated - 1% - Shared Storage (URL Selection) + Fenced Frames only
+   </td>
+  </tr>
+  <tr>
+   <td rowspan="2">Topics
+   </td>
+   <td style="border-left: 1px solid var(--color-hairline);border-right: 1px solid var(--color-hairline);">Unified - 5%
+   </td>
+   <td rowspan="2">6% of the Stable traffic starting from March 13, 2023
+   </td>
+  </tr>
+  <tr>
+   <td style="border-left: 1px solid var(--color-hairline);border-right: 1px solid var(--color-hairline);">Isolated - 1% - Topics only
+   </td>
+  </tr>
+</table>
+
+These changes will not affect your existing origin trial token setup, and you will not have to renew or generate a new origin trial token. 
 
 ### January 2023
 


### PR DESCRIPTION
This PR adds to the origin trial update that: 
* FLEDGE is being ramped back up
* Isolated experiments are launching

Preview link: https://pr-5502-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/unified-origin-trial/#march-2023