### PR TITLE
Include theme_color in splash screen audit documentation

### DIFF
--- a/site/en/docs/lighthouse/pwa/splash-screen/index.md
+++ b/site/en/docs/lighthouse/pwa/splash-screen/index.md
@@ -4,7 +4,7 @@ title: Is not configured for a custom splash screen
 description: |
   Learn how to create a custom splash screen for your Progressive Web App.
 date: 2019-05-04
-updated: 2019-09-19
+updated: 2023-03-16
 ---
 
 A custom splash screen makes your [Progressive Web App (PWA)](https://web.dev/progressive-web-apps/#make-it-installable) feel more like an
@@ -33,6 +33,7 @@ you meet the following requirements in your [web app manifest](https://web.dev/a
 
 - The `name` property is set to the name of your PWA.
 - The `background_color` property is set to a valid CSS color value.
+- The `theme_color` property is set to a valid CSS color value.
 - The `icons` array specifies an icon that is at least 512x512&nbsp;px.
 - The specified icon exists and is a PNG.
 


### PR DESCRIPTION
See [the corresponding audit code](https://github.com/GoogleChrome/lighthouse/blob/0f50514f9c7e6e32219947adab71879a2cb933bd/core/audits/splash-screen.js#L65).

Fixes [5711](https://github.com/GoogleChrome/developer.chrome.com/issues/5711)

Changes proposed in this pull request:
Updates the developer documentation for splash screens to include `theme_color`. This is minor and perhaps not worth fixing, but can't hurt to ask.

It's also possible that lighthouse shouldn't audit `theme_color`, in which case I could propose a change for that code instead. I'm treating that code as the source of truth at the moment.