### PR TITLE
Add outdated banner to Lighthouse `apple-touch-icon` audit

### DIFF
--- a/site/_data/docs/lighthouse/pwa/toc.yml
+++ b/site/_data/docs/lighthouse/pwa/toc.yml
@@ -16,7 +16,6 @@
     - url: /docs/lighthouse/pwa/content-width/
     - url: /docs/lighthouse/pwa/viewport/
     - url: /docs/lighthouse/pwa/without-javascript/
-    - url: /docs/lighthouse/pwa/apple-touch-icon/
     - url: /docs/lighthouse/pwa/maskable-icon-audit/
 - title: i18n.docs.pwa.topics.additional_items_to_manually_check
   sections:

--- a/site/en/docs/lighthouse/pwa/apple-touch-icon/index.md
+++ b/site/en/docs/lighthouse/pwa/apple-touch-icon/index.md
@@ -5,7 +5,8 @@ description: |
   Learn how to specify what icon your Progressive Web App displays on iOS home screens.
 codelabs: codelab-apple-touch-icon
 date: 2019-08-27
-updated: 2019-09-19
+updated: 2023-03-24
+is_outdated: true
 ---
 
 When iOS Safari users add [Progressive Web Apps (PWAs)](https://web.dev/progressive-web-apps/#make-it-installable) to

--- a/site/es/docs/lighthouse/pwa/apple-touch-icon/index.md
+++ b/site/es/docs/lighthouse/pwa/apple-touch-icon/index.md
@@ -4,7 +4,8 @@ title: No proporciona un ícono apple-touch-icon válido
 description: Aprenda a especificar qué icono muestra su aplicación web progresiva en las pantallas de inicio de iOS.
 codelabs: laboratorio-de-código-apple-touch-icon
 date: 2019-08-27
-updated: 2019-09-19
+updated: 2023-03-24
+is_outdated: true
 ---
 
 Cuando los usuarios de iOS Safari agregan [aplicaciones web progresivas (PWA)](/es/docs/lighthouse/pwa/#instalable) a sus pantallas de inicio, el ícono que aparece se llama *ícono táctil de Apple*. Puede especificar qué ícono debe usar su aplicación al incluir una etiqueta `<link rel="apple-touch-icon" href="/example.png">` en la `<head>` de su página. Si su página no tiene esta etiqueta de enlace, iOS genera un icono tomando una captura de pantalla del contenido de la página. En otras palabras, indicarle a iOS que descargue un icono da como resultado una experiencia de usuario más refinada.

--- a/site/ko/docs/lighthouse/pwa/apple-touch-icon/index.md
+++ b/site/ko/docs/lighthouse/pwa/apple-touch-icon/index.md
@@ -4,7 +4,8 @@ title: 유효한 apple-touch-icon을 제공하지 않음
 description: Progressive Web App이 iOS 홈 화면에 표시할 아이콘을 지정하는 방법을 알아봅니다.
 codelabs: codelab-apple-touch-icon
 date: 2019-08-27
-updated: 2019-09-19
+updated: 2023-03-24
+is_outdated: true
 ---
 
 iOS Safari 사용자가 홈 화면에 [PWA(Progressive Web App)](https://web.dev/progressive-web-apps/)를 추가하는 경우에 나타나는 아이콘을 *Apple 터치 아이콘*이라고 합니다. 페이지의 `<head>`에 `<link rel="apple-touch-icon" href="/example.png">` 태그를 포함시켜 앱에서 사용해야 하는 아이콘을 지정할 수 있습니다. 페이지에 이 링크 태그가 없으면 iOS가 페이지 콘텐츠의 스크린샷을 찍어 아이콘을 생성합니다. 즉, iOS에 아이콘을 다운로드하도록 지시하면 보다 세련된 사용자 경험을 얻을 수 있습니다.

--- a/site/pt/docs/lighthouse/pwa/apple-touch-icon/index.md
+++ b/site/pt/docs/lighthouse/pwa/apple-touch-icon/index.md
@@ -4,7 +4,8 @@ title: O apple-touch-icon fornecido não é válido
 description: Aprenda a especificar o ícone exibido pelo Progressive Web App na tela inicial do iOS.
 codelabs: codelab-apple-touch-icon
 date: 2019-08-27
-updated: 2019-09-19
+updated: 2023-03-24
+is_outdated: true
 ---
 
 Quando os usuários do Safari do iOS adicionam [Progressive Web Apps (PWAs)](https://web.dev/progressive-web-apps/) à tela inicial, o ícone exibido é chamado de _ícone Apple Touch_ (Apple touch icon). É possível especificar o ícone usado pelo app com a inclusão de uma tag `<link rel="apple-touch-icon" href="/example.png">` no `<head>` da página. Se a página não apresentar essa tag de link, o iOS faz uma captura de tela do conteúdo para gerar um ícone. Em outras palavras, instruir o iOS a fazer o download de um ícone resulta em uma experiência do usuário mais otimizada.


### PR DESCRIPTION
Fixes #5594