### PR TITLE
SPC: Note limitation for Chrome Android between M109-M111

### DIFF
--- a/site/en/articles/register-secure-payment-confirmation/index.md
+++ b/site/en/articles/register-secure-payment-confirmation/index.md
@@ -132,11 +132,8 @@ currently actively used, but is required for future compatibility.
 {% endAside %}
 
 {% Aside %}
-On Chrome Android between versions M109 and M111 (inclusive), there is a
-[technical limitation](https://bugs.chromium.org/p/chromium/issues/detail?id=1393662)
-that requires that `authenticatorSelection.residentKey` be set to `preferred`
-rather than `required`. From Chrome Android M112 onwards, `required` can be
-used as with other platforms.
+For versions M109, M110, and M111 of Chrome Android, `authenticatorSelection.residentKey` needs to be set to `preferred`
+instead of `required` due to a [technical limitation](https://bugs.chromium.org/p/chromium/issues/detail?id=1393662). From Chrome Android M112 onwards, `required` can be used as with other platforms.
 {% endAside %}
 
 In addition, specify a "payment" extension with `isPayment: true`. Specifying

--- a/site/en/articles/register-secure-payment-confirmation/index.md
+++ b/site/en/articles/register-secure-payment-confirmation/index.md
@@ -131,6 +131,14 @@ accounts for the user to sign in with upon authentication. This UX is not
 currently actively used, but is required for future compatibility.
 {% endAside %}
 
+{% Aside %}
+On Chrome Android between versions M109 and M111 (inclusive), there is a
+[technical limitation](https://bugs.chromium.org/p/chromium/issues/detail?id=1393662)
+that requires that `authenticatorSelection.residentKey` be set to `preferred`
+rather than `required`. From Chrome Android M112 onwards, `required` can be
+used as with other platforms.
+{% endAside %}
+
 In addition, specify a "payment" extension with `isPayment: true`. Specifying
 this extension without meeting the above requirements will throw an exception
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Explain to developers that between version M109-M111 (inclusive) on Chrome Android, one must
  use `residentKey=preferred` (instead of `required`) when creating a payment-enabled credential.