### PR TITLE
remove in window feature detection examples

### DIFF
--- a/site/en/blog/privacy-sandbox-unified-origin-trial/index.md
+++ b/site/en/blog/privacy-sandbox-unified-origin-trial/index.md
@@ -240,7 +240,7 @@ Check for the `attributionReporting` object in the `window` and
 the Permissions Policy for "attribution-reporting".
 
 ```javascript
-if ('attributionReporting' in window && document.featurePolicy.allowsFeature('attribution-reporting')) {
+if (document.featurePolicy.allowsFeature('attribution-reporting')) {
   // Attribution Reporting API enabled
 }
 ```

--- a/site/ja/blog/privacy-sandbox-unified-origin-trial/index.md
+++ b/site/ja/blog/privacy-sandbox-unified-origin-trial/index.md
@@ -132,7 +132,7 @@ if ('runAdAuction' in navigator && document.featurePolicy.allowsFeature('run-ad-
 `window` 内の `attributionReporting` オブジェクトと、「attribution-reporting」のアクセス許可ポリシーを確認してください。
 
 ```javascript
-if ('attributionReporting' in window && document.featurePolicy.allowsFeature('attribution-reporting')) {
+if (document.featurePolicy.allowsFeature('attribution-reporting')) {
   // Attribution Reporting API enabled
 }
 ```


### PR DESCRIPTION
Fixes b/274755162

Changes proposed in this pull request:

- remove in window feature detection examples in en and ja blog posts PS origin trial
- Japanese version not staging? I changed my language to Japanese...
- en staged: https://pr-5957-static-dot-dcc-staging.uc.r.appspot.com/blog/privacy-sandbox-unified-origin-trial/#attribution-reporting