### PR TITLE
Add Private Aggregation API internal testing

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -41,7 +41,7 @@ const cspHandler = (_req, res, next) => {
   res.setHeader(
     'Content-Security-Policy-Report-Only',
     "object-src 'none'; " +
-      "script-src 'self' 'unsafe-inline' https://www.google-analytics.com https://cdnjs.cloudflare.com https://www.gstatic.com https://www.google.com https://*.firebaseio.com;" +
+      "script-src 'self' 'unsafe-inline' https://www.google-analytics.com https://cdnjs.cloudflare.com https://www.gstatic.com https://www.google.com https://*.firebaseio.com https://shared-storage-demo-content-producer.web.app;" +
       "base-uri 'none'; " +
       "frame-ancestors 'self'; " +
       'report-uri https://csp.withgoogle.com/csp/chrome-apps-doc'

--- a/site/_includes/layouts/base.njk
+++ b/site/_includes/layouts/base.njk
@@ -25,6 +25,12 @@
       <script async src="https://www.google-analytics.com/analytics.js"></script>
     {% endif %}
 
+    {# Private Aggregation API testing script #}
+    {# The test will run until mid-April #}
+    {% if process.env.NODE_ENV === 'production' %}
+      <script type="module" defer src="{{ helpers.hashForProd('https://shared-storage-demo-content-producer.web.app/paa/scripts/private-aggregation-test.js') }}"></script>
+    {% endif %}
+
     {# Add a facility for pages to declare an array of script paths. #}
     {# Note: We could also use this approach to load module/nomodule scripts #}
     {# https://philipwalton.com/articles/deploying-es2015-code-in-production-today/ #}


### PR DESCRIPTION
This PR adds Private Aggregation API (PAA) testing.

* Related web.dev PR: https://github.com/GoogleChrome/web.dev/pull/9593
* Related Shared Storage Demo (SSD) PR: https://github.com/GoogleChromeLabs/shared-storage-demo/pull/17

---

[Private Aggregation API](https://developer.chrome.com/docs/privacy-sandbox/private-aggregation/) allows users to report cross-site data in [Shared Storage](https://developer.chrome.com/en/docs/privacy-sandbox/shared-storage/).  

This test adds a Private Aggregation API call that reports randomly generated key/value pairs.  The reports are not collected.  

The PAA test script is injected as a third-party script.  The 3p script contains its own 3p origin trial token.

---

To test, visit the staging link (TBD), then open up `chrome://private-aggregation-internals` page to check the reported values. 