### PR TITLE
fix: tabs page api example wording (#5740)

### DIFF
--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -100,7 +100,7 @@ installed. The following example shows how to do this.
 {% Label %}background.js:{% endLabel %}
 
 ```js
-chrome.runtime.onInstalled.addListener((reason) => {
+chrome.runtime.onInstalled.addListener(({reason}) => {
   if (reason === chrome.runtime.OnInstalledReason.INSTALL) {
     chrome.tabs.create({
       url: "onboarding.html"


### PR DESCRIPTION
Fixes #5740

Changes proposed in this pull request:

- deconstruct `InstalledDetails ` object