### PR TITLE
Delete mv2page-in-mv3.md

### DIFF
--- a/site/en/_partials/extensions/mv2page-in-mv3.md
+++ b/site/en/_partials/extensions/mv2page-in-mv3.md
@@ -1,5 +1,0 @@
-{% Aside 'caution' %}
-This page was migrated directly from the Manifest V2 documentation set. It has not yet
-been validated for compliance with Manifest V3.
-{% endAside %}
-


### PR DESCRIPTION
This label is no longer used on the site.

Changed Proposed by @oliverdunk 