### PR TITLE
Add Protected Audience API renaming banner

### DIFF
--- a/site/en/_partials/privacy-sandbox/protected-audience-rename-banner.md
+++ b/site/en/_partials/privacy-sandbox/protected-audience-rename-banner.md
@@ -1,0 +1,3 @@
+{% Aside 'update' %}
+FLEDGE has been renamed to Protected Audience API. To learn more about the name change, see the [blog post](https://privacysandbox.com/intl/en_us/news/protected-audience-api-our-new-name-for-fledge).
+{% endAside %}

--- a/site/en/blog/bidding-and-auction-services-availability/index.md
+++ b/site/en/blog/bidding-and-auction-services-availability/index.md
@@ -12,6 +12,8 @@ tags:
   - privacy
 ---
 
+{% Partial 'privacy-sandbox/protected-audience-rename-banner.njk' %}
+
 As FLEDGE adoption continues to grow and scale, we recently launched a collection of new optimizations to help improve on-device auction latency. In addition to these improvements, we will be expanding support for the [Bidding and Auction services](https://github.com/privacysandbox/fledge-docs/blob/main/bidding_auction_services_api.md) to the web platform. 
 
 The Bidding and Auction services integrate with existing FLEDGE designs and offload bid computation and scoring to a cloud-based trusted execution environment. This was proposed back in 2022 and, after careful consideration, both Chrome and Android plan to provide support for Bidding and Auction services.

--- a/site/en/blog/fledge-service-overview/index.md
+++ b/site/en/blog/fledge-service-overview/index.md
@@ -18,6 +18,8 @@ tags:
 	.type figcaption {text-align:left;}
 </style>
 
+{% Partial 'privacy-sandbox/protected-audience-rename-banner.njk' %}
+
 FLEDGE ([Android](https://developer.android.com/design-for-safety/ads/fledge),
 [Chrome](/docs/privacy-sandbox/fledge/#overview)) is a Privacy Sandbox proposal
 to let marketers target ads to custom audiences, based on audience members'

--- a/site/en/docs/privacy-sandbox/fledge-api/ad-auction/index.md
+++ b/site/en/docs/privacy-sandbox/fledge-api/ad-auction/index.md
@@ -11,6 +11,8 @@ authors:
   - alexandrawhite
 ---
 
+{% Partial 'privacy-sandbox/protected-audience-rename-banner.njk' %}
+
 In this article, you'll find a technical reference for the ad auction, as used in the current iteration of the experimental FLEDGE API.
 
 Read the [developer guide](/docs/privacy-sandbox/fledge-api) for the full life

--- a/site/en/docs/privacy-sandbox/fledge-api/feature-status/index.md
+++ b/site/en/docs/privacy-sandbox/fledge-api/feature-status/index.md
@@ -14,6 +14,8 @@ authors:
   - kevinkiklee
 ---
 
+{% Partial 'privacy-sandbox/protected-audience-rename-banner.njk' %}
+
 As we move [FLEDGE](/docs/privacy-sandbox/fledge/) closer to general
 availability and approach third-party cookie deprecation in Chrome, you may be
 wondering about the availability of FLEDGE services and features. Here you'll

--- a/site/en/docs/privacy-sandbox/fledge-api/index.md
+++ b/site/en/docs/privacy-sandbox/fledge-api/index.md
@@ -15,6 +15,8 @@ authors:
   - kevinkiklee
 ---
 
+{% Partial 'privacy-sandbox/protected-audience-rename-banner.njk' %}
+
 For those new to FLEDGE, read the [FLEDGE overview](/docs/privacy-sandbox/fledge)
 for a high-level explanation of the proposal.
 

--- a/site/en/docs/privacy-sandbox/fledge-api/interest-groups/index.md
+++ b/site/en/docs/privacy-sandbox/fledge-api/interest-groups/index.md
@@ -13,6 +13,8 @@ authors:
   - alexandrawhite
 ---
 
+{% Partial 'privacy-sandbox/protected-audience-rename-banner.njk' %}
+
 In this article, you'll find a technical reference for interest groups, as used
 in the current iteration of the experimental FLEDGE API.
 

--- a/site/en/docs/privacy-sandbox/fledge-api/latency/index.md
+++ b/site/en/docs/privacy-sandbox/fledge-api/latency/index.md
@@ -11,6 +11,8 @@ authors:
   - pauljensen
 ---
 
+{% Partial 'privacy-sandbox/protected-audience-rename-banner.njk' %}
+
 It's in everyone's best interest to make sure FLEDGE operates efficiently.
 
 * People browsing the web want sites to load quickly. This means developers

--- a/site/en/docs/privacy-sandbox/fledge-api/opt-out/index.md
+++ b/site/en/docs/privacy-sandbox/fledge-api/opt-out/index.md
@@ -11,6 +11,8 @@ authors:
   - alexandrawhite
 ---
 
+{% Partial 'privacy-sandbox/protected-audience-rename-banner.njk' %}
+
 You can block access to the FLEDGE API, as a [site owner](#opt-out-site) or as an [individual user](#opt-out-user).
 
 ## Site owners {: #opt-out-site}

--- a/site/en/docs/privacy-sandbox/fledge-api/reports/index.md
+++ b/site/en/docs/privacy-sandbox/fledge-api/reports/index.md
@@ -11,6 +11,8 @@ authors:
   - alexandrawhite
 ---
 
+{% Partial 'privacy-sandbox/protected-audience-rename-banner.njk' %}
+
 In this article, you'll find a technical reference for generating reports for
 FLEDGE auction wins, as used in the current iteration of the experimental
 FLEDGE API.

--- a/site/en/docs/privacy-sandbox/fledge-api/troubleshoot/index.md
+++ b/site/en/docs/privacy-sandbox/fledge-api/troubleshoot/index.md
@@ -11,6 +11,8 @@ authors:
   - alexandrawhite
 ---
 
+{% Partial 'privacy-sandbox/protected-audience-rename-banner.njk' %}
+
 From Chrome Canary 98.0.4718.0, it's possible to debug FLEDGE and FLEDGE
 worklets in Chrome DevTools.
 

--- a/site/en/docs/privacy-sandbox/fledge-experiment/index.md
+++ b/site/en/docs/privacy-sandbox/fledge-experiment/index.md
@@ -11,6 +11,8 @@ authors:
   - samdutton
 ---
 
+{% Partial 'privacy-sandbox/protected-audience-rename-banner.njk' %}
+
 ## Learn the essentials
 
 * If you're a developer or software engineer, the [FLEDGE API Developer Guide](/blog/fledge-api)

--- a/site/en/docs/privacy-sandbox/fledge/index.md
+++ b/site/en/docs/privacy-sandbox/fledge/index.md
@@ -15,6 +15,8 @@ authors:
   - kevinkiklee
 ---
 
+{% Partial 'privacy-sandbox/protected-audience-rename-banner.njk' %}
+
 {% YouTube
   id='HkvmYKqnytw'
 %}


### PR DESCRIPTION
This PR adds a banner to reflect the new name for FLEDGE: "Protected Audience API"

Announcement blog post: https://privacysandbox.com/intl/en_us/news/protected-audience-api-our-new-name-for-fledge

Live links: 
* TBD