### PR TITLE
[CRX] Remove console log step in Development Basics

### DIFF
--- a/site/en/docs/extensions/mv3/getstarted/development-basics/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/development-basics/index.md
@@ -164,10 +164,9 @@ console.log("This is a popup!")
 
 To see this message logged in the Console:
 
-  1. Refresh the extension.
-  2. Open the popup.
-  3. Right-click on the popup.
-  4. Select **Inspect**. 
+  1. Open the popup.
+  2. Right-click on the popup.
+  3. Select **Inspect**. 
       <figure> 
       {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/vHGHW1o4J0kZgUkAteRQ.png", 
       alt="Inspecting the popup", width="322", height="262", class="screenshot" %}
@@ -175,7 +174,7 @@ To see this message logged in the Console:
         Inspecting a popup 
         </figcaption>
       </figure>
-  5. In the [DevTools][dev-tools], navigate to the **Console** panel.
+  4. In the [DevTools][dev-tools], navigate to the **Console** panel.
     <figure>
     {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/1ZrcBEYcbMxW1c9UvBy9.png", 
     alt="DevTools Code Panel", width="400", height="374", class="screenshot" %}


### PR DESCRIPTION
As mentioned before in "Which components needs a reload" of this article, there is no need for a "reload" after editing a "popup.html" file to see the changes. So I suggest to delete step 1 in "how to debug your extension using chrome console section"

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

-
-
-