### PR TITLE
Update index.md

### DIFF
--- a/site/en/docs/extensions/mv3/getstarted/development-basics/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/development-basics/index.md
@@ -179,17 +179,9 @@ To see this message logged in the Console:
     {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/1ZrcBEYcbMxW1c9UvBy9.png", 
     alt="DevTools Code Panel", width="400", height="374", class="screenshot" %}
       <figcaption>
-      Inspecting a popup 
+      DevTools Console Panel
       </figcaption>
     </figure>   
-  5. In the [DevTools][dev-tools], navigate to the **Console** panel.
-    <figure>
-    {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/1ZrcBEYcbMxW1c9UvBy9.png", 
-    alt="DevTools Code Panel", width="400", height="374", class="screenshot" %}
-      <figcaption>
-      DevTools Console Panel 
-      </figcaption>
-    </figure>
 
 ### Error logs {: #errors }
 


### PR DESCRIPTION
Fixes #5843 

Changes proposed in this pull request:

On the [Developement Basics Page, under the console section](https://developer.chrome.com/docs/extensions/mv3/getstarted/development-basics/#console), there's a repeated list item.
The fifth list item is practically the same as the fourth list item. The only difference is the figure caption and the fourth's is a copy of the third's.

This pull request updates the **development basics index.md'** file to fix this issue

Anticipating a successful merge, Emmanuel Chinonso Jemeni  :love_you_gesture: 
