### PR TITLE
Revise Digital Goods docs now that the API is shipped

### DIFF
--- a/site/en/docs/android/trusted-web-activity/receive-payments-play-billing/index.md
+++ b/site/en/docs/android/trusted-web-activity/receive-payments-play-billing/index.md
@@ -2,7 +2,7 @@
 layout: "layouts/doc-post.njk"
 title: Receive Payments via Google Play Billing with the Digital Goods API and the Payment Request API
 date: 2021-01-26
-updated: 2021-01-26
+updated: 2023-03-22
 description: Receive Payments via Google Play Billing in your PWA with the Digital Goods API, the Payment Request API and Trusted Web Activity
 authors:
   - andreban
@@ -14,9 +14,8 @@ your catalog, prices and subscriptions, useful reports, and a checkout flow powe
 Store that is already familiar to your users.
 
 For apps built using [Trusted Web Activities][2], and delivered through the Google Play Store, you
-can now use the [Payment Request API][3] and the new [Digital Goods API][4] to integrate with
-Google Play Billing. It's available as an [origin trial][5] in Chrome 88 for Android, and we expect
-it to expand the origin trial to ChromeOS in version 89.
+can now use the [Payment Request API][3] and the [Digital Goods API][4] to integrate with
+Google Play Billing. It's available on Chrome 101 and above for Android and ChromeOS.
 
 In this guide, you will learn how to add Google Play Billing support to your PWA and package it for
 distribution on the Google Play Store for both ChromeOS and Play Store.
@@ -25,11 +24,6 @@ You will use two web platform APIs to add Play Billing support to your PWA. The
 [Digital Goods API][4] is used to gather SKU information and check for purchases and entitlements
 from the Play Store. The [Payment Request API][3] is used to configure the Google Play Store as the
 payment method and to complete the purchase flow.
-
-Note: While the Payment Request API is stable, the Digital Goods API is currently on Origin Trial.
-This means that the Digital Goods API may change during this period and the final API may be
-different. This also means it is a great time to test the API yourself, and
-[give feedback on the specification][6].
 
 ## How to monetize applications on the Play Store
 
@@ -57,20 +51,13 @@ In order to setup Google Play Billing, you will need:
 - To [create and configure][14] your app's products and subscriptions on the Play Store.
 - A [Bubblewrap generated project][15] with a working [Digital Asset Links configuration][16].
 
-## Request access to the Origin Trial
-
-An [origin trial][5] is a way to test a new or experimental web platform feature, and give feedback
-to the web standards community on the feature's usability, practicality, and effectiveness, before
-the feature is made available to all users. You can sign-up for the Digital Goods API origin trial
-[here][17].
-
 ## Update the Bubblewrap project
 
 If you don't have Bubblewrap installed, you will need to install it. See the
 [Quick Start Guide][18] for details on how to get started. If you already have Bubblewrap, make
 sure to update to version 1.8.2 or above.
 
-Since the Digital Goods API  is in Origin Trial, Bubblewrap also has the feature behind a flag. In
+Bubblewrap also has the feature behind a flag. In
 order to enable it, you will need to modify the project configuration in the `twa-manifest.json`,
 located at the root of the project and enable both `alphaDependencies` and the `playBilling`
 feature:
@@ -115,12 +102,16 @@ by the string `https://play.google.com/billing`:
 
 ```js
 if ('getDigitalGoodsService' in window) {
- // Digital Goods API is supported!
- const service =
-     await window.getDigitalGoodsService('https://play.google.com/billing');
- if (service) {
-   // Google Play Billing is supported!
- }
+  // Digital Goods API is supported!
+  try {
+    const service =
+        await window.getDigitalGoodsService('https://play.google.com/billing');
+    // Google Play Billing is supported!
+   
+  } catch (error) {
+    // Google Play Billing is not available. Use another payment flow.
+    return;
+  }
 }
 ```
 
@@ -132,7 +123,7 @@ product title, description, and most importantly, the price, from the payments b
 You can then use this information in your use interface and provide more details to the user:
 
 ```js
-const skuDetails = await itemService.getDetails(['shiny_sword', 'gem']);
+const skuDetails = await service.getDetails(['shiny_sword', 'gem']);
 for (item of skuDetails) {
   // Format the price according to the user locale.
   const localizedPrice = new Intl.NumberFormat(
@@ -191,13 +182,11 @@ const request = new PaymentRequest(paymentMethods, paymentDetails);
 Call the `show()` on the payment request object to start the payment flow. If the Promise succeeds
 that will may be payment was successful. If it fails, the user likely aborted the payment.
 
-If the promise succeeds, you will need to verify the purchase in order to protect against fraud.
-Due to the sensitivity of the data, this step must be implemented using your backend. Check out the
+If the promise succeeds, you will need to verify and acknowledge the purchase.
+In order to protect against fraud, this step must be implemented using your backend. Check out the
 [Play Billing documentation to learn how to implement the verification in your backend][21].
-
-When the validation passes in your backend, you will then use the Digital Goods API to acknowledge
-the purchase, otherwise,
- [after three days, the user will receive a refund and Google Play will revoke the purchase][22].
+If you do not acknowledge the purchase,
+[after three days, the user will receive a refund and Google Play will revoke the purchase][22].
 
 ```js
 ...
