### PR TITLE
topics api  new combined PR

### DIFF
--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -54,7 +54,11 @@
   sections:
     - title: i18n.docs.privacy-sandbox.interest-ads
       sections:
+        - url: /docs/privacy-sandbox/topics/overview
         - url: /docs/privacy-sandbox/topics
+        - url: /docs/privacy-sandbox/topics/topic-classification
+        - url: /docs/privacy-sandbox/topics/demo
+        - url: /docs/privacy-sandbox/topics/colab
         - url: /docs/privacy-sandbox/topics-experiment
           title: i18n.docs.privacy-sandbox.experiment-participate
         - url: /docs/privacy-sandbox/topics/latest

--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -55,8 +55,8 @@
     - title: i18n.docs.privacy-sandbox.interest-ads
       sections:
         - url: /docs/privacy-sandbox/topics/overview
-        - url: /docs/privacy-sandbox/topics
         - url: /docs/privacy-sandbox/topics/topic-classification
+        - url: /docs/privacy-sandbox/topics
         - url: /docs/privacy-sandbox/topics/demo
         - url: /docs/privacy-sandbox/topics/colab
         - url: /docs/privacy-sandbox/topics-experiment

--- a/site/en/_partials/privacy-sandbox/topics-feedback.md
+++ b/site/en/_partials/privacy-sandbox/topics-feedback.md
@@ -1,0 +1,6 @@
+## Engage and share feedback
+
+- **GitHub**: Read the Topics API [explainer](https://github.com/jkarlin/topics), and [raise questions and follow discussion in issues on the proposal repo](https://github.com/jkarlin/topics/issues).
+- **W3C**: Discuss industry use cases in the [Improving Web Advertising Business Group](https://www.w3.org/community/web-adv/participants).
+- **Announcements**: [Join or view the mailing list](http://groups.google.com/a/chromium.org/g/topics-api-announce).
+- **Privacy Sandbox developer support**: Ask questions and join discussions on the [Privacy Sandbox Developer Support repo](https://github.com/GoogleChromeLabs/privacy-sandbox-dev-support).

--- a/site/en/docs/privacy-sandbox/topics/colab/index.md
+++ b/site/en/docs/privacy-sandbox/topics/colab/index.md
@@ -51,12 +51,12 @@ For some domains you may notice a difference in topic inference, between the col
 
 This is because the colab only uses the classifier model to infer topics, whereas
 `chrome://topics-internals` uses Chrome's Topics implementation, which uses a
-[manually-curated list of topics](/docs/privacy-sandbox/topics/#manually-curated) (rather than the classifier model) for the top
-10,000 sites. <!-- will need to link to topic-classification page -->
+[manually-curated list of topics](/docs/privacy-sandbox/topics/topic-classification/#the-classifier-model) (rather than the classifier model) for the top
+10,000 sites. The list is found in `override_list.pb.gz`, which is available in the `chrome://topics-internals/` page. 
 {% endAside %}
 
 ## Next steps
 
-If you’re an ad tech developer, [experiment and participate](/docs/privacy-sandbox/topics-experiment/) with the Topics API, and check out the [Topics API demo](/docs/privacy-sandbox/topics/demo).
+If you're an ad tech developer, [experiment and participate](/docs/privacy-sandbox/topics-experiment/) with the Topics API, and check out the [Topics API demo](/docs/privacy-sandbox/topics/demo).
 
 {% Partial 'privacy-sandbox/topics-feedback.njk' %}

--- a/site/en/docs/privacy-sandbox/topics/colab/index.md
+++ b/site/en/docs/privacy-sandbox/topics/colab/index.md
@@ -11,7 +11,6 @@ authors:
   - samdutton
 ---
 
-
 A colab—or colaboratory—is a data analysis tool that combines code, output, and descriptive text into one collaborative document. You can run the [Topics Model Execution Demo colab](https://colab.research.google.com/drive/1hIVoz8bRCTpllYvads51MV7YS3zi3prn) to test how the Topics classifier model infers topics of interest to the user, from the hostnames of pages they visit.
 
 1. From the **Classifier** tab of the `chrome://topics-internals` page get the directory path for the `.tflite` file used by the Topics API. The override list, `override_list.pb.gz`, 

--- a/site/en/docs/privacy-sandbox/topics/colab/index.md
+++ b/site/en/docs/privacy-sandbox/topics/colab/index.md
@@ -14,8 +14,8 @@ authors:
 
 A colab—or colaboratory—is a data analysis tool that combines code, output, and descriptive text into one collaborative document. You can run the [Topics Model Execution Demo colab](https://colab.research.google.com/drive/1hIVoz8bRCTpllYvads51MV7YS3zi3prn) to test how the Topics classifier model infers topics of interest to the user, from the hostnames of pages they visit.
 
-1. From the *Classifier* tab of the `chrome://topics-internals` page get the directory path for the `.tflite` file used by the Topics API. The override list, `override_list.pb.gz`, 
-is available from the `chrome://topics-internals/` page under the current model in the Classifier tab.
+1. From the **Classifier** tab of the `chrome://topics-internals` page get the directory path for the `.tflite` file used by the Topics API. The override list, `override_list.pb.gz`, 
+is available from the `chrome://topics-internals/` page under the current model in the **Classifier** tab.
 
     {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/txujKqPgnQdbwmTfdPZT.png",
   alt="chrome://topics-internals page with Classifier panel selected and tflite file path highlighted.",
@@ -53,7 +53,7 @@ For some domains you may notice a difference in topic inference between the cola
 This is because the colab only uses the classifier model to infer topics, whereas
 `chrome://topics-internals` uses Chrome's Topics implementation, which uses a
 [manually-curated list of topics](/docs/privacy-sandbox/topics/topic-classification/#classifier-model) (rather than the classifier model) for the top
-10,000 sites. The list is found in `override_list.pb.gz`, which is available in the `chrome://topics-internals/` page. 
+10,000 sites. The list is found in `override_list.pb.gz`, which is available in the `s-internals/` page. 
 {% endAside %}
 
 ## Next steps

--- a/site/en/docs/privacy-sandbox/topics/colab/index.md
+++ b/site/en/docs/privacy-sandbox/topics/colab/index.md
@@ -11,6 +11,8 @@ authors:
   - samdutton
 ---
 
+## Running the colab
+
 A colab—or colaboratory—is a data analysis tool that combines code, output, and descriptive text into one collaborative document. You can run the [Topics Model Execution Demo colab](https://colab.research.google.com/drive/1hIVoz8bRCTpllYvads51MV7YS3zi3prn) to test how the Topics classifier model infers topics of interest to the user, from the hostnames of pages they visit.
 
 1. From the **Classifier** tab of the `chrome://topics-internals` page get the directory path for the `.tflite` file used by the Topics API. The override list, `override_list.pb.gz`, 

--- a/site/en/docs/privacy-sandbox/topics/colab/index.md
+++ b/site/en/docs/privacy-sandbox/topics/colab/index.md
@@ -54,10 +54,12 @@ For each of the domains defined, you can see the topic scores inferred by the cl
 {% Aside 'caution' %}
 For some domains you may notice a difference in topic inference between the colab and the `chrome://topics-internals` classifier.
 
-This is because the colab only uses the classifier model to infer topics, whereas
-`chrome://topics-internals` uses Chrome's Topics implementation, which uses a
-[manually-curated list of topics](/docs/privacy-sandbox/topics/topic-classification/#classifier-model) (rather than the classifier model) for the top
-10,000 sites. The list is found in `override_list.pb.gz`, which is available in the `s-internals/` page. 
+The colab only uses the classifier model to infer topics, whereas
+`chrome://topics-internals` uses Chrome's Topics implementation. Chrome
+[manually curates list of topics](/docs/privacy-sandbox/topics/topic-classification/#classifier-model),
+rather than using the classifier model for the top 10,000 sites. The curated list
+can be found in `override_list.pb.gz`, which is available on
+`chrome://topics-internals`. 
 {% endAside %}
 
 ## Next steps

--- a/site/en/docs/privacy-sandbox/topics/colab/index.md
+++ b/site/en/docs/privacy-sandbox/topics/colab/index.md
@@ -18,7 +18,7 @@ A colab—or colaboratory—is a data analysis tool that combines code, output, 
 is available from the `chrome://topics-internals/` page under the current model in the Classifier tab.
 
     {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/txujKqPgnQdbwmTfdPZT.png",
-  alt="chrome://topics-internal page with Classifier panel selected and tflite file path highlighted.",
+  alt="chrome://topics-internals page with Classifier panel selected and tflite file path highlighted.",
   width="800", height="696" %}
 
 1. Open the [colab](https://colab.research.google.com/drive/1hIVoz8bRCTpllYvads51MV7YS3zi3prn) and click on the folder icon.

--- a/site/en/docs/privacy-sandbox/topics/colab/index.md
+++ b/site/en/docs/privacy-sandbox/topics/colab/index.md
@@ -1,0 +1,60 @@
+---
+layout: 'layouts/doc-post.njk'
+title: 'Test topic inference in a colab'
+subhead: >
+  Try the colab to learn how to load the TensorFlow Lite model used by Chrome to infer topics from hostnames.
+description: >
+  Try the colab to learn how to load the TensorFlow Lite model used by Chrome to infer topics from hostnames.
+date: 2022-01-25
+updated: 2023-03-08
+authors:
+  - samdutton
+---
+
+
+A colab—or colaboratory—is a data analysis tool that combines code, output, and descriptive text into one collaborative document. You can run the [Topics Model Execution Demo colab](https://colab.research.google.com/drive/1hIVoz8bRCTpllYvads51MV7YS3zi3prn) to test how the Topics classifier model infers topics of interest to the user, from the hostnames of pages they visit.
+
+1. From the *Classifier* tab of the `chrome://topics-internals` page get the directory path for the `.tflite` file used by the Topics API. The [override list](/docs/privacy-sandbox/topics/#manually-curated) `.pb.gz` file is in the same directory.
+
+    {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/txujKqPgnQdbwmTfdPZT.png",
+  alt="chrome://topics-internal page with Classifier panel selected and tflite file path highlighted.",
+  width="800", height="696" %}
+
+1. Open the [colab](https://colab.research.google.com/drive/1hIVoz8bRCTpllYvads51MV7YS3zi3prn) and click on the folder icon.
+
+    {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/FcBRhBOyLm2EEU1J4ET0.png",
+  alt="Topics API colab.", width="800", height="605" %}
+
+1. Click the Upload icon and upload `model.tflite` and `override_list.pb.gz` from your computer to the colab.
+
+    {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/8PiaYhdpKUx5hyMNcVwG.png",
+  alt="Topics API colab file upload.", width="800", height="402" %}
+
+1. You can then run all the colab steps, by selecting **Run all** from the **Runtime** menu.
+
+    {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/gP8GmUH2xiwbEz27LbjO.png",
+  alt="Topics API colab page, 'Run all' selected form the Runtime menu.", width="800", height="605" %}
+
+This does the following:
+
+1.  Installs the Python packages used by the colab.
+1.  Installs the `tflite` libraries and the Topics taxonomy.
+1.  Defines the taxonomy.
+1.  Runs each of the Model Execution Demo steps to show how classification works for two example domains.
+
+You'll see a green tick next to each step that completes successfully. (Each step can also be run individually, by clicking the **Play** button next to it.)
+
+For each of the domains defined, you can see the topic scores inferred by the classifier. Try listing different domains to see how they compare.
+
+{% Aside 'caution' %}
+For some domains you may notice a difference in topic inference, between the colab and the `chrome://topics-internals` Classifier.
+
+This is because the colab only uses the classifier model to infer topics, whereas
+`chrome://topics-internals` uses Chrome's Topics implementation, which uses a
+[manually-curated list of topics](/docs/privacy-sandbox/topics/#manually-curated) (rather than the classifier model) for the top
+10,000 sites. <!-- will need to link to topic-classification page -->
+{% endAside %}
+
+## Next steps
+
+If you’re an ad tech developer, [experiment and participate](/docs/privacy-sandbox/topics-experiment/) with the Topics API, and check out the [Topics API demo](/docs/privacy-sandbox/topics/demo).

--- a/site/en/docs/privacy-sandbox/topics/colab/index.md
+++ b/site/en/docs/privacy-sandbox/topics/colab/index.md
@@ -58,3 +58,5 @@ This is because the colab only uses the classifier model to infer topics, wherea
 ## Next steps
 
 If you’re an ad tech developer, [experiment and participate](/docs/privacy-sandbox/topics-experiment/) with the Topics API, and check out the [Topics API demo](/docs/privacy-sandbox/topics/demo).
+
+{% Partial 'privacy-sandbox/topics-feedback.njk' %}

--- a/site/en/docs/privacy-sandbox/topics/colab/index.md
+++ b/site/en/docs/privacy-sandbox/topics/colab/index.md
@@ -11,6 +11,9 @@ authors:
   - samdutton
 ---
 
+## Implementation status
+{% Partial 'privacy-sandbox/ps-implementation-status.njk' %}
+
 ## Running the colab
 
 A colab—or colaboratory—is a data analysis tool that combines code, output, and descriptive text into one collaborative document. You can run the [Topics Model Execution Demo colab](https://colab.research.google.com/drive/1hIVoz8bRCTpllYvads51MV7YS3zi3prn) to test how the Topics classifier model infers topics of interest to the user, from the hostnames of pages they visit.

--- a/site/en/docs/privacy-sandbox/topics/colab/index.md
+++ b/site/en/docs/privacy-sandbox/topics/colab/index.md
@@ -14,7 +14,8 @@ authors:
 
 A colab—or colaboratory—is a data analysis tool that combines code, output, and descriptive text into one collaborative document. You can run the [Topics Model Execution Demo colab](https://colab.research.google.com/drive/1hIVoz8bRCTpllYvads51MV7YS3zi3prn) to test how the Topics classifier model infers topics of interest to the user, from the hostnames of pages they visit.
 
-1. From the *Classifier* tab of the `chrome://topics-internals` page get the directory path for the `.tflite` file used by the Topics API. The [override list](/docs/privacy-sandbox/topics/#manually-curated) `.pb.gz` file is in the same directory.
+1. From the *Classifier* tab of the `chrome://topics-internals` page get the directory path for the `.tflite` file used by the Topics API. The override list, `override_list.pb.gz`, 
+is available from the `chrome://topics-internals/` page under the current model in the Classifier tab.
 
     {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/txujKqPgnQdbwmTfdPZT.png",
   alt="chrome://topics-internal page with Classifier panel selected and tflite file path highlighted.",
@@ -25,7 +26,7 @@ A colab—or colaboratory—is a data analysis tool that combines code, output, 
     {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/FcBRhBOyLm2EEU1J4ET0.png",
   alt="Topics API colab.", width="800", height="605" %}
 
-1. Click the Upload icon and upload `model.tflite` and `override_list.pb.gz` from your computer to the colab.
+1. Click the **Upload** icon and upload `model.tflite` and `override_list.pb.gz` from your computer to the colab.
 
     {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/8PiaYhdpKUx5hyMNcVwG.png",
   alt="Topics API colab file upload.", width="800", height="402" %}
@@ -47,11 +48,11 @@ You'll see a green tick next to each step that completes successfully. (Each ste
 For each of the domains defined, you can see the topic scores inferred by the classifier. Try listing different domains to see how they compare.
 
 {% Aside 'caution' %}
-For some domains you may notice a difference in topic inference, between the colab and the `chrome://topics-internals` Classifier.
+For some domains you may notice a difference in topic inference between the colab and the `chrome://topics-internals` classifier.
 
 This is because the colab only uses the classifier model to infer topics, whereas
 `chrome://topics-internals` uses Chrome's Topics implementation, which uses a
-[manually-curated list of topics](/docs/privacy-sandbox/topics/topic-classification/#the-classifier-model) (rather than the classifier model) for the top
+[manually-curated list of topics](/docs/privacy-sandbox/topics/topic-classification/#classifier-model) (rather than the classifier model) for the top
 10,000 sites. The list is found in `override_list.pb.gz`, which is available in the `chrome://topics-internals/` page. 
 {% endAside %}
 

--- a/site/en/docs/privacy-sandbox/topics/demo/index.md
+++ b/site/en/docs/privacy-sandbox/topics/demo/index.md
@@ -1,0 +1,119 @@
+---
+layout: 'layouts/doc-post.njk'
+title: 'Topics API demos'
+subhead: >
+  Experiment and learn how topics are inferred from hostnames with minimal setup.
+description: >
+  Experiment and learn how topics are inferred from hostnames with minimal setup.
+date: 2023-03-08
+authors:
+  - samdutton
+---
+
+## Implementation status
+{% Partial 'privacy-sandbox/ps-implementation-status.njk' %}
+
+The Topics API demo provides a look at how topics are inferred from hostnames. You can preview what topics are observed when you visit a demo site, which requires very little setup.
+
+If you want to test the API with your users, sign up for the [Relevance and Measurement origin trial](/docs/privacy-sandbox/unified-origin-trial/).
+
+Our demo is a preview  that demonstrates most features of the Topics API, for you to gain familiarity with how the API is implemented.
+
+You can also run the Topics [colab](/docs/privacy-sandbox/topics/colab) to try out the Topics [classifier model](/docs/privacy-sandbox/topics/topic-classification/#the-classifier-model).
+
+The following video shows how the demo works.
+
+{% YouTube
+  id='hEBzWuXjeTQ'
+%}
+
+
+## Test with chrome://flags or feature flags
+
+There are two ways to try the Topics API as a single user; you'll need to be running Chrome 101 or above:
+
+- Enable the API in the `chrome://flags/#privacy-sandbox-ads-apis` Chrome page:
+
+    <figure>
+
+    {% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/4kpW1PAuzrMrecSAR3tU.png", alt="Enable the Topics API using the chrome://flags/#privacy-sandbox-ads-apis page", width="800", height="246" %}
+          <figcaption>Enable the Topics API using the chrome://flags/#privacy-sandbox-ads-apis page. <a href="https://wd.imgix.net/image/RtQlPaM9wdhEJGVKR8boMPkWf443/4kpW1PAuzrMrecSAR3tU.png?auto=format&w=1600">View a larger version</a></figcaption>
+    </figure>
+
+- Run Chrome from the command line with the following flags:
+    ```text
+    --enable-features=BrowsingTopics,PrivacySandboxAdsAPIsOverride,OverridePrivacySandboxSettingsLocalTesting
+    ```
+
+## The Topics API demo
+
+The [Topics demo](https://topics-demo.glitch.me/) shows how to use additional flags to adjust settings, such as epoch length. If you access the Topics API by running Chrome with command-line flags, don't set `chrome://flags`, as these can override command-line settings.
+
+[Run Chromium with flags](https://www.chromium.org/developers/how-tos/run-chromium-with-flags) explains how to set flags when running Chrome and other Chromium-based browsers from the command line, although this demo is specific to Google Chrome.
+
+## The Topics API headers demo
+
+The demo at [topics-fetch-demo.glitch.me](https://topics-fetch-demo.glitch.me/) shows how to use `fetch()` request and response headers to access topics and mark them as observed.
+
+### Access the `Sec-Browsing-Topics` request header
+
+Instead of using `document.browsingTopics()` from an iframe to view topics for a user, API callers can access observed topics from the `Sec-Browsing-Topics` request header of a [fetch() request](https://developer.mozilla.org/docs/Web/API/fetch) that includes `{browsingTopics: true}` in its options parameter—or from the same header of an [XHR request](https://developer.mozilla.org/docs/Web/API/fetch) that sets the `deprecatedBrowsingTopics` attribute to `true`.
+
+For example:
+
+```javascript
+fetch('https://topics-server.glitch.me', {browsingTopics: true})
+    .then((response) => {
+        // Process the response
+ })
+```
+
+In browsers that support the API, the `fetch()` request will include a `Sec-Browsing-Topics` header that lists topics observed for the request URL hostname: in this example, `topics-server.glitch.me`.
+
+If no topics have been observed for this hostname and this user, the header is included but the value is empty. In other words, the `Sec-Browsing-Topics` header on a `fetch()` request only includes topics that have been observed for the current user's browser by a caller whose origin matches the hostname of the request URL. This is the same as if you were calling `document.browsingTopics()` from an iframe to view observed topics for the current user.
+
+The request header is sent on a request as long as it has the appropriate permission policy is in play, the context is secure, and user settings permit it. Topics are not provided in headers for navigation requests.
+
+The Topics request header looks like this:
+
+```text
+Sec-Browsing-Topics: 186;version="chrome.1:1:2206021246";config_version="chrome.1";model_version="2206021246";taxonomy_version="1", 265;version="chrome.1:1:2206021246";config_version="chrome.1";model_version="2206021246";taxonomy_version="1"
+```
+
+This example includes two topics from the [Topics taxonomy](https://github.com/patcg-individual-drafts/topics/blob/main/taxonomy_v1.md), 186 and 265, along with each topic's version information
+
+The [fetch()](https://chromium-review.googlesource.com/c/chromium/src/+/4044267) and [XHR](https://chromium-review.googlesource.com/c/chromium/src/+/4103742) implementations were first made available in Chrome 111.
+
+Inclusion of the topics header in XHR requests is only available temporarily, and support will be removed in the future.
+
+
+### Mark topics as observed with `Observe-Browsing-Topics`
+
+If a request includes a `Sec-Browsing-Topics` header and the response to that request includes an `Observe-Browsing-Topics: ?1` header, then topics from the request header will be marked by the browser as observed. Observed topics are eligible for calculation by the Topics API. This mechanism is designed to match the functionality provided by using the JavaScript API from an iframe.
+
+
+The screenshot below shows the topics recorded from visiting the sites on the API demo page. 
+
+
+<figure>
+  {% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/7GjvLNY86mBzeXPERRam.png", alt="Topics API demo page on glitch.me", width="656", height="566" %}
+  <figcaption>Topics API demo page on glitch.me. <a href="https://wd.imgix.net/image/RtQlPaM9wdhEJGVKR8boMPkWf443/7GjvLNY86mBzeXPERRam.png?auto=format&w=1600">View a larger version</a></figcaption>
+</figure>
+
+This list shows the sites you can visit from the demo to record topics of interest. As you can see, the Arts & Entertainment/Humor category in the screenshot is not the topic of one of these websites, so this recorded topic is one that was added as the possible 5 percent random topics.
+
+- pets-animals-pets-cats.glitch.me
+- cats-cats-cats-cats.glitch.me
+- cats-pets-animals-pets.glitch.me
+- cats-feline-meow-purr-whiskers-pet.glitch.
+
+You can check to see which topics are real and which are random on the Topics State tab of the `chrome://topics-internals` page. This screenshot shows an example from different browsing sessions.
+
+<figure>
+  {% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/Ef9ml82uPg3RdX5PX5QU.png", alt="ALT_TEXT_HERE", width="474", height="416" %}
+  <figcaption>Topics State tab showing real and random topics. <a href="https://wd.imgix.net/image/RtQlPaM9wdhEJGVKR8boMPkWf443/Ef9ml82uPg3RdX5PX5QU.png?auto=format&w=1600">View a larger version</a></figcaption>
+</figure>
+
+## Next steps
+
+If you're an ad tech developer, [experiment and participate](/docs/privacy-sandbox/topics-experiment/) with the Topics API. Read the [developer guide](/docs/privacy-sandbox/topics/) for more in-depth resources.

--- a/site/en/docs/privacy-sandbox/topics/demo/index.md
+++ b/site/en/docs/privacy-sandbox/topics/demo/index.md
@@ -117,3 +117,5 @@ You can check to see which topics are real and which are random on the Topics St
 ## Next steps
 
 If you're an ad tech developer, [experiment and participate](/docs/privacy-sandbox/topics-experiment/) with the Topics API. Read the [developer guide](/docs/privacy-sandbox/topics/) for more in-depth resources.
+
+{% Partial 'privacy-sandbox/topics-feedback.njk' %}

--- a/site/en/docs/privacy-sandbox/topics/demo/index.md
+++ b/site/en/docs/privacy-sandbox/topics/demo/index.md
@@ -82,7 +82,10 @@ Sec-Browsing-Topics: 186;version="chrome.1:1:2206021246";config_version="chrome.
 
 This example includes two topics from the [Topics taxonomy](https://github.com/patcg-individual-drafts/topics/blob/main/taxonomy_v1.md), 186 and 265, along with each topic's version information
 
-The [fetch()](https://chromium-review.googlesource.com/c/chromium/src/+/4044267) and [XHR](https://chromium-review.googlesource.com/c/chromium/src/+/4103742) implementations were first made available in Chrome 111.
+{% Aside 'note' %}
+The [fetch()](https://chromium-review.googlesource.com/c/chromium/src/+/4044267) and [XHR](https://chromium-review.googlesource.com/c/chromium/src/+/4103742) implementations were first made available in Chrome 111. (Refer to these builds for more information.)
+{% endAside %}
+
 
 Inclusion of the topics header in XHR requests is only available temporarily, and support will be removed in the future.
 

--- a/site/en/docs/privacy-sandbox/topics/demo/index.md
+++ b/site/en/docs/privacy-sandbox/topics/demo/index.md
@@ -19,7 +19,7 @@ If you want to test the API with your users, sign up for the [Relevance and Meas
 
 Our demo is a preview  that demonstrates most features of the Topics API, for you to gain familiarity with how the API is implemented.
 
-You can also run the Topics [colab](/docs/privacy-sandbox/topics/colab) to try out the Topics [classifier model](/docs/privacy-sandbox/topics/topic-classification/#the-classifier-model).
+You can also run the Topics [colab](/docs/privacy-sandbox/topics/colab) to try out the Topics [classifier model](/docs/privacy-sandbox/topics/topic-classification/#classifier-model).
 
 The following video shows how the demo works.
 
@@ -37,7 +37,7 @@ There are two ways to try the Topics API as a single user; you'll need to be run
     <figure>
 
     {% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/4kpW1PAuzrMrecSAR3tU.png", alt="Enable the Topics API using the chrome://flags/#privacy-sandbox-ads-apis page", width="800", height="246" %}
-          <figcaption>Enable the Topics API using the chrome://flags/#privacy-sandbox-ads-apis page. <a href="https://wd.imgix.net/image/RtQlPaM9wdhEJGVKR8boMPkWf443/4kpW1PAuzrMrecSAR3tU.png?auto=format&w=1600">View a larger version</a></figcaption>
+          <figcaption>The chrome://flags/#privacy-sandbox-ads-apis page. <a href="https://wd.imgix.net/image/RtQlPaM9wdhEJGVKR8boMPkWf443/4kpW1PAuzrMrecSAR3tU.png?auto=format&w=1600">View a larger version</a></figcaption>
     </figure>
 
 - Run Chrome from the command line with the following flags:
@@ -100,7 +100,7 @@ The screenshot below shows the topics recorded from visiting the sites on the AP
 
 <figure>
   {% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/7GjvLNY86mBzeXPERRam.png", alt="Topics API demo page on glitch.me", width="656", height="566" %}
-  <figcaption>Topics API demo page on glitch.me. <a href="https://wd.imgix.net/image/RtQlPaM9wdhEJGVKR8boMPkWf443/7GjvLNY86mBzeXPERRam.png?auto=format&w=1600">View a larger version</a></figcaption>
+  <figcaption>The glitch.me demo. <a href="https://wd.imgix.net/image/RtQlPaM9wdhEJGVKR8boMPkWf443/7GjvLNY86mBzeXPERRam.png?auto=format&w=1600">View a larger version</a></figcaption>
 </figure>
 
 This list shows the sites you can visit from the demo to record topics of interest. As you can see, the Arts & Entertainment/Humor category in the screenshot is not the topic of one of these websites, so this recorded topic is one that was added as the possible 5 percent random topics.
@@ -113,7 +113,7 @@ This list shows the sites you can visit from the demo to record topics of intere
 You can check to see which topics are real and which are random on the Topics State tab of the `chrome://topics-internals` page. This screenshot shows an example from different browsing sessions.
 
 <figure>
-  {% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/Ef9ml82uPg3RdX5PX5QU.png", alt="ALT_TEXT_HERE", width="474", height="416" %}
+  {% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/Ef9ml82uPg3RdX5PX5QU.png", alt="Topics state", width="474", height="416" %}
   <figcaption>Topics State tab showing real and random topics. <a href="https://wd.imgix.net/image/RtQlPaM9wdhEJGVKR8boMPkWf443/Ef9ml82uPg3RdX5PX5QU.png?auto=format&w=1600">View a larger version</a></figcaption>
 </figure>
 

--- a/site/en/docs/privacy-sandbox/topics/demo/index.md
+++ b/site/en/docs/privacy-sandbox/topics/demo/index.md
@@ -28,7 +28,7 @@ The following video shows how the demo works.
 %}
 
 
-## Test with chrome://flags or feature flags
+## Test with chrome://flags or feature flags {: #feature-flags}
 
 There are two ways to try the Topics API as a single user; you'll need to be running Chrome 101 or above:
 

--- a/site/en/docs/privacy-sandbox/topics/demo/index.md
+++ b/site/en/docs/privacy-sandbox/topics/demo/index.md
@@ -17,7 +17,7 @@ The Topics API demo provides a look at how topics are inferred from hostnames. Y
 
 If you want to test the API with your users, sign up for the [Relevance and Measurement origin trial](/docs/privacy-sandbox/unified-origin-trial/).
 
-Our demo is a preview  that demonstrates most features of the Topics API, for you to gain familiarity with how the API is implemented.
+Our demo is a preview that demonstrates most features of the Topics API, for you to gain familiarity with how the API is implemented.
 
 You can also run the Topics [colab](/docs/privacy-sandbox/topics/colab) to try out the Topics [classifier model](/docs/privacy-sandbox/topics/topic-classification/#classifier-model).
 
@@ -26,7 +26,6 @@ The following video shows how the demo works.
 {% YouTube
   id='hEBzWuXjeTQ'
 %}
-
 
 ## Test with chrome://flags or feature flags {: #feature-flags}
 
@@ -37,10 +36,11 @@ There are two ways to try the Topics API as a single user; you'll need to be run
     <figure>
 
     {% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/4kpW1PAuzrMrecSAR3tU.png", alt="Enable the Topics API using the chrome://flags/#privacy-sandbox-ads-apis page", width="800", height="246" %}
-          <figcaption>The chrome://flags/#privacy-sandbox-ads-apis page. <a href="https://wd.imgix.net/image/RtQlPaM9wdhEJGVKR8boMPkWf443/4kpW1PAuzrMrecSAR3tU.png?auto=format&w=1600">View a larger version</a></figcaption>
+          <figcaption>The chrome://flags/#privacy-sandbox-ads-apis page where you can enable or disable the API. <a href="https://wd.imgix.net/image/RtQlPaM9wdhEJGVKR8boMPkWf443/4kpW1PAuzrMrecSAR3tU.png?auto=format&w=1600">View a larger version</a></figcaption>
     </figure>
 
 - Run Chrome from the command line with the following flags:
+
     ```text
     --enable-features=BrowsingTopics,PrivacySandboxAdsAPIsOverride,OverridePrivacySandboxSettingsLocalTesting
     ```
@@ -80,30 +80,26 @@ The Topics request header looks like this:
 Sec-Browsing-Topics: 186;version="chrome.1:1:2206021246";config_version="chrome.1";model_version="2206021246";taxonomy_version="1", 265;version="chrome.1:1:2206021246";config_version="chrome.1";model_version="2206021246";taxonomy_version="1"
 ```
 
-This example includes two topics from the [Topics taxonomy](https://github.com/patcg-individual-drafts/topics/blob/main/taxonomy_v1.md), 186 and 265, along with each topic's version information
+This example includes two topics from the [Topics taxonomy](https://github.com/patcg-individual-drafts/topics/blob/main/taxonomy_v1.md), 186 and 265, along with each topic's version information.
 
 {% Aside 'note' %}
 The [fetch()](https://chromium-review.googlesource.com/c/chromium/src/+/4044267) and [XHR](https://chromium-review.googlesource.com/c/chromium/src/+/4103742) implementations were first made available in Chrome 111. (Refer to these builds for more information.)
 {% endAside %}
 
-
 Inclusion of the topics header in XHR requests is only available temporarily, and support will be removed in the future.
-
 
 ### Mark topics as observed with `Observe-Browsing-Topics`
 
 If a request includes a `Sec-Browsing-Topics` header and the response to that request includes an `Observe-Browsing-Topics: ?1` header, then topics from the request header will be marked by the browser as observed. Observed topics are eligible for calculation by the Topics API. This mechanism is designed to match the functionality provided by using the JavaScript API from an iframe.
 
-
-The screenshot below shows the topics recorded from visiting the sites on the API demo page. 
-
+The screenshot below shows the topics recorded from visiting the sites on the API demo page.
 
 <figure>
   {% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/7GjvLNY86mBzeXPERRam.png", alt="Topics API demo page on glitch.me", width="656", height="566" %}
-  <figcaption>The glitch.me demo. <a href="https://wd.imgix.net/image/RtQlPaM9wdhEJGVKR8boMPkWf443/7GjvLNY86mBzeXPERRam.png?auto=format&w=1600">View a larger version</a></figcaption>
+  <figcaption>The glitch.me demo for trying the API. <a href="https://wd.imgix.net/image/RtQlPaM9wdhEJGVKR8boMPkWf443/7GjvLNY86mBzeXPERRam.png?auto=format&w=1600">View a larger version</a></figcaption>
 </figure>
 
-This list shows the sites you can visit from the demo to record topics of interest. As you can see, the Arts & Entertainment/Humor category in the screenshot is not the topic of one of these websites, so this recorded topic is one that was added as the possible 5 percent random topics.
+This list shows the sites you can visit from the demo to record topics of interest. As you can see, the Arts &amp; Entertainment/Humor category in the screenshot is not the topic of one of these websites, so this recorded topic is one that was added as the possible 5 percent random topics.
 
 - pets-animals-pets-cats.glitch.me
 - cats-cats-cats-cats.glitch.me
@@ -113,7 +109,7 @@ This list shows the sites you can visit from the demo to record topics of intere
 You can check to see which topics are real and which are random on the Topics State tab of the `chrome://topics-internals` page. This screenshot shows an example from different browsing sessions.
 
 <figure>
-  {% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/Ef9ml82uPg3RdX5PX5QU.png", alt="Topics state", width="474", height="416" %}
+  {% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/Ef9ml82uPg3RdX5PX5QU.png", alt="The Topics state tab provides information on topics observed.", width="474", height="416" %}
   <figcaption>Topics State tab showing real and random topics. <a href="https://wd.imgix.net/image/RtQlPaM9wdhEJGVKR8boMPkWf443/Ef9ml82uPg3RdX5PX5QU.png?auto=format&w=1600">View a larger version</a></figcaption>
 </figure>
 

--- a/site/en/docs/privacy-sandbox/topics/index.md
+++ b/site/en/docs/privacy-sandbox/topics/index.md
@@ -210,7 +210,7 @@ context. The browser will internally keep up to N+1 epochs.</dd>
     <dt>
       <dd><code>BrowsingTopics:time_period_per_epoch</code></dd>
       <dd><strong>Default value:</strong> 7d-0h-0m-0s</dd>
-      <dd>Duration of each <a href="/docs/privacy-sandbox/topics/#:~:text=epoch">epoch</a>.
+      <dd>Duration of each <a href="/docs/privacy-sandbox/topics/overview/#:~:text=epoch">epoch</a>.
       For debugging, it can be useful to set this to (say) 15 seconds, rather than the default 7 days.</dd>
     </dt><br />
     <dt>

--- a/site/en/docs/privacy-sandbox/topics/index.md
+++ b/site/en/docs/privacy-sandbox/topics/index.md
@@ -27,7 +27,7 @@ The demo of the Topics API is at [topics-demo.glitch.me](https://topics-demo.gli
 
 You can also run the Topics [colab](/docs/privacy-sandbox/topics/colab/) to try out the Topics [classifier model](/docs/privacy-sandbox/topics/topic-classification/#classifier-model).
 
-### Take part in a Topics origin trial
+### Test Topics in an origin trial
 
 A Privacy Sandbox Relevance and Measurement [origin trial](/docs/privacy-sandbox/unified-origin-trial/) has been made available in Chrome Beta 101.0.4951.26 and above on desktop for the Topics, [FLEDGE](/docs/privacy-sandbox/fledge/), and [Attribution Reporting](/docs/privacy-sandbox/attribution-reporting/) APIs.
 

--- a/site/en/docs/privacy-sandbox/topics/index.md
+++ b/site/en/docs/privacy-sandbox/topics/index.md
@@ -94,9 +94,9 @@ This snippet of code above is provided only to show how the Topics JavaScript AP
 
 ### Use headers to access and observe topics
 
-Rather than using the Topics JavaScript API from an iframe, topics can be accessed and marked as observed by using [request](https://developer.mozilla.org/en-US/docs/Web/API/Request/headers) and [response](https://developer.mozilla.org/en-US/docs/Web/API/Response/headers) headers:
+Rather than using the Topics JavaScript API from an iframe, topics can be accessed and marked as observed by using [request](https://developer.mozilla.org/docs/Web/API/Request/headers) and [response](https://developer.mozilla.org/docs/Web/API/Response/headers) headers:
 
--   Topics can be accessed from the `Sec-Browsing-Topics` header of a [`fetch()`](https://developer.mozilla.org/en-US/docs/Web/API/fetch) or [`XHR`](https://developer.mozilla.org/docs/Glossary/XHR_(XMLHttpRequest)) request.
+-   Topics can be accessed from the `Sec-Browsing-Topics` header of a [`fetch()`](https://developer.mozilla.org/docs/Web/API/fetch) or [`XHR`](https://developer.mozilla.org/docs/Glossary/XHR_(XMLHttpRequest)) request.
 -   Topics that were provided in a request header can be marked as observed by setting an `Observe-Browsing-Topics: ?1` header on the response to the request. The browser will then use those topics (that were included in the request header) for calculating topics of interest for a user.
 
 Using request and response headers to access topics and mark them as observed can be much more performant than using the JavaScript API from an iframe. For example, the header mechanism could be used when a `fetch()` request is made to an ad server. No iframe required! For more on this technique, check out the demo page.

--- a/site/en/docs/privacy-sandbox/topics/index.md
+++ b/site/en/docs/privacy-sandbox/topics/index.md
@@ -270,8 +270,6 @@ version used by the API.</dd>
 - Learn more about [what topics are and how they work](/docs/privacy-sandbox/topics/topic-classification). <!-- topic classification page and demo and trial links needed-->
 - Try out the [demo](/docs/privacy-sandbox/topics/demo) or join an [origin trial](/docs/web-platform/origin-trials/).
 
-{% Partial 'privacy-sandbox/topics-feedback.njk' %}
-
 ## Find out more
 
 -   [Topics API technical explainer](https://github.com/jkarlin/topics)

--- a/site/en/docs/privacy-sandbox/topics/index.md
+++ b/site/en/docs/privacy-sandbox/topics/index.md
@@ -1,6 +1,6 @@
 ---
 layout: 'layouts/doc-post.njk'
-title: 'Topics API: developer guide'
+title: 'Topics API developer guide'
 subhead: >
   Learn how to work with the API, including how to use Chrome flags for testing.
 description: >

--- a/site/en/docs/privacy-sandbox/topics/index.md
+++ b/site/en/docs/privacy-sandbox/topics/index.md
@@ -121,9 +121,9 @@ Users can view information about topics observed for their browser during the cu
 
 <figure>
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/M253GclVFDCnvPJlTSVR.png",
-  alt="The chrome://topics-internal page with Topics State panel selected.",
+  alt="The chrome://topics-internals page with Topics State panel selected.",
   width="800", height="697" %}
-<figcaption>The chrome://topics-internal page Topics State panel shows Topics IDs, random and real topic assignments, and taxonomy and model versions.
+<figcaption>The chrome://topics-internals page Topics State panel shows Topics IDs, random and real topic assignments, and taxonomy and model versions.
 </figcaption>
 </figure>
 
@@ -137,9 +137,9 @@ You can also view the topics inferred by the Topics [classifier model](https://g
 
 <figure>
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/SOTuE2ljC55PaYll1UP1.png",
-  alt="The chrome://topics-internal page with Classifier panel selected.",
+  alt="The chrome://topics-internals page with Classifier panel selected.",
   width="800", height="695" %}
-  <figcaption>The chrome://topics-internal page Classifier panel shows topics selected, hosts visited, and model version and path.</figcaption>
+  <figcaption>The chrome://topics-internals page Classifier panel shows topics selected, hosts visited, and model version and path.</figcaption>
 </figure>
 
 The current implementation of the Topics API infers topics from hostnames only; not from any other part of a URL.
@@ -152,9 +152,9 @@ Information is provided in `chrome://topics-internals` about the Topics API impl
 
 <figure>
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/7vFveJtxWgY6yB8gHnW3.png",
-  alt="chrome://topics-internal page with Features and Parameters panel selected.",
+  alt="chrome://topics-internals page with Features and Parameters panel selected.",
   width="800", height="695" %}
-<figcaption>The chrome://topics-internal Features and Parameters panel shows enabled features, time per epoch, number of epochs to use to calculate topics, taxonomy version, and other settings.
+<figcaption>The chrome://topics-internals Features and Parameters panel shows enabled features, time per epoch, number of epochs to use to calculate topics, taxonomy version, and other settings.
 </figcaption>
 </figure>
 

--- a/site/en/docs/privacy-sandbox/topics/index.md
+++ b/site/en/docs/privacy-sandbox/topics/index.md
@@ -144,7 +144,7 @@ You can view the topics inferred by the Topics [classifier model](https://github
   <figcaption>The chrome://topics-internal page Classifier panel shows topics selected, hosts visited, and model version and path.</figcaption>
 </figure>
 
-The current implementation of the Topics API infers topics from hostnames only: not any other part of a URL.
+The current implementation of the Topics API infers topics from hostnames only; not from any other part of a URL.
 
 Use hostnames only (without protocol or path) to view inferred topics from the `chrome://topics-internals` Classifier. `chrome://topics-internals` will display an error if you attempt to include a "/" in the Host field.
 

--- a/site/en/docs/privacy-sandbox/topics/index.md
+++ b/site/en/docs/privacy-sandbox/topics/index.md
@@ -113,7 +113,7 @@ Using request and response headers to access topics and mark them as observed ca
 
 ## Debug your API implementation
 
-The `chrome://topics-internals` page is available in Chrome on desktop if [you enable the Topics API](/docs/privacy-sandbox/topics/#feature-flags). This displays topics for the current user, topics inferred for hostnames, and technical information about the API implementation.
+The `chrome://topics-internals` page is available in Chrome on desktop if [you enable the Topics API](/docs/privacy-sandbox/topics/demo/#feature-flags). This displays topics for the current user, topics inferred for hostnames, and technical information about the API implementation.
 
 The `chrome://topics-internals` page is new. The design and functionality are still under discussion. We're currently iterating and improving the design based on developer feedback. Add your feedback at [bugs.chromium.org](https://bugs.chromium.org/p/chromium/issues/entry?template=Defect+report+from+developer&components=Blink%3ETopicsAPI).
 
@@ -150,7 +150,7 @@ Use hostnames only (without protocol or path) to view inferred topics from the `
 
 ### View Topics API information
 
-Information is provided about the Topics API implementation and settings, such as the [taxonomy](/docs/privacy-sandbox/topics/#taxonomy) version and [epoch](/docs/privacy-sandbox/topics/#epoch) duration. These values reflect default settings for the API or parameters successfully set [from the command line](/docs/privacy-sandbox/topics/#feature-flags). This is handy for checking that command-line flags have worked as expected. In the example below, `time_period_per_epoch` has been set to 15 seconds (the default is seven days).
+Information is provided about the Topics API implementation and settings, such as the [taxonomy](/docs/privacy-sandbox/topics/#taxonomy) version and [epoch](/docs/privacy-sandbox/topics/#epoch) duration. These values reflect default settings for the API or parameters successfully set [from the command line](#feature-flags). This is handy for checking that command-line flags have worked as expected. In the example below, `time_period_per_epoch` has been set to 15 seconds (the default is seven days).
 
 <figure>
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/7vFveJtxWgY6yB8gHnW3.png",
@@ -167,7 +167,7 @@ The parameters correspond to flags that can be set when running Chrome from the 
 --enable-features=BrowsingTopics:time_period_per_epoch/15s,PrivacySandboxAdsAPIsOverride,PrivacySandboxSettings3,OverridePrivacySandboxSettingsLocalTesting
 ```
 
-#### Chrome flags
+#### Chrome flags {: #feature-flags}
 
 
 Below are the relevant flags for Chrome, including their default value and descrptions:

--- a/site/en/docs/privacy-sandbox/topics/index.md
+++ b/site/en/docs/privacy-sandbox/topics/index.md
@@ -99,7 +99,7 @@ Rather than using the Topics JavaScript API from an iframe, topics can be access
 -   Topics can be accessed from the `Sec-Browsing-Topics` header of a [`fetch()`](https://developer.mozilla.org/docs/Web/API/fetch) or [`XHR`](https://developer.mozilla.org/docs/Glossary/XHR_(XMLHttpRequest)) request.
 -   Topics that were provided in a request header can be marked as observed by setting an `Observe-Browsing-Topics: ?1` header on the response to the request. The browser will then use those topics (that were included in the request header) for calculating topics of interest for a user.
 
-Using request and response headers to access topics and mark them as observed can be much more performant than using the JavaScript API from an iframe. For example, the header mechanism could be used when a `fetch()` request is made to an ad server. No iframe required! For more on this technique, check out the demo page.
+Using request and response headers to access topics and mark them as observed can be much more performant than using the JavaScript API from an iframe. For example, the header mechanism could be used when a `fetch()` request is made to an ad server. No iframe required! For more on this technique, check out the [demo](/docs/privacy-sandbox/topics/demo#the-topics-api-headers-demo).
 
 #### Notes
 

--- a/site/en/docs/privacy-sandbox/topics/index.md
+++ b/site/en/docs/privacy-sandbox/topics/index.md
@@ -34,7 +34,7 @@ A Privacy Sandbox Relevance and Measurement [origin trial](/blog/origin-trials/)
 
 ## Get and set topics
 
-The Topics JavaScript API has one method: `document.browsingTopics()`. It returns a promise that resolves to an array of up to three topics, one for each of the three most recent epochs, in random order.
+The Topics JavaScript API has one method: `document.browsingTopics()`. It returns a promise that resolves to an array of up to three topics, one for each of the three most recent epochs, in random order. An epoch is a period of time currently set to one week.
 
 Each topic object in the array returned by `document.browsingTopics()` will have three properties:
 
@@ -150,7 +150,7 @@ Use hostnames only (without protocol or path) to view inferred topics from the `
 
 ### View Topics API information
 
-Information is provided about the Topics API implementation and settings, such as the [taxonomy](/docs/privacy-sandbox/topics/#taxonomy) version and [epoch](/docs/privacy-sandbox/topics/#epoch) duration. These values reflect default settings for the API or parameters successfully set [from the command line](#feature-flags). This is handy for checking that command-line flags have worked as expected. In the example below, `time_period_per_epoch` has been set to 15 seconds (the default is seven days).
+Information is provided about the Topics API implementation and settings, such as the [taxonomy](/docs/privacy-sandbox/topics/#taxonomy) version and epoch duration. These values reflect default settings for the API or parameters successfully set [from the command line](#feature-flags). This is handy for checking that command-line flags have worked as expected. In the example below, `time_period_per_epoch` has been set to 15 seconds (the default is seven days).
 
 <figure>
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/7vFveJtxWgY6yB8gHnW3.png",

--- a/site/en/docs/privacy-sandbox/topics/index.md
+++ b/site/en/docs/privacy-sandbox/topics/index.md
@@ -2,328 +2,72 @@
 layout: 'layouts/doc-post.njk'
 title: 'Topics API: developer guide'
 subhead: >
-  Try out the Topics demo, and learn about the API and how to run Topics with flags or participate in an origin trial.
+  Learn how to work with the API, including how to use Chrome flags for testing.
 description: >
-  Try out the Topics demo, and learn about the API and how to run Topics with flags or participate in an origin trial.
+  Learn how to work with the API, including how to use Chrome flags for testing.
 date: 2022-01-25
-updated: 2022-02-01
+updated: 2023-03-08
 authors:
   - samdutton
 ---
 
 
 ## Implementation status
+{% Partial 'privacy-sandbox/ps-implementation-status.njk' %}
 
-This document outlines a new proposal for interest-based advertising: the Topics API.
+## Try the Topics API
 
--  The [Topics API proposal](https://github.com/jkarlin/topics) has entered [public
-   discussion](https://github.com/jkarlin/topics/issues) and is now available in an [origin trial](#origin-trial).
--  This proposal needs your feedback. If you have comments, create an issue on the [Topics
-   Explainer repository](https://github.com/jkarlin/topics) or participate in discussions in the
-   [Improving Web Advertising Business Group](https://www.w3.org/community/web-adv/participants).
-   The explainer has a number of [open questions](https://github.com/jkarlin/topics/issues) that
-   still require further definition.
--  [The Privacy Sandbox timeline](http://privacysandbox.com/timeline) provides implementation
-   timings for the Topics API and other Privacy Sandbox proposals.
+Topics is not currently available by default in any version of Chrome, but you can activate the API in two ways, as a single user or at scale:
 
-{% Aside %}
+-   The Topics API demo allows you to try it out as a single user.
+-   The Topics origin trial allows you to try the API at scale with your website users.
 
-[Topics API: latest updates](/docs/privacy-sandbox/topics/latest) details changes and enhancements to the API and implementations.
+### Try the demo
 
-{% endAside %}
+The demo of the Topics API is at [topics-demo.glitch.me](https://topics-demo.glitch.me/). It explains how to try out and debug the API for a single user.
 
----
+You can also run the Topics [colab](/docs/privacy-sandbox/topics/colab/) to try out the Topics [classifier model](/docs/privacy-sandbox/topics/topic-classification/#the-classifier-model).
 
-## Try the demo {: #demo}
+### Take part in a Topics origin trial
 
-There is a demo of the Topics API at [topics-demo.glitch.me](https://topics-demo.glitch.me/).
-This explains how to try out and debug the API for a single user.
+A Privacy Sandbox Relevance and Measurement [origin trial](/blog/origin-trials/) has been made available in Chrome Beta 101.0.4951.26 and above on desktop for the Topics, [FLEDGE](/docs/privacy-sandbox/fledge/), and [Attribution Reporting](/docs/privacy-sandbox/attribution-reporting/) APIs.
 
-You can also run the Topics [colab](#colab) to try out the Topics [classifier model](#classifier-model).
+## Get and set topics
 
-{% YouTube
-  id='hEBzWuXjeTQ'
-%}
+The Topics JavaScript API has one method: `document.browsingTopics()`. It returns a promise that resolves to an array of up to three topics, one for each of the three most recent epochs, in random order.
 
-## Take part in a Topics origin trial {: #origin-trial}
+Each topic object in the array returned by `document.browsingTopics()` will have three properties:
 
-A Privacy Sandbox Relevance and Measurement [origin trial](/blog/origin-trials/) has been
-made available in Chrome Beta 101.0.4951.26 and above on desktop for the Topics,
-[FLEDGE](/docs/privacy-sandbox/fledge) and [Attribution Reporting](/docs/privacy-sandbox/attribution-reporting/) APIs.
+-   `configVersion`: a string identifying the current Topics API configuration
+-   `modelVersion`: a string identifying the machine-learning classifier used to infer topics for the site
+-   `taxonomyVersion`: a string identifying the set of topics currently in use by the browser
+-   `topic`: a number identifying the topic in the [taxonomy](/docs/privacy-sandbox/topics/overview/#how-topics-are-curated-and-selected)
+-   `version`: a string combining the `configVersion` and the `modelVersion`
 
-To take part, [register for an origin trial token](/origintrials/#/view_trial/771241436187197441).
+The parameters described in this article, and details of the API (such as taxonomy size, the number of topics calculated per week and the number of topics returned per call) are subject to change as we incorporate ecosystem feedback and iterate on the API.
 
-Once you have successfully enrolled in the trial, you can try out the Topics JavaScript API on pages
-that provide a valid trial token:
-
-*   As a meta tag in the &lt;head&gt;:<br>
-
-    `<meta http-equiv="origin-trial" content="TOKEN_GOES_HERE">`
-
-*   As an HTTP header:<br>
-
-    `Origin-Trial: TOKEN_GOES_HERE`
-
-*   By providing a token programmatically:<br>
-
-    ```javascript
-    const otMeta = document.createElement('meta');
-    otMeta.httpEquiv = 'origin-trial';
-    otMeta.content = 'TOKEN_GOES_HERE';
-    document.head.append(otMeta);
-    ```
-
-An iframe running Topics code&mdash;such as a `document.browsingTopics()` call to observe
-topics&mdash;will need to provide a token that matches its origin.
-
-{% Aside 'caution' %}
-
-Not all users are eligible for the Privacy Sandbox Relevance and Measurement
-origin trial, even on pages that provide a valid trial token.
-
-[Testing the Privacy Sandbox ads relevance and measurement APIs](/blog/privacy-sandbox-unified-origin-trial#eligible-users)
-explains why this is, and shows how you can (and should) detect if an origin trial feature is
-available before attempting to use it.
-
-{% endAside %}
-
-
-## Test with `chrome://flags` or feature flags {: #feature-flags}
-
-There are two ways to try the Topics API as a single user, running Chrome 101 or above:
-
-*  Enable `chrome://flags/#privacy-sandbox-ads-apis`
-*  Run Chrome from the command line with the following flags:
-
-``` text
---enable-features=BrowsingTopics,PrivacySandboxAdsAPIsOverride,OverridePrivacySandboxSettingsLocalTesting
-```
-
-The [Topics demo](#demo) shows how to use additional flags to adjust settings such as epoch
-length. If you access the Topics API by running Chrome with command-line flags, don't
-set `chrome://flags`, as these can override command-line settings.
-
-[Run Chromium with flags](https://www.chromium.org/developers/how-tos/run-chromium-with-flags)
-explains how to set flags when running Chrome and other Chromium-based browsers from the command
-line.
-
-
-{% Aside %}
-
-This is an in-progress version of the API for early testing, so it should not be considered feature
-complete or indicative of the final implementation.
-
-The [Privacy Sandbox timeline](https://privacysandbox.com/timeline) provides implementation timing
-information for FLEDGE and other Privacy Sandbox proposals.
-
-{% endAside %}
-
-
-## Detect feature support
+### Detect support for document.browsingTopics
 
 Before using the API, check if it's supported by the browser and available in the document:
 
 ```javascript
 'browsingTopics' in document && document.featurePolicy.allowsFeature('browsing-topics') ?
-  console.log('document.browsingTopics() is supported on this page') :
-  console.log('document.browsingTopics() is not supported on this page');
+ console.log('document.browsingTopics() is supported on this page') :
+ console.log('document.browsingTopics() is not supported on this page');
 ```
 
 {% Aside 'caution' %}
 
-Feature support on the current page isn't a guarantee that an API is usable: the user may have
-disabled the API via browser settings, or they may have other settings that prevent the API from
-being used. To protect user privacy, there is no way to check for this programmatically.
-
+Feature support on the current page isn't a guarantee that an API is usable: the user may have disabled the API via browser settings, or they may have other settings that prevent the API from being used. To protect user privacy, there is no way to check for these other settings programmatically.
 {% endAside %}
 
----
+### Access topics without modifying state
 
-## Why do we need this API?
+From Chrome 108, the `document.browsingTopics()` method can be passed an optional argument: `{skipObservation:true}`.
+This allows the method to return topics without causing the browser to record a topic observation. By default, it does.. In other words, the call will not cause the current page to be included in the weekly epoch calculation, nor will it update the list of topics observed for the caller.
 
-The Topics API is a [Privacy Sandbox](/docs/privacy-sandbox/overview/) proposal for a mechanism to
-enable interest-based advertising, without having to resort to tracking the sites a user visits.
 
-{% Aside %}
-
-**Interest-based advertising (IBA)** is a form of personalized advertising in which an ad is
-selected for a user based on their interests, inferred from the sites they've recently visited.
-This is different from contextual advertising, which aims to match content on the page the user is
-visiting.
-
-IBA can help advertisers to reach potential customers and help fund websites that cannot
-otherwise easily monetize visits to their site purely via contextual advertising. IBA can also
-supplement contextual information for the current page to help find an appropriate advertisement
-for the visitor.
-
-{% endAside %}
-
-The Topics API proposes a way to provide topics that a user might currently be interested in, based
-on their recent browsing activity. These topics can supplement contextual information to help select
-appropriate advertisements.
-
-The Topics API has three main tasks:
-
--  Map website hostnames to topics of interest. For example, a yoga website might be classified as
-   being related to "Fitness".
--  Calculate the top topics for a user based on their recent browsing activity.
--  Provide a JavaScript API to provide topics currently of interest to the user, to help select the
-   appropriate ads.
-
-The Topics API can help facilitate robust user controls, as the API is built on top of recognizable,
-high-level topics. Chrome plans to offer users the option to remove individual topics, and to show
-the user the topics stored in the browser.
-
-### How would topics be curated and selected?
-
-Topics would be selected from a
-[taxonomy](https://github.com/jkarlin/topics/blob/main/taxonomy_v1.md): a list of items such as
-"Country Music", "Make-Up&nbsp;&&nbsp;Cosmetics" or "Vegetarian Cuisine". These topics would initially be
-curated by Chrome for testing, but with the goal that the topic taxonomy becomes a resource
-maintained by trusted ecosystem contributors. The taxonomy needs to provide a set of topics that is
-small enough in number (currently proposed to be around 350, though we expect the final number of
-topics to be between a few hundred and a few thousand) so that many browsers will be associated with
-each topic.
-
-To avoid sensitive categories, these topics must be public, human-curated, and kept
-updated. The initial taxonomy proposed for testing by Chrome has been human-curated [to exclude
-categories generally considered sensitive](#sensitive-topics), such as ethnicity or sexual
-orientation.
-
-{: #classifier-model}
-
-The Topics API proposes using
-[machine learning](https://royalsociety.org/topics-policy/projects/machine-learning/what-is-machine-learning-infographic/)
-to infer topics from hostnames. The classifier model for this would initially be trained by the
-browser vendor, or a trusted third party, using human-curated hostnames and topics. The model would
-be distributed with the browser, so it would be openly developed and freely available. The browser,
-on the user's device, could then use the model to calculate the most popular topics for a user,
-based on the [hostnames](https://web.dev/same-site-same-origin/#origin) of the sites recently
-visited.
-
-{% Aside %}
-Chrome's implementation of the Topics API downloads a [TensorFlow Lite](tensorflow.org/lite/guide)
-file representing the model, so it can be used locally on your device. The model file is in an efficient,
-portable format known as FlatBuffers, which has the `.tflite` filename extension.
-
-Access the TensorFlow Lite model file, and the topics inferred for hostnames,
-[from the `chrome://topics internal` page](#view-inferred-topics).
-{% endAside %}
-
-The diagram below outlines a simplified example, to demonstrate how the Topics API might help an
-ad tech platform to select an appropriate ad. The example assumes that the user's browser already
-has a model to map website hostnames to topics.
-
-{% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/u9e1VvzblNVHCfyk1hRY.png",
-  alt="Diagram showing the stages in the Topics API lifecycle, from a user visiting websites to an ad
-  being displayed.", width="800", height="275" %}
-
-The Topics API lifecycle: [view a larger version](https://wd.imgix.net/image/80mq7dk16vVEg8BBhsVe42n6zn82/u9e1VvzblNVHCfyk1hRY.png?auto=format&w=1600)
-
-## How does the Topics API work?
-
-{% Aside %}
-
-The Topics API proposal is in the
-[discussion phase](/docs/privacy-sandbox/proposal-lifecycle/#discussion)
-to gather and act on feedback from the ecosystem. The API design is not final
-and the details below will change as discussions progress.
-
-{% endAside %}
-
-A mechanism to facilitate interest-based advertising, such as the Topics API, must ensure that the
-topics of interest it provides are kept up to date.
-
-{: #epoch}
-
-With the Topics API proposal, the browser would infer topics for a user based on their browsing
-activity during a period of time known as an _epoch_, currently proposed to be one week. The topic
-selected for each epoch would be randomly selected from the user's top five topics for that time
-period. To further enhance privacy and ensure that all topics may be represented, there is a 5%
-chance the topic is randomly selected from all possible topics in the Taxonomy.
-
-The Topics JavaScript API has one method: `document.browsingTopics()`. This returns a promise that
-resolves to an array of up to three topics, one for each of the three most recent epochs, in random
-order.
-
-The Topics explainer proposes that each topic object in the array returned by
-`document.browsingTopics()` would have three properties:
-
--  `configVersion`: a string identifying the current configuration
--  `modelVersion`: a string identifying the machine-learning classifier used to infer site
--  `taxonomyVersion`: a string identifying the set of topics currently in use by the browser
--  `topic`: a number identifying the topic in the [taxonomy](#how-would-topics-be-curated-and-selected)
--  `version`: a string combining the `configVersion` and the `modelVersion`
-
-{% Aside %}
-
-The design of the Topics API is currently under discussion as an
-[explainer](https://github.com/patcg-individual-drafts/topics). The API is not finalized.
-
-The parameters described in this article, and details of the API (such as taxonomy size, the
-number of topics calculated per week and the number of topics returned per call) are subject to
-change as we incorporate ecosystem feedback and iterate on the API.
-
-{% endAside %}
-
-{: #observed-topics}
-
-### API callers only receive topics they've observed
-
-A design goal of the Topics API is to enable interest-based advertising without the sharing of
-information to more entities than is currently possible with third-party cookies. The Topics API
-proposes that topics can only be returned for API callers that have already observed them, within a
-limited timeframe.
-
-{: #caller}
-
-{% Aside 'key-term' %}
-
-A Topics API _caller_ is the entity that calls the `document.browsingTopics()` JavaScript
-method, and will use the topics returned by the method to help select relevant ads.
-Typically, a call to `document.browsingTopics()` would be from code included in a site from a
-third party such as an ad tech platform. The browser determines the caller from the site of the
-current document. So, if you're a third party on a page, make sure you call the API from an
-iframe that your site owns.
-
-In order for  `document.browsingTopics() `to return one or more topics, it must be called in
-code from the same origin as code that was on a site where those topics were observed.
-
-{% endAside %}
-
-An API caller is said to have _observed_ a topic for a user if it has called the
-`document.browsingTopics()` method in code included on a site that the Topics API has mapped to that
-topic. For example:
-
-1. The Topics API maps the hostname `knitting.example` to topics including "Fabric & Textile Arts".
-1. Code from `adtech.example` is included in pages on `knitting.example`.
-1. A user visits `knitting.example`.
-1. The  `adtech.example` code calls  `document.browsingTopics(). `
-1. One of the topics the browser has inferred for knitting.example is "Fabric & Textile Arts".
-1. `adtech.example` is said to have observed the topic "Fabric & Textile Arts" for that user.
-
-The API's `document.browsingTopics()` method will only provide topics that have already been
-observed by the caller within the most recent three [epochs](#epoch). This helps stop information
-about the user from being shared with more entities than technologies the API is replacing
-(including third-party cookies).
-
-The number of topics returned by `document.browsingTopics()` depends on the number of topics that
-the [API caller](#caller) has previously observed, and the number of topics that the user has
-available (such as the number of weeks of data accumulated). Anywhere from zero to three topics may
-be returned.
-
-{: #skipobservation}
-
-{% Aside %}
-From Chrome 108, the `document.browsingTopics()` method can be passed an optional `{skipObservation:true}` 
-argument.
-
-This allows the method to return topics without causing the browser to record 
-a topic observation (the default is `false`). In other words, `document.browsingTopics({skipObservation:true})` 
-can be used to return topics of interest for the current user, but with no side effects.
-{% endAside %}
-
-### Access topics with the JavaScript API {: #access-topics}
+### Access topics with the JavaScript API
 
 Here is a basic example of possible API usage to access topics for the current user. To keep it simple, there's no error handling.
 
@@ -333,11 +77,11 @@ const topics = await document.browsingTopics();
 
 // Request an ad creative.
 const response = await fetch('https://ads.example/get-creative', {
-  method: 'POST',
-  headers: {
-    'Content-Type': 'application/json',
-  },
-  body: JSON.stringify(topics)
+ method: 'POST',
+ headers: {
+   'Content-Type': 'application/json',
+ },
+ body: JSON.stringify(topics)
 })
 
 // Get the JSON from the response.
@@ -347,629 +91,193 @@ const creative = await response.json();
 ```
 
 {% Aside 'warning' %}
-This snippet of code is provided only to show how the Topics JavaScript API
-might be used. API design is subject to change.
+This snippet of code above is provided only to show how the Topics JavaScript API might be used. API design is subject to change.
 {% endAside %}
 
-#### Access topics without modifying state {: #skipobservation}
+### Use headers to access and observe topics
 
-A caller can specify that they would like to retrieve topics without modifying state by calling
-`document.browsingTopics({skipObservation: true})`.
+Rather than using the Topics JavaScript API from an iframe, topics can be accessed and marked as observed by using request and response headers:
 
-Including the `{skipObservation: true}` argument means that topics can be returned, but the call will not
-cause the current page to be included in the weekly epoch calculation, nor will it update the list
-of topics observed for the caller.
+-   Topics can be accessed from the `Sec-Browsing-Topics` header of a `fetch()` or `XHR` request.
+-   Topics that were provided in a request header can be marked as observed by setting an `Observe-Browsing-Topics: ?1` header on the response to the request. The browser will then use those topics (that were included in the request header) for calculating topics of interest for a user.
 
-### Use headers to access and observe topics {: #headers}
+Using request and response headers to access topics and mark them as observed can be much more performant than using the JavaScript API from an iframe. For example, the header mechanism could be used when a `fetch()` request is made to an ad server. No iframe required! For more on this technique, check out the demo page.
 
-Rather than use the Topics JavaScript API from an iframe, topics can be accessed and marked as 
-observed by using request and response headers:
-
-* Topics can be accessed from the `Sec-Browsing-Topics` header of a `fetch()` or `XHR` request. 
-* Topics that were provided in a request header can be marked as observed by setting a 
-`Observe-Browsing-Topics: ?1` header on the response to the request. The browser will then use those 
-topics (that were included in the request header) for calculating topics of interest for a user.
-
-Using request and response headers to access topics and mark them as observed can be much more performant 
-than using the JavaScript API from an iframe. For example, the header mechanism could be used when a `fetch()` 
-request is made to an ad server. No iframe required!
-
-#### Demo
-
-The demo at [topics-fetch-demo.glitch.me](https://topics-fetch-demo.glitch.me) shows how to use `fetch()` 
-request and response headers to access topics and mark them as observed.
-
-#### Access the `Sec-Browsing-Topics` request header to view topics
-
-Instead of using `document.browsingTopics()` from an iframe to view topics for a user, API callers 
-can access observed topics from the `Sec-Browsing-Topics` request header of a 
-[`fetch()`](https://developer.mozilla.org/docs/Web/API/fetch) request that includes `{browsingTopics: true}` 
-in its `options` parameter—or from the same header of an [`XHR`](https://developer.mozilla.org/docs/Glossary/XHR_(XMLHttpRequest)) 
-request that sets `deprecatedBrowsingTopics` attribute to `true`. 
-
-For example:
-
-``` javascript
-fetch('https://topics-server.glitch.me', {browsingTopics: true}).
-  then(...);
-```
-In browsers that support the API, the `fetch()` request will include a `Sec-Browsing-Topics` header 
-that lists topics observed for the request URL hostname: in this example, `topics-server.glitch.me`.
-
-If no topics have been observed for this hostname and this user, the header is included but the 
-value is empty. In other words, the `Sec-Browsing-Topics` header on a `fetch()` request only includes 
-topics that have been observed for the current user's browser by a caller whose origin matches the 
-hostname of the request URL. This is the same as if you were calling `document.browsingTopics()` from 
-an iframe to view observed topics for the current user.
-
-{% Aside %}
-The request header is sent on a request as long as it has the appropriate [permission policy](#site-opt-out) 
-is in play, the context is secure, and user settings permit it. Topics 
-[are not provided](https://github.com/patcg-individual-drafts/topics/issues/7) in headers for navigation requests.
-{% endAside %}
-
-The Topics request header looks like this:
-
-``` text
-Sec-Browsing-Topics: 186;version="chrome.1:1:2206021246";config_version="chrome.1";model_version="2206021246";taxonomy_version="1", 265;version="chrome.1:1:2206021246";config_version="chrome.1";model_version="2206021246";taxonomy_version="1"
-```
-
-This example includes two topics from the [Topics taxonomy](https://github.com/patcg-individual-drafts/topics/blob/main/taxonomy_v1.md), 
-186 and 265, along with each topic's version information.
-
-{% Aside %}
-The [fetch()](https://chromium-review.googlesource.com/c/chromium/src/+/4044267) and 
-[XHR](https://chromium-review.googlesource.com/c/chromium/src/+/4103742) implementations were first made available in Chrome 111.
-
-Inclusion of the topics header in `XHR` requests is only available temporarily, and support will be removed in future.
-{% endAside %}
-
-#### Use the `Observe-Browsing-Topics` response header to mark topics as observed
-
-If a request includes a `Sec-Browsing-Topics` header and the response to that request includes 
-an `Observe-Browsing-Topics: ?1` header, then topics from the request header will be marked by 
-the browser as observed. Observed topics are eligible for calculation by the Topics API.
-This mechanism is designed to match the functionality provided by using the JavaScript API from an iframe.
 
 #### Notes
 
--  Redirects will be followed, and the topics sent in the redirect request will be specific to
-    the redirect URL.
--  The request header will not modify state for the caller unless there is a corresponding
-    response header. That is, the topic of the page won't be considered observed, nor will it
-    affect the user's topic calculation for the next epoch.
--  The response header is only honored if the corresponding request included the topics
-    header (or would have included the header, if the request wasn't empty).
--  The URL of the request provides the registrable domain used for topic observation.
+-   Redirects will be followed, and the topics sent in the redirect request will be specific to the redirect URL.
+-   The request header will not modify state for the caller unless there is a corresponding response header. That is, the topic of the page won't be considered observed, nor will it affect the user's topic calculation for the next epoch.
+-   The response header is only honored if the corresponding request included the topics header (or would have included the header, if the request wasn't empty).
+-   The URL of the request provides the registrable domain used for topic observation.
 
-### How does the Topics API decide which callers can see which topic?
+## Debug your API implementation
 
-API callers only receive topics they've recently observed, and the topics for a user are refreshed
-once each epoch. That means the API provides a rolling window in which a given caller may receive
-certain topics.
+The `chrome://topics-internals` page is available in Chrome on desktop if [you enable the Topics API](/docs/privacy-sandbox/topics/#feature-flags). This displays topics for the current user, topics inferred for hostnames, and technical information about the API implementation.
 
-The table below outlines an example (though unrealistically small) of a hypothetical browsing
-history for a user during a single epoch, showing topics associated with the sites they've visited,
-and the API [callers](#caller) present on each site (the entities that call
-`document.browsingTopics()` in JavaScript code included on the site).
+The `chrome://topics-internals` page is new. The design and functionality are still under discussion. We're currently iterating and improving the design based on developer feedback. Add your feedback at [bugs.chromium.org](https://bugs.chromium.org/p/chromium/issues/entry?template=Defect+report+from+developer&components=Blink%3ETopicsAPI).
 
-<table>
-  <thead>
-  <tr>
-  <th style="text-align: left;"><strong>Site</strong></th>
-  <th style="text-align: left;"><strong>Topics</strong></th>
-  <th style="text-align: left;"><strong>API callers on site</strong></th>
-  </tr>
-  </thead>
-  <tbody>
-    <tr>
-    <td>yoga.example</td>
-    <td>Fitness</td>
-    <td>adtech1.example adtech2.example</td>
-    </tr>
-    <tr>
-    <td>knitting.example</td>
-    <td>Crafts</td>
-    <td>adtech1.example</td>
-    </tr>
-    <tr>
-    <td>hiking-holiday.example</td>
-    <td>Fitness, Travel & Transportation</td>
-    <td>adtech2.example</td>
-    </tr>
-    <tr>
-    <td>diy-clothing.example</td>
-    <td>Crafts, Fashion & Style</td>
-    <td>[none]</td>
-    </tr>
-  </tbody>
-</table>
+### View topics calculated for your browser
 
-At the end of the epoch (currently proposed to be one week) the Topics API generates the browser's
-top topics for the week.
+Users can view information about topics observed for their browser during the current and previous epochs.
 
--  adtech1.example is now eligible to receive the "Fitness" and "Crafts" topics, since it
-   observed them on yoga.example and also on knitting.example.
--  adtech1.example is not eligible to receive the "Travel & Transportation" topic for this user as it is not
-   present on any sites the user visited recently that are associated with that topic.
--  adtech2.example has seen the "Fitness" and "Travel & Transportation" topics, but has not seen the "Crafts" topic.
-
-The user visited diy-clothing.example, which has the "Fashion & Style" topic, but there were no calls to the
-Topics API on that site. At this point, this means the "Fashion & Style" topic would not be returned by the
-API for any caller.
-
-In week two, the user visits another site:
-
-<table>
-  <thead>
-    <tr>
-    <th style="text-align: left;"><strong>Site</strong></th>
-    <th style="text-align: left;"><strong>Topics</strong></th>
-    <th style="text-align: left;"><strong>API callers on site</strong></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-    <td>sewing.example</td>
-    <td>Crafts</td>
-    <td>adtech2.example</td>
-    </tr>
-  </tbody>
-</table>
-
-In addition, code from adtech2.example is added to diy-clothing.example:
-
-<table>
-  <thead>
-    <tr>
-    <th style="text-align: left;"><strong>Site</strong></th>
-    <th style="text-align: left;"><strong>Topics</strong></th>
-    <th style="text-align: left;"><strong>API callers on site</strong></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-    <td>diy-clothing.example</td>
-    <td>Crafts, Fashion & Style</td>
-    <td>adtech2.example</td>
-    </tr>
-  </tbody>
-</table>
-
-As well as "Fitness" and "Travel & Transportation" from week 1, this means that adtech2.example will now be able to
-receive the "Crafts" and "Fashion & Style" topic — but not until the following epoch, week 3. This ensures
-that third parties can't learn more about a user's past (in this case, an interest in fashion) than
-they could with cookies.
-
-After another two weeks, "Fitness" and "Travel & Transportation" may drop out of adtech2.example's list of eligible
-topics, if the user doesn't visit any sites with those topics that include code from
-adtech2.example.
-
-### How does the API infer topics for a site?
-
-The Topics API explainer proposes that topics are derived from a [classifier
-model](https://github.com/jkarlin/topics#:~:text=classifier) that maps website
-[hostnames](https://web.dev/same-site-same-origin/#origin) to zero or more topics.
-
-Analyzing additional information (such as full URLs or page contents) might
-allow for more relevant ads, but might also reduce privacy.
-
-The classifier model for mapping hostnames to topics would be publicly available, and the explainer
-proposes that it should be possible to view the topics for a site via browser developer tools.  The
-model is expected to evolve and improve over time and be updated periodically; the frequency of this
-is still under consideration.
-
-#### Where can I find the current classifier model?
-
-{: #manually-curated}
-
-Topics are manually curated for 10,000 top domains, and this curation is used to train the
-classifier. This list can be found in `override_list.pb.gz`, which is available at
-`chrome://topics-internals/` under the current model in the "Classifier" tab. The domain-to-topics
-associations in the list are used by the API in lieu of the output of the model itself.
-
-To run the model directly, refer to [TensorFlow's guide to running a model](https://www.tensorflow.org/lite/guide/inference#running_a_model).
-
-To inspect the `override_list.pb.gz` file:
-
-* Unpack it: `gunzip -c override_list.pb.gz > override_list.pb`
-* Use protoc to inspect: `protoc --decode_raw < override_list.pb > output.txt`
-
- A full [taxonomy of topics with IDs is available on GitHub](https://github.com/patcg-individual-drafts/topics/blob/main/taxonomy_v1.md).
-
-#### How can I provide feedback or input on the classifier model?
-
-There are [several channels](/docs/privacy-sandbox/feedback/) for
-providing feedback on the Topics proposal. For feedback on the classifier model, we recommend
-[submitting a GitHub issue](https://github.com/patcg-individual-drafts/topics/issues) or replying to
-an existing issue. For example:
-
-* [What topics taxonomy should be used long term?](https://github.com/patcg-individual-drafts/topics/issues/3)
-* [What if a site disagrees to the topics assigned?](https://github.com/patcg-individual-drafts/topics/issues/2)
-
-### How are the user's top five topics selected?
-
-The API returns one topic for each epoch, up to a maximum of three. If three are returned, this
-includes topics for the current epoch and the previous two.
-
-1. At the end of each epoch, the browser compiles a list of pages that meet the following
-   criteria:
-   - The page was visited by the user during the epoch.
-   - The page includes code that calls `document.browsingTopics()`
-   - The API was enabled (for example, not blocked by the user or via a [response
-      header](https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy)).
-
-1. The browser, on the user's device, uses the classifier model provided by the Topics API to map
-   the hostname for each page to a list of topics.
-1. The browser accumulates the list of topics.
-1. The browser generates a list of the top five topics by frequency.
-
-The  `document.browsingTopics()` method then returns a random topic from the top five  for each
-epoch, with a 5% chance that any of these may be randomly chosen from the full taxonomy of topics.
-In Chrome, users would also be able to remove individual topics, or clear their browsing history to
-reduce the number of topics returned by the API. Users may also opt-out of the API: see [User
-opt-out](#opt-out).
-
-{% Aside %}
-View information about topics observed during the current epoch [from the `chrome://topics internal` page](#view-current-topics).
-{% endAside %}
-
-### How can I debug API usage? {: #debug}
-
-The `chrome://topics-internals` page is available in Chrome on desktop if
-[you enable the Topics API](/docs/privacy-sandbox/topics/#feature-flags).
-This displays topics for the current user, topics inferred for hostnames, and technical information
-about the API implementation.
-
-{% Aside %}
-The `chrome://topics-internals` page is new! Design and functionality are still under discussion.
-
-We're currently iterating and improving the design based on developer feedback. Add your feedback at
-[bugs.chromium.org](https://bugs.chromium.org/p/chromium/issues/entry?template=Defect+report+from+developer&components=Blink%3ETopicsAPI).
-{% endAside %}
-
-#### View topics calculated for your browser {: #view-current-topics}
-
-You can view information about topics observed for your browser during the current and previous
-epochs.
-
+<figure>
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/M253GclVFDCnvPJlTSVR.png",
   alt="chrome://topics-internal page with Topics State panel selected.",
   width="800", height="697" %}
+<figcaption>chrome://topics-internal page with Topics State panel selected.
+</figcaption>
+</figure>
 
-In this example, recently visited sites included
-[topics-demo-cats.glitch.me](http://topics-demo-cats.glitch.me) and
-[cats-cats-cats-cats.glitch.me](cats-cats-cats-cats.glitch.me). This caused the Topics API to
-select `Pets` and `Cats` as two of the top topics for the current epoch. The remaining three
-topics have been [chosen at random](https://github.com/patcg-individual-drafts/topics#:~:text=random),
-since there is not enough browsing history (on sites that observe topics) to provide five topics.
+In this example, recently visited sites included [topics-demo-cats.glitch.me](http://topics-demo-cats.glitch.me/) and [cats-cats-cats-cats.glitch.me](/docs/privacy-sandbox/topics/cats-cats-cats-cats.glitch.me). This caused the Topics API to select `Pets` and `Cats` as two of the top topics for the current epoch. The remaining three topics have been [chosen at random](https://github.com/patcg-individual-drafts/topics#:~:text=random), since there is not enough browsing history (on sites that observe topics) to provide five topics.
 
-The **Observed-by context domains (hashed)** column provides the hashed value of a hostname for
-which a topic was observed.
+The **Observed-by context domains (hashed)** column provides the hashed value of a hostname for which a topic was observed.
 
-#### View topics inferred for hostnames {: #view-inferred-topics}
+### View topics inferred for hostnames
 
-You can view the topics inferred by the Topics
-[classifier model](https://github.com/patcg-individual-drafts/topics#:~:text=classifier%20model) for
-one or more hostnames.
+You can view the topics inferred by the Topics [classifier model](https://github.com/patcg-individual-drafts/topics#:~:text=classifier%20model) for one or more hostnames.
 
+<figure>
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/SOTuE2ljC55PaYll1UP1.png",
   alt="chrome://topics-internal page with Classifier panel selected.",
   width="800", height="695" %}
+  <figcaption>chrome://topics-internal page with Classifier panel selected.</figcaption>
+</figure>
 
-{% Aside %}
-The current implementation of the Topics API infers topics from hostnames only: not any other part
-of a URL.
+The current implementation of the Topics API infers topics from hostnames only: not any other part of a URL.
 
-Use hostnames only (without protocol or path) to view inferred topics from the
-`chrome://topics-internals` Classifier. `chrome://topics-internals` will display an error if you
-attempt to include a  "/" in the Host field.
-{% endAside %}
+Use hostnames only (without protocol or path) to view inferred topics from the `chrome://topics-internals` Classifier. `chrome://topics-internals` will display an error if you attempt to include a "/" in the Host field.
 
-####  View Topics API information {: #view-api-information}
+### View Topics API information
 
-Information is provided about the Topics API implementation and settings, such as the
-[taxonomy](/docs/privacy-sandbox/topics/#taxonomy) version and
-[epoch](/docs/privacy-sandbox/topics/#epoch) duration. These values
-reflect default settings for the API or parameters successfully set [from the command
-line](#feature-flags). This is handy for checking that command line flags have worked as expected:
-in the example below, `time_period_per_epoch` has been set to 15 seconds (the default is seven
-days).
+Information is provided about the Topics API implementation and settings, such as the [taxonomy](/docs/privacy-sandbox/topics/#taxonomy) version and [epoch](/docs/privacy-sandbox/topics/#epoch) duration. These values reflect default settings for the API or parameters successfully set [from the command line](/docs/privacy-sandbox/topics/#feature-flags). This is handy for checking that command-line flags have worked as expected. In the example below, `time_period_per_epoch` has been set to 15 seconds (the default is seven days).
 
+<figure>
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/7vFveJtxWgY6yB8gHnW3.png",
   alt="chrome://topics-internal page with Features and Parameters panel selected.",
   width="800", height="695" %}
+<figcaption>chrome://topics-internal page with Features and Parameters panel selected.
+</figcaption>
+</figure>
+The meaning of each parameter is explained in the table below. (You'll need to scroll it horizontally to see all the details!)
 
-The meaning of each parameter is explained in the table below. (You'll need to scroll it horizontally
-to see all the details!)
-
-The parameters correspond to flags that can be set when running Chrome from the command line. For
-example, the demo at [topics-demo.glitch.me](https://topics-demo.glitch.me/) recommends using the
-following flags:
+The parameters correspond to flags that can be set when running Chrome from the command line. For example, the demo at [topics-demo.glitch.me](https://topics-demo.glitch.me/) recommends using the following flags:
 
 ```text
 --enable-features=BrowsingTopics:time_period_per_epoch/15s,PrivacySandboxAdsAPIsOverride,PrivacySandboxSettings3,OverridePrivacySandboxSettingsLocalTesting
 ```
 
-<table>
-  <thead>
-    <tr>
-      <th style="text-align: left;"><strong>Parameter</strong></th>
-      <th style="text-align: left;"><strong>Default value</strong></th>
-      <th style="text-align: left;"><strong>Meaning</strong></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>BrowsingTopics</code></td>
-      <td>enabled</td>
-      <td>Whether the Topics API is enabled.</td>
-    </tr>
-    <tr>
-      <td><code>PrivacySandboxAdsAPIsOverride</code></td>
-      <td>enabled</td>
-      <td>Enables ads APIs: Attribution Reporting, FLEDGE, Topics, Fenced Frames.</td>
-    </tr>
-    <tr>
-      <td><code>PrivacySandboxSettings3</code></td>
-      <td>disabled</td>
-      <td>Enables the third release of the Privacy Sandbox UI settings.</td>
-    </tr>
-    <tr>
-      <td><code>OverridePrivacySandboxSettingsLocalTesting</code></td>
-      <td>enabled</td>
-      <td>If enabled, the browser no longer requires the underlying settings to be enabled for
-enabling the Privacy Sandbox features.</td>
-    </tr>
-    <tr>
-      <td><code>BrowsingTopicsBypassIPIsPubliclyRoutableCheck</code></td>
-      <td>disabled</td>
-      <td>If enabled, the check for whether the IP address is publicly routable will be
+#### Chrome flags
+
+
+Below are the relevant flags for Chrome, including their default value and descrptions:
+
+<dl>
+<dt>
+      <dd><code>BrowsingTopics</code></dd>
+      <dd><strong>Default value:</strong> enabled</dd>
+      <dd>Whether the Topics API is enabled.</dd>
+    </dt><br />
+    <dt>
+      <dd><code>PrivacySandboxAdsAPIsOverride</code></dd>
+      <dd><strong>Default value:</strong> enabled</dd>
+      <dd>Enables ads APIs: Attribution Reporting, FLEDGE, Topics, Fenced Frames.</dd>
+    </dt><br />
+    <dt>
+      <dd><code>PrivacySandboxSettings3</code></dd>
+      <dd><strong>Default value:</strong> disabled</dd>
+      <dd>Enables the third release of the Privacy Sandbox UI settings.</dd>
+    </dt><br />
+    <dt>
+      <dd><code>OverridePrivacySandboxSettingsLocalTesting</code></dd>
+      <dd><strong>Default value:</strong> enabled</dd>
+      <dd>If enabled, the browser no longer requires the underlying settings to be enabled for
+enabling the Privacy Sandbox features.</dd>
+    </dt><br />
+    <dt>
+      <dd><code>BrowsingTopicsBypassIPIsPubliclyRoutableCheck</code></dd>
+      <dd><strong>Default value:</strong> disabled</dd>
+      <dd>If enabled, the check for whether the IP address is publicly routable will be
 bypassed when determining the eligibility for a page to be included in topics
-calculation.</td>
-    </tr>
-    <tr>
-      <td><code>BrowsingTopics:number_of_epochs_to_expose</code></td>
-      <td>3</td>
-      <td>The number of epochs from where to calculate the topics to give to a requesting
-context. The browser will internally keep up to N+1 epochs.</td>
-    </tr>
-    <tr>
-      <td><code>BrowsingTopics:time_period_per_epoch</code></td>
-      <td style="white-space: nowrap;">7d-0h-0m-0s</td>
-      <td>Duration of each <a href="https://developer.chrome.com/docs/privacy-sandbox/topics/#:~:text=epoch">epoch</a>.
-      For debugging, it can be useful to set this to (say) 15 seconds, rather than the default 7 days.</td>
-    </tr>
-    <tr>
-      <td><code>BrowsingTopics:number_of_top_topics_per_epoch</code></td>
-      <td>5</td>
-      <td>Number of topics calculated per epoch.</td>
-    </tr>
-    <tr>
-      <td><code>BrowsingTopics:use_random_topic_probability_percent</code></td>
-      <td>5</td>
-      <td>Probability that an individual topic within an epoch is one returned at random from
+calculation.</dd>
+    </dt><br />
+    <dt>
+      <dd><code>BrowsingTopics:number_of_epochs_to_expose</code></dd>
+      <dd><strong>Default value:</strong> 3</dd>
+      <dd>The number of epochs from where to calculate the topics to give to a requesting
+context. The browser will internally keep up to N+1 epochs.</dd>
+    </dt><br />
+    <dt>
+      <dd><code>BrowsingTopics:time_period_per_epoch</code></dd>
+      <dd><strong>Default value:</strong> 7d-0h-0m-0s</dd>
+      <dd>Duration of each <a href="/docs/privacy-sandbox/topics/#:~:text=epoch">epoch</a>.
+      For debugging, it can be useful to set this to (say) 15 seconds, rather than the default 7 days.</dd>
+    </dt><br />
+    <dt>
+      <dd><code>BrowsingTopics:number_of_top_topics_per_epoch</code></dd>
+      <dd><strong>Default value:</strong> 5</dd>
+      <dd>Number of topics calculated per epoch.</dd>
+    </dt><br />
+    <dt>
+      <dd><code>BrowsingTopics:use_random_topic_probability_percent</code></dd>
+      <dd><strong>Default value:</strong> 5</dd>
+      <dd>Probability that an individual topic within an epoch is one returned at random from
 the entire <a
-href="https://developer.chrome.com/docs/privacy-sandbox/topics/#:~:text=taxonomy">taxonomy</a>
-of topics. The randomness is sticky to an epoch and site.</td>
-    </tr>
-    <tr>
-      <td><code>BrowsingTopics:number_of_epochs_of_observation_data_to_use_for_filtering</code></td>
-      <td>3</td>
-      <td>How many epochs of API usage data (i.e. topics observations) will be used for
-filtering the topics for a calling context.</td>
-    </tr>
-    <tr>
-      <td><code>BrowsingTopics:max_number_of_api_usage_context_domains_to_keep_per_topic</code></td>
-      <td>1000</td>
-      <td>The max number of observed-by context domains to keep for each top topic. The intent
-is to cap the in-use memory.</td>
-    </tr>
-    <tr>
-      <td><code>BrowsingTopics:max_number_of_api_usage_context_entries_to_load_per_epoch</code></td>
-      <td>100000</td>
-      <td>The max number of entries allowed to be retrieved from the database for each query
+href="/docs/privacy-sandbox/topics/#:~:text=taxonomy">taxonomy</a>
+of topics. The randomness is sticky to an epoch and site.</dd>
+    </dt><br />
+    <dt>
+      <dd><code>BrowsingTopics:number_of_epochs_of_observation_data_to_use_for_filtering</code></dd>
+      <dd><strong>Default value:</strong> 3</dd>
+      <dd>How many epochs of API usage data (i.e. topics observations) will be used for
+filtering the topics for a calling context.</dd>
+    </dt><br />
+    <dt>
+      <dd><code>BrowsingTopics:max_number_of_api_usage_context_domains_to_keep_per_topic</code></dd>
+      <dd><strong>Default value:</strong> 1000</dd>
+      <dd>The max number of observed-by context domains to keep for each top topic. The intent
+is to cap the in-use memory.</dd>
+    </dt><br />
+    <dt>
+      <dd><code>BrowsingTopics:max_number_of_api_usage_context_entries_to_load_per_epoch</code></dd>
+      <dd><strong>Default value:</strong> 100000</dd>
+      <dd>The max number of entries allowed to be retrieved from the database for each query
 for the API usage contexts. The query will occur once per epoch at topics calculation
-time. The intent is to cap the peak memory usage.</td>
-    </tr>
-    <tr>
-      <td><code>BrowsingTopics:max_number_of_api_usage_context_domains_to_store_per_page_load</code></td>
-      <td>30</td>
-      <td>The max number of API usage context domains allowed to be stored per page load.</td>
-    </tr>
-    <tr>
-      <td><code>BrowsingTopics:config_version</code></td>
-      <td>1</td>
-      <td>Encodes the Topics API configuration parameters. Each version number should only be
-mapped to one configuration set. Updating the configuration parameters without updating the `config_version` should
+time. The intent is to cap the peak memory usage.</dd>
+    </dt><br />
+    <dt>
+      <dd><code>BrowsingTopics:max_number_of_api_usage_context_domains_to_store_per_page_load</code></dd>
+      <dd><strong>Default value:</strong> 30</dd>
+      <dd>The max number of API usage context domains allowed to be stored per page load.</dd>
+    </dt><br />
+    <dt>
+      <dd><code>BrowsingTopics:config_version</code></dd>
+      <dd><strong>Default value:</strong> 1</dd>
+      <dd>Encodes the Topics API configuration parameters. Each version number should only be
+mapped to one configuration set. Updating the configuration parameters without updating the <code>config_version</code> should
 be usually fine for local testing, but in some situations could leave the browser in an
 inconsistent state and/or could let the browser crash, e.g. updating the
-`number_of_top_topics_per_epoch`.</td>
-    </tr>
-    <tr>
-      <td><code>BrowsingTopics:taxonomy_version</code></td>
-      <td>1</td>
-      <td>The <a
-href="https://developer.chrome.com/docs/privacy-sandbox/topics/#:~:text=taxonomy">taxonomy</a>
-version used by the API.</td>
-    </tr>
-  </tbody>
-</table>
+<code>number_of_top_topics_per_epoch</code>.</dd>
+    </dt><br />
+    <dt>
+      <dd><code>BrowsingTopics:taxonomy_version</code></dd>
+      <dd><strong>Default value:</strong> 1</dd>
+      <dd>The <a
+href="/docs/privacy-sandbox/topics/#:~:text=taxonomy">taxonomy</a>
+version used by the API.</dd>
+    </dt><br />
+</dl>
 
+## Next steps
 
-## Run the Topics colab to test topic inference {: #colab}
+- Learn more about what topics are and how they work. <!-- topic classification page and demo and trial links needed-->
+- Try out the demo or join an origin trial.
 
-A colab—or colaboratory—is a data analysis tool that combines code, output, and descriptive text
-into one collaborative document. You can run the [Topics Model Execution Demo colab](https://colab.research.google.com/drive/1hIVoz8bRCTpllYvads51MV7YS3zi3prn) to test topic inference
-using the Topics classifier model.
-
-1. From the **Classifier** tab of the `chrome://topics-internals` page get the directory path for the
-`.tflite` file used by the Topics API. The [override list](#manually-curated) `.pb.gz` file is in
-the same directory.
-
-{% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/txujKqPgnQdbwmTfdPZT.png",
-  alt="chrome://topics-internal page with Classifier panel selected and tflite file path highlighted.",
-  width="800", height="696" %}
-
-2. Open the [colab](https://colab.research.google.com/drive/1hIVoz8bRCTpllYvads51MV7YS3zi3prn) and
-click on the folder icon.
-
-{% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/FcBRhBOyLm2EEU1J4ET0.png",
-  alt="Topics API colab.", width="800", height="605" %}
-
-3. Click the Upload icon and upload `model.tflite` and `override_list.pb.gz` from your computer to
-the colab.
-
-{% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/8PiaYhdpKUx5hyMNcVwG.png",
-  alt="Topics API colab file upload.", width="800", height="402" %}
-
-You can then run all the colab steps, by selecting **Run all** from the **Runtime** menu.
-
-{% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/gP8GmUH2xiwbEz27LbjO.png",
-  alt="Topics API colab page, 'Run all' selected form the Runtime menu.", width="800", height="605" %}
-
-This does the following:
-
-1. Install the Python packages used by the colab.
-2. Install the `tflite` libraries and the Topics taxonomy.
-3. Define the taxonomy.
-4. Run each of the Model Execution Demo steps to show how classification works for two example
-domains.
-
-You'll see a green tick next to each step that completes successfully. (Each step can also be
-run individually,
-by clicking the Play button next to it.)
-
-For each of the domains defined, you can see the topic scores inferred by the classifier. Try
-listing different
-domains to see how they compare.
-
-{% Aside 'caution' %}
-For some domains you may notice a difference in topic inference, between the colab and the `chrome://topics-internals` Classifier.
-
-This is because the colab only uses the classifier model to infer topics, whereas
-`chrome://topics-internals` uses Chrome's Topics implementation, which uses a
-[manually-curated list of topics](#manually-curated) (rather than the classifier model) for the top
-10,000 sites.
-{% endAside %}
-
-
-## How does the Topics API address concerns with FLoC?
-
-The origin trial of [FLoC](https://github.com/WICG/floc) in 2021 received a wide range of feedback
-from ad tech and web ecosystem contributors. In particular, there were concerns that FLoC cohorts
-could be used as a fingerprinting surface to identify users, or could reveal a user's association
-with a sensitive category. There were also calls to make FLoC more transparent and understandable to
-users.
-
-The Topics API has been designed with this feedback in mind, to explore other ways to support
-interest-based advertising, with improved transparency, stronger privacy assurances and a different
-approach for sensitive categories.
-
-### Reduce fingerprinting
-
-The Topics API proposes multiple mechanisms to help ensure that it is difficult to reidentify
-significant numbers of users across sites using the Topics API alone:
-
--  The Topics taxonomy provides a set of coarse-grained topics (the first taxonomy has around
-   350 in total) which means that each topic is likely to have large numbers of users (depending on
-   the total number of users the given browser has). In fact, there is a guaranteed minimum number
-   of users per topic, because 5% of the time the returned topic is random.
--  Topics are returned at random from the user's top five.
--  5% of the time, a random topic (chosen from the full set of topics) is provided.
--  If a user frequently visits the same site (every week, for example) code running on the site
-   can only learn at most one new topic per week.
--  Different sites will receive distinct topics for the same user in the same epoch. There is
-   only a one-in-five chance that the topic returned for a user on one site matches the topic
-   returned for them on another. This makes it more difficult to determine if they're the same user.
--  Topics are updated for a user once each week, which limits the rate at which information can
-   be shared.
--  A topic will only be returned for an API caller that [previously observed the same
-   topic](#observed-topics) for the same user recently. This approach helps limit the potential for
-   entities to learn about (or share) information about user interests they have not observed
-   firsthand.
-
-{: #sensitive-topics}
-
-### Sensitive topics
-
-The Topics [taxonomy](https://github.com/jkarlin/topics/blob/main/taxonomy_v1.md) will be public and
-human-curated to avoid sensitive categories.
-
-In addition, both sites and users can [opt out](#opt-out) of the Topics API.
-
-{% Aside %}
-
-The [Topics proposal explainer states](https://github.com/jkarlin/topics#meeting-the-privacy-goals):
-
-"Third party cookies can be used to track anything about a user, from the
-exact URLs they visited, to the precise page content on those pages. This
-could include limitless sensitive material. The Topics API, on the other
-hand, is restricted to a human-curated taxonomy of topics. That's not to say
-that other things couldn't be statistically correlated with the topics in
-that taxonomy. That is possible. But when comparing the two, Topics seems
-like a clear improvement over cookies."
-
-{% endAside %}
-
-### User controls and transparency
-
-Users should be able to understand the purpose of the Topics API, recognize what is being said about
-them, know when the API is in use, and be provided with controls to enable or disable it.
-
-The API's human-readable taxonomy enables people to learn about and control the topics that may be
-suggested for them by their browser. Users can remove topics they specifically do not want the Topics
-API to share with advertisers or publishers, and there can be UX for informing the user about the API
-and how to enable or disable it. Chrome would provide information and settings for the Topics API at
-`chrome://settings/privacySandbox`. In addition, topics are not available to API callers in Incognito
-mode, and topics are cleared when browsing history is cleared.
-
-{: #opt-out}
-
-### Site opt-out
-
-Only sites that include code which calls the Topics API would be included in the browsing history
-eligible for topic frequency calculations, and API callers [only receive topics they've
-observed](#observed-topics). In other words, sites are not eligible for topic frequency calculations
-without the site or an embedded service taking action to call the API.
-
-The Topics explainer also proposes sites be allowed to block topic
-calculation for their visitors with the following
-[Permissions-Policy](https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy) header:
-
-```text
-Permissions-Policy: browsing-topics=()
-```
-
-### User opt-out
-
-The Topics API explainer [proposes](https://github.com/jkarlin/topics#:~:text=empty) that the list
-of topics returned will be empty if:
-
--  The user opts out of the Topics API via browser settings at chrome://settings/privacySandbox.
--  The user has cleared their topics (via the browser settings at
-   chrome://settings/privacySandbox) or [cleared their
-   cookies](https://support.google.com/accounts/answer/32050).
--  The browser is in Incognito mode.
-
-The explainer provides [more detail about privacy
-goals](https://github.com/jkarlin/topics#meeting-the-privacy-goals) and how the API seeks to address
-them.
-
----
-
-## Engage and share feedback
-
--  **GitHub**: Read the [proposal explainer](https://github.com/jkarlin/topics), and raise
-   questions and follow discussion in [issues on the proposal
-   repo](https://github.com/jkarlin/topics/issues).
--  **W3C**: Discuss industry use cases in the [Improving Web Advertising Business
-   Group](https://www.w3.org/community/web-adv/participants).
--  **Topics API announcements**:  join or view the mailing list at [groups.google.com/a/chromium.org/g/topics-api-announce](https://groups.google.com/a/chromium.org/g/topics-api-announce)
--  **Privacy Sandbox developer support**: Ask questions and join discussions on the
-   [Privacy Sandbox Developer Support repo](https://github.com/GoogleChromeLabs/privacy-sandbox-dev-support).
+{% Partial 'privacy-sandbox/topics-feedback.njk' %}
 
 ## Find out more
 
--  [Topics API technical explainer](https://github.com/jkarlin/topics)
--  [Digging into the Privacy Sandbox](https://web.dev/digging-into-the-privacy-sandbox)
+-   [Topics API technical explainer](https://github.com/jkarlin/topics)
+-   [Digging into the Privacy Sandbox](https://web.dev/digging-into-the-privacy-sandbox)
+
+{% Partial 'privacy-sandbox/topics-feedback.njk' %}

--- a/site/en/docs/privacy-sandbox/topics/index.md
+++ b/site/en/docs/privacy-sandbox/topics/index.md
@@ -34,9 +34,9 @@ A Privacy Sandbox Relevance and Measurement [origin trial](/blog/origin-trials/)
 
 ## Get and set topics
 
-The Topics JavaScript API has one method: `document.browsingTopics()`. It returns a promise that resolves to an array of up to three topics, one for each of the three most recent epochs, in random order. An epoch is a period of time currently set to one week.
+The Topics JavaScript API has one method: `document.browsingTopics()`, which is used to get and set Topics. It returns a promise that resolves to an array of up to three topics, one for each of the three most recent epochs, in random order. An epoch is a period of time currently set to one week.
 
-Each topic object in the array returned by `document.browsingTopics()` will have three properties:
+Each topic object in the array returned by `document.browsingTopics()` will have these properties:
 
 -   `configVersion`: a string identifying the current Topics API configuration
 -   `modelVersion`: a string identifying the machine-learning classifier used to infer topics for the site
@@ -64,7 +64,7 @@ Feature support on the current page isn't a guarantee that an API is usable: the
 ### Access topics without modifying state
 
 From Chrome 108, the `document.browsingTopics()` method can be passed an optional argument: `{skipObservation:true}`.
-This allows the method to return topics without causing the browser to record a topic observation. By default, it does.. In other words, the call will not cause the current page to be included in the weekly epoch calculation, nor will it update the list of topics observed for the caller.
+This allows the method to return topics without causing the browser to record a topic observation. By default, it does. In other words, the call will not cause the current page to be included in the weekly epoch calculation, nor will it update the list of topics observed for the caller.
 
 ### Access topics with the JavaScript API
 
@@ -95,9 +95,9 @@ This snippet of code above is provided only to show how the Topics JavaScript AP
 
 ### Use headers to access and observe topics
 
-Rather than using the Topics JavaScript API from an iframe, topics can be accessed and marked as observed by using request and response headers:
+Rather than using the Topics JavaScript API from an iframe, topics can be accessed and marked as observed by using [request](https://developer.mozilla.org/en-US/docs/Web/API/Request/headers) and [response](https://developer.mozilla.org/en-US/docs/Web/API/Response/headers) headers:
 
--   Topics can be accessed from the `Sec-Browsing-Topics` header of a `fetch()` or `XHR` request.
+-   Topics can be accessed from the `Sec-Browsing-Topics` header of a [`fetch()`](https://developer.mozilla.org/en-US/docs/Web/API/fetch) or [`XHR`](https://developer.mozilla.org/docs/Glossary/XHR_(XMLHttpRequest)) request.
 -   Topics that were provided in a request header can be marked as observed by setting an `Observe-Browsing-Topics: ?1` header on the response to the request. The browser will then use those topics (that were included in the request header) for calculating topics of interest for a user.
 
 Using request and response headers to access topics and mark them as observed can be much more performant than using the JavaScript API from an iframe. For example, the header mechanism could be used when a `fetch()` request is made to an ad server. No iframe required! For more on this technique, check out the demo page.
@@ -111,7 +111,7 @@ Using request and response headers to access topics and mark them as observed ca
 
 ## Debug your API implementation
 
-The `chrome://topics-internals` page is available in Chrome on desktop if [you enable the Topics API](#feature-flags). This displays topics for the current user, topics inferred for hostnames, and technical information about the API implementation.
+The `chrome://topics-internals` page is available in Chrome on desktop once [you enable the Topics API](#feature-flags). This displays topics for the current user, topics inferred for hostnames, and technical information about the API implementation.
 
 The `chrome://topics-internals` page is new. The design and functionality are still under discussion. We're currently iterating and improving the design based on developer feedback. Add your feedback at [bugs.chromium.org](https://bugs.chromium.org/p/chromium/issues/entry?template=Defect+report+from+developer&components=Blink%3ETopicsAPI).
 
@@ -127,7 +127,7 @@ Users can view information about topics observed for their browser during the cu
 </figcaption>
 </figure>
 
-In this example, recently visited sites included [topics-demo-cats.glitch.me](http://topics-demo-cats.glitch.me/) and [cats-cats-cats-cats.glitch.me](/docs/privacy-sandbox/topics/cats-cats-cats-cats.glitch.me). This caused the Topics API to select `Pets` and `Cats` as two of the top topics for the current epoch. The remaining three topics have been [chosen at random](https://github.com/patcg-individual-drafts/topics#:~:text=random), since there is not enough browsing history (on sites that observe topics) to provide five topics.
+In this example, recently visited sites include [topics-demo-cats.glitch.me](http://topics-demo-cats.glitch.me/) and [cats-cats-cats-cats.glitch.me](/docs/privacy-sandbox/topics/cats-cats-cats-cats.glitch.me). This causes the Topics API to select `Pets` and `Cats` as two of the top topics for the current epoch. The remaining three topics have been [chosen at random](https://github.com/patcg-individual-drafts/topics#:~:text=random), since there is not enough browsing history (on sites that observe topics) to provide five topics.
 
 The **Observed-by context domains (hashed)** column provides the hashed value of a hostname for which a topic was observed.
 

--- a/site/en/docs/privacy-sandbox/topics/index.md
+++ b/site/en/docs/privacy-sandbox/topics/index.md
@@ -147,7 +147,9 @@ Use hostnames only (without protocol or path) to view inferred topics from the `
 
 ### View Topics API information
 
-Information is provided in `chrome://topics-internals` about the Topics API implementation and settings, such as the [taxonomy](https://github.com/jkarlin/topics/blob/main/taxonomy_v1.md) version and epoch duration. These values reflect default settings for the API or parameters successfully set [from the command line](#feature-flags). This is handy for checking that command-line flags have worked as expected. In the example below, `time_period_per_epoch` has been set to 15 seconds (the default is seven days).
+You can find information about the Topics API implementation and settings, such as the [taxonomy](https://github.com/jkarlin/topics/blob/main/taxonomy_v1.md) version and epoch duration, in `chrome://topics-internals`. These values reflect default settings for the API or parameters successfully set [from the command line](#feature-flags). This may be helpful to confirm that command line flags have worked as expected.
+
+In the example below, `time_period_per_epoch` has been set to 15 seconds (the default is seven days).
 
 <figure>
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/7vFveJtxWgY6yB8gHnW3.png",

--- a/site/en/docs/privacy-sandbox/topics/index.md
+++ b/site/en/docs/privacy-sandbox/topics/index.md
@@ -26,7 +26,7 @@ Topics is not currently available by default in any version of Chrome, but you c
 
 The demo of the Topics API is at [topics-demo.glitch.me](https://topics-demo.glitch.me/). It explains how to try out and debug the API for a single user.
 
-You can also run the Topics [colab](/docs/privacy-sandbox/topics/colab/) to try out the Topics [classifier model](/docs/privacy-sandbox/topics/topic-classification/#the-classifier-model).
+You can also run the Topics [colab](/docs/privacy-sandbox/topics/colab/) to try out the Topics [classifier model](/docs/privacy-sandbox/topics/topic-classification/#classifier-model).
 
 ### Take part in a Topics origin trial
 

--- a/site/en/docs/privacy-sandbox/topics/index.md
+++ b/site/en/docs/privacy-sandbox/topics/index.md
@@ -123,9 +123,9 @@ Users can view information about topics observed for their browser during the cu
 
 <figure>
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/M253GclVFDCnvPJlTSVR.png",
-  alt="chrome://topics-internal page with Topics State panel selected.",
+  alt="The chrome://topics-internal page with Topics State panel selected.",
   width="800", height="697" %}
-<figcaption>chrome://topics-internal page with Topics State panel selected.
+<figcaption>The chrome://topics-internal page Topics State panel shows Topics IDs, random and real topic assignments, and taxonomy and model versions.
 </figcaption>
 </figure>
 
@@ -139,9 +139,9 @@ You can view the topics inferred by the Topics [classifier model](https://github
 
 <figure>
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/SOTuE2ljC55PaYll1UP1.png",
-  alt="chrome://topics-internal page with Classifier panel selected.",
+  alt="The chrome://topics-internal page with Classifier panel selected.",
   width="800", height="695" %}
-  <figcaption>chrome://topics-internal page with Classifier panel selected.</figcaption>
+  <figcaption>The chrome://topics-internal page Classifier panel shows topics selected, hosts visited, and model version and path.</figcaption>
 </figure>
 
 The current implementation of the Topics API infers topics from hostnames only: not any other part of a URL.
@@ -270,8 +270,8 @@ version used by the API.</dd>
 
 ## Next steps
 
-- Learn more about what topics are and how they work. <!-- topic classification page and demo and trial links needed-->
-- Try out the demo or join an origin trial.
+- Learn more about [what topics are and how they work](/docs/privacy-sandbox/topics/topic-classification). <!-- topic classification page and demo and trial links needed-->
+- Try out the [demo](/docs/privacy-sandbox/topics/demo) or join an [origin trial](/docs/privacy-sandbox/unified-origin-trial/).
 
 {% Partial 'privacy-sandbox/topics-feedback.njk' %}
 

--- a/site/en/docs/privacy-sandbox/topics/index.md
+++ b/site/en/docs/privacy-sandbox/topics/index.md
@@ -66,7 +66,6 @@ Feature support on the current page isn't a guarantee that an API is usable: the
 From Chrome 108, the `document.browsingTopics()` method can be passed an optional argument: `{skipObservation:true}`.
 This allows the method to return topics without causing the browser to record a topic observation. By default, it does.. In other words, the call will not cause the current page to be included in the weekly epoch calculation, nor will it update the list of topics observed for the caller.
 
-
 ### Access topics with the JavaScript API
 
 Here is a basic example of possible API usage to access topics for the current user. To keep it simple, there's no error handling.
@@ -102,7 +101,6 @@ Rather than using the Topics JavaScript API from an iframe, topics can be access
 -   Topics that were provided in a request header can be marked as observed by setting an `Observe-Browsing-Topics: ?1` header on the response to the request. The browser will then use those topics (that were included in the request header) for calculating topics of interest for a user.
 
 Using request and response headers to access topics and mark them as observed can be much more performant than using the JavaScript API from an iframe. For example, the header mechanism could be used when a `fetch()` request is made to an ad server. No iframe required! For more on this technique, check out the demo page.
-
 
 #### Notes
 
@@ -156,9 +154,10 @@ Information is provided about the Topics API implementation and settings, such a
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/7vFveJtxWgY6yB8gHnW3.png",
   alt="chrome://topics-internal page with Features and Parameters panel selected.",
   width="800", height="695" %}
-<figcaption>chrome://topics-internal page with Features and Parameters panel selected.
+<figcaption>The chrome://topics-internal Features and Parameters panel shows enabled features, time per epoch, number of epochs to use to calculate topics, taxonomy version, and other settings.
 </figcaption>
 </figure>
+
 The meaning of each parameter is explained in the table below. (You'll need to scroll it horizontally to see all the details!)
 
 The parameters correspond to flags that can be set when running Chrome from the command line. For example, the demo at [topics-demo.glitch.me](https://topics-demo.glitch.me/) recommends using the following flags:

--- a/site/en/docs/privacy-sandbox/topics/index.md
+++ b/site/en/docs/privacy-sandbox/topics/index.md
@@ -11,7 +11,6 @@ authors:
   - samdutton
 ---
 
-
 ## Implementation status
 {% Partial 'privacy-sandbox/ps-implementation-status.njk' %}
 
@@ -157,7 +156,6 @@ Information is provided in `chrome://topics-internals` about the Topics API impl
 <figcaption>The chrome://topics-internals Features and Parameters panel shows enabled features, time per epoch, number of epochs to use to calculate topics, taxonomy version, and other settings.
 </figcaption>
 </figure>
-
 
 The parameters shown in the screenshot correspond to flags that can be set when running Chrome from the command line. For example, the demo at [topics-demo.glitch.me](https://topics-demo.glitch.me/) recommends using the following flags:
 

--- a/site/en/docs/privacy-sandbox/topics/index.md
+++ b/site/en/docs/privacy-sandbox/topics/index.md
@@ -117,7 +117,7 @@ The `chrome://topics-internals` page is new. The design and functionality are st
 
 ### View topics calculated for your browser
 
-Users can view information about topics observed for their browser during the current and previous epochs.
+Users can view information about topics observed for their browser during the current and previous epochs by viewing `chrome://topics-internals`.
 
 <figure>
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/M253GclVFDCnvPJlTSVR.png",
@@ -127,13 +127,13 @@ Users can view information about topics observed for their browser during the cu
 </figcaption>
 </figure>
 
-In this example, recently visited sites include [topics-demo-cats.glitch.me](http://topics-demo-cats.glitch.me/) and [cats-cats-cats-cats.glitch.me](/docs/privacy-sandbox/topics/cats-cats-cats-cats.glitch.me). This causes the Topics API to select `Pets` and `Cats` as two of the top topics for the current epoch. The remaining three topics have been [chosen at random](https://github.com/patcg-individual-drafts/topics#:~:text=random), since there is not enough browsing history (on sites that observe topics) to provide five topics.
+In this example, recently visited sites include topics-demo-cats.glitch.me and cats-cats-cats-cats.glitch.me. This causes the Topics API to select `Pets` and `Cats` as two of the top topics for the current epoch. The remaining three topics have been [chosen at random](https://github.com/patcg-individual-drafts/topics#:~:text=random), since there is not enough browsing history (on sites that observe topics) to provide five topics.
 
 The **Observed-by context domains (hashed)** column provides the hashed value of a hostname for which a topic was observed.
 
 ### View topics inferred for hostnames
 
-You can view the topics inferred by the Topics [classifier model](https://github.com/patcg-individual-drafts/topics#:~:text=classifier%20model) for one or more hostnames.
+You can also view the topics inferred by the Topics [classifier model](https://github.com/patcg-individual-drafts/topics#:~:text=classifier%20model) for one or more hostnames in `chrome://topics-internals`.
 
 <figure>
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/SOTuE2ljC55PaYll1UP1.png",
@@ -148,7 +148,7 @@ Use hostnames only (without protocol or path) to view inferred topics from the `
 
 ### View Topics API information
 
-Information is provided about the Topics API implementation and settings, such as the [taxonomy](https://github.com/jkarlin/topics/blob/main/taxonomy_v1.md) version and epoch duration. These values reflect default settings for the API or parameters successfully set [from the command line](#feature-flags). This is handy for checking that command-line flags have worked as expected. In the example below, `time_period_per_epoch` has been set to 15 seconds (the default is seven days).
+Information is provided in `chrome://topics-internals` about the Topics API implementation and settings, such as the [taxonomy](https://github.com/jkarlin/topics/blob/main/taxonomy_v1.md) version and epoch duration. These values reflect default settings for the API or parameters successfully set [from the command line](#feature-flags). This is handy for checking that command-line flags have worked as expected. In the example below, `time_period_per_epoch` has been set to 15 seconds (the default is seven days).
 
 <figure>
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/7vFveJtxWgY6yB8gHnW3.png",
@@ -158,18 +158,16 @@ Information is provided about the Topics API implementation and settings, such a
 </figcaption>
 </figure>
 
-The meaning of each parameter is explained in the table below. (You'll need to scroll it horizontally to see all the details!)
 
-The parameters correspond to flags that can be set when running Chrome from the command line. For example, the demo at [topics-demo.glitch.me](https://topics-demo.glitch.me/) recommends using the following flags:
+The parameters shown in the screenshot correspond to flags that can be set when running Chrome from the command line. For example, the demo at [topics-demo.glitch.me](https://topics-demo.glitch.me/) recommends using the following flags:
 
 ```text
 --enable-features=BrowsingTopics:time_period_per_epoch/15s,PrivacySandboxAdsAPIsOverride,PrivacySandboxSettings3,OverridePrivacySandboxSettingsLocalTesting
 ```
 
+Each parameter, its default value, and its purpose is explained in the list below.
+
 #### Chrome flags {: #feature-flags}
-
-
-Below are the relevant flags for Chrome, including their default value and descrptions:
 
 <dl>
 <dt>

--- a/site/en/docs/privacy-sandbox/topics/index.md
+++ b/site/en/docs/privacy-sandbox/topics/index.md
@@ -113,7 +113,7 @@ Using request and response headers to access topics and mark them as observed ca
 
 ## Debug your API implementation
 
-The `chrome://topics-internals` page is available in Chrome on desktop if [you enable the Topics API](/docs/privacy-sandbox/topics/demo/#feature-flags). This displays topics for the current user, topics inferred for hostnames, and technical information about the API implementation.
+The `chrome://topics-internals` page is available in Chrome on desktop if [you enable the Topics API](#feature-flags). This displays topics for the current user, topics inferred for hostnames, and technical information about the API implementation.
 
 The `chrome://topics-internals` page is new. The design and functionality are still under discussion. We're currently iterating and improving the design based on developer feedback. Add your feedback at [bugs.chromium.org](https://bugs.chromium.org/p/chromium/issues/entry?template=Defect+report+from+developer&components=Blink%3ETopicsAPI).
 
@@ -150,7 +150,7 @@ Use hostnames only (without protocol or path) to view inferred topics from the `
 
 ### View Topics API information
 
-Information is provided about the Topics API implementation and settings, such as the [taxonomy](/docs/privacy-sandbox/topics/#taxonomy) version and epoch duration. These values reflect default settings for the API or parameters successfully set [from the command line](#feature-flags). This is handy for checking that command-line flags have worked as expected. In the example below, `time_period_per_epoch` has been set to 15 seconds (the default is seven days).
+Information is provided about the Topics API implementation and settings, such as the [taxonomy](https://github.com/jkarlin/topics/blob/main/taxonomy_v1.md) version and epoch duration. These values reflect default settings for the API or parameters successfully set [from the command line](#feature-flags). This is handy for checking that command-line flags have worked as expected. In the example below, `time_period_per_epoch` has been set to 15 seconds (the default is seven days).
 
 <figure>
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/7vFveJtxWgY6yB8gHnW3.png",
@@ -210,7 +210,7 @@ context. The browser will internally keep up to N+1 epochs.</dd>
     <dt>
       <dd><code>BrowsingTopics:time_period_per_epoch</code></dd>
       <dd><strong>Default value:</strong> 7d-0h-0m-0s</dd>
-      <dd>Duration of each <a href="/docs/privacy-sandbox/topics/overview/#:~:text=epoch">epoch</a>.
+      <dd>Duration of each epoch.
       For debugging, it can be useful to set this to (say) 15 seconds, rather than the default 7 days.</dd>
     </dt><br />
     <dt>
@@ -223,7 +223,7 @@ context. The browser will internally keep up to N+1 epochs.</dd>
       <dd><strong>Default value:</strong> 5</dd>
       <dd>Probability that an individual topic within an epoch is one returned at random from
 the entire <a
-href="/docs/privacy-sandbox/topics/#:~:text=taxonomy">taxonomy</a>
+href="https://github.com/jkarlin/topics/blob/main/taxonomy_v1.md">taxonomy</a>
 of topics. The randomness is sticky to an epoch and site.</dd>
     </dt><br />
     <dt>
@@ -263,7 +263,7 @@ inconsistent state and/or could let the browser crash, e.g. updating the
       <dd><code>BrowsingTopics:taxonomy_version</code></dd>
       <dd><strong>Default value:</strong> 1</dd>
       <dd>The <a
-href="/docs/privacy-sandbox/topics/#:~:text=taxonomy">taxonomy</a>
+href="https://github.com/jkarlin/topics/blob/main/taxonomy_v1.md">taxonomy</a>
 version used by the API.</dd>
     </dt><br />
 </dl>
@@ -271,7 +271,7 @@ version used by the API.</dd>
 ## Next steps
 
 - Learn more about [what topics are and how they work](/docs/privacy-sandbox/topics/topic-classification). <!-- topic classification page and demo and trial links needed-->
-- Try out the [demo](/docs/privacy-sandbox/topics/demo) or join an [origin trial](/docs/privacy-sandbox/unified-origin-trial/).
+- Try out the [demo](/docs/privacy-sandbox/topics/demo) or join an [origin trial](/docs/web-platform/origin-trials/).
 
 {% Partial 'privacy-sandbox/topics-feedback.njk' %}
 

--- a/site/en/docs/privacy-sandbox/topics/index.md
+++ b/site/en/docs/privacy-sandbox/topics/index.md
@@ -29,7 +29,7 @@ You can also run the Topics [colab](/docs/privacy-sandbox/topics/colab/) to try 
 
 ### Take part in a Topics origin trial
 
-A Privacy Sandbox Relevance and Measurement [origin trial](/blog/origin-trials/) has been made available in Chrome Beta 101.0.4951.26 and above on desktop for the Topics, [FLEDGE](/docs/privacy-sandbox/fledge/), and [Attribution Reporting](/docs/privacy-sandbox/attribution-reporting/) APIs.
+A Privacy Sandbox Relevance and Measurement [origin trial](/docs/privacy-sandbox/unified-origin-trial/) has been made available in Chrome Beta 101.0.4951.26 and above on desktop for the Topics, [FLEDGE](/docs/privacy-sandbox/fledge/), and [Attribution Reporting](/docs/privacy-sandbox/attribution-reporting/) APIs.
 
 ## Get and set topics
 

--- a/site/en/docs/privacy-sandbox/topics/latest/index.md
+++ b/site/en/docs/privacy-sandbox/topics/latest/index.md
@@ -1,6 +1,6 @@
 ---
 layout: 'layouts/doc-post.njk'
-title: 'Topics API: latest updates'
+title: 'Topics API latest updates'
 subhead: >
  Updates and enhancements to the design and implementation of the API.
 description: >

--- a/site/en/docs/privacy-sandbox/topics/overview/index.md
+++ b/site/en/docs/privacy-sandbox/topics/overview/index.md
@@ -37,6 +37,8 @@ In the past, third-party cookies and other mechanisms have been used to track us
 
 With the Topics API, the browser observes and records topics that appear to be of interest to the user, based on their browsing activity. This information is recorded on the user's device. The Topics API can then give API callers (such as ad tech platforms) access to a user's topics of interest, but without revealing additional information about the user's browsing activity.
 
+{: #epoch}
+
 Of course the Topics API must ensure that the topics of interest it provides are kept up to date. The browser infers topics for a user based on their browsing activity during a period of time known as an *epoch*, currently one week. The topic selected for each epoch is randomly selected from the user's top five topics for that time period. To further enhance privacy and ensure that all topics may be represented, there is a 5% chance the topic is randomly selected from all possible topics in a [taxonomy](https://github.com/jkarlin/topics/blob/main/taxonomy_v1.md) of interests.
 
 The Topics API has three main tasks:

--- a/site/en/docs/privacy-sandbox/topics/overview/index.md
+++ b/site/en/docs/privacy-sandbox/topics/overview/index.md
@@ -2,9 +2,9 @@
 layout: 'layouts/doc-post.njk'
 title: 'Topics API: overview'
 subhead: >
-  Learn about the Topics API; why it was developed and how to prepare. 
+  Learn about this privacy-preserving API to enable interest-based advertising without third-party tracking.
 description: >
-  Learn about the Topics API; why it was developed and how to prepare. 
+  Learn about this privacy-preserving API to enable interest-based advertising without third-party tracking.
 date: 2022-01-25
 updated: 2023-03-08
 authors:

--- a/site/en/docs/privacy-sandbox/topics/overview/index.md
+++ b/site/en/docs/privacy-sandbox/topics/overview/index.md
@@ -71,11 +71,11 @@ The Topics API lifecycle: [view a larger version](https://wd.imgix.net/image/80m
 
 ### API callers only receive topics they've observed
 
-A design goal of the Topics API is to enable interest-based advertising without the sharing of information to more entities than is currently possible with third-party cookies. The Topics API is designed so topics can only be returned for API callers that have already observed them, within a limited timeframe.
+A design goal of the Topics API is to enable interest-based advertising without the sharing of information to more entities than is currently possible with third-party cookies. The Topics API is designed so topics can only be returned for API callers that have already observed them, within a limited timeframe. An API caller is said to have observed a topic for a user if it has called the `document.browsingTopics()` method in code included on a site that the Topics API has mapped to that topic.
 
-The API provides only topics that have been observed by the caller within the most recent three [epochs](/docs/privacy-sandbox/topics/#epoch). This helps stop information about the user from being shared with more entities than the technologies the API is replacing (including third-party cookies).
+The API provides only topics that have been observed by the caller within the most recent three epochs. This helps stop information about the user from being shared with more entities than the technologies the API is replacing (including third-party cookies).
 
-The number of topics returned  depends on the number of topics that the [API caller](/docs/privacy-sandbox/topics/#caller) has previously observed, and the number of topics that the user has available (such as the number of weeks of data accumulated). Anywhere from zero to three topics may be returned, as one topic can be indicated for each of the three recent epochs
+The number of topics returned  depends on the number of topics that the API caller has previously observed, and the number of topics that the user has available (such as the number of weeks of data accumulated). Anywhere from zero to three topics may be returned, as one topic can be indicated for each of the three recent epochs
 
 For more information on how to use and test the Topics API, refer to the [Topics API developer guide](/docs/privacy-sandbox/topics/).
 
@@ -91,7 +91,7 @@ The Topics API proposes multiple mechanisms to help ensure that it is difficult 
 - If a user frequently visits the same site (every week, for example) code running on the site can only learn at most one new topic per week.
 - Different sites will receive different topics for the same user in the same epoch. There is only a one-in-five chance that the topic returned for a user on one site matches the topic returned for them on another. This makes it more difficult to determine if they're the same user.
 - Topics are updated for a user once each week, which limits the rate at which information can be shared. In other words, the API helps mitigate against fingerprinting by not providing topics updates too frequently.
-- A topic will only be returned for an API caller that [previously observed the same topic](/docs/privacy-sandbox/topics/#observed-topics) for the same user recently. This approach helps limit the potential for entities to learn about (or share) information about user interests they have not observed firsthand.
+- A topic will only be returned for an API caller that previously observed the same topic for the same user recently. This approach helps limit the potential for entities to learn about (or share) information about user interests they have not observed firsthand.
 
 {% endDetails %}
 

--- a/site/en/docs/privacy-sandbox/topics/overview/index.md
+++ b/site/en/docs/privacy-sandbox/topics/overview/index.md
@@ -1,0 +1,113 @@
+---
+layout: 'layouts/doc-post.njk'
+title: 'Topics API: overview'
+subhead: >
+  Learn about the Topics API; why it was developed and how to prepare. 
+description: >
+  Learn about the Topics API; why it was developed and how to prepare. 
+date: 2022-01-25
+updated: 2023-03-08
+authors:
+  - samdutton
+---
+
+
+## Implementation status
+
+{% Partial 'privacy-sandbox/ps-implementation-status.njk' %}
+
+## What is the Topics API?
+
+The Topics API is a [Privacy Sandbox](/docs/privacy-sandbox/overview/) mechanism designed to preserve privacy while allowing a browser to share information with third parties about a user's interests. It enables interest-based advertising (IBA) without having to resort to tracking the sites a user visits. 
+Interest-based advertising (IBA) is a key concept to understand the Topics API.
+
+IBA is a form of personalized advertising in which an ad is selected for a user based on their interests, inferred from the sites they've recently visited. This is different from contextual advertising, which aims to match ads to the content on the page the user is visiting.
+
+Interest-based advertising can help both advertisers (sites that want to advertise their products or services)  and publishers (sites that use ads to help monetize their content):
+
+- IBA can help advertisers reach potential customers.
+- IBA can supplement contextual information to help publishers use advertising to fund websites.
+
+The Topics API provides a new form of interest-based advertising using topics (categories of interest) that are assigned to a browser based on recent user activity. These topics can supplement contextual information to help select appropriate advertisements.
+
+
+## How it works
+
+In the past, third-party cookies and other mechanisms have been used to track user browsing behavior across sites to infer topics of interest. These mechanisms are being phased out.
+
+With the Topics API, the browser observes and records topics that appear to be of interest to the user, based on their browsing activity. This information is recorded on the user's device. The Topics API can then give API callers (such as ad tech platforms) access to a user's topics of interest, but without revealing additional information about the user's browsing activity.
+
+Of course the Topics API must ensure that the topics of interest it provides are kept up to date. The browser infers topics for a user based on their browsing activity during a period of time known as an *epoch*, currently one week. The topic selected for each epoch is randomly selected from the user's top five topics for that time period. To further enhance privacy and ensure that all topics may be represented, there is a 5% chance the topic is randomly selected from all possible topics in a [taxonomy](https://github.com/jkarlin/topics/blob/main/taxonomy_v1.md) of interests.
+
+The Topics API has three main tasks:
+
+-   Map browser activity to topics of interest. With the current design of the Topics API, topics are inferred from the hostnames of pages the user visits. For example, the topic inferred for a website about aquariums might be [/Pets & Animals/Pets/Fish & Aquaria](https://github.com/patcg-individual-drafts/topics/blob/main/taxonomy_v1.md#:~:text=/Pets%20%26%20Animals/Pets/Fish%20%26%20Aquaria).
+-   Calculate the top topics for a user based on their recent browsing activity.
+-   Provide mechanisms to access topics currently of interest to the user, to help select the appropriate ads.
+
+The Topics API provides human-readable, easily understandable topics, so it's possible to provide meaningful controls to users.
+
+### How topics are curated and selected
+
+Topics are selected from a [taxonomy](https://github.com/jkarlin/topics/blob/main/taxonomy_v1.md), with hierarchical categories such as [/Arts & Entertainment/Music & Audio/Soul & R&B](https://github.com/patcg-individual-drafts/topics/blob/main/taxonomy_v1.md#:~:text=/Arts%20%26%20Entertainment/Music%20%26%20Audio/Soul%20%26%20R%26B) and [/Business & Industrial/Agriculture & Forestry](https://github.com/patcg-individual-drafts/topics/blob/main/taxonomy_v1.md#:~:text=106-,/Business%20%26%20Industrial/Agriculture%20%26%20Forestry,-107). These topics have been curated by Chrome for initial testing, but with the goal that the taxonomy becomes a resource maintained by trusted ecosystem contributors. The taxonomy needs to be small enough that many users' browsers will be associated with each topic. Currently the number of topics is 349, but we expect the final number of topics to be between a few hundred and a few thousand.
+
+To avoid sensitive categories, topics must be public, human-curated, and kept updated. The initial taxonomy proposed for testing by Chrome has been human-curated [to exclude categories generally considered sensitive](https://github.com/patcg-individual-drafts/topics#meeting-the-privacy-goals:~:text=of%20a%20page.-,The,-topics%20revealed%20by), such as ethnicity or sexual orientation.
+
+For 10,000 top sites, the Topics API implementation in Chrome uses a manually curated, publicly available [override list](/docs/privacy-sandbox/topics/topic-classification/#the-classifier-model) to map hostnames to topics. For other sites, the Topics API uses a [machine learning](https://royalsociety.org/topics-policy/projects/machine-learning/what-is-machine-learning-infographic/) model to infer topics from hostnames. 
+
+Chrome's implementation of the Topics API downloads a [TensorFlow Lite](https://www.tensorflow.org/lite/guide) file representing the model, so it can be used locally on the user's device. 
+
+You can access the TensorFlow Lite model file, and the topics inferred for hostnames, from `chrome://topics`.
+
+The diagram below outlines a simplified example to demonstrate how the Topics API might help an ad tech platform select an appropriate ad. The example assumes that the user's browser already has a model to map website hostnames to topics.
+
+{% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/u9e1VvzblNVHCfyk1hRY.png",
+  alt="Diagram showing the stages in the Topics API lifecycle, from a user visiting websites to an ad
+  being displayed.", width="800", height="275" %}
+
+The Topics API lifecycle: [view a larger version](https://wd.imgix.net/image/80mq7dk16vVEg8BBhsVe42n6zn82/u9e1VvzblNVHCfyk1hRY.png?auto=format&w=1600)
+
+### API callers only receive topics they've observed
+
+A design goal of the Topics API is to enable interest-based advertising without the sharing of information to more entities than is currently possible with third-party cookies. The Topics API is designed so topics can only be returned for API callers that have already observed them, within a limited timeframe.
+
+The API provides only topics that have been observed by the caller within the most recent three [epochs](/docs/privacy-sandbox/topics/#epoch). This helps stop information about the user from being shared with more entities than the technologies the API is replacing (including third-party cookies).
+
+The number of topics returned  depends on the number of topics that the [API caller](/docs/privacy-sandbox/topics/#caller) has previously observed, and the number of topics that the user has available (such as the number of weeks of data accumulated). Anywhere from zero to three topics may be returned, as one topic can be indicated for each of the three recent epochs
+
+For more information on how to use and test the Topics API, refer to the [Topics API developer guide](/docs/privacy-sandbox/topics/).
+
+{% Details %}
+{% DetailsSummary %}
+#### How the API reduces fingerprinting
+{% endDetailsSummary %}
+
+The Topics API proposes multiple mechanisms to help ensure that it is difficult to re-identify significant numbers of users *across* sites using the Topics API alone:
+
+- Because the Topics taxonomy provides  coarse-grained topics, each topic is expected to have large numbers of users (depending on the total number of users the given browser has). In fact, there is a guaranteed minimum number of users per topic, because 5% of the time the returned topic is random.
+- Topics are returned at random from the user's top five.
+- If a user frequently visits the same site (every week, for example) code running on the site can only learn at most one new topic per week.
+- Different sites will receive different topics for the same user in the same epoch. There is only a one-in-five chance that the topic returned for a user on one site matches the topic returned for them on another. This makes it more difficult to determine if they're the same user.
+- Topics are updated for a user once each week, which limits the rate at which information can be shared. In other words, the API helps mitigate against fingerprinting by not providing topics updates too frequently.
+- A topic will only be returned for an API caller that [previously observed the same topic](/docs/privacy-sandbox/topics/#observed-topics) for the same user recently. This approach helps limit the potential for entities to learn about (or share) information about user interests they have not observed firsthand.
+
+{% endDetails %}
+
+{% Details %}
+{% DetailsSummary %}
+#### How the API addressed concerns with FLoC
+{% endDetailsSummary %}
+
+The origin trial of [FLoC](https://github.com/WICG/floc) in 2021 received a wide range of feedback from ad tech and web ecosystem contributors. In particular, there were concerns that FLoC cohorts could be used as a fingerprinting surface to identify users, or could reveal a user's association with a sensitive category. There were also calls to make FLoC more transparent and understandable to users.
+
+The Topics API has been designed with this feedback in mind, to explore other ways to support interest-based advertising, with improved transparency, stronger privacy assurances and a different approach for sensitive categories.
+{% endDetails %}
+
+## Next steps
+
+Learn more about [what topics are and how they work](/docs/privacy-sandbox/topics/topic-classification/).
+
+If you're an ad tech developer, [experiment and participate](/docs/privacy-sandbox/topics-experiment/) with the Topics API. Read the developer guide for more in-depth resources.
+
+{% Partial 'privacy-sandbox/topics-feedback.njk' %}
+

--- a/site/en/docs/privacy-sandbox/topics/overview/index.md
+++ b/site/en/docs/privacy-sandbox/topics/overview/index.md
@@ -18,10 +18,9 @@ authors:
 
 ## What is the Topics API?
 
-The Topics API is a [Privacy Sandbox](/docs/privacy-sandbox/overview/) mechanism designed to preserve privacy while allowing a browser to share information with third parties about a user's interests. It enables interest-based advertising (IBA) without having to resort to tracking the sites a user visits. 
-Interest-based advertising (IBA) is a key concept to understand the Topics API.
+The Topics API is a [Privacy Sandbox](/docs/privacy-sandbox/overview/) mechanism designed to preserve privacy while allowing a browser to share information with third parties about a user's interests. It enables interest-based advertising (IBA) without having to resort to tracking the sites a user visits.
 
-IBA is a form of personalized advertising in which an ad is selected for a user based on their interests, inferred from the sites they've recently visited. This is different from contextual advertising, which aims to match ads to the content on the page the user is visiting.
+Interest-based advertising is a key concept in the Topics API. It is a form of personalized advertising in which an ad is selected for a user based on their interests, inferred from the sites they've recently visited. This is different from contextual advertising, which aims to match ads to the content on the page the user is visiting.
 
 Interest-based advertising can help both advertisers (sites that want to advertise their products or services)  and publishers (sites that use ads to help monetize their content):
 
@@ -59,7 +58,7 @@ For 10,000 top sites, the Topics API implementation in Chrome uses a manually cu
 
 Chrome's implementation of the Topics API downloads a [TensorFlow Lite](https://www.tensorflow.org/lite/guide) file representing the model so it can be used locally on the user's device. 
 
-You can access the TensorFlow Lite model file and the topics inferred for hostnames from `chrome://topics`.
+You can access the TensorFlow Lite model file and the topics inferred for hostnames from `chrome://topics-internals`.
 
 The diagram below shows a simplified example to demonstrate how the Topics API might help an ad tech platform select an appropriate ad. The example assumes that the user's browser already has a model to map website hostnames to topics.
 
@@ -68,7 +67,7 @@ The diagram below shows a simplified example to demonstrate how the Topics API m
   alt="Diagram showing the stages in the Topics API lifecycle, from a user visiting websites to an ad
   being displayed.", width="800", height="275" %}
 <figcaption>
-The Topics API lifecycle diagram walks through the stages of the API actions from a high-level point of view. [View a larger version](https://wd.imgix.net/image/80mq7dk16vVEg8BBhsVe42n6zn82/u9e1VvzblNVHCfyk1hRY.png?auto=format&w=1600)
+The Topics API lifecycle diagram walks through the stages of the API actions from a high-level point of view. <a href="https://wd.imgix.net/image/80mq7dk16vVEg8BBhsVe42n6zn82/u9e1VvzblNVHCfyk1hRY.png?auto=format&w=1600">View a larger version</a>.
 </figcaption>
 </figure>
 

--- a/site/en/docs/privacy-sandbox/topics/overview/index.md
+++ b/site/en/docs/privacy-sandbox/topics/overview/index.md
@@ -11,7 +11,6 @@ authors:
   - samdutton
 ---
 
-
 ## Implementation status
 
 {% Partial 'privacy-sandbox/ps-implementation-status.njk' %}
@@ -28,7 +27,6 @@ Interest-based advertising can help both advertisers (sites that want to adverti
 - IBA can supplement contextual information to help publishers use advertising to fund websites.
 
 The Topics API provides a new form of interest-based advertising using topics (categories of interest) that are assigned to a browser based on recent user activity. These topics can supplement contextual information to help select appropriate advertisements.
-
 
 ## How it works
 
@@ -88,7 +86,7 @@ For more information on how to use and test the Topics API, refer to the [Topics
 
 The Topics API provides multiple mechanisms to help ensure that it is difficult to re-identify significant numbers of users *across* sites using the Topics API alone:
 
-- Because the Topics taxonomy provides  coarsely grained topics, each topic is expected to have large numbers of users. In fact, there is a guaranteed minimum number of users per topic, because 5% of the time the returned topic is random.
+- Because the Topics taxonomy provides coarsely grained topics, each topic is expected to have large numbers of users. In fact, there is a guaranteed minimum number of users per topic, because 5% of the time the returned topic is random.
 - Topics are returned at random from the user's top five.
 - If a user frequently visits the same site (every week, for example) code running on the site can learn one new topic per week, at most.
 - Different sites will receive different topics for the same user in the same epoch. There is only a one-in-five chance that the topic returned for a user on one site matches the topic returned for them on another. This makes it more difficult to determine if they're the same user.

--- a/site/en/docs/privacy-sandbox/topics/overview/index.md
+++ b/site/en/docs/privacy-sandbox/topics/overview/index.md
@@ -1,6 +1,6 @@
 ---
 layout: 'layouts/doc-post.njk'
-title: 'Topics API: overview'
+title: 'Topics API overview'
 subhead: >
   Learn about this privacy-preserving API to enable interest-based advertising without third-party tracking.
 description: >

--- a/site/en/docs/privacy-sandbox/topics/overview/index.md
+++ b/site/en/docs/privacy-sandbox/topics/overview/index.md
@@ -51,29 +51,32 @@ The Topics API provides human-readable, easily understandable topics, so it's po
 
 ### How topics are curated and selected
 
-Topics are selected from a [taxonomy](https://github.com/jkarlin/topics/blob/main/taxonomy_v1.md), with hierarchical categories such as [/Arts & Entertainment/Music & Audio/Soul & R&B](https://github.com/patcg-individual-drafts/topics/blob/main/taxonomy_v1.md#:~:text=/Arts%20%26%20Entertainment/Music%20%26%20Audio/Soul%20%26%20R%26B) and [/Business & Industrial/Agriculture & Forestry](https://github.com/patcg-individual-drafts/topics/blob/main/taxonomy_v1.md#:~:text=106-,/Business%20%26%20Industrial/Agriculture%20%26%20Forestry,-107). These topics have been curated by Chrome for initial testing, but with the goal that the taxonomy becomes a resource maintained by trusted ecosystem contributors. The taxonomy needs to be small enough that many users' browsers will be associated with each topic. Currently the number of topics is 349, but we expect the final number of topics to be between a few hundred and a few thousand.
+Topics are selected from a [taxonomy](https://github.com/jkarlin/topics/blob/main/taxonomy_v1.md) consisting of hierarchical categories such as [/Arts & Entertainment/Music & Audio/Soul & R&B](https://github.com/patcg-individual-drafts/topics/blob/main/taxonomy_v1.md#:~:text=/Arts%20%26%20Entertainment/Music%20%26%20Audio/Soul%20%26%20R%26B) and [/Business & Industrial/Agriculture & Forestry](https://github.com/patcg-individual-drafts/topics/blob/main/taxonomy_v1.md#:~:text=106-,/Business%20%26%20Industrial/Agriculture%20%26%20Forestry,-107). These topics have been curated by Chrome for initial testing, but with the goal that the taxonomy becomes a resource maintained by trusted ecosystem contributors. The taxonomy needs to be small enough that many users' browsers will be associated with each topic. Currently the number of topics is 349, but we expect the final number of topics to be between a few hundred and a few thousand.
 
-To avoid sensitive categories, topics must be public, human-curated, and kept updated. The initial taxonomy proposed for testing by Chrome has been human-curated [to exclude categories generally considered sensitive](https://github.com/patcg-individual-drafts/topics#meeting-the-privacy-goals:~:text=of%20a%20page.-,The,-topics%20revealed%20by), such as ethnicity or sexual orientation.
+To avoid sensitive categories, topics must be public, human-curated, and remain up to date. The initial taxonomy proposed for testing by Chrome has been human-curated [to exclude categories generally considered sensitive](https://github.com/patcg-individual-drafts/topics#meeting-the-privacy-goals:~:text=of%20a%20page.-,The,-topics%20revealed%20by), such as ethnicity or sexual orientation.
 
-For 10,000 top sites, the Topics API implementation in Chrome uses a manually curated, publicly available [override list](/docs/privacy-sandbox/topics/topic-classification/#the-classifier-model) to map hostnames to topics. For other sites, the Topics API uses a [machine learning](https://royalsociety.org/topics-policy/projects/machine-learning/what-is-machine-learning-infographic/) model to infer topics from hostnames. 
+For 10,000 top sites, the Topics API implementation in Chrome uses a manually curated, publicly available [override list](/docs/privacy-sandbox/topics/topic-classification/#classifier-model) to map hostnames to topics. For other sites, the Topics API uses a [machine learning](https://royalsociety.org/topics-policy/projects/machine-learning/what-is-machine-learning-infographic/) model to infer topics from hostnames. 
 
-Chrome's implementation of the Topics API downloads a [TensorFlow Lite](https://www.tensorflow.org/lite/guide) file representing the model, so it can be used locally on the user's device. 
+Chrome's implementation of the Topics API downloads a [TensorFlow Lite](https://www.tensorflow.org/lite/guide) file representing the model so it can be used locally on the user's device. 
 
-You can access the TensorFlow Lite model file, and the topics inferred for hostnames, from `chrome://topics`.
+You can access the TensorFlow Lite model file and the topics inferred for hostnames from `chrome://topics`.
 
-The diagram below outlines a simplified example to demonstrate how the Topics API might help an ad tech platform select an appropriate ad. The example assumes that the user's browser already has a model to map website hostnames to topics.
+The diagram below shows a simplified example to demonstrate how the Topics API might help an ad tech platform select an appropriate ad. The example assumes that the user's browser already has a model to map website hostnames to topics.
 
+<figure>
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/u9e1VvzblNVHCfyk1hRY.png",
   alt="Diagram showing the stages in the Topics API lifecycle, from a user visiting websites to an ad
   being displayed.", width="800", height="275" %}
-
-The Topics API lifecycle: [view a larger version](https://wd.imgix.net/image/80mq7dk16vVEg8BBhsVe42n6zn82/u9e1VvzblNVHCfyk1hRY.png?auto=format&w=1600)
+<figcaption>
+The Topics API lifecycle diagram walks through the stages of the API actions from a high-level point of view. [View a larger version](https://wd.imgix.net/image/80mq7dk16vVEg8BBhsVe42n6zn82/u9e1VvzblNVHCfyk1hRY.png?auto=format&w=1600)
+</figcaption>
+</figure>
 
 ### API callers only receive topics they've observed
 
-A design goal of the Topics API is to enable interest-based advertising without the sharing of information to more entities than is currently possible with third-party cookies. The Topics API is designed so topics can only be returned for API callers that have already observed them, within a limited timeframe. An API caller is said to have observed a topic for a user if it has called the `document.browsingTopics()` method in code included on a site that the Topics API has mapped to that topic.
+A design goal of the Topics API is to enable interest-based advertising without sharing information with more entities than is currently possible with third-party cookies. The Topics API is designed so topics can only be returned for API callers that have already observed them, within a limited timeframe. An API caller is said to have observed a topic for a user if it has called the `document.browsingTopics()` method in code included on a site that the Topics API has mapped to that topic.
 
-The API provides only topics that have been observed by the caller within the most recent three epochs. This helps stop information about the user from being shared with more entities than the technologies the API is replacing (including third-party cookies).
+The API returns only topics that have been observed by the caller within the most recent three epochs. This helps stop information about the user from being shared with more entities than the technologies the API is replacing (including third-party cookies).
 
 The number of topics returned  depends on the number of topics that the API caller has previously observed, and the number of topics that the user has available (such as the number of weeks of data accumulated). Anywhere from zero to three topics may be returned, as one topic can be indicated for each of the three recent epochs
 
@@ -84,13 +87,13 @@ For more information on how to use and test the Topics API, refer to the [Topics
 #### How the API reduces fingerprinting
 {% endDetailsSummary %}
 
-The Topics API proposes multiple mechanisms to help ensure that it is difficult to re-identify significant numbers of users *across* sites using the Topics API alone:
+The Topics API provides multiple mechanisms to help ensure that it is difficult to re-identify significant numbers of users *across* sites using the Topics API alone:
 
-- Because the Topics taxonomy provides  coarse-grained topics, each topic is expected to have large numbers of users (depending on the total number of users the given browser has). In fact, there is a guaranteed minimum number of users per topic, because 5% of the time the returned topic is random.
+- Because the Topics taxonomy provides  coarsely grained topics, each topic is expected to have large numbers of users. In fact, there is a guaranteed minimum number of users per topic, because 5% of the time the returned topic is random.
 - Topics are returned at random from the user's top five.
-- If a user frequently visits the same site (every week, for example) code running on the site can only learn at most one new topic per week.
+- If a user frequently visits the same site (every week, for example) code running on the site can learn one new topic per week, at most.
 - Different sites will receive different topics for the same user in the same epoch. There is only a one-in-five chance that the topic returned for a user on one site matches the topic returned for them on another. This makes it more difficult to determine if they're the same user.
-- Topics are updated for a user once each week, which limits the rate at which information can be shared. In other words, the API helps mitigate against fingerprinting by not providing topics updates too frequently.
+- Topics are updated for a user once each week, which limits the rate at which information can be shared. In other words, the API helps mitigate against fingerprinting by not providing topic updates too frequently.
 - A topic will only be returned for an API caller that previously observed the same topic for the same user recently. This approach helps limit the potential for entities to learn about (or share) information about user interests they have not observed firsthand.
 
 {% endDetails %}
@@ -102,14 +105,14 @@ The Topics API proposes multiple mechanisms to help ensure that it is difficult 
 
 The origin trial of [FLoC](https://github.com/WICG/floc) in 2021 received a wide range of feedback from ad tech and web ecosystem contributors. In particular, there were concerns that FLoC cohorts could be used as a fingerprinting surface to identify users, or could reveal a user's association with a sensitive category. There were also calls to make FLoC more transparent and understandable to users.
 
-The Topics API has been designed with this feedback in mind, to explore other ways to support interest-based advertising, with improved transparency, stronger privacy assurances and a different approach for sensitive categories.
+The Topics API has been designed with this feedback in mind. It aims to explore other ways to support interest-based advertising, with improved transparency, stronger privacy assurances and a different approach for sensitive categories.
 {% endDetails %}
 
 ## Next steps
 
 Learn more about [what topics are and how they work](/docs/privacy-sandbox/topics/topic-classification/).
 
-If you're an ad tech developer, [experiment and participate](/docs/privacy-sandbox/topics-experiment/) with the Topics API. Read the developer guide for more in-depth resources.
+If you're an ad tech developer, [experiment and participate](/docs/privacy-sandbox/topics-experiment/) with the Topics API. Read the [developer guide](/docs/privacy-sandbox/topics) for more in-depth resources.
 
 {% Partial 'privacy-sandbox/topics-feedback.njk' %}
 

--- a/site/en/docs/privacy-sandbox/topics/topic-classification/index.md
+++ b/site/en/docs/privacy-sandbox/topics/topic-classification/index.md
@@ -22,15 +22,17 @@ Topics are a signal to help ad tech platforms select relevant ads. Unlike third-
 
 The Topics API allows third parties, such as ad tech platforms, to observe and then access topics of interest to a user. For example, the API might suggest the topic "Fiber & Textile Arts" for a user who visits the website `knitting.example`. 
 
-The [list of topics used by the Topics API](https://github.com/patcg-individual-drafts/topics/blob/main/taxonomy_v1.md) is public, human-curated, human-readable, and designed to avoid sensitive categories. This is the current list, which will expand over time. This type of list is known as a _taxonomy_. The topics can be high-level or more specific. For example, `Food & Drink` is a broad category, with a subcategory of `Cooking & Recipes`. Subcategories may be further divided into additional subcategories.
+The list of topics used by the Topics API is public, human-curated, human-readable, and designed to avoid sensitive categories. This is [the current list](https://github.com/patcg-individual-drafts/topics/blob/main/taxonomy_v1.md), which will expand over time. The list is structured as a _taxonomy_. The topics can be high-level or more specific. For example, `Food & Drink` is a broad category, with a subcategory of `Cooking & Recipes`. Subcategories may be further divided into additional subcategories.
 
-A taxonomy of topics needs to make a tradeoff between utility and privacy. If topics are too specific, they could be used to identify an individual user. If they are too general, they aren't useful for selecting advertising or other content.
+Such a taxonomy of topics needs to make a tradeoff between utility and privacy. If topics are too specific, they could be used to identify an individual user. If they are too general, they aren't useful for selecting advertising or other content.
 
 The topics taxonomy is constructed with two underlying requirements in mind:
+
 - Support interest-based advertising
 - Keep users safe and protect their privacy
 
 This suggests several questions. For example:
+
 - What's the best way for the API to infer topics of interest for a user, based on their browsing activity, while preserving the user's privacy?
 - How could the taxonomy be structured to make it more useful?
 - What specific items should the taxonomy include?
@@ -40,9 +42,9 @@ This suggests several questions. For example:
 Topics are derived from a [classifier model](https://github.com/jkarlin/topics#:~:text=classifier) that maps website [hostnames](https://web.dev/same-site-same-origin/#origin) to zero or more topics.
 Analyzing additional information (such as full URLs or page contents) might allow for more relevant ads, but might also reduce privacy.
 
-The classifier model for mapping hostnames to topics is publicly available, and the [explainer](https://github.com/patcg-individual-drafts/topics) proposes that it should be possible to view the topics for a site via browser developer tools. The model is expected to evolve and improve over time and be updated periodically; the frequency of this is still under consideration.
+The classifier model for mapping hostnames to topics is publicly available, and as the [explainer](https://github.com/patcg-individual-drafts/topics) notes, it is possible to view the topics for a site via browser developer tools. The model is expected to evolve and improve over time and be updated periodically; the frequency of this is still under consideration.
 
-Only sites that include code that calls the Topics API are included in the browsing history eligible for topic frequency calculations, and API callers only receive topics they've observed. In other words, sites are not eligible for topic frequency calculations without the site or an embedded service taking action to call the API.
+Only sites that include code that calls the Topics API are included in the browsing history eligible for topic frequency calculations, and API callers only receive topics they've observed. In other words, sites are not eligible for topic frequency calculations without the site or an embedded service callingß the API.
 
 {% Aside 'key-term' %}
 
@@ -70,7 +72,7 @@ Permissions-Policy: browsing-topics=()
 
 ## The classifier model {: #classifier-model}
 
-Topics are manually curated for 10,000 top domains, and this curation is used to train the classifier. This list can be found in `override_list.pb.gz`, which is available at `chrome://topics-internals/` under the current model in the "Classifier" tab. The domain-to-topics associations in the list are used by the API in lieu of the output of the model itself.
+Topics are manually curated for 10,000 top domains, and this curation is used to train the classifier. This list can be found in `override_list.pb.gz`, which is available at `chrome://topics-internals/` under the current model in the **Classifier** tab. The domain-to-topics associations in the list are used by the API in lieu of the output of the model itself.
 
 <figure>
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/SOTuE2ljC55PaYll1UP1.png",
@@ -88,7 +90,7 @@ To inspect the `override_list.pb.gz` file, first unpack it:
 ```text
 gunzip -c override_list.pb.gz > override_list.pb
 ```
-Use `protoc` to inspect: 
+Use [`protoc`](https://grpc.io/docs/protoc-installation/) to inspect it as text: 
 ```text
 protoc --decode_raw < override_list.pb > output.txt
 ```
@@ -109,7 +111,7 @@ The API returns one topic for each epoch, up to a maximum of three. If three are
 
 1. At the end of each epoch, the browser compiles a list of pages that meet the following criteria:
     - The page was visited by the user during the epoch.
-    - The page includes code that calls `document.browsingTopics()`
+    - The page includes code that calls `document.browsingTopics()`.
     - The API was enabled (for example, not blocked by the user or via a [response header](https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy)).
 2. The browser, on the user's device, uses the classifier model provided by the Topics API to map the hostname for each page to a list of topics.
 3. The browser accumulates the list of topics.
@@ -117,7 +119,7 @@ The API returns one topic for each epoch, up to a maximum of three. If three are
 
 The `document.browsingTopics()` method then returns a random topic from the top five for each epoch, with a 5% chance that any of these may be randomly chosen from the full taxonomy of topics. In Chrome, users are also able to remove individual topics, or clear their browsing history to reduce the number of topics returned by the API. Users may also [opt out](#opt-out) of the API.
 
-View information about topics observed during the current epoch from the `chrome://topics-internals` page.
+You can view information about topics observed during the current epoch from the `chrome://topics-internals` page.
 
 
 ## How the API decides which callers see which topics

--- a/site/en/docs/privacy-sandbox/topics/topic-classification/index.md
+++ b/site/en/docs/privacy-sandbox/topics/topic-classification/index.md
@@ -1,0 +1,230 @@
+---
+layout: 'layouts/doc-post.njk'
+title: 'Topic classification'
+subhead: >
+  Read how topics are inferred, how they're assigned to users' browsers, and how users can control their topics list.
+description: >
+  More in-depth information about the topics themselves and how they are chosen.
+  
+date: 2022-01-25
+updated: 2023-03-08
+authors:
+  - samdutton
+---
+
+## Implementation status
+{% Partial 'privacy-sandbox/ps-implementation-status.njk' %}
+
+## What is a topic?
+A topic, in the Topics API, is a subject a user is interested in as evidenced by the websites they visit.
+
+Topics are a signal to help ad tech platforms select relevant ads. Unlike third-party cookies, this information is shared without revealing further information about the user themself or the user's browsing activity.
+
+The Topics API allows third parties, such as ad tech platforms, to observe and then access topics of interest to a user. For example, the API might suggest the topic "Fiber & Textile Arts" for a user who visits the website `knitting.example`. 
+
+The [list of topics used by the Topics API](https://github.com/patcg-individual-drafts/topics/blob/main/taxonomy_v1.md) is public, human-curated, human-readable, and designed to avoid sensitive categories. This is the current list, which will expand over time. This type of list is known as a _taxonomy_. The topics can be high-level or more specific. For example, `Food & Drink` is a broad category, with a subcategory of `Cooking & Recipes`. Subcategories may be further divided into additional subcategories.
+
+A taxonomy of topics needs to make a tradeoff between utility and privacy. If topics are too specific, they could be used to identify an individual user. If they are too general, they aren't useful for selecting advertising or other content.
+
+The topics taxonomy is constructed with two underlying requirements in mind:
+- Support interest-based advertising
+- Keep users safe and protect their privacy
+
+This suggests several questions. For example:
+- What's the best way for the API to infer topics of interest for a user, based on their browsing activity, while preserving the user's privacy?
+- How could the taxonomy be structured to make it more useful?
+- What specific items should the taxonomy include?
+
+## How the API infers topics for a site
+
+Topics are derived from a [classifier model](https://github.com/jkarlin/topics#:~:text=classifier) that maps website [hostnames](https://web.dev/same-site-same-origin/#origin) to zero or more topics.
+Analyzing additional information (such as full URLs or page contents) might allow for more relevant ads, but might also reduce privacy.
+
+The classifier model for mapping hostnames to topics is publicly available, and the [explainer](https://github.com/patcg-individual-drafts/topics) proposes that it should be possible to view the topics for a site via browser developer tools. The model is expected to evolve and improve over time and be updated periodically; the frequency of this is still under consideration.
+
+Only sites that include code that calls the Topics API are included in the browsing history eligible for topic frequency calculations, and API callers only receive topics they've observed. In other words, sites are not eligible for topic frequency calculations without the site or an embedded service taking action to call the API.
+
+{% Aside 'key-term' %}
+
+A Topics API _caller_ is the entity that observes and requests topics with
+`document.browsingTopics()`. Typically, this caller is a third party (such as an
+ad tech) who uses the topics returned by this method to help select relevant
+ads.
+
+The browser determines the caller from the origin of the request. If Site A
+requests topics from their code in an iframe hosted on Site B, the browser determines the caller is Site A. If you're a third party, make sure you
+call the Topics API from an iframe you own.
+
+To retrieve one or more topics with `document.browsingTopics()`, an API
+caller must observe and request topics from the same origin.
+
+{% endAside %}
+
+In addition, a caller can only receive topics that their code has "seen." So if another caller's code registered a topic, say `/Autos & Vehicles/Motor Vehicles (By Type)/Hatchbacks`, for a user's browser and your code did not cause that topic to be registered for that user's browser, you will not be able to learn of that topic of interest for that user's browser when you call the API from your embedded code.
+
+Sites can block topic calculation for their visitors with the following [Permissions-Policy](https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy) header:
+
+```text
+Permissions-Policy: browsing-topics=()
+```
+
+## The classifier model
+
+Topics are manually curated for 10,000 top domains, and this curation is used to train the classifier. This list can be found in `override_list.pb.gz`, which is available at `chrome://topics-internals/` under the current model in the "Classifier" tab. The domain-to-topics associations in the list are used by the API in lieu of the output of the model itself.
+
+<figure>
+{% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/SOTuE2ljC55PaYll1UP1.png",
+  alt="chrome://topics-internal page with Classifier panel selected.",
+  width="800", height="695" %}
+  <figcaption>
+    The chrome://topics-internal page Classifier panel lists the model version, its path, and the topics associated with each host listed.
+  </figcaption>
+</figure>
+
+
+To run the model directly, refer to [TensorFlow's guide to running a model](https://www.tensorflow.org/lite/guide/inference#running_a_model).
+
+To inspect the `override_list.pb.gz` file, first unpack it: 
+```text
+gunzip -c override_list.pb.gz > override_list.pb
+```
+Use `protoc` to inspect: 
+```text
+protoc --decode_raw < override_list.pb > output.txt
+```
+
+A full [taxonomy of topics with IDs](https://github.com/patcg-individual-drafts/topics/blob/main/taxonomy_v1.md) is available on GitHub.
+
+
+### Providing feedback or input on the classifier model
+
+There are [several channels](/docs/privacy-sandbox/feedback/) for providing feedback on the Topics proposal. For feedback on the classifier model, we recommend [submitting a GitHub issue](https://github.com/patcg-individual-drafts/topics/issues) or replying to an existing issue. For example:
+
+- [What topics taxonomy should be used long term?](https://github.com/patcg-individual-drafts/topics/issues/3)
+- [What if a site disagrees with the topics assigned?](https://github.com/patcg-individual-drafts/topics/issues/2)
+
+## How the user's top five topics are selected
+
+The API returns one topic for each epoch, up to a maximum of three. If three are returned, this includes topics for the current epoch and the previous two.
+
+1. At the end of each epoch, the browser compiles a list of pages that meet the following criteria:
+    - The page was visited by the user during the epoch.
+    - The page includes code that calls `document.browsingTopics()`
+    - The API was enabled (for example, not blocked by the user or via a [response header](https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy)).
+2. The browser, on the user's device, uses the classifier model provided by the Topics API to map the hostname for each page to a list of topics.
+3. The browser accumulates the list of topics.
+4. The browser generates a list of the top five topics by frequency.
+
+The `document.browsingTopics()` method then returns a random topic from the top five for each epoch, with a 5% chance that any of these may be randomly chosen from the full taxonomy of topics. In Chrome, users are also able to remove individual topics, or clear their browsing history to reduce the number of topics returned by the API. Users may also [opt out](#opt-out) of the API.
+
+View information about topics observed during the current epoch from the `chrome://topics-internals` page.
+
+
+## How the API decides which callers see which topics
+
+API callers only receive topics they've recently observed, and the topics for a user are refreshed once each epoch. That means the API provides a rolling window in which a given caller may receive certain topics.
+
+The table below outlines an example (though unrealistically small) of a hypothetical browsing history for a user during a single epoch, showing topics associated with the sites they've visited, and the API callers present on each site (the entities that call `document.browsingTopics()` in JavaScript code included on the site).
+
+<table class="with-heading-tint">
+  <thead>
+  <tr>
+  <th><strong>Site</strong></th>
+  <th><strong>Topics</strong></th>
+  <th><strong>API callers on site</strong></th>
+  </tr>
+  </thead>
+  <tbody>
+    <tr>
+    <td>yoga.example</td>
+    <td>Fitness</td>
+    <td>adtech1.example adtech2.example</td>
+    </tr>
+    <tr>
+    <td>knitting.example</td>
+    <td>Crafts</td>
+    <td>adtech1.example</td>
+    </tr>
+    <tr>
+    <td>hiking-holiday.example</td>
+    <td>Fitness, Travel & Transportation</td>
+    <td>adtech2.example</td>
+    </tr>
+    <tr>
+    <td>diy-clothing.example</td>
+    <td>Crafts, Fashion & Style</td>
+    <td>[none]</td>
+    </tr>
+  </tbody>
+</table>
+
+At the end of the epoch (currently proposed to be one week) the Topics API generates the browser's top topics for the week.
+
+- adtech1.example is now eligible to receive the "Fitness" and "Crafts" topics, since it observed them on yoga.example and also on knitting.example.
+- adtech1.example is not eligible to receive the "Travel & Transportation" topic for this user as it is not present on any sites the user visited recently that are associated with that topic.
+- adtech2.example has seen the "Fitness" and "Travel & Transportation" topics, but has not seen the "Crafts" topic.
+
+The user visited diy-clothing.example, which has the "Fashion & Style" topic, but there were no calls to the Topics API on that site. At this point, this means the "Fashion & Style" topic would not be returned by the API for any caller.
+
+In week two, the user visits another site:
+
+<table class="with-heading-tint">
+  <thead>
+    <tr>
+    <th><strong>Site</strong></th>
+    <th><strong>Topics</strong></th>
+    <th><strong>API callers on site</strong></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+    <td>sewing.example</td>
+    <td>Crafts</td>
+    <td>adtech2.example</td>
+    </tr>
+  </tbody>
+</table>
+
+In addition, code from adtech2.example is added to diy-clothing.example:
+
+
+<table class="with-heading-tint">
+  <thead>
+    <tr>
+    <th><strong>Site</strong></th>
+    <th><strong>Topics</strong></th>
+    <th><strong>API callers on site</strong></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+    <td>diy-clothing.example</td>
+    <td>Crafts, Fashion & Style</td>
+    <td>adtech2.example</td>
+    </tr>
+  </tbody>
+</table>
+
+As well as "Fitness" and "Travel & Transportation" from week 1, this means that adtech2.example will now be able to receive the "Crafts" and "Fashion & Style" topic — but not until the following epoch, week 3. This ensures that third parties can't learn more about a user's past (in this case, an interest in fashion) than they could with cookies.
+
+After another two weeks, "Fitness" and "Travel & Transportation" may drop out of adtech2.example's list of eligible topics if the user doesn't visit any sites with those topics that include code from adtech2.example.
+
+
+## User controls, transparency, and opting out {: #opt-out}
+
+Users should be able to understand the purpose of the Topics API, recognize what is being said about them, know when the API is in use, and be provided with controls to enable or disable it.
+
+The API's human-readable taxonomy enables users to learn about and control the topics that may be suggested for them by their browser. Users can remove topics they specifically do not want the Topics API to share with advertisers or publishers, and there can be controls to inform the user about the API and show how to enable or disable it. Chrome provides information and settings for the Topics API at `chrome://settings/privacySandbox`. In addition, topics are not available to API callers in Incognito mode, and topics are cleared when browsing history is cleared.
+
+The list of topics returned will be empty if:
+
+- The user opts out of the Topics API via browser settings at `chrome://settings/privacySandbox`.
+- The user has cleared their topics (via the browser settings at `chrome://settings/privacySandbox`) or cleared their cookies.
+- The browser is in Incognito mode.
+
+The explainer [provides more detail about privacy goals](https://github.com/jkarlin/topics#meeting-the-privacy-goals) and how the API seeks to address them.
+
+## Next steps
+
+If you're an ad tech developer, [experiment and participate](/docs/privacy-sandbox/topics-experiment/) with the Topics API. Read the [developer guide](/docs/privacy-sandbox/topics/) for more in-depth resources.
+

--- a/site/en/docs/privacy-sandbox/topics/topic-classification/index.md
+++ b/site/en/docs/privacy-sandbox/topics/topic-classification/index.md
@@ -228,3 +228,4 @@ The explainer [provides more detail about privacy goals](https://github.com/jkar
 
 If you're an ad tech developer, [experiment and participate](/docs/privacy-sandbox/topics-experiment/) with the Topics API. Read the [developer guide](/docs/privacy-sandbox/topics/) for more in-depth resources.
 
+{% Partial 'privacy-sandbox/topics-feedback.njk' %}

--- a/site/en/docs/privacy-sandbox/topics/topic-classification/index.md
+++ b/site/en/docs/privacy-sandbox/topics/topic-classification/index.md
@@ -74,10 +74,10 @@ Topics are manually curated for 10,000 top domains, and this curation is used to
 
 <figure>
 {% Img src="image/80mq7dk16vVEg8BBhsVe42n6zn82/SOTuE2ljC55PaYll1UP1.png",
-  alt="chrome://topics-internal page with Classifier panel selected.",
+  alt="chrome://topics-internals page with Classifier panel selected.",
   width="800", height="695" %}
   <figcaption>
-    The chrome://topics-internal page Classifier panel lists the model version, its path, and the topics associated with each host listed.
+    The chrome://topics-internals page Classifier panel lists the model version, its path, and the topics associated with each host listed.
   </figcaption>
 </figure>
 

--- a/site/en/docs/privacy-sandbox/topics/topic-classification/index.md
+++ b/site/en/docs/privacy-sandbox/topics/topic-classification/index.md
@@ -86,11 +86,14 @@ Topics are manually curated for 10,000 top domains, and this curation is used to
 
 To run the model directly, refer to [TensorFlow's guide to running a model](https://www.tensorflow.org/lite/guide/inference#running_a_model).
 
-To inspect the `override_list.pb.gz` file, first unpack it: 
+To inspect the `override_list.pb.gz` file, first unpack it:
+
 ```text
 gunzip -c override_list.pb.gz > override_list.pb
 ```
-Use [`protoc`](https://grpc.io/docs/protoc-installation/) to inspect it as text: 
+
+Use [`protoc`](https://grpc.io/docs/protoc-installation/) to inspect it as text:
+
 ```text
 protoc --decode_raw < override_list.pb > output.txt
 ```
@@ -120,7 +123,6 @@ The API returns one topic for each epoch, up to a maximum of three. If three are
 The `document.browsingTopics()` method then returns a random topic from the top five for each epoch, with a 5% chance that any of these may be randomly chosen from the full taxonomy of topics. In Chrome, users are also able to remove individual topics, or clear their browsing history to reduce the number of topics returned by the API. Users may also [opt out](#opt-out) of the API.
 
 You can view information about topics observed during the current epoch from the `chrome://topics-internals` page.
-
 
 ## How the API decides which callers see which topics
 
@@ -189,7 +191,6 @@ In week two, the user visits another site:
 
 In addition, code from adtech2.example is added to diy-clothing.example:
 
-
 <table class="with-heading-tint">
   <thead>
     <tr>
@@ -210,7 +211,6 @@ In addition, code from adtech2.example is added to diy-clothing.example:
 As well as "Fitness" and "Travel & Transportation" from week 1, this means that adtech2.example will now be able to receive the "Crafts" and "Fashion & Style" topic — but not until the following epoch, week 3. This ensures that third parties can't learn more about a user's past (in this case, an interest in fashion) than they could with cookies.
 
 After another two weeks, "Fitness" and "Travel & Transportation" may drop out of adtech2.example's list of eligible topics if the user doesn't visit any sites with those topics that include code from adtech2.example.
-
 
 ## User controls, transparency, and opting out {: #opt-out}
 

--- a/site/en/docs/privacy-sandbox/topics/topic-classification/index.md
+++ b/site/en/docs/privacy-sandbox/topics/topic-classification/index.md
@@ -68,7 +68,7 @@ Sites can block topic calculation for their visitors with the following [Permiss
 Permissions-Policy: browsing-topics=()
 ```
 
-## The classifier model
+## The classifier model {: #classifier-model}
 
 Topics are manually curated for 10,000 top domains, and this curation is used to train the classifier. This list can be found in `override_list.pb.gz`, which is available at `chrome://topics-internals/` under the current model in the "Classifier" tab. The domain-to-topics associations in the list are used by the API in lieu of the output of the model itself.
 


### PR DESCRIPTION
Fixes b/265810661

Changes proposed in this pull request:
- Break up Topics API dev guide into 5 pages
- (note lots of ampersands should possibly be changed. see note in demo/index.md)
- **the nav /site/_data/docs/privacy-sandbox/toc.yml not yet changed FYI**
- staged:
    - https://pr-5585-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/topics/colab/
    - https://pr-5585-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/topics/demo/
    - https://pr-5585-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/topics/
    - https://pr-5585-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/topics/overview/
    - https://pr-5585-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/topics/topic-classification/