### PR TITLE
[WordPress Playground] Update Pendant theme link to WordPress.org instead of WordPress.com

### DIFF
--- a/site/en/blog/wordpress-playground/index.md
+++ b/site/en/blog/wordpress-playground/index.md
@@ -47,7 +47,7 @@ WordPress Playground in an `<iframe>` and configure it using the
 [query parameters API](https://wordpress.github.io/wordpress-playground/pages/embedding-wordpress-playground-on-other-websites.html).
 That's what the [official showcase](https://developer.wordpress.org/playground)
 does. When you select, for example, the
-[Pendant theme](https://wordpress.com/theme/pendant) and the
+[Pendant theme](https://wordpress.org/themes/pendant/) and the
 [Coblocks plugin](https://wordpress.org/plugins/coblocks/), the embedded iframe
 gets updated to point to
 [https://playground.wordpress.net/?theme=pendant&plugin=coblocks](https://playground.wordpress.net/?theme=pendant&plugin=coblocks).


### PR DESCRIPTION
The Pendant theme exists in the open-source theme directory on WordPress.org and I've accidentally linked to the directory on WordPress.com. Let's update it to link to the .org site.

cc @tomayac 
