### PR TITLE
Adds a new component: tag-pill-list

### DIFF
--- a/site/_js/styleguide.js
+++ b/site/_js/styleguide.js
@@ -16,3 +16,4 @@
 
 import './web-components/enhanced-select';
 import './web-components/checkbox-group';
+import './web-components/tag-pill-list';

--- a/site/_js/web-components/tag-pill-list.js
+++ b/site/_js/web-components/tag-pill-list.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/site/_js/web-components/tag-pill-list.js
+++ b/site/_js/web-components/tag-pill-list.js
@@ -39,7 +39,7 @@ export class TagPillList extends BaseElement {
     const items = this.items.map(
       item => html`
         <span
-          class="surface color-blue-medium hairline rounded-lg tag-pill type--label display-inline-flex align-center"
+          class="surface hairline rounded-lg tag-pill type--label display-inline-flex align-center"
           data-key="${item.key}"
           data-value="${item.value}"
         >

--- a/site/_js/web-components/tag-pill-list.js
+++ b/site/_js/web-components/tag-pill-list.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Given a key-value array, renders
+ * a list of tag-pills
+ */
+import {BaseElement} from './base-element';
+import {html} from 'lit-element';
+
+export class TagPillList extends BaseElement {
+  constructor() {
+    super();
+
+    this.items = [];
+    this.icon = this.querySelector('tag-pill-list-icon svg');
+  }
+
+  static get properties() {
+    return {
+      items: {type: Array, reflect: true},
+    };
+  }
+
+  render() {
+    const items = this.items.map(
+      item => html`
+        <span
+          class="surface color-blue-medium hairline rounded-lg tag-pill type--label display-inline-flex align-center"
+          data-key="${item.key}"
+          data-value="${item.value}"
+        >
+          ${item.value} ${this.icon?.cloneNode(true)}
+        </span>
+      `
+    );
+
+    return html`${items}`;
+  }
+}
+
+customElements.define('tag-pill-list', TagPillList);

--- a/site/_scss/blocks/_tag-pill-list.scss
+++ b/site/_scss/blocks/_tag-pill-list.scss
@@ -1,0 +1,7 @@
+tag-pill-list {
+  display: none;
+
+  &:defined {
+    display: initial;
+  }
+}

--- a/site/_scss/blocks/_tag-pill-list.scss
+++ b/site/_scss/blocks/_tag-pill-list.scss
@@ -1,7 +1,7 @@
 tag-pill-list {
   display: none;
-  gap: get-size(100);
   flex-wrap: wrap;
+  gap: get-size(100);
 
   &:defined {
     display: inline-flex;

--- a/site/_scss/blocks/_tag-pill-list.scss
+++ b/site/_scss/blocks/_tag-pill-list.scss
@@ -1,7 +1,9 @@
 tag-pill-list {
   display: none;
+  gap: get-size(100);
+  flex-wrap: wrap;
 
   &:defined {
-    display: initial;
+    display: inline-flex;
   }
 }

--- a/site/_scss/blocks/_tag-pill-list.scss
+++ b/site/_scss/blocks/_tag-pill-list.scss
@@ -3,6 +3,12 @@ tag-pill-list {
   flex-wrap: wrap;
   gap: get-size(100);
 
+  .icon {
+    height: get-size(300);
+    margin-left: 0.5rem;
+    width: get-size(300);
+  }
+
   &:defined {
     display: inline-flex;
   }

--- a/site/_scss/styleguide-main.scss
+++ b/site/_scss/styleguide-main.scss
@@ -28,3 +28,4 @@
 @import 'blocks/checkbox-group';
 @import 'blocks/filter-sheet';
 @import 'blocks/enhanced-select';
+@import 'blocks/tag-pill-list';

--- a/site/en/docs/handbook/style-guide/index.njk
+++ b/site/en/docs/handbook/style-guide/index.njk
@@ -8,6 +8,8 @@ banner:
 ---
 {% extends 'layouts/base.njk' %}
 
+{% from 'macros/icon.njk' import icon with context %}
+
 {% block css %}
 {% InlineCss '/css/styleguide-main.css' %}
 {% endblock %}
@@ -503,7 +505,7 @@ line-height: 160%;
   </div>
 
   {% set checkboxGroupI18n = {
-    reset: 'i18n.common.checkbox_group.reset'|i18n, 
+    reset: 'i18n.common.checkbox_group.reset'|i18n,
     select_all: 'i18n.common.checkbox_group.select_all'|i18n
   } %}
   <checkbox-group show="4" i18n='{{ checkboxGroupI18n|dump|safe }}''>
@@ -569,6 +571,27 @@ line-height: 160%;
       </div>
     </div>
   </div>
+
+  {% set tagPillListItems = [
+    {
+      "key": "googlers",
+      "value": "adamsilverstein"
+    },
+    {
+      "key": "locations",
+      "value": "Amsterdam, Netherlands"
+    },
+    {
+      "key": "topics",
+      "value": "Advanced Apps and Project Fugu"
+    }
+  ] %}
+
+  <p class="type--h4">Tag pill list:</p>
+
+  <tag-pill-list items='{{ tagPillListItems | dump | safe }}'>
+    <tag-pill-list-icon>{{ icon('close') }}</tag-pill-list-icon>
+  </tag-pill-list>
 
 </article>
 {% endblock %}

--- a/tests/rollup.config.js
+++ b/tests/rollup.config.js
@@ -3,6 +3,7 @@ import originalConfig from '../rollup.config';
 const inputs = [
   'site/_js/web-components/enhanced-select/_enhanced-select',
   'site/_js/web-components/checkbox-group/_checkbox-group',
+  'site/_js/web-components/tag-pill-list/_tag-pill-list',
   'site/_js/misc/load-more/_load-more',
 ];
 

--- a/tests/site/_js/web-components/tag-pill-list/_tag-pill-list.js
+++ b/tests/site/_js/web-components/tag-pill-list/_tag-pill-list.js
@@ -1,0 +1,1 @@
+import '../../../../../site/_js/web-components/tag-pill-list';

--- a/tests/site/_js/web-components/tag-pill-list/tag-pill-list.js
+++ b/tests/site/_js/web-components/tag-pill-list/tag-pill-list.js
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const test = require('ava');
+const {withPage, addPageScript} = require('../../../../puppeteer');
+const {html} = require('common-tags');
+
+test(
+  'tag-pill-list: renders expected items',
+  withPage,
+  async (t, page) => {
+    const data =  [
+      {
+        "key": "googlers",
+        "value": "adamsilverstein"
+      },
+      {
+        "key": "locations",
+        "value": "Amsterdam, Netherlands"
+      },
+      {
+        "key": "topics",
+        "value": "Advanced Apps and Project Fugu"
+      }
+    ];
+
+    await page.setContent(html`
+      <tag-pill-list items='${JSON.stringify(data)}' />
+    `);
+
+    await addPageScript(page, '_tag-pill-list.js');
+
+    const items = await page.evaluate(() => {
+      return Array.from(document.querySelectorAll('.tag-pill'))
+        .map((e) => (
+          {
+            label: e.innerText.trim(),
+            key: e.dataset.key,
+            value: e.dataset.value,
+          }
+        ));
+    });
+
+    t.is(items[0].label, 'adamsilverstein');
+    t.is(items[0].key, 'googlers');
+    t.is(items[0].value, 'adamsilverstein');
+
+    t.is(items[1].label, 'Amsterdam, Netherlands');
+    t.is(items[1].key, 'locations');
+    t.is(items[1].value, 'Amsterdam, Netherlands');
+
+    t.is(items[2].label, 'Advanced Apps and Project Fugu');
+    t.is(items[2].key, 'topics');
+    t.is(items[2].value, 'Advanced Apps and Project Fugu');
+  }
+);
+
+test(
+  'tag-pill-list: adds icon to pills',
+  withPage,
+  async (t, page) => {
+    const data =  [
+      {
+        "key": "googlers",
+        "value": "adamsilverstein"
+      },
+      {
+        "key": "locations",
+        "value": "Amsterdam, Netherlands"
+      },
+    ];
+
+    await page.setContent(html`
+      <tag-pill-list items='${JSON.stringify(data)}'>
+        <tag-pill-list-icon>
+          <svg>
+            <rect width="100" height="100" x="50" y="50" />
+          </svg>
+        </tag-pill-list-icon>
+      </tag-pill-list>
+    `);
+
+    await addPageScript(page, '_tag-pill-list.js');
+
+    const numPills = await page.evaluate(() => {
+      return document.querySelectorAll('.tag-pill').length
+    });
+
+    const haveItemsWithoutIcon = await page.evaluate(() => {
+      const pills = Array.from(document.querySelectorAll('.tag-pill'));
+
+      return pills.some(e => e.querySelector('svg') === null);
+    });
+
+
+    t.is(numPills, 2);
+    t.is(haveItemsWithoutIcon, false);
+  }
+);
+

--- a/tests/site/_js/web-components/tag-pill-list/tag-pill-list.js
+++ b/tests/site/_js/web-components/tag-pill-list/tag-pill-list.js
@@ -18,96 +18,83 @@ const test = require('ava');
 const {withPage, addPageScript} = require('../../../../puppeteer');
 const {html} = require('common-tags');
 
-test(
-  'tag-pill-list: renders expected items',
-  withPage,
-  async (t, page) => {
-    const data =  [
-      {
-        "key": "googlers",
-        "value": "adamsilverstein"
-      },
-      {
-        "key": "locations",
-        "value": "Amsterdam, Netherlands"
-      },
-      {
-        "key": "topics",
-        "value": "Advanced Apps and Project Fugu"
-      }
-    ];
+test('tag-pill-list: renders expected items', withPage, async (t, page) => {
+  const data = [
+    {
+      key: 'googlers',
+      value: 'adamsilverstein',
+    },
+    {
+      key: 'locations',
+      value: 'Amsterdam, Netherlands',
+    },
+    {
+      key: 'topics',
+      value: 'Advanced Apps and Project Fugu',
+    },
+  ];
 
-    await page.setContent(html`
-      <tag-pill-list items='${JSON.stringify(data)}' />
-    `);
+  await page.setContent(html`
+    <tag-pill-list items="${JSON.stringify(data)}" />
+  `);
 
-    await addPageScript(page, '_tag-pill-list.js');
+  await addPageScript(page, '_tag-pill-list.js');
 
-    const items = await page.evaluate(() => {
-      return Array.from(document.querySelectorAll('.tag-pill'))
-        .map((e) => (
-          {
-            label: e.innerText.trim(),
-            key: e.dataset.key,
-            value: e.dataset.value,
-          }
-        ));
-    });
+  const items = await page.evaluate(() => {
+    return Array.from(document.querySelectorAll('.tag-pill')).map(e => ({
+      label: e.innerText.trim(),
+      key: e.dataset.key,
+      value: e.dataset.value,
+    }));
+  });
 
-    t.is(items[0].label, 'adamsilverstein');
-    t.is(items[0].key, 'googlers');
-    t.is(items[0].value, 'adamsilverstein');
+  t.is(items[0].label, 'adamsilverstein');
+  t.is(items[0].key, 'googlers');
+  t.is(items[0].value, 'adamsilverstein');
 
-    t.is(items[1].label, 'Amsterdam, Netherlands');
-    t.is(items[1].key, 'locations');
-    t.is(items[1].value, 'Amsterdam, Netherlands');
+  t.is(items[1].label, 'Amsterdam, Netherlands');
+  t.is(items[1].key, 'locations');
+  t.is(items[1].value, 'Amsterdam, Netherlands');
 
-    t.is(items[2].label, 'Advanced Apps and Project Fugu');
-    t.is(items[2].key, 'topics');
-    t.is(items[2].value, 'Advanced Apps and Project Fugu');
-  }
-);
+  t.is(items[2].label, 'Advanced Apps and Project Fugu');
+  t.is(items[2].key, 'topics');
+  t.is(items[2].value, 'Advanced Apps and Project Fugu');
+});
 
-test(
-  'tag-pill-list: adds icon to pills',
-  withPage,
-  async (t, page) => {
-    const data =  [
-      {
-        "key": "googlers",
-        "value": "adamsilverstein"
-      },
-      {
-        "key": "locations",
-        "value": "Amsterdam, Netherlands"
-      },
-    ];
+test('tag-pill-list: adds icon to pills', withPage, async (t, page) => {
+  const data = [
+    {
+      key: 'googlers',
+      value: 'adamsilverstein',
+    },
+    {
+      key: 'locations',
+      value: 'Amsterdam, Netherlands',
+    },
+  ];
 
-    await page.setContent(html`
-      <tag-pill-list items='${JSON.stringify(data)}'>
-        <tag-pill-list-icon>
-          <svg>
-            <rect width="100" height="100" x="50" y="50" />
-          </svg>
-        </tag-pill-list-icon>
-      </tag-pill-list>
-    `);
+  await page.setContent(html`
+    <tag-pill-list items="${JSON.stringify(data)}">
+      <tag-pill-list-icon>
+        <svg>
+          <rect width="100" height="100" x="50" y="50" />
+        </svg>
+      </tag-pill-list-icon>
+    </tag-pill-list>
+  `);
 
-    await addPageScript(page, '_tag-pill-list.js');
+  await addPageScript(page, '_tag-pill-list.js');
 
-    const numPills = await page.evaluate(() => {
-      return document.querySelectorAll('.tag-pill').length
-    });
+  const numPills = await page.evaluate(() => {
+    return document.querySelectorAll('.tag-pill').length;
+  });
 
-    const haveItemsWithoutIcon = await page.evaluate(() => {
-      const pills = Array.from(document.querySelectorAll('.tag-pill'));
+  const haveItemsWithoutIcon = await page.evaluate(() => {
+    const pills = Array.from(document.querySelectorAll('.tag-pill'));
 
-      return pills.some(e => e.querySelector('svg') === null);
-    });
+    return pills.some(e => e.querySelector('svg') === null);
+  });
 
-
-    t.is(numPills, 2);
-    t.is(haveItemsWithoutIcon, false);
-  }
-);
-
+  t.is(numPills, 2);
+  t.is(haveItemsWithoutIcon, false);
+});


### PR DESCRIPTION
Changes proposed in this pull request:

When the users applies filters on the events page, their selections need to render as tag-pills, as per the design below. This PR introduces a new data driven tag-pill-list component which renders the tags.

![image](https://user-images.githubusercontent.com/1577555/223109634-cb4e0aac-82df-4146-9b71-8f441ed0d2c6.png)