### PR TITLE
typo: keyframe → keyFrame

### DIFF
--- a/site/en/articles/webcodecs/index.md
+++ b/site/en/articles/webcodecs/index.md
@@ -207,7 +207,7 @@ while (true) {
     frame.close();
   } else {
     frameCounter++;
-    const keyframe = frameCounter % 150 == 0;
+    const keyFrame = frameCounter % 150 == 0;
     encoder.encode(frame, { keyFrame });
     frame.close();
   }


### PR DESCRIPTION
Fantastic article! 
It is very helpful to understand what WebCodecs API is.

I found a simple typo when I'm creating a app using WebCodecs.