### PR TITLE
5932-closing-keyboard-when-search-empty-safari

### DIFF
--- a/site/_js/web-components/search-box.js
+++ b/site/_js/web-components/search-box.js
@@ -96,6 +96,7 @@ export class SearchBox extends BaseElement {
   }
 
   clearSearch() {
+    this.input.blur();
     this.active = false;
     this.input.value = '';
     this.search('');


### PR DESCRIPTION
Fixes #5932

Changes proposed in this pull request:

- keyboard on mobile gets hidden once the search box gets cleared