### PR TITLE
Update web_accessible_resources index.md

### DIFF
--- a/site/en/docs/extensions/mv3/manifest/web_accessible_resources/index.md
+++ b/site/en/docs/extensions/mv3/manifest/web_accessible_resources/index.md
@@ -56,7 +56,7 @@ Each object in the array contains these elements:
 : An array of strings, each containing a relative path to a given resource from the extension's root directory. Resources may contain asterisks (`*`) for wildcard matches. For example, `"/images/*"` exposes everything in the extension's `images/` directory, recursively, while `"*.png"` exposes all PNG files.
 
 `"matches"`
-: An array of strings, each containing a [match pattern](/docs/extensions/mv3/match_patterns/) that specifies which sites can access this set of resources. Only the origin is used to match URLs. Origins include subdomain matching. Paths are ignored. 
+: An array of strings, each containing a [match pattern](/docs/extensions/mv3/match_patterns/) that specifies which sites can access this set of resources. Only the origin is used to match URLs. Origins include subdomain matching. Google Chrome emits an "Invalid match pattern" error if the pattern has a path other than '/'.
 
 `"extension_ids"`
 : An array of strings, each containing the ID of an extension that can access the resources.


### PR DESCRIPTION
According to

https://developer.chrome.com/docs/extensions/mv3/manifest/web_accessible_resources/

`web_accessible_resources`'s `matches` is:

> An array of strings, each containing a match pattern that specifies which sites can access this set of resources. Only the origin is used to match URLs. Origins include subdomain matching. Paths are ignored.

However, the description on the site differs from the actual behavior of Chrome so I adjusted to it.
