### PR TITLE
Move site opt out to topics dev guide

### DIFF
--- a/site/en/docs/privacy-sandbox/topics/index.md
+++ b/site/en/docs/privacy-sandbox/topics/index.md
@@ -108,6 +108,21 @@ Using request and response headers to access topics and mark them as observed ca
 -   The response header is only honored if the corresponding request included the topics header (or would have included the header, if the request wasn't empty).
 -   The URL of the request provides the registrable domain used for topic observation.
 
+## Opt out {: #site-opt-out}
+
+You can opt out of topic calculation for specific pages on your site by including the `Permissions-Policy: browsing-topics=()` [Permissions-Policy](https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy) header on a page to prevent topics calculation for all users on that page only. Subsequent visits to other pages on your site will not be affected. If you set a policy to block the Topics API on one page, this won't affect other pages.
+
+You can also control which third parties have access to topics on your page by using the Permission Policy header to control third-party access to the Topics API.
+
+Use `self` and any domains you would like to allow access to the API as parameters.
+
+For example, to completely disable use of the Topics API within all browsing contexts except for your own origin and those whose origin is `https://example.com`, set the following HTTP response header: 
+
+```text
+Permissions-Policy: geolocation=(self "https://example.com")
+```
+
+
 ## Debug your API implementation
 
 The `chrome://topics-internals` page is available in Chrome on desktop once [you enable the Topics API](#feature-flags). This displays topics for the current user, topics inferred for hostnames, and technical information about the API implementation.

--- a/site/en/docs/privacy-sandbox/topics/topic-classification/index.md
+++ b/site/en/docs/privacy-sandbox/topics/topic-classification/index.md
@@ -220,7 +220,7 @@ The list of topics returned will be empty if:
 
 The explainer [provides more detail about privacy goals](https://github.com/jkarlin/topics#meeting-the-privacy-goals) and how the API seeks to address them.
 
-{: #out-out }
+{: #opt-out }
 
 ### Site opt out
 

--- a/site/en/docs/privacy-sandbox/topics/topic-classification/index.md
+++ b/site/en/docs/privacy-sandbox/topics/topic-classification/index.md
@@ -220,17 +220,7 @@ The list of topics returned will be empty if:
 
 The explainer [provides more detail about privacy goals](https://github.com/jkarlin/topics#meeting-the-privacy-goals) and how the API seeks to address them.
 
-You can opt out of topic calculation for specific pages on your site by including the `Permissions-Policy: browsing-topics=()` [Permissions-Policy](https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy) header on a page to prevent topics calculation for all users on that page only. Subsequent visits to other pages on your site will not be affected. If you set a policy to block the Topics API on one page, this won't affect other pages.
-
-You can also control which third parties have access to topics on your page by using the Permission Policy header to control third-party access to the Topics API.
-
-Use `self` and any domains you would like to allow access to the API as parameters.
-
-For example, to completely disable use of the Topics API within all browsing contexts except for your own origin and those whose origin is `https://example.com`, set the following HTTP response header: 
-
-```text
-Permissions-Policy: geolocation=(self "https://example.com")
-```
+The [Developer guide](/docs/privacy-sandbox/topics/#site-opt-out) explains how you can opt out of Topics for your sire or pges on it. 
 
 ## Using the Topics API on websites with `prebid.js`
 

--- a/site/en/docs/privacy-sandbox/topics/topic-classification/index.md
+++ b/site/en/docs/privacy-sandbox/topics/topic-classification/index.md
@@ -220,6 +220,8 @@ The list of topics returned will be empty if:
 
 The explainer [provides more detail about privacy goals](https://github.com/jkarlin/topics#meeting-the-privacy-goals) and how the API seeks to address them.
 
+{: #out-out }
+
 ### Site opt out
 
 In addition to the user's ability to opt out, you can opt out of Topics for your site or pages on it. The [Developer guide](/docs/privacy-sandbox/topics/#site-opt-out) explains how.

--- a/site/en/docs/privacy-sandbox/topics/topic-classification/index.md
+++ b/site/en/docs/privacy-sandbox/topics/topic-classification/index.md
@@ -220,7 +220,9 @@ The list of topics returned will be empty if:
 
 The explainer [provides more detail about privacy goals](https://github.com/jkarlin/topics#meeting-the-privacy-goals) and how the API seeks to address them.
 
-The [Developer guide](/docs/privacy-sandbox/topics/#site-opt-out) explains how you can opt out of Topics for your sire or pges on it. 
+### Site opt out
+
+In addition to the user's ability to opt out, you can opt out of Topics for your site or pages on it. The [Developer guide](/docs/privacy-sandbox/topics/#site-opt-out) explains how.
 
 ## Using the Topics API on websites with `prebid.js`
 


### PR DESCRIPTION
Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- Move site opt out to topics dev guide from topic classification page
- note: because site opt out does require code, it's probably better in the dev guide, so there is a mention of it in the classification page now with a link to the section in the dev guide,
- staged
  - https://pr-5783-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/topics/#site-opt-out
  - https://pr-5783-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/topics/topic-classification/#opt-out 