### PR TITLE
Document `world` key in static content_scripts declaration

### DIFF
--- a/site/en/docs/extensions/mv3/content_scripts/index.md
+++ b/site/en/docs/extensions/mv3/content_scripts/index.md
@@ -168,6 +168,14 @@ They can include JavaScript files, CSS files, or both. All auto-run content scri
         <a href="#injecting-in-related-frames">Injecting in related frames</a>.
       </td>
     </tr>
+    <tr id="world">
+      <td><code>world</code></td>
+      <td><a href="/docs/extensions/reference/scripting/#type-ExecutionWorld">ExecutionWorld</a></td>
+      <td>
+        <em>Optional.</em> The JavaScript world for a script to execute within. Defaults to <code>ISOLATED</code>. See also
+        <a href="#isolated_world">Work in isolated worlds</a>.
+      </td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
Support for specifying a `world` for content scripts was added in https://bugs.chromium.org/p/chromium/issues/detail?id=1330986. This updates our documentation accordingly.