### PR TITLE
Add redirect from old to new MV3 migration guide.

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -174,6 +174,9 @@ redirects:
 - from: /extensions/manifestVersion
   to: /docs/extensions/mv3/manifest/version/
 
+- from: /docs/extensions/mv3/mv3-migration/
+  to: /docs/extensions/migrating/
+
 # Fixes #675
 - from: /apps/manifestVersion
   to: /docs/apps/manifestVersion

--- a/site/en/docs/extensions/migrating/index.md
+++ b/site/en/docs/extensions/migrating/index.md
@@ -6,7 +6,7 @@ description: A guide to converting Manifest V2 extensions to Manifest V3 extensi
 date: 2023-03-09
 ---
 
-This section helps you upgrade an extension from Manifest V2 to Manifest V3, the newest version of the Chrome Extensions platform. A summary of the work is provided below with links to pages for each of the task areas. There is also a list of new extension features you should consider incorporating into your extension. Finally, there is a [migration checklist](/docs/extensions/mv3-migration-checklist) to help you keep track of your work.
+This section helps you upgrade an extension from Manifest V2 to Manifest V3, the newest version of the Chrome Extensions platform. A summary of the work is provided below with links to pages for each of the task areas. There is also a list of new extension features you should consider incorporating into your extension. Finally, there is a [migration checklist](/docs/extensions/migrating/checklist) to help you keep track of your work.
 
 {% Aside %}
 Follow [What's new in Chrome Extensions](/docs/extensions/whatsnew/) to read about new Manifest V3 features as they become available.

--- a/site/en/docs/extensions/mv3/intro/index.md
+++ b/site/en/docs/extensions/mv3/intro/index.md
@@ -49,7 +49,7 @@ We're excited about the improvements that Manifest V3 brings to the platform. Lo
 [doc-new]: /docs/extensions/whatsnew/
 [manifest-version]: /docs/extensions/mv3/manifest/manifest_version/
 [mv2-sunset]: /docs/extensions/mv3/mv2-sunset/
-[mv3-checklist]: /docs/extensions/mv3/mv3-migration-checklist/
-[mv3-migration]: /docs/extensions/mv3/intro/mv3-migration/
+[mv3-checklist]: /docs/extensions/migrating/checklist/
+[mv3-migration]: /docs/extensions/migrating/
 [mv3-overview]: /docs/extensions/mv3/intro/mv3-overview/
 [mv3-platform]: /docs/extensions/mv3/intro/platform-vision/


### PR DESCRIPTION
In https://github.com/GoogleChrome/developer.chrome.com/pull/5396, we changed the path of some MV3 documentation, and this has led to broken links across a few articles/other places. I've fixed the main ones I noticed here.