### PR TITLE
Support URLs with query params in dismissable banners

### DIFF
--- a/site/_includes/partials/script.js
+++ b/site/_includes/partials/script.js
@@ -72,7 +72,7 @@
   // Note that it's possible for a banner to have more than one action but
   // we always use the url from the first action as the localStorage value.
   try {
-    const bannerCtaUrl = '{{ banner.actions[0].href }}';
+    const bannerCtaUrl = '{{ banner.actions[0].href|safe }}';
     const savedBannerCtaUrl = localStorage.getItem('user-banner');
 
     if (savedBannerCtaUrl === bannerCtaUrl) {


### PR DESCRIPTION
Using a banner URL with multiple query params in it (like `http://site.com?query1&query2`) led to bannerCtaUrl being `http://site.com?query1&amp;query2`(`&` being escaped to `&amp;`) while savedBannerCtaUrl is always unescaped. Marking the template string as safe fixes this.