### PR TITLE
Interest groups limit section FAQ

### DIFF
--- a/site/en/docs/privacy-sandbox/fledge-api/interest-groups/index.md
+++ b/site/en/docs/privacy-sandbox/fledge-api/interest-groups/index.md
@@ -494,10 +494,8 @@ A user's browsing history for the site that called `joinAdInterestGroup()` can b
 
 {% Details %}
 {% DetailsSummary %}
-### What's the maximum number of interest groups per-group owner for a single user?
+### What's the maximum number of interest groups per group owner for a single user?
 {% endDetailsSummary %}
-
-{: #interest-group-limits}
 
 Chrome allows up to 1000 interest groups per owner, and up to 1000 interest group
 owners. These limits are meant as guard rails, not to be hit in regular operation.

--- a/site/en/docs/privacy-sandbox/fledge-api/interest-groups/index.md
+++ b/site/en/docs/privacy-sandbox/fledge-api/interest-groups/index.md
@@ -500,8 +500,8 @@ A user's browsing history for the site that called `joinAdInterestGroup()` can b
 {: #interest-group-limits}
 
 Chrome allows up to 1000 interest groups per owner, and up to 1000 interest group
-
 owners. These limits are meant as guard rails, not to be hit in regular operation.
+
 {% endDetails %}
 
 ## All FLEDGE API references

--- a/site/en/docs/privacy-sandbox/fledge-api/interest-groups/index.md
+++ b/site/en/docs/privacy-sandbox/fledge-api/interest-groups/index.md
@@ -494,7 +494,7 @@ A user's browsing history for the site that called `joinAdInterestGroup()` can b
 
 {% Details %}
 {% DetailsSummary %}
-### What is an owner's interest group limit for a single browser?
+### What's the maximum number of interest groups per-group owner for a single user?
 {% endDetailsSummary %}
 
 {: #interest-group-limits}

--- a/site/en/docs/privacy-sandbox/fledge-api/interest-groups/index.md
+++ b/site/en/docs/privacy-sandbox/fledge-api/interest-groups/index.md
@@ -492,6 +492,18 @@ A user's browsing history for the site that called `joinAdInterestGroup()` can b
 `dailyUpdateUrl` provides a mechanism to periodically update the attributes of the interest group, but this update is not based on the user's browsing history. 
 {% endDetails %}
 
+{% Details %}
+{% DetailsSummary %}
+### What is an owner's interest group limit for a single browser?
+{% endDetailsSummary %}
+
+{: #interest-group-limits}
+
+Chrome allows up to 1000 interest groups per owner, and up to 1000 interest group
+
+owners. These limits are meant as guard rails, not to be hit in regular operation.
+{% endDetails %}
+
 ## All FLEDGE API references
 
 {% Partial 'privacy-sandbox/fledge-api-reference.njk' %}

--- a/site/en/docs/privacy-sandbox/fledge/index.md
+++ b/site/en/docs/privacy-sandbox/fledge/index.md
@@ -277,7 +277,11 @@ The table below provides examples of different types of FLEDGE interest group an
   </table>
 </div>
 
-<br>
+{: #interest-group-limits}
+
+Chrome allows up to 1000 interest groups per owner, and up to 1000 interest group
+owners. These limits are meant as guard rails, not to be hit in regular operation.
+
 
 {% endDetails %}
 


### PR DESCRIPTION
Replaces https://github.com/GoogleChrome/developer.chrome.com/pull/5616/files, to add copy to the appropriate FLEDGE docs.

- https://pr-5849-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/fledge-api/interest-groups/#whats-the-maximum-number-of-interest-groups-per-group-owner-for-a-single-user
- https://pr-5849-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/fledge/#interest-group-limits