### PR TITLE
DevTools: Lighthouse tutorial refresh

### DIFF
--- a/site/_data/docs/devtools/toc.yml
+++ b/site/_data/docs/devtools/toc.yml
@@ -57,6 +57,7 @@
     - url: /docs/devtools/performance/reference/
     - url: /docs/devtools/performance/timeline-reference/
 - url: /docs/devtools/performance-insights/
+- url: /docs/devtools/lighthouse/
 - title: i18n.docs.devtools.memory
   sections:
     - url: /docs/devtools/memory-problems/memory-101/

--- a/site/en/blog/new-in-devtools-112/index.md
+++ b/site/en/blog/new-in-devtools-112/index.md
@@ -189,6 +189,8 @@ Chromium issues: [1412719](https://crbug.com/1412719), [1412721](https://crbug.c
 
 The **Lighthouse** panel now runs [Lighthouse 10.0.1](/blog/lighthouse-10-0/). For more details, see [What's new in Lighthouse 10.0.1](/blog/lighthouse-10-0/).
 
+To learn the basics of using the **Lighthouse** panel in DevTools, see [Lighthouse: Optimize website speed](/docs/devtools/lighthouse/).
+
 **Lighthouse** > {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/9gzXiTYY0nZzBxGI6KrV.svg", alt="Settings.", width="24", height="24" %} > {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/ZtDyFg7cjkxacORB3GQn.svg", alt="Empty checkbox.", width="24", height="24" %} **Legacy navigation** is now disabled by default. This option uses legacy [Lighthouse configuration](https://github.com/GoogleChrome/lighthouse/blob/main/docs/configuration.md) in navigation mode.
 
 {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/mYuX9d2TFaJuWBOYGN5R.png", alt="Disabled legacy navigation.", width="800", height="548" %}

--- a/site/en/docs/devtools/lighthouse/index.md
+++ b/site/en/docs/devtools/lighthouse/index.md
@@ -228,7 +228,7 @@ Use the workflows that you learned earlier to manually check that the compressio
 
 1. Go back to the demo tab and reload the page.
 
-   The **Size** column should now show 2 different values for text resources like `bundle.js`. The top value of `269 KB` for `bundle.js` is the size of the file that was sent over the network, and the bottom value of `1.4 MB` is the uncompressed file size.
+   The **Size** column should now show two different values for text resources like `bundle.js`. The top value of `269 KB` for `bundle.js` is the size of the file that was sent over the network, and the bottom value of `1.4 MB` is the uncompressed file size.
 
    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/feaqTS50BT1JlFSXLFLr.png", alt="The Size column now shows 2 different values for text resources.", width="800", height="572" %}
 

--- a/site/en/docs/devtools/lighthouse/index.md
+++ b/site/en/docs/devtools/lighthouse/index.md
@@ -88,17 +88,17 @@ The baseline is a record of how the site performed before you made any performan
 2.  Match your Lighthouse report configuration settings to those on the screenshot. Here's an explanation of the
     different options:
 
-    - **Mode** > {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/ljri3HPj5aVym9qgMfkx.svg", alt="Radio button checked.", width="20", height="20" %} **Navigation (default)**. This mode analyses a single page load and that's what we need in this tutorial. For more information, see [The three modes](https://github.com/GoogleChrome/lighthouse/blob/HEAD/docs/user-flows.md#the-three-modes-navigation-timespan-snapshot).
+    - {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/hmp8j3HiLMCcqPArD9yt.svg", alt="Checkbox.", width="24", height="24" %} **Clear Storage**. Enabling this checkbox clears all storage associated with the page before every audit. Leave this setting on if you want to audit how first-time visitors experience your site. Disable this setting when you want the repeat-visit experience.
+    - **Simulated throttling (default)** {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/C8J2TiWeNKJhQn3eEauv.svg", alt="Drop-down.", width="20", height="20" %}. This option simulates the typical conditions of browsing on a mobile device. It's called "simulated" because Lighthouse doesn't actually throttle during the auditing process. Instead, it just extrapolates how long the page would take to load under mobile conditions. The **DevTools throttling (advanced)** setting, on the other hand, actually throttles your CPU and network, with the tradeoff of a longer auditing process.
+    - **Mode** > {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/ljri3HPj5aVym9qgMfkx.svg", alt="Radio button checked.", width="20", height="20" %} **Navigation (Default)**. This mode analyses a single page load and that's what we need in this tutorial. For more information, see [The three modes](https://github.com/GoogleChrome/lighthouse/blob/HEAD/docs/user-flows.md#the-three-modes-navigation-timespan-snapshot).
     - **Device** > {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/ljri3HPj5aVym9qgMfkx.svg", alt="Radio button checked.", width="20", height="20" %} **Mobile**. The mobile option changes the user agent string and simulates a mobile
       viewport. The desktop option pretty much just disables the mobile changes.
     - **Categories** > {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/hmp8j3HiLMCcqPArD9yt.svg", alt="Checkbox.", width="24", height="24" %} **Performance**. A single enabled category makes Lighthouse generate a report only with the corresponding set of audits. You can leave the other categories enabled, if you want to see the types of recommendations they provide. Disabling irrelevant categories slightly speeds up the auditing process.
-    - **Simulated throttling (default)** {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/C8J2TiWeNKJhQn3eEauv.svg", alt="Drop-down.", width="20", height="20" %}. This option simulates the typical conditions of browsing on a mobile device. It's called "simulated" because Lighthouse doesn't actually throttle during the auditing process. Instead, it just extrapolates how long the page would take to load under mobile conditions. The **DevTools throttling (advanced)** setting, on the other hand, actually throttles your CPU and network, with the tradeoff of a longer auditing process.
-    - {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/hmp8j3HiLMCcqPArD9yt.svg", alt="Checkbox.", width="24", height="24" %} **Clear Storage**. Enabling this checkbox clears all storage associated with the page before every audit. Leave this setting on if you want to audit how first-time visitors experience your site. Disable this setting when you want the repeat-visit experience.
 
 3.  Click **Analyze page load**. After 10 to 30 seconds, the **Lighthouse** panel shows you a report of the site's
     performance.
 
-    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/aCoPjdb6CKbHmPxjCcgR.png", alt="A Lighthouse report of the site's performance.", width="800", height="959" %}
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/CvzyCerAE3dyr2mPdHgm.png", alt="A Lighthouse report of the site's performance.", width="800", height="918" %}
 
 #### Handling report errors {: #errors }
 
@@ -106,68 +106,64 @@ If you ever get an error in your Lighthouse report, try running the demo tab fro
 window][4] with no other tabs open. This ensures that you're running Chrome from a clean state.
 Chrome Extensions in particular often interfere with the auditing process.
 
-{% Img src="image/admin/BQOnt1Z7Qp1CUZ1Ln6ve.png", alt="A report with an error.", width="800", height="552" %}
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/qw1Qx8ijvLy1FziWKo7v.png", alt="A report with an error.", width="800", height="787" %}
 
 ### Understand your report {: #report }
 
 The number at the top of your report is the overall performance score for the site. Later, as you
 make changes to the code, you should see this number rise. A higher score means better performance.
 
-{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/aZwib1rLHMcOMioP1SKG.png", alt="The overall performance score.", width="800", height="959" %}
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/2oZzGYcMuQTwdCigBOCu.png", alt="The overall performance score.", width="800", height="612" %}
 
-Scroll down to the **Metrics** section and click **Expand view**. This section provides quantitative measurements of the site's performance.
+#### Metrics {: #metrics }
+
+Scroll down to the **Metrics** section and click **Expand view**. Click **Learn more...** to read documentation on a metric.
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/fhK91fGcQEPIkuhYbj7r.png", alt="The Metrics section.", width="800", height="712" %}
+
+This section provides quantitative measurements of the site's performance.
 Each metric provides insight into a different aspect of the performance. For example, **First Contentful Paint**
 tells you when content is first painted to the screen, which is an important milestone in the user's
 perception of the page load, whereas **Time To Interactive** marks the point at which the page
 appears ready enough to handle user interactions.
 
-{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/agfthX3hQb21pMTYn44B.png", alt="The Metrics section.", width="800", height="699" %}
+#### Screenshots {: #screenshots }
 
-Click **Learn more** to read documentation on a metric.
+Next is a collection of screenshots that show you how the page looked as it loaded.
 
-Below Metrics is a collection of screenshots that show you how the page looked as it loaded.
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/xpsXdrm5FAT5VphFQf42.png", alt="Screenshots of how the page looked while loading.", width="800", height="889" %}
 
-{% Img src="image/admin/1tTDKtRCRyOFq7umNNjV.png", alt="Screenshots of how the page looked while loading.", width="800", height="607" %}
+#### Opportunities {: #opportunities }
 
-**Figure 13**. Screenshots of how the page looked while loading
-
-The **Opportunities** section provides specific tips on how to improve this particular page's load
+Next is the **Opportunities** section that provides specific tips on how to improve this particular page's load
 performance.
 
-{% Img src="image/admin/dWEuVD1kQ4nXTiqnPSYr.png", alt="The Opportunities section.", width="800", height="607" %}
-
-**Figure 14**. The Opportunities section
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/UDstrdYONbJ7bGMiWPOl.png", alt="The Opportunities section.", width="800", height="800" %}
 
 Click an opportunity to learn more about it.
 
-{% Img src="image/admin/zzNtRlnwivYQRztxvTQg.png", alt="More information about the text compression opportunity.", width="800", height="607" %}
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/QgCxFrXCcAFaPtUNcobY.png", alt="More information about the text compression opportunity.", width="800", height="833" %}
 
-**Figure 15**. More information about the text compression opportunity
-
-Click **Learn More** to see documentation about why an opportunity is important, and specific
+Click **Learn more...** to see documentation about why an opportunity is important, and specific
 recommendations on how to fix it.
 
-{% Img src="image/admin/vbaaxqIidyig4woShl7L.png", alt="Documentation for the text compression opportunity.", width="800", height="539" %}
-
-**Figure 16**. Documentation for the text compression opportunity
+#### Diagnostics {: #diagnostics }
 
 The **Diagnostics** section provides more information about factors that contribute to the page's
 load time.
 
-{% Img src="image/admin/fsV4sOVHK1J59ieTlX3c.png", alt="The Diagnostics section", width="800", height="607" %}
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/YrQNNIO2VcL2CA484gJW.png", alt="The Diagnostics section.", width="800", height="677" %}
 
-**Figure 17**. The Diagnostics section
+#### Passed audits {: #passed-audits }
 
-The **Passed Audits** section shows you what the site is doing correctly. Click to expand the
+The **Passed audits** section shows you what the site is doing correctly. Click to expand the
 section.
 
-{% Img src="image/admin/4G7pw92Q89MgJYKCrHVz.png", alt="The Passed Audits section.", width="800", height="607" %}
-
-**Figure 18**. The Passed Audits section
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/E0r6FOmGToQqo1JCHVEt.png", alt="The Passed audits section.", width="800", height="685" %}
 
 ## Step 2: Experiment {: #experiment }
 
-The Opportunities section of your audit report gives you tips on how to improve the page's
+The **Opportunities** section of your Lighthouse report gives you tips on how to improve the page's
 performance. In this section, you implement the recommended changes to the codebase, auditing the
 site after each change to measure how it affects site speed.
 
@@ -182,38 +178,26 @@ network. Kind of like how you might zip a folder before emailing it to reduce it
 Before you enable compression, here are a couple of ways you can manually check whether text
 resources are compressed.
 
-1.  Click the **Network** tab.
+Open the **Network** panel and check {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/9gzXiTYY0nZzBxGI6KrV.svg", alt="Settings.", width="24", height="24" %} **Settings** > {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/hmp8j3HiLMCcqPArD9yt.svg", alt="Checkbox.", width="22", height="22" %} [**Use large request rows**](/docs/devtools/network/reference/#uncompressed).
 
-    {% Img src="image/admin/g11RtVWK4hcRDwj4WGJZ.png", alt="The Network panel.", width="800", height="599" %}
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/nNsmXoPqFVHDLiB0ubNJ.png", alt="The Size column in the Network panel showing large request rows.", width="800", height="669" %}
 
-    **Figure 19**. The Network panel
-
-2.  Click **Use Large Request Rows**
-    {% Img src="image/admin/156xToAGxtuF9W5EQ3Ag.png", alt="Use Large Request Rows", width="28", height="20" %}.
-    The height of the rows in the table of network requests increases.
-
-    {% Img src="image/admin/a5QbfNJhyb20gc9hS6XL.png", alt="Large rows in the network requests table.", width="800", height="607" %}
-
-    **Figure 20**. Large rows in the network requests table
-
-3.  If you don't see the **Size** column in the table of network requests, click the table header
-    and then select **Size**.
+{% Aside 'important' %}
+If you don't see the **Size** column in the table of network requests, right-click the table header and select **Size**.
+{% endAside %}
 
 Each **Size** cell shows two values. The top value is the size of the downloaded resource. The
 bottom value is the size of the uncompressed resource. If the two values are the same, then the
-resource is not being compressed when it's sent over the network. For example, in **Figure 20** the
+resource is not being compressed when it's sent over the network. In this example, the
 top and bottom values for `bundle.js` are both `1.4 MB`.
 
 You can also check for compression by inspecting a resource's HTTP headers:
 
-1.  Click **bundle.js**.
-2.  Click the **Headers** tab.
+1.  Click **bundle.js** and open the **Headers** tab.
 
-    {% Img src="image/admin/a2tGTXojvtJNXs5jFH8y.png", alt="The Headers tab.", width="800", height="631" %}
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/PxVuojBXc56hcnIurfMf.png", alt="The Headers tab.", width="800", height="624" %}
 
-    **Figure 21**. The Headers tab
-
-3.  Search the **Response Headers** section for a `content-encoding` header. You shouldn't see one,
+1.  Search the **Response Headers** section for a `content-encoding` header. You shouldn't see one,
     meaning that `bundle.js` was not compressed. When a resource _is_ compressed, this header is
     usually set to `gzip`, `deflate`, or `br`. See [Directives][5] for an explanation of these
     values.
@@ -221,66 +205,51 @@ You can also check for compression by inspecting a resource's HTTP headers:
 Enough with the explanations. Time to make some changes! Enable text compression by adding a couple
 of lines of code:
 
-1.  In the editor tab, click **server.js**.
+1. In the editor tab, open **server.js** and add the following two (highlighted) lines:
 
-    {% Img src="image/admin/1xABsKdRgfthMK0131pr.png", alt="Editing server.js.", width="800", height="425" %}
+   ```js/2-4
+   ...
+   const fs = require('fs');
+   const compression = require('compression'); 
 
-    **Figure 22**. Editing `server.js`
+   app.use(compression());
+   app.use(express.static('build'));
+   ...
+   ```
+1. Make sure to put `app.use(compression())` before `app.use(express.static('build'))`.
 
-2.  Add the following code to **server.js**. Make sure to put `app.use(compression())` before
-    `app.use(express.static('build'))`.
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/lMHWtiX9c0isp9Ycy5gd.png", alt="Editing server.js.", width="800", height="498" %}
 
-    ... const fs = require('fs'); const compression = require('compression');
-    app.use(compression()); app.use(express.static('build')); ...
+   {% Aside %}
+   **Note**: Usually, you'd have to install the `compression` package via something like `npm i -S compression`, but this has already been done for you.
+   {% endAside %}
 
-    {% Aside %}
-
-    **Note**: Usually, you'd have to install the `compression` package via something like
-    `npm i -S compression`, but this has already been done for you.
-
-    {% endAside %}
-
-3.  Wait for Glitch to deploy the new build of the site. The fancy animation that you see next to
-    **Logs** and **Show** means that the site is getting rebuilt and redeployed. The change is ready
-    when you see **Show Live** again.
-
-    {% Img src="image/admin/mmhq1c5QiB0DtICtZKSN.png", alt="The animation that indicates that the site is getting built.", width="800", height="470" %}
-
-    **Figure 23**. The animation that indicates that the site is getting built
+3.  Wait for Glitch to deploy the new build of the site. A happy emoji in the bottom left corner indicates a successful deployment.
 
 Use the workflows that you learned earlier to manually check that the compression is working:
 
-1.  Go back to the demo tab and reload the page. The **Size** column should now show 2 different
-    values for text resources like `bundle.js`. In **Figure 24** the top value of `261 KB` for
-    `bundle.js` is the size of the file that was sent over the network, and the bottom value of
-    `1.4 MB` is the uncompressed file size.
+1. Go back to the demo tab and reload the page.
 
-    {% Img src="image/admin/F6WaqKTo3NkxzUrGnt7T.png", alt="The Size column now shows 2 different values for text resources.", width="800", height="562" %}
+   The **Size** column should now show 2 different values for text resources like `bundle.js`. The top value of `269 KB` for `bundle.js` is the size of the file that was sent over the network, and the bottom value of `1.4 MB` is the uncompressed file size.
 
-    **Figure 24**. The Size column now shows 2 different values for text resources
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/feaqTS50BT1JlFSXLFLr.png", alt="The Size column now shows 2 different values for text resources.", width="800", height="572" %}
 
-2.  The **Response Headers** section for `bundle.js` should now include a `content-encoding: gzip`
-    header.
+1. The **Response Headers** section for `bundle.js` should now include a `content-encoding: gzip` header.
 
-    {% Img src="image/admin/2mALWw5969topkCeKfc9.png", alt="The Response Headers section now contains a content-encoding header.", width="800", height="562" %}
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/XA7T3Nq1GGlctovKWDJ4.png", alt="The Response Headers section now contains a content-encoding header.", width="800", height="641" %}
 
-    **Figure 25**. The Response Headers section now contains a `content-encoding` header
-
-Audit the page again to measure what kind of impact text compression has on the page's load
+Run the Lighthouse report on the page again to measure the impact the text compression has on the page's load
 performance:
 
-1.  Click the **Audits** tab.
-2.  Click **Perform an audit**
-    {% Img src="image/admin/9GXCdrHJFoccxgwFYFBm.png", alt="Perform an audit", width="20", height="20" %}.
-3.  Leave the settings the same as before.
-4.  Click **Run audit**.
+1. Open the **Lighthouse** panel and click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/YihNsXarRhDgEi9rOT4H.svg", alt="Add.", width="24", height="24" %} **Perform an audit...** on the action bar at the top.
 
-    {% Img src="image/admin/3AAwanwyXAGgYS20JRa9.png", alt="An Audits report after enabling text compression.", width="800", height="631" %}
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/gHLiRXOQu16Z7C2Shekj.png", alt="The Perform an audit button.", width="800", height="612" %}
 
-    **Figure 26**. An Audits report after enabling text compression
+1. Leave the settings the same as before and click **Analyze page load**.
 
-Woohoo! That looks like progress. Your overall performance score should have increased, meaning that
-the site is getting faster.
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/q3QUuwMcVKxgtoVKXobK.png", alt="A Lighthouse report after enabling text compression.", width="800", height="609" %}
+
+Woohoo! That looks like progress. Your overall performance score should have increased, meaning that the site is getting faster.
 
 #### Text compression in the real world {: #real-world-compression }
 
@@ -295,25 +264,22 @@ Resizing images helps speed up load time by reducing the file size of images. If
 viewing your images on a mobile device screen that's 500-pixels-wide, there's really no point in
 sending a 1500-pixel-wide image. Ideally, you'd send a 500-pixel-wide image, at most.
 
-1.  In your report, click **Properly size images** to see what images should be resized. It looks
-    like all 4 images are bigger than necessary.
+1. In your report, click **Properly size images** to see what images should be resized. It looks like all 4 images are bigger than necessary.
 
-    {% Img src="image/admin/MQEebrl7WbkRsSQ9Xm4H.png", alt="Details about the 'properly size images' opportunity.", width="800", height="533" %}
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/BfnbGrzVWejznp4fx1pz.png", alt="Details about the 'properly size images' opportunity", width="800", height="578" %}
 
-    **Figure 27**. Details about the _Properly size images_ opportunity
+1. Back in the editor tab, open `src/model.js`.
+1. Replace `const dir = 'big'` with `const dir = 'small'`. This directory contains copies of the same images which have been resized.
+1. Audit the page again to see how this change affects load performance.
 
-2.  Back in the editor tab, open `src/model.js`.
-3.  Replace `const dir = 'big'` with `const dir = 'small'`. This directory contains copies of the
-    same images which have been resized.
-4.  Audit the page again to see how this change affects load performance.
-
-    {% Img src="image/admin/ln4bwb1bVEIgnR9pNb32.png", alt="An Audits report after resizing images.", width="800", height="573" %}
-
-    **Figure 28**. An Audits report after resizing images
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/IEOT5AR8E802u94FzSqx.png", alt="A Lighthouse report after resizing images.", width="800", height="606" %}
 
 Looks like the change only has a minor affect on the overall performance score. However, one thing
 that the score doesn't show clearly is how much network data you're saving your users. The total
-size of the old photos was around 5.3 megabytes, whereas now it's only about 0.18 megabytes.
+size of the old photos was around 6.1 MB, whereas now it's only about 633 kB.
+You can check this on the status bar at the bottom of the **Network** panel.
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/tHb1AzPxKPHqpK5Ta5G9.png", alt="Amount of data transferred before and after resizing images.", width="800", height="504" %}
 
 #### Resizing images in the real world {: #real-world-resizing }
 
@@ -342,88 +308,82 @@ The first task, then, is to find code that doesn't need to be executed on page l
 1.  Click **Eliminate render-blocking resources** to see the resources that are blocking:
     `lodash.js` and `jquery.js`.
 
-    {% Img src="image/admin/30KsfDd87y7S1Tx7KsdY.png", alt="More information about the 'reduce render-blocking resources' opportunity.", width="800", height="470" %}
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/qIwOLr4ToqMYvDC9Gz5C.png", alt="More information about the 'reduce render-blocking resources' opportunity.", width="800", height="729" %}
 
-    **Figure 29**. More information about the _Reduce render-blocking resources_ opportunity
+2.  Depending on your operating system, press to [open the Command Menu](/docs/devtools/command-menu/#ope):
 
-2.  Press Command+Shift+P (Mac) or Control+Shift+P (Windows, Linux, ChromeOS) to open the Command
-    Menu, start typing `Coverage`, and then select **Show Coverage**.
+    - On Mac, <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>
+    - On Windows, Linux, or ChromeOS, <kbd>Control</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>
 
-    {% Img src="image/admin/Cy7cW3nb11D7A2ndQcsS.png", alt="Opening the Command Menu from the Audits panel.", width="800", height="438" %}
+    Start typing `Coverage` and select **Show Coverage**.
 
-    **Figure 30**. Opening the Command Menu from the Audits panel
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/weuz6NdR0mufsgCMf0E6.png", alt="Opening the Command Menu from the Lighthouse panel.", width="800", height="508" %}
 
-    {% Img src="image/admin/aG2vkytNQ4ohI3grGxXP.png", alt="The Coverage tab.", width="800", height="546" %}
+    [The **Coverage** tab](/docs/devtools/coverage/) opens in the **Drawer**.
 
-    **Figure 31**. The Coverage tab
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Pjwv19SbL16QGDoDdQ97.png", alt="The Coverage tab.", width="800", height="654" %}
 
-3.  Click **Reload** {% Img src="image/admin/sUKAx2esbJbYN6Ti3K8j.png", alt="Reload", width="24", height="25" %}. The Coverage tab
-    provides an overview of how much of the code in `bundle.js`, `jquery.js`, and `lodash.js` is
-    being executed while the page loads. **Figure 32** says that about 76% and 30% of the jQuery and
-    Lodash files aren't used, respectively.
+3.  Click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/sX65QEDYhwBFHCM24BtV.svg", alt="Reload.", width="22", height="22" %} **Reload**. The **Coverage** tab provides an overview of how much of the code in `bundle.js`, `jquery.js`, and `lodash.js` is being executed while the page loads.
 
-    {% Img src="image/admin/QmkjKS7ovEnvxmOwdva0.png", alt="The Coverage report.", width="800", height="565" %}
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/wBN9y0nBe5zulsFT7uTx.png", alt="The Coverage report.", width="800", height="611" %}
 
-    **Figure 32**. The Coverage report
+    This screenshot says that about 74% and 30% of the jQuery and Lodash files aren't used, respectively.
 
-4.  Click the **jquery.js** row. DevTools opens the file in the Sources panel. A line of code was
-    executed if it has a green bar next to it. A red bar means it was not executed, and is
+4.  Click the **jquery.js** row. DevTools opens the file in the **Sources** panel. A line of code was
+    executed if it has a green bar next to it. A red bar next to a line of code means it was not executed, and is
     definitely not needed on page load.
 
-    {% Img src="image/admin/xiqQiVD1TIga3vAjhOTp.png", alt="Viewing the jQuery file in the Sources panel.", width="800", height="727" %}
-
-    **Figure 33**. Viewing the jQuery file in the Sources panel
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/EzmNiqgdBYxLSS0F6APM.png", alt="Viewing the jQuery file in the Sources panel.", width="800", height="660" %}
 
 5.  Scroll through the jQuery code a bit. Some of the lines that get "executed" are actually just
     comments. Running this code through a minifier that strips comments is another way to reduce the
     size of this file.
 
-In short, when you're working with your own code, the Coverage tab can help you analyze your code,
+In short, when you're working with your own code, the **Coverage** tab can help you analyze your code,
 line-by-line, and only ship the code that's needed for page load.
 
-Are the `jquery.js` and `lodash.js` files even needed to load the page? The Request Blocking tab can
+Are the `jquery.js` and `lodash.js` files even needed to load the page? The **Request Blocking** tab can
 show you what happens when resources aren't available.
 
 1.  Click the **Network** tab.
-2.  Press Command+Shift+P (Mac) or Control+Shift+P (Windows, Linux, ChromeOS) to open the Command
-    Menu again.
-3.  Start typing `blocking` and then select **Show Request Blocking**.
+2.  Press <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> (Mac) or <kbd>Control</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> (Windows, Linux, ChromeOS) to open the **Command Menu** again.
+3.  Start typing `blocking` and then select **Show Request Blocking**. The Request Blocking tab opens.
 
-    {% Img src="image/admin/QzxdwawxAL7lcTDITDUr.png", alt="The Request Blocking tab.", width="800", height="628" %}
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/kYQ5X5AMm8bRBcqr4ylT.png", alt="The Request Blocking tab.", width="800", height="585" %}
 
-    **Figure 34**. The Request Blocking tab
+4.  Click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/YihNsXarRhDgEi9rOT4H.svg", alt="Add.", width="24", height="24" %} **Add Pattern**, type `/libs/*` in the textbox, and press <kbd>Enter</kbd> to confirm.
 
-4.  Click **Add Pattern** {% Img src="image/admin/VxE1QVPuOBQU1jNi6daa.png", alt="Add Pattern", width="20", height="20" %}, type
-    `/libs/*`, and then press Enter to confirm.
-
-    {% Img src="image/admin/4VOUHS947Tl88W04BhlQ.png", alt="Adding a pattern to block any request to the 'libs' directory.", width="800", height="628" %}
-
-    **Figure 35**. Adding a pattern to block any request to the `libs` directory
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/S7L1CsLkI7DAg7X24YtD.png", alt="Adding a pattern to block any request to the 'libs' directory.", width="800", height="556" %}
 
 5.  Reload the page. The jQuery and Lodash requests are red, meaning that they were blocked. The
     page still loads and is interactive, so it looks like these resources aren't needed whatsoever!
 
-    {% Img src="image/admin/6uapC5Z2q18AdsytxmLY.png", alt="The Network panel shows that the requests have been blocked.", width="800", height="649" %}
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/B7IpHXkLQdInfffZ2FcO.png", alt="The Network panel shows that the requests have been blocked.", width="800", height="556" %}
 
-    **Figure 36**. The Network panel shows that the requests have been blocked
+6.  Click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Nh5W7S7oEdlTcjarzxKC.svg", alt="Remove.", width="22", height="22" %} **Remove all patterns** to delete the `/libs/*` blocking pattern.
 
-6.  Click **Remove all patterns**
-    {% Img src="image/admin/68qlmwDuexzRmvlmENsm.png", alt="Remove all patterns", width="26", height="26" %} to delete the `/libs/*`
-    blocking pattern.
-
-In general, the Request Blocking tab is useful for simulating how your page behaves when any given
+In general, the **Request Blocking** tab is useful for simulating how your page behaves when any given
 resource isn't available.
 
 Now, remove the references to these files from the code and audit the page again:
 
 1.  Back in the editor tab, open `template.html`.
-2.  Delete `<script src="/libs/lodash.js">` and `<script src="/libs/jquery.js"></script>`.
+2.  Delete the corresponding `<script>` tags:
+
+    ```js//3-4
+    <head>
+        ...
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <script src="/libs/lodash.js"></script>
+        <script src="/libs/jquery.js"></script>
+        <title>Tony's Favorite Foods</title>
+    </head>
+    ```
+
 3.  Wait for the site to re-build and re-deploy.
-4.  Audit the page again from the **Audits** panel. Your overall score should have improved again.
+4.  Audit the page again from the **Lighthouse** panel. Your overall score should have improved again.
 
-    {% Img src="image/admin/1CCrhlIeucyJLLH373f7.png", alt="An Audits report after removing the render-blocking resources.", width="800", height="555" %}
-
-    **Figure 37**. An Audits report after removing the render-blocking resources
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/PPWlXU4Wml8zFwVjdfsU.png", alt="A Lighthouse report after removing the render-blocking resources.", width="800", height="614" %}
 
 #### Optimizing the Critical Rendering Path in the real-world {: #crp }
 
@@ -439,93 +399,81 @@ everything else.
 
 ### Do less main thread work {: #main }
 
-Your latest report shows some minor potential savings in the Opportunities section, but if you look
-down in the Diagnostics section, it looks like the biggest bottleneck is too much main thread
+Your latest report shows some minor potential savings in the **Opportunities** section, but if you scroll
+down to the **Diagnostics** section, it looks like the biggest bottleneck is too much main thread
 activity.
 
 The main thread is where the browser does most of the work needed to display a page, such as parsing
 and executing HTML, CSS, and JavaScript.
 
-The goal is to use the Performance panel to analyze what work the main thread is doing while the
+{% Aside %}
+**Note:** This section provides a rather brief introduction to the Performance panel. See
+[Performance features reference][12] to learn more about how you can use it to analyze page
+performance.
+{% endAside %}
+
+The goal is to use the **Performance** panel to analyze what work the main thread is doing while the
 page loads, and find ways to defer or remove unnecessary work.
 
-1.  Click the **Performance** tab.
-2.  Click **Capture Settings**
-    {% Img src="image/admin/II9FuwvOLWrZAaaPOKTL.png", alt="Capture Settings", width="28", height="28" %}.
-3.  Set **Network** to **Slow 3G** and **CPU** to **6x slowdown**. Mobile devices typically have
-    more hardware constraints than laptops or desktops, so these settings let you experience the
-    page load as if you were using a less powerful device.
-4.  Click **Reload** {% Img src="image/admin/sUKAx2esbJbYN6Ti3K8j.png", alt="Reload", width="24", height="25" %}. DevTools reloads
-    the page and then produces a visualization of all it had to do in order to load the page. This
-    visualization will be referred to as the _trace_.
+1. Open **Performance** > {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/9gzXiTYY0nZzBxGI6KrV.svg", alt="Settings.", width="24", height="24" %} **Capture Settings** and set **Network** to **Slow 3G** and **CPU** to **6x slowdown**.
 
-    {% Img src="image/admin/XM6GIspnPnqxmE516rYP.png", alt="The Performance panel's trace of the page load.", width="800", height="713" %}
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/0yh9DC4HsvPFKYcjNSWi.png", alt="Settings CPU and network throttling in the Performance panel", width="800", height="416" %}
 
-    **Figure 38**. The Performance panel's trace of the page load
+   Mobile devices typically have more hardware constraints than laptops or desktops, so these settings let you experience the page load as if you were using a less powerful device.
+1. Click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/sX65QEDYhwBFHCM24BtV.svg", alt="Reload.", width="22", height="22" %} **Reload**.
+   DevTools reloads the page and then produces a visualization of all it had to do in order to load the page. This visualization will be referred to as the _trace_.
+
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/oSnPlb5GpIZIY1jjr1aa.png", alt="The Performance panel's trace of the page load.", width="800", height="577" %}
 
 The trace shows activity chronologically, from left to right. The FPS, CPU, and NET charts at the
-top give you an overview of frames per second, CPU activity, and network activity. The wall of
-yellow that you see in **Figure 39** means that the CPU was completely busy with scripting activity.
+top give you an overview of frames per second, CPU activity, and network activity.
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/xfGEi6BAKBqnqdHUVnOX.png", alt="The Overview section of the trace.", width="800", height="443" %}
+
+The wall of yellow that you see in the **Overview** section means that the CPU was completely busy with scripting activity.
 This is a clue that you may be able to speed up page load by doing less JavaScript work.
-
-{% Img src="image/admin/dN3o50JaLqXs5SsXKczC.png", alt="The Overview section of the trace.", width="800", height="552" %}
-
-**Figure 39**. The Overview section of the trace
 
 Investigate the trace to find ways to do less JavaScript work:
 
-1.  Click the **User Timing** section to expand it. Based on the fact that there seems to be a bunch
-    of [User Timing][11] measures from React, it seems like Tony's app is using the development mode
-    of React. Switching to the production mode of React will probably yield some easy performance
-    wins.
+1.  Click the **Timings** section to expand it.
 
-    {% Img src="image/admin/fyFy1OSmVToyqYkEhCrU.png", alt="The User Timing section.", width="800", height="556" %}
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/egPNqylDWyGLRKhqHGh9.png", alt="The Timings section.", width="800", height="500" %}
 
-    **Figure 40**. The User Timing section
+    There is a bunch of [User Timing][11] measures from React, it seems like Tony's app is using the development mode of React. Switching to the production mode of React will probably yield some easy performance wins.
 
-2.  Click **User Timing** again to collapse that section.
-3.  Browse the **Main** section. This section shows a chronological log of main thread activity,
-    from left to right. The y-axis (top to bottom) shows why events occurred. For example, in
-    **Figure 41**, the `Evaluate Script` event caused the `(anonymous)` function to execute, which
-    caused `../rbd/pnpm-volume/...` to execute, which caused `__webpack__require__` to execute, and
-    so on.
+1.  Click **Timings** again to collapse that section.
+1.  Browse the **Main** section. This section shows a chronological log of main thread activity,
+    from left to right. The y-axis (top to bottom) shows why events occurred.
 
-    {% Img src="image/admin/vfnYkoiAVM61wxyXIbXc.png", alt="The Main section", width="800", height="609" %}
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/DbX2VPBm6wLZ0G4l2K6L.png", alt="The Main section.", width="800", height="500" %}
 
-    **Figure 41**. The Main section
+    In this example, the `Evaluate Script` event caused the `(anonymous)` function to execute, which caused `__webpack__require__` to execute, which caused `./src/index.jsx` to execute, and so on.
 
-4.  Scroll down to the bottom of the **Main** section. When you use a framework, most of the upper
+1.  Scroll down to the bottom of the **Main** section. When you use a framework, most of the upper
     activity is caused by the framework, which is usually out of your control. The activity caused
-    by your app is usually at the bottom. In this app, it seems like a function called `App` is
-    causing a lot of calls to a `mineBitcoin` function. It sounds like Tony might be using the
-    devices of his fans to mine cryptocurrency...
+    by your app is usually at the bottom.
 
-    {% Img src="image/admin/UmtH1RZihmBQxNcmVtE3.png", alt="Hovering over the mineBitcoin activity.", width="800", height="512" %}
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/yfrefJPKh6TljAaO8iXl.png", alt="The mineBitcoin activity.", width="800", height="443" %}
 
-    **Figure 42**. Hovering over the `mineBitcoin` activity
+    In this app, it seems like a function called `App` is causing a lot of calls to a `mineBitcoin` function. It sounds like Tony might be using the devices of his fans to mine cryptocurrency...
 
     {% Aside %}
-
     **Note:** Although the calls that your framework makes are usually out of your control,
     sometimes you may structure your app in a way that causes the framework to run inefficiently.
     Restructuring your app to use the framework efficiently can be a way to do less main thread
     work. However, this requires a deep understanding of how your framework works, and what kind of
     changes you can make in your own code in order to use the framework more efficiently.
-
     {% endAside %}
 
-5.  Expand the **Bottom-Up** section. This tab breaks down what activities took up the most time. If
-    you don't see anything in the Bottom-Up section, click the label for **Main** section. The
-    Bottom-Up section only shows information for whatever activity, or group of activity, you have
+1.  Open the **Bottom-Up** tab at the bottom. This tab breaks down what activities took up the most time. If you don't see anything in the **Bottom-Up** section, click the label for **Main** section.
+
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/RsybUenV27IbQfzwsezE.png", alt="The Bottom-Up tab.", width="800", height="594" %}
+
+    The **Bottom-Up** section only shows information for whatever activity, or group of activity, you have
     currently selected. For example, if you clicked on one of the `mineBitcoin` activities, the
-    Bottom-Up section is only going to show information for that one activity.
+    **Bottom-Up** section is only going to show information for that one activity.
 
-    {% Img src="image/admin/SkSkmxCFJGTrMa9YsBdi.png", alt="The Bottom-Up tab.", width="800", height="614" %}
-
-    **Figure 43**. The Bottom-Up tab
-
-The **Self Time** column shows you how much time was spent directly in each activity. For example,
-**Figure 43** shows that about 57% of main thread time was spent on the `mineBitcoin` function.
+The **Self Time** column shows you how much time was spent directly in each activity. In this case, about 82% of main thread time was spent on the `mineBitcoin` function.
 
 Time to see whether using production mode and reducing JavaScript activity will speed up the page
 load. Start with production mode:
@@ -535,9 +483,7 @@ load. Start with production mode:
 3.  Wait for the new build to deploy.
 4.  Audit the page again.
 
-    {% Img src="image/admin/dzTo8Pt5AyXipmvq5gEF.png", alt="An Audits report after configuring webpack to use production mode.", width="800", height="601" %}
-
-    **Figure 44**. An Audits report after configuring webpack to use production mode
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/ChupOjK8HHF9i9PFFrUX.png", alt="A Lighthouse report after configuring webpack to use production mode.", width="800", height="640" %}
 
 Reduce JavaScript activity by removing the call to `mineBitcoin`:
 
@@ -546,23 +492,17 @@ Reduce JavaScript activity by removing the call to `mineBitcoin`:
 3.  Wait for the new build to deploy.
 4.  Audit the page again.
 
-    {% Img src="image/admin/fdW3Jstcwj3Wpjd5RTqy.png", alt="An Audits report after removing unnecessary JavaScript work.", width="800", height="601" %}
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Ug3mIDzuacvZwGSt6StX.png", alt="A Lighthouse report after removing unnecessary JavaScript work.", width="800", height="692" %}
 
-    **Figure 45**. An Audits report after removing unnecessary JavaScript work
+As always, there still are things to do, for example, reduce the [Largest Contentful Paint](/docs/lighthouse/performance/lighthouse-largest-contentful-paint/) and [Cumulative Layout Shift](https://web.dev/cls/) metrics.
 
-Looks like that last change caused a massive jump in performance!
-
-{% Aside %}
-
-**Note:** This section provided a rather brief introduction to the Performance panel. See
-[Performance Analysis Reference][12] to learn more about how you can use it to analyze page
-performance.
-
+{% Aside 'success' %}
+But it looks like the last change caused a massive jump in performance!
 {% endAside %}
 
 #### Doing less main thread work in the real world {: #real-world-main-thread }
 
-In general, the Performance panel is the most common way to understand what activity your site does
+In general, the **Performance** panel is the most common way to understand what activity your site does
 as it loads, and find ways to remove unnecessary activity.
 
 If you'd prefer an approach that feels more like `console.log()`, the [User Timing][13] API lets you
@@ -578,13 +518,9 @@ phases takes.
 
 ## Next steps {: #next-steps }
 
-- Run audits on your own site! If you need help interpreting your report, or finding ways to improve
-  your load performance, check out [Feedback][14] for ways to get help from the DevTools community.
-  Stack Overflow, the mailing list, or Twitter are probably best for these types of questions.
-- Please leave [feedback][15] on this tutorial. I really do use the data to make better tutorials
-  for you.
+Run audits on your own site! If you need help interpreting your report or finding ways to improve your load performance, check out all the ways to get help from the DevTools community:
 
-- File bugs on this doc in the [Web Fundamentals][16] repository.
+- File bugs on this doc in the [developer.chrome.com][16] repository.
 - File bug reports on DevTools at [Chromium Bugs][17].
 - Discuss features and changes on the [Mailing List][18]. Please don't use the mailing list for
   support questions. Use Stack Overflow, instead.
@@ -606,9 +542,7 @@ phases takes.
 [11]: https://developer.mozilla.org/docs/Web/API/User_Timing_API
 [12]: /docs/devtools/evaluate-performance/reference
 [13]: https://developer.mozilla.org/docs/Web/API/User_Timing_API
-[14]: #feedback
-[15]: #feedback
-[16]: https://github.com/google/webfundamentals/issues/new
+[16]: https://github.com/GoogleChrome/developer.chrome.com/issues/new/choose
 [17]: https://crbug.com
 [18]: https://groups.google.com/forum/#!forum/google-chrome-developer-tools
 [19]: https://stackoverflow.com/questions/tagged/google-chrome-devtools

--- a/site/en/docs/devtools/lighthouse/index.md
+++ b/site/en/docs/devtools/lighthouse/index.md
@@ -34,7 +34,7 @@ For more information, see [What's new in Lighthouse](/tags/new-in-lighthouse/).
 
 ## Introduction {: #intro }
 
-This is Tony. Tony is very famous in cat society. He has built a website so that his fans can learn
+This is Tony. Tony is very famous in cat society. He has built a [website](https://tony.glitch.me/) so that his fans can learn
 what his favorite foods are. His fans love the site, but Tony keeps hearing complaints that the site
 loads slowly. Tony has asked you to help him speed the site up.
 
@@ -55,9 +55,9 @@ has two important functions:
 
 ### Set up {: #setup }
 
-But first, you need to set up the site so that you can make changes to it later:
+But first, you need to set up a new working environment for [Tony's website](https://glitch.com/edit/#!/tony) so that you can make changes to it later:
 
-1. Open the [source of this demo website][2] and click **Remix** in the upper right corner. A new project opens in a tab. This tab will be referred to as the _editor tab_.
+1. [Remix the website's project on Glitch][2]. Your new project opens in a tab. This tab will be referred to as the _editor tab_.
 
    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/vNL328lOu6idOm4AKNdP.png", alt="The original source and the editor tab after clicking Remix.", width="800", height="466" %}
 
@@ -79,7 +79,11 @@ For the rest of the screenshots in this tutorial, DevTools is shown in a [separa
 
 The baseline is a record of how the site performed before you made any performance improvements.
 
-1.  Open the **Lighthouse** panel. It may be hidden behind {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/V93Xxk8HvmByCBGzMdW4.svg", alt="More panels.", width="20", height="20" %} **More panels**. The panel is powered by [**Lighthouse**](/docs/lighthouse).
+1.  Open the **Lighthouse** panel. It may be hidden behind {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/V93Xxk8HvmByCBGzMdW4.svg", alt="More panels.", width="20", height="20" %} **More panels**.
+   
+    {% Aside %}
+    This panel is powered by its namesake—[**Lighthouse**](/docs/lighthouse), an automated tool for improving the quality of your web apps.
+    {% endAside %}
 
     {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/4zA1JQLNurO4o8WyAy9T.png", alt="The Lighthouse panel.", width="800", height="830" %}
 
@@ -526,7 +530,7 @@ Run audits on your own site! If you need help interpreting your report or findin
 - Tweet us at [@ChromeDevTools][20].
 
 [1]: https://www.coursera.org/learn/web-development#syllabus
-[2]: https://glitch.com/edit/#!/tony
+[2]: https://glitch.com/edit/#!/remix/tony
 [3]: /docs/lighthouse/overview/
 [4]: https://support.google.com/chrome/answer/95464
 [5]: https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Encoding#Directives

--- a/site/en/docs/devtools/lighthouse/index.md
+++ b/site/en/docs/devtools/lighthouse/index.md
@@ -57,9 +57,9 @@ has two important functions:
 
 But first, you need to set up the site so that you can make changes to it later:
 
-1. Open the [source of this demo website][2] and click **Remix to Edit** in the upper right corner. A tab opens. This tab will be referred to as the _editor tab_.
+1. Open the [source of this demo website][2] and click **Remix** in the upper right corner. A new project opens in a tab. This tab will be referred to as the _editor tab_.
 
-   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/PzSGlC0EiBWw9JmpqLMu.png", alt="The editor tab.", width="800", height="488" %}
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/vNL328lOu6idOm4AKNdP.png", alt="The original source and the editor tab after clicking Remix.", width="800", height="466" %}
 
    The name of the project changes from **tony** to some randomly-generated name. You now have your own editable copy of the code. Later on, you'll make changes to this code.
 
@@ -79,11 +79,9 @@ For the rest of the screenshots in this tutorial, DevTools is shown in a [separa
 
 The baseline is a record of how the site performed before you made any performance improvements.
 
-1.  Open the **Lighthouse** panel. It may be hidden behind {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/V93Xxk8HvmByCBGzMdW4.svg", alt="More panels.", width="20", height="20" %} **More panels**.
+1.  Open the **Lighthouse** panel. It may be hidden behind {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/V93Xxk8HvmByCBGzMdW4.svg", alt="More panels.", width="20", height="20" %} **More panels**. The panel is powered by [**Lighthouse**](/docs/lighthouse).
 
     {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/4zA1JQLNurO4o8WyAy9T.png", alt="The Lighthouse panel.", width="800", height="830" %}
-
-    The panel is powered by [**Lighthouse**](/docs/lighthouse).
 
 2.  Match your Lighthouse report configuration settings to those on the screenshot. Here's an explanation of the
     different options:
@@ -117,7 +115,7 @@ make changes to the code, you should see this number rise. A higher score means 
 
 #### Metrics {: #metrics }
 
-Scroll down to the **Metrics** section and click **Expand view**. Click **Learn more...** to read documentation on a metric.
+Scroll down to the **Metrics** section and click **Expand view**. To read documentation on a metric, click **Learn more...**.
 
 {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/fhK91fGcQEPIkuhYbj7r.png", alt="The Metrics section.", width="800", height="712" %}
 
@@ -310,12 +308,12 @@ The first task, then, is to find code that doesn't need to be executed on page l
 
     {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/qIwOLr4ToqMYvDC9Gz5C.png", alt="More information about the 'reduce render-blocking resources' opportunity.", width="800", height="729" %}
 
-2.  Depending on your operating system, press to [open the Command Menu](/docs/devtools/command-menu/#ope):
+1.  Depending on your operating system, press the following to [open the Command Menu](/docs/devtools/command-menu/#ope):
 
     - On Mac, <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>
     - On Windows, Linux, or ChromeOS, <kbd>Control</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>
 
-    Start typing `Coverage` and select **Show Coverage**.
+1.  Start typing `Coverage` and select **Show Coverage**.
 
     {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/weuz6NdR0mufsgCMf0E6.png", alt="Opening the Command Menu from the Lighthouse panel.", width="800", height="508" %}
 
@@ -323,19 +321,19 @@ The first task, then, is to find code that doesn't need to be executed on page l
 
     {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Pjwv19SbL16QGDoDdQ97.png", alt="The Coverage tab.", width="800", height="654" %}
 
-3.  Click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/sX65QEDYhwBFHCM24BtV.svg", alt="Reload.", width="22", height="22" %} **Reload**. The **Coverage** tab provides an overview of how much of the code in `bundle.js`, `jquery.js`, and `lodash.js` is being executed while the page loads.
+1.  Click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/sX65QEDYhwBFHCM24BtV.svg", alt="Reload.", width="22", height="22" %} **Reload**. The **Coverage** tab provides an overview of how much of the code in `bundle.js`, `jquery.js`, and `lodash.js` is being executed while the page loads.
 
     {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/wBN9y0nBe5zulsFT7uTx.png", alt="The Coverage report.", width="800", height="611" %}
 
     This screenshot says that about 74% and 30% of the jQuery and Lodash files aren't used, respectively.
 
-4.  Click the **jquery.js** row. DevTools opens the file in the **Sources** panel. A line of code was
+1.  Click the **jquery.js** row. DevTools opens the file in the **Sources** panel. A line of code was
     executed if it has a green bar next to it. A red bar next to a line of code means it was not executed, and is
     definitely not needed on page load.
 
     {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/EzmNiqgdBYxLSS0F6APM.png", alt="Viewing the jQuery file in the Sources panel.", width="800", height="660" %}
 
-5.  Scroll through the jQuery code a bit. Some of the lines that get "executed" are actually just
+1.  Scroll through the jQuery code a bit. Some of the lines that get "executed" are actually just
     comments. Running this code through a minifier that strips comments is another way to reduce the
     size of this file.
 
@@ -345,22 +343,21 @@ line-by-line, and only ship the code that's needed for page load.
 Are the `jquery.js` and `lodash.js` files even needed to load the page? The **Request Blocking** tab can
 show you what happens when resources aren't available.
 
-1.  Click the **Network** tab.
-2.  Press <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> (Mac) or <kbd>Control</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> (Windows, Linux, ChromeOS) to open the **Command Menu** again.
-3.  Start typing `blocking` and then select **Show Request Blocking**. The Request Blocking tab opens.
+1.  Click the **Network** tab and [open the **Command Menu** again](/docs/devtools/command-menu/#open).
+1.  Start typing `blocking` and then select **Show Request Blocking**. The **Request Blocking** tab opens.
 
     {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/kYQ5X5AMm8bRBcqr4ylT.png", alt="The Request Blocking tab.", width="800", height="585" %}
 
-4.  Click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/YihNsXarRhDgEi9rOT4H.svg", alt="Add.", width="24", height="24" %} **Add Pattern**, type `/libs/*` in the textbox, and press <kbd>Enter</kbd> to confirm.
+1.  Click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/YihNsXarRhDgEi9rOT4H.svg", alt="Add.", width="24", height="24" %} **Add Pattern**, type `/libs/*` in the textbox, and press <kbd>Enter</kbd> to confirm.
 
     {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/S7L1CsLkI7DAg7X24YtD.png", alt="Adding a pattern to block any request to the 'libs' directory.", width="800", height="556" %}
 
-5.  Reload the page. The jQuery and Lodash requests are red, meaning that they were blocked. The
+1.  Reload the page. The jQuery and Lodash requests are red, meaning that they were blocked. The
     page still loads and is interactive, so it looks like these resources aren't needed whatsoever!
 
     {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/B7IpHXkLQdInfffZ2FcO.png", alt="The Network panel shows that the requests have been blocked.", width="800", height="556" %}
 
-6.  Click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Nh5W7S7oEdlTcjarzxKC.svg", alt="Remove.", width="22", height="22" %} **Remove all patterns** to delete the `/libs/*` blocking pattern.
+1.  Click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Nh5W7S7oEdlTcjarzxKC.svg", alt="Remove.", width="22", height="22" %} **Remove all patterns** to delete the `/libs/*` blocking pattern.
 
 In general, the **Request Blocking** tab is useful for simulating how your page behaves when any given
 resource isn't available.
@@ -473,7 +470,7 @@ Investigate the trace to find ways to do less JavaScript work:
     currently selected. For example, if you clicked on one of the `mineBitcoin` activities, the
     **Bottom-Up** section is only going to show information for that one activity.
 
-The **Self Time** column shows you how much time was spent directly in each activity. In this case, about 82% of main thread time was spent on the `mineBitcoin` function.
+    The **Self Time** column shows you how much time was spent directly in each activity. In this case, about 82% of main thread time was spent on the `mineBitcoin` function.
 
 Time to see whether using production mode and reducing JavaScript activity will speed up the page
 load. Start with production mode:

--- a/site/en/docs/devtools/lighthouse/index.md
+++ b/site/en/docs/devtools/lighthouse/index.md
@@ -230,7 +230,7 @@ Use the workflows that you learned earlier to manually check that the compressio
 
    The **Size** column should now show two different values for text resources like `bundle.js`. The top value of `269 KB` for `bundle.js` is the size of the file that was sent over the network, and the bottom value of `1.4 MB` is the uncompressed file size.
 
-   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/feaqTS50BT1JlFSXLFLr.png", alt="The Size column now shows 2 different values for text resources.", width="800", height="572" %}
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/feaqTS50BT1JlFSXLFLr.png", alt="The Size column now shows two different values for text resources.", width="800", height="572" %}
 
 1. The **Response Headers** section for `bundle.js` should now include a `content-encoding: gzip` header.
 

--- a/site/en/docs/devtools/lighthouse/index.md
+++ b/site/en/docs/devtools/lighthouse/index.md
@@ -5,7 +5,7 @@ authors:
   - kaycebasques
   - sofiayem
 date: 2018-06-18
-updated: 2023-03-14
+updated: 2023-03-15
 description: "Learn how to use Chrome DevTools to find ways to make your websites load faster."
 tags:
   - get-started

--- a/site/en/docs/devtools/lighthouse/index.md
+++ b/site/en/docs/devtools/lighthouse/index.md
@@ -3,8 +3,9 @@ layout: "layouts/doc-post.njk"
 title: "Lighthouse: Optimize website speed"
 authors:
   - kaycebasques
+  - sofiayem
 date: 2018-06-18
-#updated: YYYY-MM-DD
+updated: 2023-03-14
 description: "Learn how to use Chrome DevTools to find ways to make your websites load faster."
 tags:
   - get-started
@@ -19,6 +20,12 @@ Read on, or watch the video version of this tutorial:
 
 {% YouTube id="5fLW5Q5ODiE" %}
 
+{% Aside 'important' %}
+This video was made with Chrome 68. Most of it is still true but some features have been updated.
+For example, the **Audits** panel is now called **Lighthouse**, and it has a different look but all of the same options are still there.
+For more information, see [What's new in Lighthouse](/tags/new-in-lighthouse/).
+{% endAside %}
+
 ## Prerequisites {: #prerequisites }
 
 - You should have basic web development experience, similar to what's taught in this [Introduction
@@ -31,14 +38,17 @@ This is Tony. Tony is very famous in cat society. He has built a website so that
 what his favorite foods are. His fans love the site, but Tony keeps hearing complaints that the site
 loads slowly. Tony has asked you to help him speed the site up.
 
+<figure>
 {% Img src="image/admin/TLlf3OH689gZcCLnEY67.jpg", alt="Tony the cat.", width="800", height="600" %}
-
-**Figure 1**. Tony the cat
+  <figcaption>
+    Tony the cat.
+  </figcaption>
+</figure>
 
 ## Step 1: Audit the site {: #audit }
 
 Whenever you set out to improve a site's load performance, **always start with an audit**. The audit
-has 2 important functions:
+has two important functions:
 
 - It creates a **baseline** for you to measure subsequent changes against.
 - It gives you **actionable tips** on what changes will have the most impact.
@@ -47,120 +57,73 @@ has 2 important functions:
 
 But first, you need to set up the site so that you can make changes to it later:
 
-1.  Go to `chrome://version` to check what version of Chrome you're using. This tutorial was made
-    with Chrome 68. If you're using an earlier or later version, some features may look different or
-    not be available. You should be able to complete the tutorial still, just keep in mind that your
-    UI may look different than the screenshots.
-2.  [Open the source code for the site][2]. This tab will be referred to as the _editor tab_.
+1. Open the [source of this demo website][2] and click **Remix to Edit** in the upper right corner. A tab opens. This tab will be referred to as the _editor tab_.
 
-    {% Img src="image/admin/h2JSHSXIa8G3kOqRILbk.png", alt="The editor tab.", width="800", height="457" %}
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/PzSGlC0EiBWw9JmpqLMu.png", alt="The editor tab.", width="800", height="488" %}
 
-    **Figure 2**. The editor tab
+   The name of the project changes from **tony** to some randomly-generated name. You now have your own editable copy of the code. Later on, you'll make changes to this code.
 
-3.  Click **tony**. A menu appears.
+1. At the bottom of the editor tab, click **Preview** > **Preview in a new window**. The demo opens in a new tab. This tab will be referred to as the _demo tab_. It may take a while for the site to load.
 
-    {% Img src="image/admin/N9c7p2yrUhWgUobkDuVs.png", alt="The menu that appears after clicking 'tony'.", width="800", height="457" %}
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/dX6kVyYogDqrDVcM4WzJ.png", alt="The demo tab.", width="800", height="614" %}
 
-    **Figure 3**. The menu that appears after clicking **tony**
+1. [Open DevTools](/docs/devtools/open) alongside the demo.
 
-4.  Click **Remix This**. The name of the project changes from **tony** to some randomly-generated
-    name. You now have your own editable copy of the code. Later on, you'll make changes to this
-    code.
-5.  Click **Show Live**. The demo opens in a new tab. This tab will be referred to as the _demo
-    tab_. It may take a while for the site to load.
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/IgZOUlF1RxARqEGoKjKF.png", alt="DevTools and the demo.", width="800", height="535" %}
 
-    {% Img src="image/admin/2kZXAZgIbvKrafszL6X3.png", alt="The demo tab.", width="800", height="588" %}
-
-    **Figure 4**. The demo tab
-
-6.  Press Command+Option+J (Mac) Control+Shift+J (Windows, Linux, ChromeOS). Chrome DevTools opens
-    up alongside the demo.
-
-    {% Img src="image/admin/QyoSneXNo8Npiy28nJlU.png", alt="DevTools and the demo.", width="800", height="476" %}
-
-    **Figure 5**. DevTools and the demo
-
-For the rest of the screenshots in this tutorial, DevTools will be shown as a separate window. You
-can do this by pressing Command+Shift+P (Mac) or Control+Shift+P (Windows, Linux, ChromeOS) to open
-the Command Menu, typing `Undock`, and then selecting **Undock into separate window**.
-
-{% Img src="image/admin/YgPOzT6Re0aIGezSKPZr.png", alt="Undocked DevTools.", width="800", height="514" %}
-
-**Figure 6**. Undocked DevTools
+{% Aside 'important' %}
+For the rest of the screenshots in this tutorial, DevTools is shown in a [separate window](/docs/devtools/customize/#placement).
+{% endAside %}
 
 ### Establish a baseline {: #baseline }
 
 The baseline is a record of how the site performed before you made any performance improvements.
 
-1.  Click the **Audits** tab. It may be hidden behind the **More Panels**
-    {% Img src="image/admin/IxLXhwoZksgzzdzr9OCx.png", alt="More Panels", width="18", height="16" %} button. There's a
-    Lighthouse on this panel because the project that powers the Audits panel is called
-    [Lighthouse][3].
+1.  Open the **Lighthouse** panel. It may be hidden behind {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/V93Xxk8HvmByCBGzMdW4.svg", alt="More panels.", width="20", height="20" %} **More panels**.
 
-    {% Img src="image/admin/3pLUyTJ93xjvm0itZ3Lb.png", alt="The Audits panel.", width="800", height="1068" %}
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/4zA1JQLNurO4o8WyAy9T.png", alt="The Lighthouse panel.", width="800", height="830" %}
 
-    **Figure 7**. The Audits panel
+    The panel is powered by [**Lighthouse**](/docs/lighthouse).
 
-2.  Match your audit configuration settings to those in **Figure 7**. Here's an explanation of the
+2.  Match your Lighthouse report configuration settings to those on the screenshot. Here's an explanation of the
     different options:
 
-    - **Device**. Setting to **Mobile** changes the user agent string and simulates a mobile
-      viewport. Setting to **Desktop** pretty much just disables the **Mobile** changes.
-    - **Audits**. Disabling a category prevents the Audits panel from running those audits, and
-      excludes those audits from your report. You can leave the other categories enabled, if you
-      want to see the types of recommendations they provide. Disabling categories slightly speeds up
-      the auditing process.
-    - **Throttling**. Setting to **Simulated Fast 3G, 4x CPU Slowdown** simulates the typical
-      conditions of browsing on a mobile device. It's called "simulated" because the Audits panel
-      doesn't actually throttle during the auditing process. Instead, it just extrapolates how long
-      the page would take to load under mobile conditions. The **Applied...** setting, on the other
-      hand, actually throttles your CPU and network, with the tradeoff of a longer auditing process.
-    - **Clear Storage**. Enabling this checkbox clears all storage associated with the page before
-      every audit. Leave this setting on if you want to audit how first-time visitors experience
-      your site. Disable this setting when you want the repeat-visit experience.
+    - **Mode** > {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/ljri3HPj5aVym9qgMfkx.svg", alt="Radio button checked.", width="20", height="20" %} **Navigation (default)**. This mode analyses a single page load and that's what we need in this tutorial. For more information, see [The three modes](https://github.com/GoogleChrome/lighthouse/blob/HEAD/docs/user-flows.md#the-three-modes-navigation-timespan-snapshot).
+    - **Device** > {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/ljri3HPj5aVym9qgMfkx.svg", alt="Radio button checked.", width="20", height="20" %} **Mobile**. The mobile option changes the user agent string and simulates a mobile
+      viewport. The desktop option pretty much just disables the mobile changes.
+    - **Categories** > {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/hmp8j3HiLMCcqPArD9yt.svg", alt="Checkbox.", width="24", height="24" %} **Performance**. A single enabled category makes Lighthouse generate a report only with the corresponding set of audits. You can leave the other categories enabled, if you want to see the types of recommendations they provide. Disabling irrelevant categories slightly speeds up the auditing process.
+    - **Simulated throttling (default)** {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/C8J2TiWeNKJhQn3eEauv.svg", alt="Drop-down.", width="20", height="20" %}. This option simulates the typical conditions of browsing on a mobile device. It's called "simulated" because Lighthouse doesn't actually throttle during the auditing process. Instead, it just extrapolates how long the page would take to load under mobile conditions. The **DevTools throttling (advanced)** setting, on the other hand, actually throttles your CPU and network, with the tradeoff of a longer auditing process.
+    - {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/hmp8j3HiLMCcqPArD9yt.svg", alt="Checkbox.", width="24", height="24" %} **Clear Storage**. Enabling this checkbox clears all storage associated with the page before every audit. Leave this setting on if you want to audit how first-time visitors experience your site. Disable this setting when you want the repeat-visit experience.
 
-3.  Click **Run Audits**. After 10 to 30 seconds, the Audits panel shows you a report of the site's
+3.  Click **Analyze page load**. After 10 to 30 seconds, the **Lighthouse** panel shows you a report of the site's
     performance.
 
-    {% Img src="image/admin/NgjLST0tdYLxJIyaLMAo.png", alt="An Audits panel report of the site's performance.", width="800", height="966" %}
-
-    **Figure 8**. The Audits panel's report of the site's performance
+    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/aCoPjdb6CKbHmPxjCcgR.png", alt="A Lighthouse report of the site's performance.", width="800", height="959" %}
 
 #### Handling report errors {: #errors }
 
-If you ever get an error in your Audits panel report, try running the demo tab from an [incognito
+If you ever get an error in your Lighthouse report, try running the demo tab from an [incognito
 window][4] with no other tabs open. This ensures that you're running Chrome from a clean state.
 Chrome Extensions in particular often interfere with the auditing process.
 
-{% Img src="image/admin/BQOnt1Z7Qp1CUZ1Ln6ve.png", alt="A report that errored.", width="800", height="552" %}
-
-**Figure 9**. A report that errored
+{% Img src="image/admin/BQOnt1Z7Qp1CUZ1Ln6ve.png", alt="A report with an error.", width="800", height="552" %}
 
 ### Understand your report {: #report }
 
 The number at the top of your report is the overall performance score for the site. Later, as you
 make changes to the code, you should see this number rise. A higher score means better performance.
 
-{% Img src="image/admin/V9sAawCdJGzkcYHlGaom.png", alt="The overall performance score.", width="800", height="607" %}
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/aZwib1rLHMcOMioP1SKG.png", alt="The overall performance score.", width="800", height="959" %}
 
-**Figure 10**. The overall performance score
-
-The **Metrics** section provides quantitative measurements of the site's performance. Each metric
-provides insight into a different aspect of the performance. For example, **First Contentful Paint**
+Scroll down to the **Metrics** section and click **Expand view**. This section provides quantitative measurements of the site's performance.
+Each metric provides insight into a different aspect of the performance. For example, **First Contentful Paint**
 tells you when content is first painted to the screen, which is an important milestone in the user's
 perception of the page load, whereas **Time To Interactive** marks the point at which the page
 appears ready enough to handle user interactions.
 
-{% Img src="image/admin/rPpuNEgtEJVOtfbOCS8Z.png", alt="The Metrics section.", width="800", height="607" %}
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/agfthX3hQb21pMTYn44B.png", alt="The Metrics section.", width="800", height="699" %}
 
-**Figure 11**. The Metrics section
-
-Hover over a metric to see a description of it, and click **Learn More** to read documentation about
-it.
-
-{% Img src="image/admin/5t8Vg0jVnMqsTj3E8mqC.png", alt="Hovering over the First Meaningful Paint metric.", width="800", height="607" %}
-
-**Figure 12**. Hovering over the First Meaningful Paint metric
+Click **Learn more** to read documentation on a metric.
 
 Below Metrics is a collection of screenshots that show you how the page looked as it loaded.
 
@@ -330,7 +293,7 @@ Your new report says that properly sizing images is another big opportunity.
 
 Resizing images helps speed up load time by reducing the file size of images. If your user is
 viewing your images on a mobile device screen that's 500-pixels-wide, there's really no point in
-sending a 1500-pixel-wide image. Ideally, you'd send a 500-pixel-wided image, at most.
+sending a 1500-pixel-wide image. Ideally, you'd send a 500-pixel-wide image, at most.
 
 1.  In your report, click **Properly size images** to see what images should be resized. It looks
     like all 4 images are bigger than necessary.


### PR DESCRIPTION
A long-overdue refresh of https://developer.chrome.com/docs/devtools/lighthouse/.
Stayed true to the original video, fixed the demo to fail all of the same audits.

Merge as soon as reviewed.