### PR TITLE
[ext] Update Development basics log instructions

### DIFF
--- a/site/en/docs/extensions/mv3/getstarted/development-basics/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/development-basics/index.md
@@ -178,6 +178,10 @@ To see this message logged in the Console:
     <figure>
     {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/1ZrcBEYcbMxW1c9UvBy9.png", 
     alt="DevTools Code Panel", width="400", height="374", class="screenshot" %}
+      <figcaption>
+      Inspecting a popup 
+      </figcaption>
+    </figure>   
   5. In the [DevTools][dev-tools], navigate to the **Console** panel.
     <figure>
     {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/1ZrcBEYcbMxW1c9UvBy9.png", 

--- a/site/en/docs/extensions/mv3/getstarted/development-basics/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/development-basics/index.md
@@ -164,10 +164,9 @@ console.log("This is a popup!")
 
 To see this message logged in the Console:
 
-  1. Refresh the extension.
-  2. Open the popup.
-  3. Right-click on the popup.
-  4. Select **Inspect**. 
+  1. Open the popup.
+  2. Right-click on the popup.
+  3. Select **Inspect**. 
       <figure> 
       {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/vHGHW1o4J0kZgUkAteRQ.png", 
       alt="Inspecting the popup", width="322", height="262", class="screenshot" %}
@@ -175,6 +174,10 @@ To see this message logged in the Console:
         Inspecting a popup 
         </figcaption>
       </figure>
+  4. In the [DevTools][dev-tools], navigate to the **Console** panel.
+    <figure>
+    {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/1ZrcBEYcbMxW1c9UvBy9.png", 
+    alt="DevTools Code Panel", width="400", height="374", class="screenshot" %}
   5. In the [DevTools][dev-tools], navigate to the **Console** panel.
     <figure>
     {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/1ZrcBEYcbMxW1c9UvBy9.png", 
@@ -219,7 +222,7 @@ package [chrome-types][npm-chrome-types] to take advantage of auto-completion fo
 API][doc-apis]. This npm package is updated automatically when the Chromium source code
 changes.
 
-{% Aside  'gotchas' %}
+{% Aside  'important' %}
 
 Update this npm package frequently to work with the latest Chromium version.
 

--- a/site/en/docs/extensions/mv3/getstarted/development-basics/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/development-basics/index.md
@@ -169,9 +169,9 @@ To see this message logged in the Console:
   3. Select **Inspect**. 
       <figure> 
       {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/vHGHW1o4J0kZgUkAteRQ.png", 
-      alt="Inspecting the popup", width="322", height="262", class="screenshot" %}
+      alt="Inspecting the popup.", width="322", height="262", class="screenshot" %}
         <figcaption>
-        Inspecting a popup 
+        Inspecting a popup. 
         </figcaption>
       </figure>
   4. In the [DevTools][dev-tools], navigate to the **Console** panel.


### PR DESCRIPTION
Removes the step to refresh the extension, since the popup doesn't need to be refreshed to see changes made.

Related PR #5547