### PR TITLE
Added "Copy Code Snippet" Button

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -41,6 +41,7 @@ const {LanguageList} = require('./site/_shortcodes/LanguageList');
 const {Partial} = require('./site/_shortcodes/Partial');
 const {ChromeDate} = require('./site/_shortcodes/ChromeDate');
 const {BrowserCompat} = require('webdev-infra/shortcodes/BrowserCompat');
+const {CopyCodeButton} = require('./site/_shortcodes/CopyCodeButton');
 
 // Transforms
 const {domTransformer} = require('./site/_transforms/dom-transformer-pool');
@@ -155,6 +156,7 @@ module.exports = eleventyConfig => {
   eleventyConfig.addShortcode('BrowserCompat', BrowserCompat);
   eleventyConfig.addNunjucksAsyncShortcode('Partial', Partial);
   eleventyConfig.addShortcode('ChromeDate', ChromeDate);
+  eleventyConfig.addShortcode('CopyCodeButton', CopyCodeButton);
 
   // Empty shortcodes. They are added for backward compatibility with web.dev.
   // They will not render any html, but will prevent the build from failing.

--- a/site/_includes/layouts/base.njk
+++ b/site/_includes/layouts/base.njk
@@ -118,5 +118,8 @@
     {% include 'partials/cookie-banner.njk' %}
 
     {% block scripts %}{% endblock %}
+    
+    {% CopyCodeButton %}
+    
   </body>
 </html>

--- a/site/_shortcodes/CopyCodeButton.js
+++ b/site/_shortcodes/CopyCodeButton.js
@@ -1,0 +1,106 @@
+const {html} = require("common-tags");
+
+// The button will be added to all 'pre' blocks as a new child element.
+function CopyCodeButton() {
+    return html`
+        <script type="module">
+            // Pulls all 'pre' blocks from the current web page.
+            let blocks = document.querySelectorAll('pre');
+
+            // A button is created to each block.
+            blocks.forEach((block) => {
+                // Adjusting styles for the 'pre' block.
+                block.style = \`
+                    display: inline-flex;
+                    width: 100%;
+                    position: relative;
+                \`;
+                // The button is created.
+                let button = document.createElement('button');
+                // Adjusting styles to the button.
+                button.style = \`
+                    display: inline-flex;
+                    align-items: center;
+                    justify-content: center;
+
+                    width: 1.5rem;
+                    height: auto;
+
+                    position: absolute;
+                    top: 0.5rem;
+                    right: 0.5rem;
+
+                    margin: 0;
+                    padding: 0.15rem;
+                    
+                    background: #f8f9fa;
+                    border: 0.1rem solid #959D9C;
+                    border-radius: 0.25rem;
+
+                    color: #fff;
+                    font-weight: 600;
+                
+                    cursor: pointer;
+                \`;
+
+                // Creating an image element ("copy code" icon).
+                let img = document.createElement('img');
+                img.src = "https://img.icons8.com/fluency-systems-regular/512/clone-figure--v3.png";
+                // Adjusting styles for the icon.
+                img.style = \`
+                    filter: none;
+                    width: 100%;
+                    height: auto;
+
+                    margin: 0;
+                    padding: 0;
+                \`;
+                // The image is added as a child to the button.
+                button.appendChild(img);
+
+                // Button behavior when clicked.
+                button.onclick = () => {
+                    console.log("Copy code to clipboard.");
+
+                    // The content of the 'code' block (also a child fo the 'pre' block)
+                    // is added to the selection.
+                    let code = block.querySelector('code');
+                    const range = document.createRange();
+                    range.selectNode(code);
+                    window.getSelection().removeAllRanges();
+                    window.getSelection().addRange(range);
+                    // We save that selection.
+                    let selection = window.getSelection();
+                    // We temporarily change the icon to a checkmark ("code copied" icon).
+                    img.src = "https://img.icons8.com/color/512/checkmark.png";
+    
+
+                    // If the browser does not support clipboard API...
+                    if (!navigator.clipboard) {
+                        // ...use the old commandExec() way.
+                        document.execCommand('copy');
+                    // If it is supported...
+                    } else {
+                        // ...the selection is converted to string and saved on the clipboard.
+                        try {
+                            navigator.clipboard.writeText(selection.toString());
+                        } catch (error) {
+                            console.error(error);
+                        }
+                    }
+                    // Finally, everything is de-selected.
+                    window.getSelection().removeAllRanges();
+                    // After 2 seconds, the icon is returned to the "copy code" icon.
+                    setTimeout(() => {
+                        img.src = "https://img.icons8.com/fluency-systems-regular/512/clone-figure--v3.png";
+                    }, 2000);
+                };
+
+                // The button is added as a child to the 'pre' block.
+                block.appendChild(button);
+            });
+        </script>
+    `;
+}
+
+module.exports = {CopyCodeButton};

--- a/site/_shortcodes/CopyCodeButton.js
+++ b/site/_shortcodes/CopyCodeButton.js
@@ -1,106 +1,94 @@
-const {html} = require("common-tags");
+const {html} = require('common-tags');
 
 // The button will be added to all 'pre' blocks as a new child element.
 function CopyCodeButton() {
-    return html`
-        <script type="module">
-            // Pulls all 'pre' blocks from the current web page.
-            let blocks = document.querySelectorAll('pre');
-
-            // A button is created to each block.
-            blocks.forEach((block) => {
-                // Adjusting styles for the 'pre' block.
-                block.style = \`
-                    display: inline-flex;
-                    width: 100%;
-                    position: relative;
-                \`;
-                // The button is created.
-                let button = document.createElement('button');
-                // Adjusting styles to the button.
-                button.style = \`
-                    display: inline-flex;
-                    align-items: center;
-                    justify-content: center;
-
-                    width: 1.5rem;
-                    height: auto;
-
-                    position: absolute;
-                    top: 0.5rem;
-                    right: 0.5rem;
-
-                    margin: 0;
-                    padding: 0.15rem;
-                    
-                    background: #f8f9fa;
-                    border: 0.1rem solid #959D9C;
-                    border-radius: 0.25rem;
-
-                    color: #fff;
-                    font-weight: 600;
-                
-                    cursor: pointer;
-                \`;
-
-                // Creating an image element ("copy code" icon).
-                let img = document.createElement('img');
-                img.src = "https://img.icons8.com/fluency-systems-regular/512/clone-figure--v3.png";
-                // Adjusting styles for the icon.
-                img.style = \`
-                    filter: none;
-                    width: 100%;
-                    height: auto;
-
-                    margin: 0;
-                    padding: 0;
-                \`;
-                // The image is added as a child to the button.
-                button.appendChild(img);
-
-                // Button behavior when clicked.
-                button.onclick = () => {
-                    console.log("Copy code to clipboard.");
-
-                    // The content of the 'code' block (also a child fo the 'pre' block)
-                    // is added to the selection.
-                    let code = block.querySelector('code');
-                    const range = document.createRange();
-                    range.selectNode(code);
-                    window.getSelection().removeAllRanges();
-                    window.getSelection().addRange(range);
-                    // We save that selection.
-                    let selection = window.getSelection();
-                    // We temporarily change the icon to a checkmark ("code copied" icon).
-                    img.src = "https://img.icons8.com/color/512/checkmark.png";
-    
-
-                    // If the browser does not support clipboard API...
-                    if (!navigator.clipboard) {
-                        // ...use the old commandExec() way.
-                        document.execCommand('copy');
-                    // If it is supported...
-                    } else {
-                        // ...the selection is converted to string and saved on the clipboard.
-                        try {
-                            navigator.clipboard.writeText(selection.toString());
-                        } catch (error) {
-                            console.error(error);
-                        }
-                    }
-                    // Finally, everything is de-selected.
-                    window.getSelection().removeAllRanges();
-                    // After 2 seconds, the icon is returned to the "copy code" icon.
-                    setTimeout(() => {
-                        img.src = "https://img.icons8.com/fluency-systems-regular/512/clone-figure--v3.png";
-                    }, 2000);
-                };
-
-                // The button is added as a child to the 'pre' block.
-                block.appendChild(button);
-            });
-        </script>
-    `;
+  return html`
+    <script type="module">
+      // Pulls all 'pre' blocks from the current web page.
+      let blocks = document.querySelectorAll('pre');
+      // A button is created to each block.
+      blocks.forEach(block => {
+        // Adjusting styles for the 'pre' block.
+        block.style = \`
+                display: inline-flex;
+                width: 100%;
+                position: relative;
+            \`;
+        // The button is created.
+        let button = document.createElement('button');
+        // Adjusting styles to the button.
+        button.style = \`
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                width: 1.5rem;
+                height: auto;
+                position: absolute;
+                top: 0.5rem;
+                right: 0.5rem;
+                margin: 0;
+                padding: 0.15rem;
+                background: #f8f9fa;
+                border: 0.1rem solid #959D9C;
+                border-radius: 0.25rem;
+                color: #fff;
+                font-weight: 600;
+                cursor: pointer;
+            \`;
+        // Creating an image element ('copy code' icon).
+        let img = document.createElement('img');
+        img.src =
+          'https://img.icons8.com/fluency-systems-regular/512/clone-figure--v3.png';
+        // Adjusting styles for the icon.
+        img.style = \`
+                filter: none;
+                width: 100%;
+                height: auto;
+                margin: 0;
+                padding: 0;
+            \`;
+        // The image is added as a child to the button.
+        button.appendChild(img);
+        // Button behavior when clicked.
+        button.onclick = () => {
+          console.log('Copy code to clipboard.');
+          // The content of the 'code' block (also a child fo the 'pre' block)
+          // is added to the selection.
+          let code = block.querySelector('code');
+          const range = document.createRange();
+          range.selectNode(code);
+          window.getSelection().removeAllRanges();
+          window.getSelection().addRange(range);
+          // We save that selection.
+          let selection = window.getSelection();
+          // We temporarily change the icon to a checkmark ('code copied' icon).
+          img.src = 'https://img.icons8.com/color/512/checkmark.png';
+          // If the browser does not support clipboard API...
+          if (!navigator.clipboard) {
+            // ...use the old commandExec() way.
+            document.execCommand('copy');
+            // If it is supported...
+          } else {
+            // ...the selection is converted to string and saved on the clipboard.
+            try {
+              navigator.clipboard.writeText(selection.toString());
+            } catch (error) {
+              console.error(error);
+            }
+          }
+          // Finally, everything is de-selected.
+          window.getSelection().removeAllRanges();
+          // After 2 seconds, the icon is returned to the 'copy code' icon.
+          setTimeout(() => {
+            img.src =
+              'https://img.icons8.com/fluency-systems-regular/512/clone-figure--v3.png';
+          }, 2000);
+        };
+        // The button is added as a child to the 'pre' block.
+        block.appendChild(button);
+      });
+    </script>
+  `;
 }
 
 module.exports = {CopyCodeButton};


### PR DESCRIPTION
Fixes #5296

Changes proposed in this pull request:

- A button was added in the top right corner of all code snippets (specifically, every 'pre' block in the page).
- The script that creates the button was added to the _shortcode directory.
- The shortcode script is added at the end of the body in the base.njk layout. That way all 'pre' blocks on the page have already been created by the time the scripts runs, pulling each block and adding the button.

Signed the Individual CLA as MaAnCoSa (Manuel Andrés Cota Santeliz).