### PR TITLE
Add MV3 support blurb to selected pages.

### DIFF
--- a/site/en/_partials/extensions/mv3-support.md
+++ b/site/en/_partials/extensions/mv3-support.md
@@ -1,3 +1,3 @@
 {% Aside %}
-Manifest V3 is supported generally in Chrome 88 or later. For extension features added in later Chrome versions, see the descriptions of specific APIs or their members for support information. If your extension requires a specific API, you can specify [a minimum chrome version](/docs/extensions/mv3/manifest/minimum_chrome_version/) in the manifest file.
+Manifest V3 is supported generally in Chrome 88 or later. For extension features added in later Chrome versions, see the [API reference documentation](/docs/extensions/reference/) for support information. If your extension requires a specific API, you can specify [a minimum chrome version](/docs/extensions/mv3/manifest/minimum_chrome_version/) in the manifest file.
 {% endAside %}

--- a/site/en/_partials/extensions/mv3-support.md
+++ b/site/en/_partials/extensions/mv3-support.md
@@ -1,0 +1,3 @@
+{% Aside %}
+Manifest V3 is supported generally in Chrome 88 or later. For extension features added in later Chrome versions, see the descriptions of specific APIs or their members for support information. If your extension requires a specific API, you can specify [a minimum chrome version](/docs/extensions/mv3/manifest/minimum_chrome_version/) in the manifest file.
+{% endAside %}

--- a/site/en/docs/extensions/migrating/api-calls/index.md
+++ b/site/en/docs/extensions/migrating/api-calls/index.md
@@ -7,6 +7,8 @@ date: 2023-03-09
 updated: 2023-04-17
 ---
 
+{% Partial 'extensions/mv3-support.md' %}
+
 This is the first of three sections describing changes needed for code that is not part of the extension service worker. This section is for required code changes that are unrelated to other issues. The next two sections cover [replacing blocking web requests](/docs/extensions/migrating/blocking-web-requests) and [improving security](/docs/extensions/migrating/improve-security).
 
 ## Replace tabs.executeScript() with scripting.executeScript() {: #replace-executescript }

--- a/site/en/docs/extensions/migrating/blocking-web-requests/index.md
+++ b/site/en/docs/extensions/migrating/blocking-web-requests/index.md
@@ -6,6 +6,8 @@ description: 'The second of three sections describing changes needed for code th
 date: 2023-03-09
 ---
 
+{% Partial 'extensions/mv3-support.md' %}
+
 Manifest V3 changes how extensions handle modification of network requests. Instead of intercepting network requests and altering them at runtime with `chrome.webRequest`, your extension specifies rules that describe actions to perform when a given set of conditions is met. Do this using the [Declarative Net Request API](/docs/extensions/reference/declarativeNetRequest/).
 
 The Web Request API and the Declarative Net Request APIs are significantly different. Instead of replacing one function call with another, you need to rewrite your code in terms of use cases. This section walks you through that process.

--- a/site/en/docs/extensions/migrating/checklist/index.md
+++ b/site/en/docs/extensions/migrating/checklist/index.md
@@ -6,6 +6,8 @@ description: A quick reference for upgrading your extensions from Manifest V2 to
 date: 2023-03-09
 ---
 
+{% Partial 'extensions/mv3-support.md' %}
+
 The checklists below are here to help you keep track of your migration work. They define tasks that must be completed with links to instructions. Migration work is broadly divided into five categories as described in the [Migration summary](). 
 
 {% Details  'open' %}

--- a/site/en/docs/extensions/migrating/improve-security/index.md
+++ b/site/en/docs/extensions/migrating/improve-security/index.md
@@ -6,6 +6,8 @@ description: 'The last of three sections describing changes needed for code that
 date: 2023-03-08
 ---
 
+{% Partial 'extensions/mv3-support.md' %}
+
 This is the last of three sections describing changes needed for code that is not part of the extension service worker. It describes changes required to improve the security of extensions. The other two sections cover [updating your code](/docs/extensions/migrating/api-calls) needed for upgrading to Manifest V3 and [replacing blocking web requests](/docs/extensions/migrating/blocking-web-requests).
 
 ## Remove execution of arbitrary strings {: #remove-execution-of-strings }

--- a/site/en/docs/extensions/migrating/index.md
+++ b/site/en/docs/extensions/migrating/index.md
@@ -7,6 +7,8 @@ date: 2023-03-09
 updated: 2023-04-14
 ---
 
