### PR TITLE
Fix anchor typo

### DIFF
--- a/site/en/docs/extensions/reference/runtime/index.md
+++ b/site/en/docs/extensions/reference/runtime/index.md
@@ -192,7 +192,7 @@ See the [Manifest V3 - Web Accessible Resources demo][github-war-sample] for mor
 [method-geturl]: #method-getURL
 [method-onconnect]: #event-onConnect
 [method-onconnectexternal]: #event-onConnectExternal
-[method-onconnect]: #event-onMessage
+[method-onmessage]: #event-onMessage
 [method-onmessageexternal]: #event-onMessageExternal
 [method-oninstalled]: #event-onInstalled
 [method-onstartup]: #event-onStartup

--- a/site/en/docs/extensions/reference/runtime/index.md
+++ b/site/en/docs/extensions/reference/runtime/index.md
@@ -14,7 +14,7 @@ Message passing
 [onConnect][method-onconnect], 
 [onConnectExternal][method-onconnectexternal],
 [sendMessage()][method-sendmessage], 
-[onMessage][method-onconnect] and
+[onMessage][method-onmessage] and
 [onMessageExternal][method-onmessageexternal]. 
 In addition, your extension can pass messages to native applications on the user's device using 
 [connectNative()][method-connectnative] and
@@ -192,6 +192,7 @@ See the [Manifest V3 - Web Accessible Resources demo][github-war-sample] for mor
 [method-geturl]: #method-getURL
 [method-onconnect]: #event-onConnect
 [method-onconnectexternal]: #event-onConnectExternal
+[method-onconnect]: #event-onMessage
 [method-onmessageexternal]: #event-onMessageExternal
 [method-oninstalled]: #event-onInstalled
 [method-onstartup]: #event-onStartup


### PR DESCRIPTION
Changes proposed in this pull request:

- Fixed an anchor typo in https://developer.chrome.com/docs/extensions/reference/runtime

![image](https://user-images.githubusercontent.com/18638914/229345361-0ea38993-f0be-4e2f-834e-f08bfbab9bb2.png)
