### PR TITLE
DevTools: Local overrides

### DIFF
--- a/site/_data/docs/devtools/toc.yml
+++ b/site/_data/docs/devtools/toc.yml
@@ -46,6 +46,7 @@
     - url: /docs/devtools/javascript/snippets/
     - url: /docs/devtools/javascript/source-maps/
     - url: /docs/devtools/workspaces/
+    - url: /docs/devtools/overrides/
     - url: /docs/devtools/javascript/reference/
 - title: i18n.docs.devtools.network
   sections:

--- a/site/_data/i18n/tags.yml
+++ b/site/_data/i18n/tags.yml
@@ -66,6 +66,9 @@ sourcemap:
 storage:
   en: Storage
 
+network:
+  en: Network
+
 dom:
   en: DOM
 

--- a/site/en/docs/devtools/network/reference/index.md
+++ b/site/en/docs/devtools/network/reference/index.md
@@ -156,6 +156,10 @@ To manually clear browser cookies at any time, right-click anywhere in the **Req
 
 {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/4mVbTicUyxwkmd5TB1HS.png", alt="Selecting Clear Browser Cookies.", width="800", height="497" %}
 
+### Override HTTP response headers {: #override-headers }
+
+See [Override files and HTTP response headers locally](/docs/devtools/overrides/#override-headers).
+
 ### Override the user agent {: #user-agent }
 
 To manually override the user agent:

--- a/site/en/docs/devtools/overrides/index.md
+++ b/site/en/docs/devtools/overrides/index.md
@@ -1,0 +1,100 @@
+---
+layout: "layouts/doc-post.njk"
+title: "Override files and HTTP response headers locally"
+authors:
+  - sofiayem
+date: 2023-04-12
+#updated: YYYY-MM-DD
+description: "Use local overrides to keep changes you make in DevTools across page loads."
+tags:
+  - prototype-fixes
+  - javascript
+  - css
+  - network
+---
+
+With local overrides, you can keep changes you make in DevTools to your code across page loads. You can also override HTTP response headers.
+
+How it works:
+
+- When you make changes in DevTools, DevTools saves a copy of the modified file to a folder you specify.
+- When you reload the page, DevTools serves the local, modified file, rather than the network resource.
+
+{% Aside 'important' %}
+You can also save your changes directly to source files. See [Edit and save files with Workspaces](/docs/devtools/workspaces/).
+{% endAside %}
+
+## Limitations {: #limitations }
+
+Local overrides work for network response headers and for most file types, with a couple of exceptions:
+
+- DevTools doesn't save changes made in the DOM tree of the [**Elements**](/docs/devtools/dom/) panel.
+- If you edit CSS in the **Styles** pane, and the source of that CSS is an HTML file, DevTools won't save the change.
+
+Instead, you can edit HTML files in the [**Sources**](/docs/devtools/sources/) panel.
+
+## Enable or disable local overrides {: #enable-overrides }
+
+Specify a folder where DevTools will keep your changes:
+
+1. [Open DevTools](/docs/devtools/open) on a page.
+1. Go to [**Sources**](/docs/devtools/sources/) > **Overrides** and click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/eY8MaTQqlXF3oiT6STmy.svg", alt="Add.", width="20", height="20" %} **Select folder for overrides**.
+
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Mcwf0iY9MPSBTsbm3MWH.png", alt="The 'Select folder for overrides' button.", width="800", height="425" %}
+
+1. Pick a folder and, when prompted, allow DevTools access to it.
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Uq6nmriJ6PMGAWqRzTtq.png", alt="Local overrides enabled in a specified folder.", width="800", height="404" %}
+
+To view the files served by the server again, clear {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/ZtDyFg7cjkxacORB3GQn.svg", alt="Cleared checkbox.", width="24", height="24" %} **Enable local overrides** at any time.
+
+To delete the files with changes, click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/MadqZsIZpo1sj3qQ3GsZ.svg", alt="Clear.", width="24", height="24" %}.
+
+## Make changes {: #make-changes }
+
+Make changes to your code, for example, edit [CSS in the **Elements** panel](/docs/devtools/css/reference/#change-declaration), or [JavaScript in **Sources**](/docs/devtools/javascript/reference/#edit).
+
+DevTools saves the modified files, lists them in **Sources** > **Overrides**, and shows you the {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/s81rU6SgdmbseeBDGbPl.png", alt="Saved.", width="34", height="40" %} icon next to the overridden files.
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/FPuaWwuQ3HFlgOuc4ZP4.png", alt="Overridden files listed in the Sources > Overrides and icons next to these files.", width="800", height="540" %}
+
+## Override HTTP response headers {: #override-headers }
+
+From the **Network** panel, you can override HTTP response headers without the access to the web server.
+
+With response header overrides, you can locally prototype fixes for various headers, including but not limited to:
+
+- [Cross-Origin Resource Sharing (CORS) Headers](https://developer.mozilla.org/docs/Web/HTTP/CORS)
+- [Permissions-Policy Headers](https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy)
+- [Cross-Origin Isolation Headers](https://web.dev/coop-coep/)
+
+To override a response header:
+
+1. [Open DevTools](/docs/devtools/open), for example, on [this demo page](https://cors-demo-devtools.glitch.me/).
+1. Go to **Network**, select a request from the table, open **Headers** > **Response Headers**.
+1. Hover over a response header value and click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/JJEyylF1sToNKTtoFm4Q.svg", alt="Edit.", width="22", height="22" %}.
+
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/U9f8IhtBACotmtYUNjtO.png", alt="The edit button next to a response header.", width="800", height="552" %}
+
+1. If prompted, pick a folder for DevTools to save chages to and allow access.
+1. Modify a header: 
+
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/IhXa4zihNp5Gsi9eBPhN.png", alt="Modifying an existing header value, adding a new one, and removing an override.", width="800", height="653" %}
+
+   - To edit a header value, click it.
+   - To add a new header, click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/eY8MaTQqlXF3oiT6STmy.svg", alt="Add.", width="20", height="20" %} **Add header**.
+   - To remove a header override, click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Bg5rfKrzHBaF621Ag9IN.svg", alt="Delete.", width="20", height="20" %} next to it.
+   
+   DevTools highlights modified headers in green and removed ones in red.
+
+   This example adds `Access-Control-Allow-Origin: *` to get rid of a [CORS error](https://web.dev/cross-origin-resource-sharing/).
+
+1. {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/sX65QEDYhwBFHCM24BtV.svg", alt="Refresh.", width="20", height="20" %} Refresh the page for the changes to take effect.
+
+### Edit all response header overrides {: #edit-response-header-overrides }
+
+
+
+## Track your local changes {: #track-changes }
+
+You can keep track of all the changes you make in one place—the [**Changes**](/docs/devtools/changes/) drawer tab.

--- a/site/en/docs/devtools/overrides/index.md
+++ b/site/en/docs/devtools/overrides/index.md
@@ -13,7 +13,7 @@ tags:
   - network
 ---
 
-With local overrides, you can keep changes you make in DevTools to your code across page loads. You can also override HTTP response headers.
+With local overrides, you can keep the changes you make in DevTools across page loads. You can also [override HTTP response headers](#override-headers).
 
 How it works:
 
@@ -48,15 +48,19 @@ Specify a folder where DevTools will keep your changes:
 
 To view the files served by the server again, clear {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/ZtDyFg7cjkxacORB3GQn.svg", alt="Cleared checkbox.", width="24", height="24" %} **Enable local overrides** at any time.
 
-To delete the files with changes, click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/MadqZsIZpo1sj3qQ3GsZ.svg", alt="Clear.", width="24", height="24" %}.
+To delete all the files with changes, click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/MadqZsIZpo1sj3qQ3GsZ.svg", alt="Clear.", width="24", height="24" %}.
 
 ## Make changes {: #make-changes }
 
 Make changes to your code, for example, edit [CSS in the **Elements** panel](/docs/devtools/css/reference/#change-declaration), or [JavaScript in **Sources**](/docs/devtools/javascript/reference/#edit).
 
-DevTools saves the modified files, lists them in **Sources** > **Overrides**, and shows you the {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/s81rU6SgdmbseeBDGbPl.png", alt="Saved.", width="34", height="40" %} icon next to the overridden files.
+DevTools saves the modified files, lists them in **Sources** > **Overrides**, and shows you the {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/s81rU6SgdmbseeBDGbPl.png", alt="Saved.", width="17", height="20" %} icon next to the overridden files.
 
 {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/FPuaWwuQ3HFlgOuc4ZP4.png", alt="Overridden files listed in the Sources > Overrides and icons next to these files.", width="800", height="540" %}
+
+## Track your local changes {: #track-changes }
+
+You can keep track of all the changes you make in one place—the [**Changes**](/docs/devtools/changes/) drawer tab.
 
 ## Override HTTP response headers {: #override-headers }
 
@@ -76,25 +80,45 @@ To override a response header:
 
    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/U9f8IhtBACotmtYUNjtO.png", alt="The edit button next to a response header.", width="800", height="552" %}
 
-1. If prompted, pick a folder for DevTools to save chages to and allow access.
-1. Modify a header: 
+1. If prompted, pick a folder for DevTools to save changes to and allow access.
+1. Modify a header.
+
+   {% Aside %}
+   This example adds the `Access-Control-Allow-Origin: *` header to get rid of a [CORS error](https://web.dev/cross-origin-resource-sharing/).
+   {% endAside %}
 
    {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/IhXa4zihNp5Gsi9eBPhN.png", alt="Modifying an existing header value, adding a new one, and removing an override.", width="800", height="653" %}
 
    - To edit a header value, click it.
    - To add a new header, click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/eY8MaTQqlXF3oiT6STmy.svg", alt="Add.", width="20", height="20" %} **Add header**.
-   - To remove a header override, click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Bg5rfKrzHBaF621Ag9IN.svg", alt="Delete.", width="20", height="20" %} next to it.
+   - To remove a header override, click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Bg5rfKrzHBaF621Ag9IN.svg", alt="Delete.", width="20", height="20" %} next to it. This removes the headers you added or reverts modified values back to original values.
    
-   DevTools highlights modified headers in green and removed ones in red.
+   DevTools highlights modified headers <span style="background-color:#e9f2ec;">in green</span> and removed overrides <span style="background-color:#ffeff0;text-decoration-line: line-through;">in red</span>.
 
-   This example adds `Access-Control-Allow-Origin: *` to get rid of a [CORS error](https://web.dev/cross-origin-resource-sharing/).
-
-1. {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/sX65QEDYhwBFHCM24BtV.svg", alt="Refresh.", width="20", height="20" %} Refresh the page for the changes to take effect.
+1. {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/sX65QEDYhwBFHCM24BtV.svg", alt="Refresh.", width="20", height="20" %} Refresh the page to apply the changes.
 
 ### Edit all response header overrides {: #edit-response-header-overrides }
 
+To edit all header overrides in one place:
 
+1. Click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/s81rU6SgdmbseeBDGbPl.png", alt="Saved.", width="17", height="20" %} **Header overrides** next to the **Response Headers** section.
 
-## Track your local changes {: #track-changes }
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/LMtR86HKtlYF7JgmFM6W.png", alt="The Header overrides link next to the Response Headers section.", width="800", height="631" %}
 
-You can keep track of all the changes you make in one place—the [**Changes**](/docs/devtools/changes/) drawer tab.
+   DevTools takes you to the corresponding `.headers` file in **Sources** > **Overrides**.
+
+1. Edit the `.headers` file:
+
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/X8qHpRfwGOLdFTDYWeCb.png", alt="Editing the .headers file.", width="800", height="503" %}
+
+   - To add a new override rule, click **Add override rule**. A rule here is a set of headers and values and a single or multiple request to apply them to.
+
+     {% Aside %}
+     You can use [wildcards](https://chromedevtools.github.io/devtools-protocol/tot/Fetch/#type-RequestPattern) to specify multiple requests at once. Designate multiple characters with `*` and a single one with `?`.
+     {% endAside %}
+
+   - To add a header-value pair to a rule, hover over another pair and click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/eY8MaTQqlXF3oiT6STmy.svg", alt="Add.", width="20", height="20" %}.
+   - To revert a header value, remove an added header or a rule, hover over it and click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Bg5rfKrzHBaF621Ag9IN.svg", alt="Delete.", width="20", height="20" %}.
+
+1. Save the `.headers` file with <kbd>Command</kbd> / <kbd>Control</kbd> + <kbd>S</kbd>.
+1. {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/sX65QEDYhwBFHCM24BtV.svg", alt="Refresh.", width="20", height="20" %} Refresh the page to apply the changes.

--- a/site/en/docs/devtools/workspaces/index.md
+++ b/site/en/docs/devtools/workspaces/index.md
@@ -60,7 +60,7 @@ on Stack Overflow][6] to share your knowledge with the rest of the DevTools comm
 
 ## Related feature: Local Overrides {: #overrides }
 
-[Local Overrides][7] is another DevTools feature that is similar to Workspaces. Use Local Overrides
+[Local overrides][7] is another DevTools feature that is similar to Workspaces. Use local overrides
 when you want to experiment with changes to a page, and you need to see those changes across page
 loads, but you don't care about mapping your changes to the page's source code.
 
@@ -241,7 +241,7 @@ Next, learn how to use DevTools to [change CSS](/docs/devtools/css/) and [debug 
 [4]: http://blog.teamtreehouse.com/introduction-source-maps
 [5]: https://groups.google.com/forum/#!forum/google-chrome-developer-tools
 [6]: https://stackoverflow.com/questions/ask?tags=google-chrome-devtools
-[7]: /blog/new-in-devtools-65/#overrides
+[7]: /docs/devtools/overrides/
 [8]: https://glitch.com/edit/#!/remix/workspaces
 [9]: https://en.wikipedia.org/wiki/Port_(computer_networking)#Use_in_URLs
 [10]: #elements


### PR DESCRIPTION
Documented the (missing) "Local overrides" feature, including [header overrides](https://developer.chrome.com/blog/new-in-devtools-113/#network) coming in 113.

Publish on May 2.