### PR TITLE
fix: fixed video id in YT playlist external data flow

### DIFF
--- a/external/build/youtube-playlist.js
+++ b/external/build/youtube-playlist.js
@@ -120,7 +120,7 @@ async function getPlaylistItemData(id) {
   }
   for (const video of videos) {
     data.push({
-      id: video.id,
+      id: video?.snippet?.resourceId?.videoId,
       title: video?.snippet?.title,
       description: video?.snippet?.description,
       thumbnail: video?.snippet?.thumbnails?.medium?.url,
@@ -172,7 +172,7 @@ async function checkDataTimestamp() {
 
     const fileTimestamp = new Date(fileMetadata.timeCreated).getTime();
 
-    if (currentTimestamp - fileTimestamp < FETCH_INTERVAL) {
+    if (currentTimestamp - fileTimestamp > FETCH_INTERVAL) {
       return false;
     }
     return true;


### PR DESCRIPTION
Fixes #5827 

Changes proposed in this pull request:

- fixed id data fetched for each video of a playlist