### PR TITLE
Improve formatting of posted dates on 'What\'s new'.

### DIFF
--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -18,13 +18,13 @@ and related policy or other changes. You'll find other notices posted on the [Ex
 
 ### Chrome 112: Increased storage.session quota {: #m112-storage-session-quota}
 
-March 3, 2023
+<p class="color-secondary-text type--caption">Posted on <time>March 3, 2023</time></p>
 
 From Chrome 112, the quota for the [`storage.session`](/docs/extensions/reference/storage/#property-session) property has been increased to approximately 10 MB. This was agreed in the Web Extensions Community Group: [https://github.com/w3c/webextensions/issues/350](https://github.com/w3c/webextensions/issues/350)
 
 ### Chrome 109: Is an exension enabled {: #m110-action }
 
-January 12, 2023
+<p class="color-secondary-text type--caption">Posted on <time>January 12, 2023</time></p>
 
 The [`chrome.action.isEnabled()`](/docs/extensions/reference/action/#method-isEnabled) method programmatically checks whether an extension has been enabled for a specific tab. This saves you from maintaining the enabled state of your tabs. This new method takes a tab ID and a reference to a callback and returns a boolean. It has one limitation: tabs created using [`chrome.declarativeContent`](/docs/extensions/reference/declarativeContent/) always return false.
 
@@ -32,61 +32,61 @@ The [`chrome.action.isEnabled()`](/docs/extensions/reference/action/#method-isEn
 
 ### Chrome 110: Change in service worker idle timeout {: #m110-sw-idle }
 
-January 5, 2023
+<p class="color-secondary-text type--caption">Posted on <time>January 5, 2023</time></p>
 
 Previously, an extension service worker would frequently shut down at the five minute mark. We've changed this behavior to more closely resemble service worker lifetime's on the web. An extension service worker will be shut down after either thirty seconds of inactivity or if a single activity takes longer than 5 minutes to process. For more information, see [Longer extension service worker lifetimes](/blog/longer-esw-lifetimes).
 
 ### Post: Pausing Manifest V2 phase-out
 
-December 9, 2022
+<p class="color-secondary-text type--caption">Posted on <time>December 9, 2022</time></p>
 
 The Manifest V2 deprecation timelines are under review and the experiments scheduled for early 2023 are being postponed. For more information, [read the update](https://groups.google.com/u/1/a/chromium.org/g/chromium-extensions/c/zQ77HkGmK9E) in the chromium-extensions Google Group.
 
 ### Chrome 108: Setting badge colors {: #m110-badge-color }
 
-November 29, 2022
+<p class="color-secondary-text type--caption">Posted on <time>November 29, 2022</time></p>
 
 The `chrome.action` namespace has two new methods to give you more control over the appearance extension badges. The [`setBadgeTextColor()`](/docs/extensions/reference/action/#method-setBadgeTextColor) and [`getBadgeTextColor()`](/docs/extensions/reference/action/#method-getBadgeTextColor) methods allow an extension to change and query its toolbar icon's badge text color. When used with [`setBadgeBackgroundColor`](/docs/extensions/reference/action/#method-setBadgeBackgroundColor) and [`getBadgeBackgroundColor`](/docs/extensions/reference/action/#method-getBadgeBackgroundColor) these new methods let you enforce design and brand consistency.
 
 ### Blog post: More details on the transition to Manifest V3 {: #blog-mv3-transition-details }
 
-September 28, 2022
+<p class="color-secondary-text type--caption">Posted on <time>September 28, 2022</time></p>
 
 We have [clarified the Manifest V2 deprecation timeline](/blog/more-mv2-transition/). The [Manifest V2 support timeline](/docs/extensions/mv3/mv2-sunset/) has also been updated to reflect this information.
 
 ### Docs update: Known issues when migrating to Manifest V3 {: #known-issues }
 
-September 28, 2022
+<p class="color-secondary-text type--caption">Posted on <time>September 28, 2022</time></p>
 
 We've put together a list of [major features currently in development and open bugs](/docs/extensions/mv3/known-issues/). Our goal with this page is to help developers better understand the current state of the platform and what features they can target as they prepare for the future.
 
 ### Chrome Web Store: "large promo tile" image upload removed {: #cws-large-promo-tile }
 
-August 17, 2022
+<p class="color-secondary-text type--caption">Posted on <time>August 17, 2022</time></p>
 
 Chrome Web Store has removed the "large promo tile" upload UI from the item Store Listing tab in the developer dashboard. This change does not affect the end user experience as these images were not used in the consumer UI. See this chromium-extensions post for additional details.
 
 ### Chrome 106: Allow pages on file:// urls to access web accessible resources {: #m106-file-pages }
 
-August 15, 2022
+<p class="color-secondary-text type--caption">Posted on <time>August 15, 2022</time></p>
 
 Opaque origins such as sandboxed iframes and dynamic import should also be able to access web accessible resources, according to [crbug.com/1219825#c11](https://crbug.com/1219825#c11).
 
 ### Chrome 106: Fixed bug allowing incorrect final arguments on some async API functions {: #m106-async-arg-fix }
 
-August 8, 2022
+<p class="color-secondary-text type--caption">Posted on <time>August 8, 2022</time></p>
 
 Previously, Manifest V3 calling async APIs could provide an invalid final argument and Chrome would not error. With this fix Chrome will now correctly error and report that there was no matching signature. Developers are encouraged to check their extensions on Canary for any errors in case they accidentally using incorrect signature for an API call that will be broken by this bug fix.
 
 ### Blog post: Chrome Web Store analytics revamp {: #cws-analytics-revamp }
 
-July 28, 2022
+<p class="color-secondary-text type--caption">Posted on <time>July 28, 2022</time></p>
 
 Chrome Web Store has a revamped item analytics experience for the Chrome Web Store Developer Dashboard. The new dashboard is easier to understand at a glance and consolidates the most useful information up front. [Read the blog post](/blog/cws-analytics-revamp/) for more information.
 
 ### Chrome 105: promises for the Identity API {: #m105-identity-promise }
 
-July 15, 2022
+<p class="color-secondary-text type--caption">Posted on <time>July 15, 2022</time></p>
 
 Functions on the [Identity API](/docs/extensions/reference/identity/#method-getAuthToken) now
 support promise based calls. This comes with a slight change to the surface for
@@ -97,20 +97,20 @@ callback).
 
 ### Chrome 104: New favicons API for Manifest V3 {: #m104-favicon-api }
 
-June 08, 2022
+<p class="color-secondary-text type--caption">Posted on <time>June 08, 2022</time></p>
 
  Manifest V3 extensions can now access favicons using a new URL pattern: `chrome-extension://<id>/_favicon/`, where <id> is the ID of your extension. This replaces the Manifest V2 platform's `chrome://favicons` API. See the [Favicon API](/docs/extensions/mv3/favicon/) docs for more information.
 
 ### Docs update: Developer trader/non-trader disclosure {: #cws-trader-disclosure-doc }
 
-May 26, 2022
+<p class="color-secondary-text type--caption">Posted on <time>May 26, 2022</time></p>
 
 Added the [trader/non-trader developer identification](/docs/webstore/trader-disclosure) that
 informs developers to accurately self-declare their trader/non-trader status.
 
 ### Chrome 103: Wasm in Manifest V3 requires wasm-unsafe-eval {: #m103-wasm-csp }
 
-May 12, 2022
+<p class="color-secondary-text type--caption">Posted on <time>May 12, 2022</time></p>
 
 Chrome no longer grants extensions `script-src: wasm-unsafe-eval` by default. Extensions that use
 WebAssembly must now explicitly add this directive and value to `extension_pages` in their
@@ -118,7 +118,7 @@ WebAssembly must now explicitly add this directive and value to `extension_pages
 
 ### Chrome 103: Changing MV3 shortcuts take effect immediately {: #m103-keyboard-shortcut }
 
-April 28, 2022
+<p class="color-secondary-text type--caption">Posted on <time>April 28, 2022</time></p>
 
 When changing a Manifest V3 extension's keyboard shortcut on `chrome://extensions/shortcuts`,
 updates are now applied immediately. Previously the extension would have to be reloaded before the
@@ -126,7 +126,7 @@ change would take effect.
 
 ### Chrome 102: Dynamic content scripts in main world {: #m102-registercontentscripts-main-world }
 
-April 14, 2022
+<p class="color-secondary-text type--caption">Posted on <time>April 14, 2022</time></p>
 
 Dynamically registered content scripts can now specify the
 [world](/docs/extensions/mv3/content_scripts/#isolated_world) that assets will be injected into. See
@@ -135,7 +135,7 @@ for details.
 
 ### Chrome 102: New manifest field "optional_host_permissions" {: #m102-optional-host-permissions }
 
-April 4, 2022
+<p class="color-secondary-text type--caption">Posted on <time>April 4, 2022</time></p>
 
 Manifest V3 extensions can now specify the `optional_host_permissions` key in manifest.json. This
 allows Manifest V3 extensions to declare optional match patterns for hosts just as Manifest V2
@@ -143,7 +143,7 @@ extensions could using the `optional_permissions` key.
 
 ### Chrome 102: injectImmediately property in scripting.executeScript() {: #m102-injectimmediately }
 
-April 4, 2022
+<p class="color-secondary-text type--caption">Posted on <time>April 4, 2022</time></p>
 
 `chrome.scripting.executeScript()` now accepts an optional `injectImmediately` property on it's
 `injection` argument. If present and set to true, the script will inject into the target as soon as
@@ -152,7 +152,7 @@ inject before the page is loaded since the page continues to load while the API 
 
 ### Chrome 102: Omnibox API support in Manifest V3 {: #m102-omnibox }
 
-March 31, 2022
+<p class="color-secondary-text type--caption">Posted on <time>March 31, 2022</time></p>
 
 The [Omnibox API](/docs/extensions/reference/omnibox) can now be used in service worker-based
 extensions. Previously, some of this API's methods would throw on invocation due to internal
@@ -160,21 +160,21 @@ dependencies on DOM capabilities.
 
 ### Chrome 102: wasm-unsafe-eval allowed in Manifest V3 CSP {: #m102-wasm }
 
-March 22, 2022
+<p class="color-secondary-text type--caption">Posted on <time>March 22, 2022</time></p>
 
 Manifest V3 extensions can now include `wasm-unsafe-eval` in their `content_security_policy`
 declarations. This change allows Manifest V3 extensions to use WebAssembly.
 
 ### Docs update: Chrome Web Store item discovery {: #cws-discovery-doc }
 
-March 21, 2022
+<p class="color-secondary-text type--caption">Posted on <time>March 21, 2022</time></p>
 
 [Discovery on Chrome Web Store](/docs/webstore/discovery/) gives an overview of how users find items
 on the Chrome Web Store and how our editors select items to feature.
 
 ### Chrome 101: Improved declarativeNetRequest domain conditions {: #m101-dnr-conditions }
 
-March 9, 2022
+<p class="color-secondary-text type--caption">Posted on <time>March 9, 2022</time></p>
 
 [declarativeNetRequest](/docs/extensions/reference/declarativeNetRequest/) rule conditions have been
 updated to allow extensions to better target requests based on the request's "request" and
@@ -190,7 +190,7 @@ window could fail.
 
 ### Chrome 100: native messaging port keeps service worker alive {: #m100-native-msg-lifetime }
 
-February 9, 2022
+<p class="color-secondary-text type--caption">Posted on <time>February 9, 2022</time></p>
 
 {% Aside 'warning' %}
 
@@ -204,7 +204,7 @@ service worker should keep the service worker alive as long as the port is open.
 
 ### Chrome 100: omnibox.setDefaultSuggestion() supports promises and callbacks {: #m100-omnibox-setdefault }
 
-February 8, 2022
+<p class="color-secondary-text type--caption">Posted on <time>February 8, 2022</time></p>
 
 The
 [`omnibox.setDefaultSuggestion()`](/docs/extensions/reference/omnibox/#method-setDefaultSuggestion)
@@ -213,14 +213,14 @@ suggestion has been properly set.
 
 ### Chrome 100: i18n.getMessage() support in extension service workers {: #m100-i18n-getmessage }
 
-January 27, 2022
+<p class="color-secondary-text type--caption">Posted on <time>January 27, 2022</time></p>
 
 The [`chrome.i18n.getMessage()`](/docs/extensions/reference/i18n/#method-getMessage) API is now
 supported in extension service worker contexts.
 
 ### Chrome 99: match_origin_as_fallback in Canary {: #canary-match-origin-as-fallback }
 
-January 5, 2022
+<p class="color-secondary-text type--caption">Posted on <time>January 5, 2022</time></p>
 
 Content scripts can now specify the `match_origin_as_fallback` key to inject into frames that are
 related to a matching frame, including frames with `about:`, `data:`, `blob:`, and `filesystem:`
@@ -229,7 +229,7 @@ documentation for details.
 
 ### Chrome 99: extension service worker support for file: schemes in Canary {: #canary-file-access }
 
-December 30, 2021
+<p class="color-secondary-text type--caption">Posted on <time>December 30, 2021</time></p>
 
 Service worker-based Manifest V2 and Manifest V3 extensions can now use the Fetch API to request
 `file:`-scheme URLs. Access to `file:`-scheme URLs still requires that the user enable 'Allow access
@@ -237,7 +237,7 @@ to File URLs' for the extension in the `chrome://extensions` page.
 
 ### Chrome 99: promise support for messaging APIs in Canary {: #canary-message-promise-support }
 
-December 28, 2021
+<p class="color-secondary-text type--caption">Posted on <time>December 28, 2021</time></p>
 
 Promise support has been added to
 [`tabs.sendMessage`](/docs/extensions/reference/tabs/#method-sendMessage),
@@ -247,7 +247,7 @@ extensions built for Manifest V3.
 
 ### Docs update: Chrome Web Store review documentation {: #cws-review-doc }
 
-December 10, 2021
+<p class="color-secondary-text type--caption">Posted on <time>December 10, 2021</time></p>
 
 Added [a new reference page](/docs/webstore/review-process) that provides an overview of the Chrome
 Web Store review process and explains how [developer program
@@ -255,7 +255,7 @@ policy](/docs/webstore/program-policies/) enforcement is handled.
 
 ### Chrome 98: scripting.executeScript() and scripting.insertCSS() accept multiple files {: #m98-execute-multiple-files }
 
-November 9, 2021
+<p class="color-secondary-text type--caption">Posted on <time>November 9, 2021</time></p>
 
 The Scripting API's [`executeScript()`](/docs/extensions/reference/scripting/#method-executeScript)
 and [`insertCSS()`](/docs/extensions/reference/scripting/#method-insertCSS) methods now accept
@@ -263,14 +263,14 @@ multiple files. Previously these methods required an array with a single file en
 
 ### Docs update: review violation troubleshooting updates {: #2021-10-27-reivew-troubleshooting }
 
-October 27, 2021
+<p class="color-secondary-text type--caption">Posted on <time>October 27, 2021</time></p>
 
 The [Troubleshooting Chrome Web Store violations](/docs/webstore/troubleshooting/) page has been
 updated to provide developers with more detailed guidance for common reasons for rejection.
 
 ### Chrome 96: expanded promise support to 27 more APIs {: #m96-promise-support }
 
-October 1, 2021
+<p class="color-secondary-text type--caption">Posted on <time>October 1, 2021</time></p>
 
 This release contains significantly more promise updates than any previous release. Updates include
 both general and ChromeOS-specific extensions APIs. Expand the following sections for details.
@@ -325,7 +325,7 @@ ChromeOS APIs
 
 ### Chrome 96: dynamic content scripts {: #m96-dynamic-content-scripts }
 
-September 24, 2021
+<p class="color-secondary-text type--caption">Posted on <time>September 24, 2021</time></p>
 
 The [`chrome.scripting`](/docs/extensions/reference/scripting/) API now supports
 [registering](/docs/extensions/reference/scripting/#method-registerContentScripts),
@@ -338,14 +338,14 @@ manifest.json or programmatically injected at runtime with
 
 ### Docs update: Manifest V2 support timeline {: #manifest-v2-support-timeline }
 
-September 23, 2021
+<p class="color-secondary-text type--caption">Posted on <time>September 23, 2021</time></p>
 
 The Manifest V2 to V3 transition timeline was [announced in this blog post](/blog/mv2-transition/) and
 a more detailed [timeline page](/docs/extensions/mv3/mv2-sunset) was published.
 
 ### Chrome 96: declarativeNetRequestWithHostAccess permission
 
-September 20, 2021
+<p class="color-secondary-text type--caption">Posted on <time>September 20, 2021</time></p>
 
 The new `declarativeNetRequestWithHostAccess` permission allows extensions to use the
 [`chrome.declarativeNetRequest`](/docs/extensions/reference/declarativeNetRequest/) API on sites the
@@ -356,7 +356,7 @@ requiring the user to approve new permissions.
 
 ### Chrome 95: inject scripts directly into pages {: #m95-page-script-injection }
 
-September 2, 2021
+<p class="color-secondary-text type--caption">Posted on <time>September 2, 2021</time></p>
 
 The [`chrome.scripting`](/docs/extensions/reference/scripting) API's
 [`executeScript()`](/docs/extensions/reference/scripting/#method-executeScript) method can now
@@ -366,21 +366,21 @@ on [content scripts](/docs/extensions/mv3/content_scripts/#isolated_world).
 
 ### Chrome 95: promise support for Storage API {: #m95-storage-promise-support }
 
-August 30, 2021
+<p class="color-secondary-text type--caption">Posted on <time>August 30, 2021</time></p>
 
 Methods on the Manifest V3 version of the [`chrome.storage`](/docs/extensions/reference/storage/)
 API now return promises.
 
 ### Policy update: two step verification enforcement {: #two-step-verification-enforcement }
 
-August 4, 2021
+<p class="color-secondary-text type--caption">Posted on <time>August 4, 2021</time></p>
 
 The [policy update blog post](/blog/policy-update-2sv/) published on June 29, 2021 has been updated
 to correct the two step verification deployment timeline.
 
 ### Chrome 94: declarative net request static ruleset changes
 
-July 28, 2021
+<p class="color-secondary-text type--caption">Posted on <time>July 28, 2021</time></p>
 
 The [`chrome.declarativeNetRequest`](/docs/extensions/reference/declarativeNetRequest/) now supports
 specifying up to 50 static rulesets
@@ -391,7 +391,7 @@ at a time.
 
 ### Chrome 93: cross origin isolation support
 
-July 12, 2021
+<p class="color-secondary-text type--caption">Posted on <time>July 12, 2021</time></p>
 
 Both [Manifest V2](/docs/extensions/mv2/cross-origin-isolation/) and [Manifest
 V3](/docs/extensions/mv3/cross-origin-isolation/) extensions can now opt into [cross origin
@@ -401,7 +401,7 @@ resources can load an extension's pages and enables the use of low level web pla
 
 ### Policy update: developer program policies updated {: #developer-program-policies-updated }
 
-June 29, 2021
+<p class="color-secondary-text type--caption">Posted on <time>June 29, 2021</time></p>
 
 The Chrome Web Store [Developer Program Policies](/docs/webstore/program-policies) have been updated
 with clarifications to the deceptive installation tactics, spam, and repetitive content policies.
@@ -410,7 +410,7 @@ Store. [Read the blog post](/blog/policy-update-2sv/) for more information.
 
 ### Blog post: extension actions in Manifest V3 {: #new-blog-post-extension-actions-in-manifest-v3 }
 
-June 23, 2021
+<p class="color-secondary-text type--caption">Posted on <time>June 23, 2021</time></p>
 
 Chrome extensions had `chrome.browserAction` and `chrome.pageActions` APIs for years, but Manifest
 V3 replaced both with a generic [`chrome.actions`](/docs/extensions/reference/action/) API. This
@@ -419,7 +419,7 @@ post](/blog/mv3-actions).
 
 ### Blog post: introducing chrome.scripting {: #new-blog-post-introducing-chromescripting }
 
-June 8, 2021
+<p class="color-secondary-text type--caption">Posted on <time>June 8, 2021</time></p>
 
 The [`chrome.scripting`](/docs/extensions/reference/scripting/) API is a new Manifest V3 API focused
 on, well, scripting. In this post we dig into the motivations for this change and take a closer look
@@ -427,7 +427,7 @@ at it's new capabilities. [Read the post](/blog/crx-scripting-api).
 
 ### Chrome 92: module service worker support {: #es-modules-for-service-workers }
 
-April 13, 2021
+<p class="color-secondary-text type--caption">Posted on <time>April 13, 2021</time></p>
 
 Chrome now supports JavaScript modules in service workers. To specify a module a module in your
 manifest:
@@ -444,7 +444,7 @@ worker's script to import other modules.
 
 ### Chrome 91: chrome.action.getUserSettings() {: #chromeactiongetusersettings-available }
 
-April 2, 2021
+<p class="color-secondary-text type--caption">Posted on <time>April 2, 2021</time></p>
 
 The new
 [`chrome.action.getUserSettings()`](/docs/extensions/reference/action/#method-getUserSettings)
@@ -452,7 +452,7 @@ method allows extensions to determine if the user has pinned the extension to th
 
 ### Chrome 90: chrome.scripting.removeCSS() {: #chromescriptingremovecss-available }
 
-February 10, 2021
+<p class="color-secondary-text type--caption">Posted on <time>February 10, 2021</time></p>
 
 The new [`chrome.scripting.removeCSS()`](/docs/extensions/reference/scripting/#method-removeCSS)
 method allows extensions to remove CSS that was previously inserted via
@@ -461,7 +461,7 @@ replaces [`chrome.tabs.removeCSS()`](/docs/extensions/reference/tabs/#method-rem
 
 ### Chrome 90: returning promises from scripting.executeScript() {: #m96-execute-script }
 
-February 24, 2021
+<p class="color-secondary-text type--caption">Posted on <time>February 24, 2021</time></p>
 
 [`chrome.scripting.executeScript()`](/docs/extensions/reference/scripting/#method-executeScript) now
 supports returning promises. If the resulting value of the script execution is a promise, Chrome
@@ -469,7 +469,7 @@ will wait for the promise to settle and return its resulting value.
 
 ### Chrome 90: chrome.scripting.executeScript() results include frameId {: # chromescriptingexecutescript-results-include-frameid }
 
-January 27, 2021
+<p class="color-secondary-text type--caption">Posted on <time>January 27, 2021</time></p>
 
 Results returned from
 [`chrome.scripting.executeScript()`](/docs/extensions/reference/scripting/#method-executeScript)
@@ -479,7 +479,7 @@ associate results with the individual frames when injecting in multiple frames.
 
 ### Chrome 89: new API for managing tab groups {: #new-api-for-tab-groups-mv3-only }
 
-January 14, 2021
+<p class="color-secondary-text type--caption">Posted on <time>January 14, 2021</time></p>
 
 The new [`chrome.tabGroups`](/docs/extensions/reference/tabGroups/) API and new capabilities in
 [`chrome.tabs`](/docs/extensions/reference/tabs/) let extensions read and manipulate tab groups.
@@ -487,7 +487,7 @@ Requires Manifest V3.
 
 ### Chrome 89: customizable permissions for web accessible resources {: #customizable-permissions-for-mv3-web-accessible-resources }
 
-December 23, 2020
+<p class="color-secondary-text type--caption">Posted on <time>December 23, 2020</time></p>
 
 [Web accessible resources](/docs/extensions/mv3/manifest/web_accessible_resources/) definitions in
 Manifest V3 have changed to let extensions restrict resource access based on the requester's origin
@@ -495,7 +495,7 @@ or extension ID.
 
 ### Blog post: Extension Manifest Converter {: #extension-manifest-converter}
 
-April 28, 2021
+<p class="color-secondary-text type--caption">Posted on <time>April 28, 2021</time></p>
 
 The Chrome Extensions team has open sourced "Extension Manifest Converter", a Python tool that
 automates some of the mechanical aspects of converting extensions to Manifest V3. See the
@@ -504,7 +504,7 @@ GitHub](https://github.com/GoogleChromeLabs/extension-manifest-converter).
 
 ### Chrome 88: Manifest V3 general availability {: #manifest-v3-general-availability }
 
-January 19, 2021
+<p class="color-secondary-text type--caption">Posted on <time>January 19, 2021</time></p>
 
 Manifest V3 is a major update to the extensions platform; see [Overview of Manifest
 V3](/docs/extensions/mv3/intro/mv3-overview/) for a summary of new and changed features. Extensions

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -22,7 +22,7 @@ and related policy or other changes. You'll find other notices posted on the [Ex
 
 From Chrome 112, the quota for the [`storage.session`](/docs/extensions/reference/storage/#property-session) property has been increased to approximately 10 MB. This was agreed in the Web Extensions Community Group: [https://github.com/w3c/webextensions/issues/350](https://github.com/w3c/webextensions/issues/350)
 
-### Chrome 109: Is an exension enabled {: #m110-action }
+### Chrome 109: Is an extension enabled {: #m110-action }
 
 <p class="color-secondary-text type--caption">Posted on <time>January 12, 2023</time></p>
 


### PR DESCRIPTION
This clarifies that dates are 'posted on' dates rather than 'enabled on' dates. It also applies formatting similar to [what's in dcc's blog posts](https://developer.chrome.com/blog/Offscreen-Documents-in-Manifest-v3/). I'm putting in a feature request so that we don't need to do this manually.