### PR TITLE
Add Storage Partitioning to TOC

### DIFF
--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -24,6 +24,7 @@
     - url: /docs/privacy-sandbox/first-party-sets-integration
     - url: /docs/privacy-sandbox/first-party-sets-evolution
     - url: /docs/privacy-sandbox/chips
+    - url: /docs/privacy-sandbox/storage-partitioning/
     - url: /docs/privacy-sandbox/fenced-frame
     - title: i18n.docs.privacy-sandbox.cross-site-federation
       sections:


### PR DESCRIPTION
This link features on the landing page, but was missing from the table of contents. This adds it.