### PR TITLE
Redirect maximize ad relevence

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -112,6 +112,9 @@ redirects:
 
 - from: /docs/privacy-sandbox/attribution-reporting-changes-january-2022/
   to: /blog/attribution-reporting-jan-2022-updates/
+  
+- from: /docs/privacy-sandbox/maximize-ad-relevance/
+  to: https://privacysandbox.com/news/maximize-ad-relevance-after-third-party-cookies
 
 - from: /blog/capture-handle/
   to: /docs/web-platform/capture-handle/

--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -79,7 +79,8 @@
         - url: /docs/privacy-sandbox/shared-storage/creative-selection-by-frequency
         - url: /docs/privacy-sandbox/shared-storage/ab-testing
         - url: /docs/privacy-sandbox/shared-storage/known-customer
-    - url: /docs/privacy-sandbox/maximize-ad-relevance
+    - url: https://privacysandbox.com/news/maximize-ad-relevance-after-third-party-cookies
+      title: i18n.docs.privacy-sandbox.maximize-relevence
 - title: i18n.docs.privacy-sandbox.measure
   sections:
     - title: i18n.docs.privacy-sandbox.measure-ads

--- a/site/_data/i18n/docs/privacy-sandbox.yml
+++ b/site/_data/i18n/docs/privacy-sandbox.yml
@@ -74,6 +74,8 @@ attribution-reporting-system:
   en: 'Attribution Reporting end-to-end'
 attribution-reporting-summary:
   en: 'Summary reports'
+maximize-relevence:
+  en: 'Maximize ad relevance'
 private-aggregation:
   en: 'Private Aggregation API'
 tracking-prevention:


### PR DESCRIPTION
This article has since been published on privacysandbox.com. 

Redirected in TOC: https://pr-6107-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/#show-relevant-content

For canonical signal documentation, see: https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls