### PR TITLE
Add note to quit chrome first

### DIFF
--- a/site/en/docs/privacy-sandbox/topics/demo/index.md
+++ b/site/en/docs/privacy-sandbox/topics/demo/index.md
@@ -45,6 +45,10 @@ There are two ways to try the Topics API as a single user; you'll need to be run
     --enable-features=BrowsingTopics,PrivacySandboxAdsAPIsOverride,OverridePrivacySandboxSettingsLocalTesting
     ```
 
+{% Aside %}
+Before starting Chrome using flags, quit the Chrome running processes.
+{% endAside %}
+
 ## The Topics API demo
 
 The [Topics demo](https://topics-demo.glitch.me/) shows how to use additional flags to adjust settings, such as epoch length. If you access the Topics API by running Chrome with command-line flags, don't set `chrome://flags`, as these can override command-line settings.

--- a/site/en/docs/privacy-sandbox/topics/demo/index.md
+++ b/site/en/docs/privacy-sandbox/topics/demo/index.md
@@ -46,7 +46,7 @@ There are two ways to try the Topics API as a single user; you'll need to be run
     ```
 
 {% Aside %}
-Before starting Chrome using flags, quit the Chrome running processes.
+Before starting Chrome using flags, quit any Chrome running processes.
 {% endAside %}
 
 ## The Topics API demo

--- a/site/en/docs/privacy-sandbox/topics/demo/index.md
+++ b/site/en/docs/privacy-sandbox/topics/demo/index.md
@@ -46,7 +46,7 @@ There are two ways to try the Topics API as a single user; you'll need to be run
     ```
 
 {% Aside %}
-Before starting Chrome using flags, quit any Chrome running processes.
+Before starting Chrome using flags, quit any Chrome running processes or use "force quit."
 {% endAside %}
 
 ## The Topics API demo


### PR DESCRIPTION
Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- Add a note to quit Chrome before running with flags. Not mentioned anywhere but the demo would not work otherwise...
- https://pr-5669-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/topics/demo/#the-topics-api-demo:~:text=BrowsingTopics%2CPrivacySandboxAdsAPIsOverride%2COverridePrivacySandboxSettingsLocalTesting-,Before,-starting%20Chrome%20using
-