### PR TITLE
Change Vaatika's picture

### DIFF
--- a/site/_data/authorsData.json
+++ b/site/_data/authorsData.json
@@ -1152,6 +1152,6 @@
   "vaatika": {
     "country": "DE",
     "twitter": "vaatika",
-    "image": "image/3ILBH0X0aDOqDIm6SgH3OTHT8832/Ryt5ICGoMplYcTgLtKev.jpg"
+    "image": "image/3ILBH0X0aDOqDIm6SgH3OTHT8832/vL2uGtk2NKGT9two4PWy.jpg"
   }
 }


### PR DESCRIPTION
This changes the format of Vaatika's author picture (previous picture would not scale well with how the author's picture is shown in the blogpost).