### PR TITLE
Web-tabs: adds the ability to place content between the tab buttons and content

### DIFF
--- a/site/_js/web-components/web-tabs.js
+++ b/site/_js/web-components/web-tabs.js
@@ -113,17 +113,15 @@ export class WebTabs extends BaseElement {
   }
 
   render() {
+    const children = Array.from(this.children);
+
     if ('resolved' in this.dataset) {
-      return Array.from(this.children);
+      return children;
     }
 
-    this._tabPanels = Array.from(this.children).filter(
-      e => e.nodeName === 'WEB-TAB'
-    );
+    this._tabPanels = children.filter(e => e.nodeName === 'WEB-TAB');
 
-    const interlude = Array.from(this.children).filter(
-      e => e.nodeName === 'WEB-TABS-INTERLUDE'
-    );
+    const interlude = children.filter(e => e.nodeName === 'WEB-TABS-INTERLUDE');
 
     const tabs = this._formatTabs();
 

--- a/site/_js/web-components/web-tabs.js
+++ b/site/_js/web-components/web-tabs.js
@@ -107,7 +107,9 @@ export class WebTabs extends BaseElement {
       return 0;
     }
 
-    return Array.from(this.children).indexOf(tab);
+    return Array.from(this.children)
+      .filter(e => e.nodeName === 'WEB-TAB')
+      .indexOf(tab);
   }
 
   render() {
@@ -115,12 +117,19 @@ export class WebTabs extends BaseElement {
       return Array.from(this.children);
     }
 
-    this._tabPanels = Array.from(this.children);
+    this._tabPanels = Array.from(this.children).filter(
+      e => e.nodeName === 'WEB-TAB'
+    );
+
+    const interlude = Array.from(this.children).filter(
+      e => e.nodeName === 'WEB-TABS-INTERLUDE'
+    );
+
     const tabs = this._formatTabs();
 
     return html`
       <div role="tablist">${tabs}</div>
-      ${this._tabPanels}
+      ${interlude} ${this._tabPanels}
     `;
   }
 }

--- a/site/en/docs/handbook/components/index.md
+++ b/site/en/docs/handbook/components/index.md
@@ -777,6 +777,8 @@ Attribute `title` becomes the title of the corresponding tab panel.
 
 ````html
 <web-tabs>
+  <web-tabs-interlude>Use a `web-tabs-interlude` element to add content between the tabs and content.</web-tabs-interlude>
+
   <web-tab title="Tab 1 (html)">
     <p>I'm content of Tab 1</p>
   </web-tab>
@@ -805,6 +807,8 @@ const hello = 'world';
 ````
 
 <web-tabs>
+  <web-tabs-interlude>Use a `web-tabs-interlude` element to add content between the tabs and content.</web-tabs-interlude>
+
   <web-tab title="Tab 1 (html)">
     <p>I'm content of Tab 1</p>
   </web-tab>


### PR DESCRIPTION
Changes proposed in this pull request:

Once filters are added to the events page, the current selections need to show as tag-pills between the tab buttons and content. This PR facilitates that by adding an optional interlude element to web-tabs.

![image](https://user-images.githubusercontent.com/1577555/223109634-cb4e0aac-82df-4146-9b71-8f441ed0d2c6.png)
