### PR TITLE
Pin webpack to a version with working types

### DIFF
--- a/external/build/workbox-types.js
+++ b/external/build/workbox-types.js
@@ -57,7 +57,7 @@ async function run() {
   try {
     // webpack is a peerDependency of workbox-webpack-plugin, and needs to be
     // manually installed.
-    childProcess.execFileSync('npm', ['install', 'webpack'], {
+    childProcess.execFileSync('npm', ['install', 'webpack@5.75.0'], {
       cwd: t.name,
       stdio: 'inherit',
     });


### PR DESCRIPTION
This unblocks the external-data flow by pinning webpack to a version that has working types for `ServerOptionsImport` and fixes this error:

```
Error: failed to parse typedoc: ../../../../private/var/folders/59/tpsxg9ws0f9chbl9cy31_dgr010q23/T/tmp-51220-0RCXnQGtWutF/node_modules/webpack/types.d.ts:6148:5 - error TS2315: Type 'ServerOptions' is not generic.

6148   | ServerOptionsImport<typeof IncomingMessage>
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```