### PR TITLE
Add April CrUX release (for March data) to the CrUX release notes

### DIFF
--- a/site/en/docs/crux/release-notes/index.md
+++ b/site/en/docs/crux/release-notes/index.md
@@ -21,7 +21,7 @@ date: 2017-10-01
 
 # Optional
 # Include an updated date when you update your post
-updated: 2023-03-14
+updated: 2023-04-11
 
 # Optional
 # How to add a new author
@@ -42,6 +42,17 @@ In the list below, we've curated some release notes for each monthly dataset. Su
 The CrUX dataset on BigQuery is generally updated on the second Tuesday of every month. Each release is numbered according to the year and calendar month of the data collection period, for example 201912 corresponds to the UX data collected during December 2019 and would be released on the second Tuesday of January 2020 after the data collection period has ended.
 
 In the list below, we've curated some release notes for each monthly dataset. Subscribe to our [CrUX Announce](https://groups.google.com/a/chromium.org/forum/#!forum/chrome-ux-report-announce) mailing list or follow [@ChromeUXReport](https://twitter.com/ChromeUXReport) on Twitter for release Announcements.
+
+## 202303
+
+[Announcement](https://groups.google.com/a/chromium.org/g/chrome-ux-report-announce/c/1hHxnk9ZOCk)
+
+Publication date
+ : Apri 11, 2023
+
+Notable stats
+ : - 18,495,210 origins
+ : - 44.2% of origins have good [Core Web Vitals](https://web.dev/vitals/#core-web-vitals)
 
 ## 202302
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Adds the April CrUX release (for March data) to the CrUX release notes page
