### PR TITLE
remove asterisk-not needed

### DIFF
--- a/site/en/docs/privacy-sandbox/fledge-api/ad-auction/index.md
+++ b/site/en/docs/privacy-sandbox/fledge-api/ad-auction/index.md
@@ -188,7 +188,7 @@ desirability score.
         <dd>Optional</dd>
         <dd>Example: <code>'https://ssp.example/scoring-signals'</code></dd>
         <dd>Role: URL of seller's trusted server.</dd>
-    <dt><code>interestGroupBuyers*</code></dt>
+    <dt><code>interestGroupBuyers</code></dt>
         <dd>Required</dd>
         <dd>Example: <code>['https://dsp.example', 'https://buyer2.example', ...]</code></dd>
         <dd>Role: Origins of all interest group owners asked to bid in the auction.</dd>


### PR DESCRIPTION
left over from table

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- oops. remove asterisk because I added the note to the description instead
- staged https://pr-6082-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/fledge-api/ad-auction/#:~:text=seller%27s%20trusted%20server.-,interestGroupBuyers,-Required
-