### PR TITLE
keyboard lock demo fix demo proposal

### DIFF
--- a/site/en/articles/keyboard-lock/index.md
+++ b/site/en/articles/keyboard-lock/index.md
@@ -100,10 +100,10 @@ When a document is closed, the browser always implicitly calls `unlock()`.
 
 You can test the Keyboard Lock API by running the [demo](https://keyboard-lock.glitch.me/) on Glitch. Be sure to [check out the source code](https://glitch.com/edit/#!/keyboard-lock). Clicking the Enter full screen button below launches the demo in a new window so it can enter full screen mode.
 
-{% Glitch {
-id: 'keyboard-lock',
-path: 'script.js'
-} %}
+<iframe src="https://keyboard-lock.glitch.me/"
+       sandbox="allow-same-origin allow-scripts allow-popups allow-forms" width="100%" height="6%">
+</iframe>
+
 
 ## Security Considerations
 


### PR DESCRIPTION
Fixes #5611 

Changes proposed in this pull request:

- This way of making the demo opens it in a new window with no permission error.
   However this a proposal because it changes the way it originally looks.
   If you have any suggestions please let me know. Thanks.
  
<img width="777" alt="Pasted Graphic" src="https://user-images.githubusercontent.com/98627735/224432307-0c3d5318-7140-4af0-9a59-3ce74769239c.png">
