### PR TITLE
[ext] Change title and descriptions for the GS guides

### DIFF
--- a/site/en/docs/extensions/mv3/getstarted/tut-focus-mode/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/tut-focus-mode/index.md
@@ -1,9 +1,9 @@
 ---
 layout: 'layouts/doc-post.njk'
-title: 'Focus Mode'
+title: 'Inject scripts into the active tab'
 seoTitle: 'Chrome Extensions Tutorial: Focus Mode'
 subhead: 'Simplify the styling of the current page by clicking the extension toolbar icon.'
-description: 'Learn how to run code in the active tab.'
+description: 'Learn how to simplify the style of the current page.'
 date: 2022-10-04
 # updated: 2022-06-13
 ---

--- a/site/en/docs/extensions/mv3/getstarted/tut-reading-time/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/tut-reading-time/index.md
@@ -1,8 +1,8 @@
 ---
 layout: 'layouts/doc-post.njk'
-title: 'Reading time'
+title: 'Run scripts on every page'
 seoTitle: 'Chrome Extensions Tutorial: Reading time'
-description: 'Learn how to insert an element on each page.'
+description: 'Learn how to automatically add new elements to existing webpages.'
 subhead: 'Create your first extension that inserts a new element on the page.'
 date: 2022-10-04
 # updated: 2022-06-13

--- a/site/en/docs/extensions/mv3/getstarted/tut-tabs-manager/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/tut-tabs-manager/index.md
@@ -1,8 +1,8 @@
 ---
 layout: 'layouts/doc-post.njk'
-title: 'Tabs Manager'
+title: 'Manage tabs'
 subhead: 'Build your first tabs manager.'
-description: 'Learn how to create a tabs manager.'
+description: 'Learn how to programmatically organize tabs using tab groups.'
 date: 2022-10-04
 # updated: 2022-06-13
 ---


### PR DESCRIPTION
During a recent tech review for the new extension service worker tutorial, it was suggested that [the title should be renamed for better SEO](https://github.com/GoogleChrome/developer.chrome.com/pull/5743/files#r1143635094). In addition to this, we agreed that the changes should be made across all of the tutorials. 

This PR implements these changes throughout the extension Getting started tutorials.