### PR TITLE
Added cope snippet labels to Localization Messages page

### DIFF
--- a/site/en/docs/extensions/mv3/i18n-messages/index.md
+++ b/site/en/docs/extensions/mv3/i18n-messages/index.md
@@ -16,6 +16,7 @@ how to internationalize and localize, see the [Internationalization][1] page.
 The following code shows the supported fields for `messages.json`. Only the "_name_" and "message"
 fields are required.
 
+{% Label %}messages.json:{% endLabel %}
 ```json
 {
   "name": {
@@ -38,6 +39,7 @@ fields are required.
 Here's a `messages.json` file that defines three messages named "prompt_for_name", "hello", and
 "bye":
 
+{% Label %}messages.json:{% endLabel %}
 ```json
 {
   "prompt_for_name": {
@@ -98,6 +100,7 @@ include the following characters:
 
 Here are three examples of names, taken from the [Example][8] section:
 
+{% Label %}messages.json:{% endLabel %}
 ```json
 "prompt_for_name": {
   ...
@@ -120,6 +123,7 @@ refer to a placeholder named "our_site" as `$our_site$`, `$OUR_SITE$`, or `$oUR_
 
 Here are three examples of messages, taken from the [Example][8] section:
 
+{% Label %}messages.json:{% endLabel %}
 ```json
 "message": "What's your name?"
 ...
@@ -131,6 +135,7 @@ Here are three examples of messages, taken from the [Example][8] section:
 To put a dollar sign (`$`) into the string, use `$$`. For example, use the following code to specify
 the message **Amount (in \$)**:
 
+{% Label %}messages.json:{% endLabel %}
 ```json
 "message": "Amount (in $$)"
 ```
@@ -140,6 +145,7 @@ Although placeholders such as `$USER$` are the preferred way of referring to _su
 to substitution strings directly within the message. For example, the following message refers to
 the first three substitution strings passed into `getMessage()`:
 
+{% Label %}messages.json:{% endLabel %}
 ```json
 "message": "Params: $1, $2, $3"
 ```
@@ -156,6 +162,7 @@ make the best possible translation.
 
 Here are three examples of descriptions, taken from the [Example][8] section:
 
+{% Label %}messages.json:{% endLabel %}
 ```json
 "description": "Ask for the user's name"
 ...
@@ -192,6 +199,7 @@ The following snippet, taken from the [Example][8] section, shows a "placeholder
 contains two placeholders named "our_site" and "user". The "our_site" placeholder has no "example"
 item because its value is obvious from the "content" field.
 
+{% Label %}messages.json:{% endLabel %}
 ```json
 "placeholders": {
   "our_site": {


### PR DESCRIPTION
Changes proposed in this pull request:

Add labels to code snippets across the page.