### PR TITLE
Added message passing example to tabs API page

### DIFF
--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -247,11 +247,10 @@ populates chrome.runtime.lastError is not unchecked.
 This example demonstrates how an extension's service worker can communicate with content scripts in specific browser tabs using `tabs.sendMessage`.
 
 ```js
-function messagePasser(messageInfo) {
+function sendMessageToActiveTab(messageInfo) {
 const [tab] = await chrome.tabs.query({active: true, lastFocusedWindow: true});
   const response = await chrome.tabs.sendMessage(tab.id, messageInfo);
   // TODO: Do something with the response.
-  console.log(response);
 }
 ```
 

--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -152,7 +152,7 @@ can usually be thought of as the user's current tab.
 </web-tabs>
 
 
-### Mute the specified tab
+### Mute the specified tab {: #mute }
 
 This example shows how an extension can toggle the muted state for a given tab.
 
@@ -184,7 +184,7 @@ This example shows how an extension can toggle the muted state for a given tab.
   </web-tab>
 </web-tabs>
 
-### Move the current tab to the first position when clicked
+### Move the current tab to the first position when clicked {: #move }
 
 This example shows how to move a tab while a drag may or may not be in progress. While this example
 uses `chrome.tabs.move`, you can use the same waiting pattern for other calls that modify tabs while
@@ -242,7 +242,7 @@ populates chrome.runtime.lastError is not unchecked.
   </web-tab>
 </web-tabs>
 
-### Pass a message to a selected tab's content script
+### Pass a message to a selected tab's content script {: #messaging }
 
 This example demonstrates how an extension's service worker can communicate with content scripts in specific browser tabs using `tabs.sendMessage`.
 

--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -247,9 +247,9 @@ populates chrome.runtime.lastError is not unchecked.
 This example demonstrates how an extension's service worker can communicate with content scripts in specific browser tabs using `tabs.sendMessage`.
 
 ```js
-function sendMessageToActiveTab(messageInfo) {
-const [tab] = await chrome.tabs.query({active: true, lastFocusedWindow: true});
-  const response = await chrome.tabs.sendMessage(tab.id, messageInfo);
+function sendMessageToActiveTab(message) {
+  const [tab] = await chrome.tabs.query({active: true, lastFocusedWindow: true });
+  const response = await chrome.tabs.sendMessage(tab.id, message);
   // TODO: Do something with the response.
 }
 ```

--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -250,7 +250,7 @@ This example demonstrates how an extension's service worker can communicate with
 function messagePasser(messageInfo) {
 const [tab] = await chrome.tabs.query({active: true, lastFocusedWindow: true});
   const response = await chrome.tabs.sendMessage(tab.id, messageInfo);
-  // do something with response here, not outside the function
+  // TODO: Do something with the response.
   console.log(response);
 }
 ```

--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -244,7 +244,7 @@ populates chrome.runtime.lastError is not unchecked.
 
 ### Pass a message to a selected tab's content script {: #messaging }
 
-This example demonstrates how an extension's service worker can communicate with content scripts in specific browser tabs using `tabs.sendMessage`.
+This example demonstrates how an extension's service worker can communicate with content scripts in specific browser tabs using `tabs.sendMessage()`.
 
 ```js
 function sendMessageToActiveTab(message) {

--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -248,7 +248,7 @@ This example demonstrates how an extension's service worker can communicate with
 
 ```js
 function sendMessageToActiveTab(message) {
-  const [tab] = await chrome.tabs.query({active: true, lastFocusedWindow: true });
+  const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
   const response = await chrome.tabs.sendMessage(tab.id, message);
   // TODO: Do something with the response.
 }

--- a/site/en/docs/extensions/reference/tabs/index.md
+++ b/site/en/docs/extensions/reference/tabs/index.md
@@ -242,6 +242,20 @@ populates chrome.runtime.lastError is not unchecked.
   </web-tab>
 </web-tabs>
 
+### Pass a message to a selected tab's content script
+
+This example demonstrates how an extension's service worker can communicate with content scripts in specific browser tabs using `tabs.sendMessage`.
+
+```js
+function messagePasser(messageInfo) {
+const [tab] = await chrome.tabs.query({active: true, lastFocusedWindow: true});
+  const response = await chrome.tabs.sendMessage(tab.id, messageInfo);
+  // do something with response here, not outside the function
+  console.log(response);
+}
+```
+
+
 ## Extension examples {: #more-samples}
 
 For more Tabs API extensions demos, explore any of the following:


### PR DESCRIPTION
Fixes #665

Changes proposed in this pull request:

-Addressed need to demonstrate the tabs API sendMessage method.