@@ -206,13 +195,8 @@ try {
     const paymentResponse = await request.show();
     const {purchaseToken} = paymentResponse.details;
 
-    // Call backend to validate the purchase.
-    if (validatePurchaseOnBackend(purchaseToken)) {
-        // Acknowledge using the Digital Goods API. Use 'onetime' for items
-        // that can only be purchased once and 'repeatable' for items
-        // that can be purchased multiple times.
-        await service.acknowledge(purchaseToken, 'onetime');
-
+    // Call backend to validate and acknowledge the purchase.
+    if (await acknowledgePurchaseOnBackend(purchaseToken, sku)) {
         // Optional: tell the PaymentRequest API the validation was
         // successful. The user-agent may show a "payment successful"
         // message to the user.
@@ -229,8 +213,8 @@ try {
 ...
 ```
 
-The second parameter of the acknowledge call is a purchase type. Use `onetime` for items that can
-only be purchased once and `repeatable` for items that can be purchased multiple times.
+Optionally, `consume()` may be called on a purchaseToken to mark the purchase as used up and
+allow it to be purchased again.
 
 Putting everything together, a purchase method looks like the following:
 
@@ -259,12 +243,11 @@ async function makePurchase(service, sku) {
         const paymentResponse = await request.show();
         const {purchaseToken} = paymentResponse.details;
 
-        // Call backend to validate the purchase.
-        if (validatePurchaseOnBackend(purchaseToken)) {
-            // Acknowledge using the Digital Goods API. Use ‘onetime' for
-            // items that can only be purchased once and ‘repeatable for
-            // items that can be purchased multiple times.
-            await service.acknowledge(purchaseToken, 'onetime');
+        // Call backend to validate and acknowledge the purchase.
+        if (await acknowledgePurchaseOnBackend(purchaseToken, sku)) {
+            // Optional: consume the purchase, allowing the user to purchase
+            // the same item again.
+            service.consume(purchaseToken);
 
             // Optional: tell the PaymentRequest API the validation was
             // successful. The user-agent may show a "payment successful"
@@ -312,11 +295,8 @@ const service =
 ...
 const existingPurchases = await service.listPurchases();
 for (const p of existingPurchases) {
-    if (!p.acknowledged) {
-       await service.acknowledge(p.purchaseToken, 'onetime');
-       // Do something to record successful acknowledgement of a purchase
-       // e.g. update backend server
-    }
+    await verifyOrAcknowledgePurchaseOnBackend(p.purchaseToken, p.itemId);
+    
     // Update the UI with items the user is already entitled to.
     console.log(`Users has entitlement for ${p.itemId}`);
 }
@@ -326,15 +306,12 @@ for (const p of existingPurchases) {
 
 ### On a Development Android device
 
-It is possible to enable the Digital Goods API on an development Android device for testing, even
-without enabling the Origin Trial:
+It is possible to enable the Digital Goods API on an development Android device for testing:
 
  - Ensure you are on Android 9 or greater with [developer mode enabled][23].
- - Install Chrome 88 or above.
+ - Install Chrome 101 or newer.
  - Enable the following flags in Chrome by navigating to `chrome://flags` and searching for the
    flag by name:
-     - `#enable-experimental-web-platform-features`
-     - `#enable-web-payments-experimental-features`
      - `#enable-debug-for-store-billing`
  - Ensure that the site is hosted using a https protocol. Using http will cause the API to be `undefined`
 
@@ -346,20 +323,12 @@ from the Play Store.
 The Digital Goods API will be available on ChromeOS stable starting with version 89. In the
 meantime, it is possible to test the Digital Goods API:
 
- - Enable the [ChromeOS dev channel][24],
- - Enable the following flags in Chrome by navigating to `chrome://flags` and searching for the
-   flag by name:
-     - `#enable-experimental-web-platform-features`
-     - `#enable-web-payments-experimental-features`
  - Install your app from the Play Store on the device.
  - Ensure that the site is hosted using a https protocol. Using http will cause the API to be `undefined`
 
 ## With test users and QA teams
 
-In order to test with a broader audience, you will need to sign-up for the Origin Trial, as asking
-every user to enable the Chrome flags is not practical.
-
-The Play Store also provides affordances for testing, including user test accounts and test SKUs.
+The Play Store provides affordances for testing, including user test accounts and test SKUs.
 Checkout the [Google Play Billing test documentation][25] for more information.
 
 ## Where to go next?


### PR DESCRIPTION
The Digital Goods API shipped in Chrome 101.
Several instructions in this documentation were outdated - you no longer need to enable experimental flags, developer mode, or origin trials.
Some APIs have changed - notably `acknowledge` was removed (must happen on backend) and `consume` was added. 

FYI I am one of the authors of the DGAPI (glenrob)

Fixes #1631
