### PR TITLE
Explain that Native Messaging is not available from content scripts

### DIFF
--- a/site/en/docs/extensions/mv3/nativeMessaging/index.md
+++ b/site/en/docs/extensions/mv3/nativeMessaging/index.md
@@ -120,8 +120,8 @@ messaging. The main difference is that [`runtime.connectNative`][connect-native]
 To use these methods, the "nativeMessaging" permission must be [declared][declare-permissions] in your
 extensions's manifest file.
 
-These methods are not available inside content scripts, only inside your extension's pages and ServiceWorker. If you
-wish to communicate from a content script to the native application, send the message to your background script page
+These methods are not available inside content scripts, only inside your extension's pages and service worker. If you
+wish to communicate from a content script to the native application, send the message to your background context
 or service worker, and have it pass it along to the native application.
 
 The following example creates a [`runtime.Port`][port] object that's connected to native messaging host

--- a/site/en/docs/extensions/mv3/nativeMessaging/index.md
+++ b/site/en/docs/extensions/mv3/nativeMessaging/index.md
@@ -116,8 +116,13 @@ Sending and receiving messages to and from a native application is very similar 
 messaging. The main difference is that [`runtime.connectNative`][connect-native] is used instead of
 [`runtime.connect`][connect], and [`runtime.sendNativeMessage`][send-native-message] is used instead of
 [`runtime.sendMessage`][send-message].
+
 To use these methods, the "nativeMessaging" permission must be [declared][declare-permissions] in your
 extensions's manifest file.
+
+These methods are not available inside content scripts, only inside your extension's pages and ServiceWorker. If you
+wish to communicate from a content script to the native application, send the message to your background script page
+or service worker, and have it pass it along to the native application.
 
 The following example creates a [`runtime.Port`][port] object that's connected to native messaging host
 `com.my_company.my_application`, starts listening for messages from that port and sends one outgoing


### PR DESCRIPTION
We don't seem to document this anywhere obvious, requiring users to either find the StackOverflow answer or read the Chromium source code.


https://chromium.googlesource.com/chromium/src/+/main/chrome/common/extensions/api/_features.md#Feature-Contexts

https://source.chromium.org/chromium/chromium/src/+/main:extensions/common/api/_api_features.json

  "runtime.connectNative": {
    "dependencies": ["permission:nativeMessaging"],
    "contexts": ["blessed_extension"]
  },

  "runtime.sendNativeMessage": {
    "dependencies": ["permission:nativeMessaging"],
    "contexts": ["blessed_extension"]
  },


The blessed_extension context refers to a JavaScript context running from an extension process. These are typically the most secure JavaScript contexts, as it reduces the likelihood that a compromised web page renderer will have access to secure APIs.

The content_script context refers to a JavaScript context for an extension content script. Since content scripts share a process with (and run on the same content as) web pages, these are considered very insecure contexts. Very few features should be exposed to these contexts.