+{% Partial 'extensions/mv3-support.md' %}
+
 This section helps you upgrade an extension from Manifest V2 to Manifest V3, the newest version of the Chrome Extensions platform. Migration work is broadly divided into the categories below. To help you track your work, we've provided a [checklist](/docs/extensions/migrating/checklist/) summarizing the contents of these documents. You can access the content via the checklist, or dive into the content. Both paths end with an upgraded extension. 
 
 * [Update the manifest](/docs/extensions/migrating/manifest/)&mdash;The `manifest.json` must be specific to V3. Changes that can be made on their own are described in this section. Manifest changes related to code are described with the code changes they support.

--- a/site/en/docs/extensions/migrating/manifest/index.md
+++ b/site/en/docs/extensions/migrating/manifest/index.md
@@ -6,6 +6,8 @@ description: The manifest.json file requires a slightly different format for Man
 date: 2023-03-09
 ---
 
+{% Partial 'extensions/mv3-support.md' %}
+
 The `manifest.json` file requires a slightly different format for Manifest V3 than for Manifest V2. This page describes changes that only affect the `manifest.json` file. But many of the changes to scripts and pages also require changes to the manifest. Those changes are covered with the migration tasks that require them.
 
 ## Change the manifest version number {: #change-version }

--- a/site/en/docs/extensions/migrating/to-service-workers/index.md
+++ b/site/en/docs/extensions/migrating/to-service-workers/index.md
@@ -7,6 +7,8 @@ date: 2023-03-09
 updated: 2023-04-14
 ---
 
+{% Partial 'extensions/mv3-support.md' %}
+
 A service worker replaces the extension's background or event page to ensure that background code stays off the main thread. This enables extensions to run only when needed, saving resources. 
 
 Background pages have been a fundamental component of extensions since their introduction. To put it simply, background pages provide an environment that lives independent of any other window or tab. This allows extensions to observe and act in response to events.

--- a/site/en/docs/extensions/mv3/intro/index.md
+++ b/site/en/docs/extensions/mv3/intro/index.md
@@ -8,6 +8,8 @@ date: 2020-11-09
 updated: 2022-09-28
 ---
 
+{% Partial 'extensions/mv3-support.md' %}
+
 This site introduces Manifest V3, short for Manifest Version 3, which is the latest iteration of the Chrome extension platform. It shares the background and reasons for introducing Manifest V3 and the vision for the platform's future, along with resources on how to migrate.
 
 ## What is a manifest? {: #what-is-a-manifest }

--- a/site/en/docs/extensions/mv3/intro/mv3-overview/index.md
+++ b/site/en/docs/extensions/mv3/intro/mv3-overview/index.md
@@ -8,6 +8,8 @@ date: 2020-11-09
 updated: 2023-02-22
 ---
 
+{% Partial 'extensions/mv3-support.md' %}
+
 Manifest V3 is a major step towards our
 [vision for the extensions platform](/docs/extensions/mv3/intro/platform-vision/).
 Manifest V3 focuses on the three pillars of that vision: privacy, security, and

--- a/site/en/docs/extensions/mv3/intro/platform-vision/index.md
+++ b/site/en/docs/extensions/mv3/intro/platform-vision/index.md
@@ -21,6 +21,8 @@ date: 2020-11-09
 
 ---
 
+{% Partial 'extensions/mv3-support.md' %}
+
 Chrome extensions are one of the most-loved and most-used features of the
 Chrome browser.  Extensions can solve a myriad of use cases for a diverse set
 of users, and in one form or another they are becoming a staple feature of most

--- a/site/en/docs/extensions/reference/index.md
+++ b/site/en/docs/extensions/reference/index.md
@@ -6,6 +6,8 @@ layout: 'layouts/reference-landing.njk'
 
 Chrome provides extensions with many special-purpose APIs such as `chrome.alarms` and `chrome.action`. Many APIs consist of a namespace and its related manifest fields. These fields are frequently permissions, but not always. For example, `chrome.alarms` requires only the `alarms` permission, while `chrome.action` requires an action object in the `manifest.json` file.
 
+{% Partial 'extensions/mv3-support.md' %}
+
 ## API conventions
 
 Unless stated otherwise, methods in the `chrome.*` APIs are **asynchronous**: they return immediately, without waiting for the operation to finish. If you need to know the result of calling such methods, use the returned promise or pass a callback function into the method. For more information, see [Asynchronous methods](/docs/extensions/mv3/architecture-overview/#async-sync).


### PR DESCRIPTION
@sebastianbenz I don't think there's an issue with this being on the API landing page. The process of removing or modifying it in 2 years will being with grepping the repo.