### PR TITLE
Remove demo link in attribution reporting

### DIFF
--- a/site/en/docs/privacy-sandbox/attribution-reporting/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/index.md
@@ -25,9 +25,6 @@ underlying concepts, but doesn't go into much technical detail.
 
 - If you're a **developer or software engineer**, head over to the [Attribution Reporting: experiment and participate](/docs/privacy-sandbox/attribution-reporting-experiment/).
 
-- [The Attribution Reporting demo](https://attribution-reporting-demo.glitch.me/) provides a walkthrough of a basic Attribution Reporting
-  deployment.
-
 {% Aside %}
 If you're unfamiliar with some of these terms, consult the
 [Privacy Sandbox glossary](/docs/privacy-sandbox/glossary/).


### PR DESCRIPTION
Fixes b/271895203

Changes proposed in this pull request:

- Remove demo link in attribution reporting
-
-