### PR TITLE
[Extension-docs] Remove duplicated steps

### DIFF
--- a/site/en/docs/extensions/mv3/getstarted/development-basics/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/development-basics/index.md
@@ -182,14 +182,6 @@ To see this message logged in the Console:
       Inspecting a popup 
       </figcaption>
     </figure>   
-  5. In the [DevTools][dev-tools], navigate to the **Console** panel.
-    <figure>
-    {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/1ZrcBEYcbMxW1c9UvBy9.png", 
-    alt="DevTools Code Panel", width="400", height="374", class="screenshot" %}
-      <figcaption>
-      DevTools Console Panel 
-      </figcaption>
-    </figure>
 
 ### Error logs {: #errors }
 


### PR DESCRIPTION
In the debugging section, step 4 and 5 has same content

Changes proposed in this pull request:

- removes the duplicates