### PR TITLE
Update omahaproxy links

### DIFF
--- a/site/en/docs/extensions/mv3/faq/index.md
+++ b/site/en/docs/extensions/mv3/faq/index.md
@@ -3,7 +3,7 @@ layout: "layouts/doc-post.njk"
 title: "Frequently asked questions"
 seoTitle: "Chrome Extensions: Frequently asked questions"
 date: 2014-02-28
-updated: 2020-11-20
+updated: 2023-03-13
 description: Frequently asked questions about Chrome Extensions.
 ---
 
@@ -49,32 +49,8 @@ with a web service or pull new content from the web.
 ### How do I determine which version of Chrome is deployed to which channel? {: #faq-dev-14 }
 
 To determine which version of Chrome is currently available on each of the different platforms,
-visit [omahaproxy.appspot.com][34]. On that site you will see data in a format similar to:
-
-```text
-cf,dev,#.#.###.#,#.#.###.#,mm/dd/yy,mm/dd/yy,#####,#####,#####
-cf,beta,#.#.###.#,#.#.###.#,mm/dd/yy,mm/dd/yy,#####,#####,#####
-cf,stable,#.#.###.#,#.#.###.#,mm/dd/yy,mm/dd/yy,#####,#####,#####
-linux,dev,#.#.###.#,#.#.###.#,mm/dd/yy,mm/dd/yy,#####,#####,#####
-linux,beta,#.#.###.#,#.#.###.#,mm/dd/yy,mm/dd/yy,#####,#####,#####
-linux,stable,#.#.###.#,#.#.###.#,mm/dd/yy,mm/dd/yy,#####,#####,#####
-mac,dev,#.#.###.#,#.#.###.#,mm/dd/yy,mm/dd/yy,#####,#####,#####
-mac,beta,#.#.###.#,#.#.###.#,mm/dd/yy,mm/dd/yy,#####,#####,#####
-mac,stable,#.#.###.#,#.#.###.#,mm/dd/yy,mm/dd/yy,#####,#####,#####
-win,canary,#.#.###.#,#.#.###.#,mm/dd/yy,mm/dd/yy,#####,#####,#####
-win,dev,#.#.###.#,#.#.###.#,mm/dd/yy,mm/dd/yy,#####,#####,#####
-win,beta,#.#.###.#,#.#.###.#,mm/dd/yy,mm/dd/yy,#####,#####,#####
-win,stable,#.#.###.#,#.#.###.#,mm/dd/yy,mm/dd/yy,#####,#####,#####
-cros,dev,#.#.###.#,#.#.###.#,mm/dd/yy,mm/dd/yy,#####,#####,#####
-cros,beta,#.#.###.#,#.#.###.#,mm/dd/yy,mm/dd/yy,#####,#####,#####
-```
-
-Each line represents information about a different platform and channel combination. The listed
-platforms are `cf` (Google Chrome Frame), `linux`, `mac`, `win`, and `cros` (Google ChromeOS). The
-listed channels are `canary`, `dev`, `beta`, and `stable`. The two four-part numbers after the
-channel represent the current and previous versions of Chrome deployed to that platform-channel
-combination. The rest of the information is metadata about when the releases were first pushed, as
-well as revision numbers associated with each build.
+visit [chromiumdash.appspot.com][34]. On that site you can cycle through each platform with the
+dropdown menu. For programmatic access to Chrome version history use the [VersionHistory API][63].
 
 ## Capabilities {: #capabilities2 }
 
@@ -305,7 +281,7 @@ The steps you should follow to ensure this are:
 [31]: #faq-fea-02
 [32]: /docs/extensions/mv3/getstarted
 [33]: https://developer.mozilla.org/docs/Web/API
-[34]: https://omahaproxy.appspot.com
+[34]: https://chromiumdash.appspot.com/releases
 [35]: /docs/extensions/mv3/xhr
 [36]: https://json.org/js.html
 [37]: https://dev.w3.org/html5/webstorage/
@@ -338,3 +314,4 @@ The steps you should follow to ensure this are:
 [62]: https://groups.google.com/a/chromium.org/group/chromium-extensions/topics
 [stringify]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
 [parse]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse
+[63]: /docs/versionhistory/guide

--- a/site/en/docs/puppeteer/faq/index.md
+++ b/site/en/docs/puppeteer/faq/index.md
@@ -74,7 +74,9 @@ npm install puppeteer-core@chrome-71
 
 Find the version using one of the following ways:
 
-- Look for the `chromium` entry in [revisions.ts](https://github.com/puppeteer/puppeteer/blob/main/src/revisions.ts). To find the corresponding Chromium commit and version number, search for the revision prefixed by an `r` in [OmahaProxy](https://omahaproxy.appspot.com/)'s "Find Releases" section.
+- Look for the `chromium` entry in [revisions.ts](https://github.com/puppeteer/puppeteer/blob/main/src/revisions.ts). To find the corresponding Chromium commit and version number, append the entry onto 
+`crrev.com/` for example [crrev.com/1095492](https://crrev.com/1095492). Then search the commit hash on [chromiumdash.appspot.com](https://chromiumdash.appspot.com/commits)
+
 - Look for the `versionsPerRelease` map in [versions.js](https://github.com/puppeteer/puppeteer/blob/main/versions.js) which contains mapping between Chromium and Puppeteer versions. Note: The file contains only Puppeteer versions where Chromium is updated. Not all Puppeteer versions are listed.
 
 ## Q: Which Firefox version does Puppeteer use?

--- a/site/en/docs/web-platform/chrome-release-channels/index.md
+++ b/site/en/docs/web-platform/chrome-release-channels/index.md
@@ -97,7 +97,7 @@ these major numbers referred to as _milestones_: for example, M101 or M102.
 If you're curious about the version you're using, take a look at the `chrome://version` page. You
 can observe how the [version number](https://www.chromium.org/developers/version-numbers/) changes
 over time for each channel. You can check the latest versions for each Chrome release channel and
-platform at [omahaproxy.appspot.com](https://omahaproxy.appspot.com/). This site also provides tools
+platform at [chromiumdash.appspot.com/releases](https://chromiumdash.appspot.com/releases). This site also provides tools
 to view code differences between versions.
  
 {% Aside %}
@@ -244,6 +244,6 @@ different Chrome OS channel](support.google.com/chromebook/answer/1086915).
 - [Understand Chrome version numbers](https://www.chromium.org/developers/version-numbers/)
 - [View the Chrome release blog](http://chromereleases.googleblog.com)
 - Find the latest versions for each Chrome release channel and platform, and access tools for
-    viewing the difference between versions: [omahaproxy.appspot.com](https://omahaproxy.appspot.com/)
+    viewing the difference between versions: [chromiumdash.appspot.com](https://chromiumdash.appspot.com/)
 - [Report bugs](https://www.chromium.org/getting-involved/dev-channel/#reporting-dev-channel-and-canary-build-problems)
 - [Manage Chrome release channels for enterprise and education](support.google.com/chrome/a/answer/9027636)


### PR DESCRIPTION
CL to update links referencing omahaproxy to the chromiumdash. Due to it's [impending
deprecation.](https://groups.google.com/a/chromium.org/g/chromium-dev/c/uH-nFrOLWtE/m/PhUj_inyAQAJ)

Changes proposed in this pull request:

- Update chrome-release-channels web-platform docs to use new link
- Update old puppeteer faq to use new process of finding chromium commit positions
- Update mv3 FAQ's with new link and where to find the version history api