### PR TITLE
Add active link to Squoosh in the Richer UI article

### DIFF
--- a/site/en/blog/richer-install-ui-desktop/index.md
+++ b/site/en/blog/richer-install-ui-desktop/index.md
@@ -53,7 +53,7 @@ The older style of install prompt provided little information and context. This 
 
 Richer installs let you create experiences more like those on operating systems.
 
-You can build your own by following the example from the Squoosh app [manifest file](https://squoosh.app/manifest.json) and you can try the dialog live at: https://squoosh.app/.
+You can build your own by following the example from the Squoosh app [manifest file](https://squoosh.app/manifest.json) and you can try the dialog live at: [https://squoosh.app/](https://squoosh.app/).
 
 Feedback
 We're considering other options for richer installs including categories and app ratings. To make that decision, we need your feedback.


### PR DESCRIPTION
It seems like your Markdown preprocessor doesn’t auto generate links by default.

![](https://user-images.githubusercontent.com/105274/233418320-817e1ad9-aca1-4a52-ab44-2004af5514a8.jpeg)

Changes proposed in this pull request:

- Explicit link to the Squoosh
