### PR TITLE
fix: project card are broken on the safari v16.4

### DIFF
--- a/site/_includes/macros/cards/hero-card-wide.njk
+++ b/site/_includes/macros/cards/hero-card-wide.njk
@@ -8,6 +8,8 @@
       <h1 class="type--h1 color-{{color}}-darkest">
         {% if titleIcon %}
           <div class="project-icon gap-right-300">
+            <div class="project-icon__cover cover-last"></div>
+            <div class="project-icon__cover cover-mid"></div>
             <div class="project-icon__cover">
               {# image/jxu1OdD7LKOGIDU7jURMpSH2lyK2/TvE0fdJmcXI8fuPc8R7A.svg #}
               {% Img

--- a/site/_includes/macros/cards/hero-card.njk
+++ b/site/_includes/macros/cards/hero-card.njk
@@ -8,6 +8,8 @@
       <h1 class="type--h1 color-{{color}}-darkest">
         {% if titleIcon %}
           <div class="project-icon gap-right-300">
+            <div class="project-icon__cover cover-last" style="color: var(--title-icon-color)"></div>
+            <div class="project-icon__cover cover-mid" style="color: var(--title-icon-color)"></div>
             <div class="project-icon__cover" style="color: var(--title-icon-color)">
               {# image/jxu1OdD7LKOGIDU7jURMpSH2lyK2/TvE0fdJmcXI8fuPc8R7A.svg #}
               {% Img

--- a/site/_includes/macros/project-icon.njk
+++ b/site/_includes/macros/project-icon.njk
@@ -4,6 +4,8 @@
   <div class="project-icon">
     {% set styles = (project_key | embededDoc(docs)).styles %}
     {% set color = styles.project_icon_color %}
+    <div class="project-icon__cover cover-last"{% if color %} style="color: var(--{{color}})"{% endif %}></div>
+    <div class="project-icon__cover cover-mid"{% if color %} style="color: var(--{{color}})"{% endif %}></div>
     <div class="project-icon__cover"{% if color %} style="color: var(--{{color}})"{% endif %}>
       {# svg() looks in "_includes", so find the project image in the parent directory #}
       {{ svg('../_static/images/project/' + project_key | replace("/", "-") + '.svg', {hidden: true}) }}

--- a/site/_scss/blocks/_project-icon.scss
+++ b/site/_scss/blocks/_project-icon.scss
@@ -27,42 +27,35 @@
   justify-content: center;
   position: relative;
   transform-style: preserve-3d;  // only needed for Firefox
+  transition: transform 0.4s;
   width: 128px;
 
-  &::before,
-  &::after {
-    background-color: inherit;
-    border-radius: 6px;
-    bottom: 0;
-    content: '';
-    display: block;
+  &.cover-last,
+  &.cover-mid {
+    background-image: none;
     left: 0;
     position: absolute;
-    right: 0;
     top: 0;
-    transition: transform 0.4s;
   }
 
-  &::before {
-    filter: saturate(90%) contrast(0.9) brightness(1.4);
-    transform: translate3D(0, 0, -1rem) scale(0.95);
-    z-index: -1;
-  }
-
-  &::after {
+  &.cover-last {
     filter: saturate(50%) contrast(0.7) brightness(2);
     transform: translate3D(0, 0, -2rem) scale(0.9);
-    z-index: -2;
+  }
+
+  &.cover-mid {
+    filter: saturate(90%) contrast(0.9) brightness(1.4);
+    transform: translate3D(0, 0, -1rem) scale(0.95);
   }
 }
 
 .project-icon:hover {
   .project-icon__cover {
-    &::before {
+    &.cover-mid {
       transform: translate3D(0, 0, -0.25em) scale(1);
     }
 
-    &::after {
+    &.cover-last {
       transform: translate3D(0, 0, -0.5em) scale(1);
     }
   }


### PR DESCRIPTION
Fixes #5893 

The project cards on https://developer.chrome.com/docs/ are broken for Safari 16.4 (17615.1.26.101.9, 17615). 

<img width="444" alt="Screenshot 2023-04-12 at 17 00 17" src="https://user-images.githubusercontent.com/45324326/231424567-6abe1be2-52f1-48db-b43b-4dff5a75574a.png">


**Expected result:**

<img width="451" alt="Screenshot 2023-04-12 at 17 02 21" src="https://user-images.githubusercontent.com/45324326/231425286-f790c5e4-4176-4eaa-9211-63ef8e371ded.png">


 It seems like the styling for `::before` and `::after` CSS selectors did not render perfectly as expected on Safari browser v16.4, and probably other versions too. 

The change in this pull request is removing the `::before` and `::after` CSS selectors for rendering the card layers behind the project card and adding `<div>` tags then applying the styling to these tags to display the layers of card instead.  
