### PR TITLE
Updated: Post authors shown on three columns when there's more than two

### DIFF
--- a/site/_includes/partials/post-authors.njk
+++ b/site/_includes/partials/post-authors.njk
@@ -1,7 +1,15 @@
 {% from "macros/post-author.njk" import postAuthor with context %}
 
-<div class="post-authors">
-  {% for item in authors %}
-    {{ postAuthor(item, locale) }}
-  {% endfor %}
-</div>
+{% if authors | length > 2%}
+  <div class="condensed-post-authors">
+    {% for item in authors %}
+      {{ postAuthor(item, locale) }}
+    {% endfor %}
+  </div>
+{% else %}
+  <div class="post-authors">
+    {% for item in authors %}
+      {{ postAuthor(item, locale) }}
+    {% endfor %}
+  </div>
+{% endif %}

--- a/site/_scss/blocks/_condensed-post-authors.scss
+++ b/site/_scss/blocks/_condensed-post-authors.scss
@@ -1,0 +1,5 @@
+.condensed-post-authors {
+  display: grid;
+  gap: get-size(200);
+  grid-template-columns: repeat(auto-fit, minmax(px-to-rem(220px), 1fr));
+}

--- a/site/_scss/blocks/_post-authors.scss
+++ b/site/_scss/blocks/_post-authors.scss
@@ -5,6 +5,7 @@
 }
 
 .post-authors-social {
+  column-gap: get-size(200);
   display: flex;
-  gap: get-size(200);
+  flex-wrap: wrap;
 }

--- a/site/_scss/main.scss
+++ b/site/_scss/main.scss
@@ -30,6 +30,7 @@
 @import 'blocks/navigation-tree';
 @import 'blocks/side-nav';
 @import 'blocks/post-authors';
+@import 'blocks/condensed-post-authors';
 @import 'blocks/card-authors';
 @import 'blocks/project-icon';
 @import 'blocks/project-hero';


### PR DESCRIPTION
Fixes #5662 

Changes proposed in this pull request:

- When a post has more than two authors it shows them on three columns to reduce the space used
- On the `post-authors` template an if statement is added, when there's more than three authors they are contained on a `<div>` with class `condensed-post-authors`, where they're shown in three columns. Otherwise, they are contained on a `<div>` with class `post-authors`, with no changes.

Example:
- Before the change:
<img width="731" alt="Screen Shot 2023-03-16 at 22 22 50" src="https://user-images.githubusercontent.com/44093701/225812186-51f32fac-0752-43a6-b756-575bb59d658b.png">

- After the change:
<img width="729" alt="Screen Shot 2023-03-16 at 22 24 33" src="https://user-images.githubusercontent.com/44093701/225812290-231ae900-216c-4c54-918b-c8fbf76f6084.png">

Signed the Individual CLA as EduardoMtz1 (Eduardo Martínez).
