### PR TITLE
docs: fix wrong figcaption in richer-install-ui-desktop

### DIFF
--- a/site/en/blog/richer-install-ui-desktop/index.md
+++ b/site/en/blog/richer-install-ui-desktop/index.md
@@ -17,14 +17,14 @@ Users typically get apps, especially platform apps, through app stores, or throu
 For web apps the model is different: users don’t have to visit a centralized app depot to get a web app, by design, not all web experiences are installable, installing an app can differ between platforms and browsers, browsers even have different menus and surfaces to install the app. Once the user clicks on that install option the default dialog doesn’t include any extra information, as shown below:
 
 <figure>
-{% Img src="image/SeARmcA1EicLXagFnVOe0ou9cqK2/yshUdzH27Gm1Rzdj9s8O.png", alt="The browser default install dialog for desktop.", width="385", height="676" %}
+{% Img src="image/SeARmcA1EicLXagFnVOe0ou9cqK2/y5sNbIN19bPNbqni3xay.png", alt="The browser default install dialog for desktop.", width="556", height="781" %}
  <figcaption>
     Default install dialog on desktop.
   </figcaption>
 </figure>
 
 <figure>
-{% Img src="image/SeARmcA1EicLXagFnVOe0ou9cqK2/y5sNbIN19bPNbqni3xay.png", alt="The  browser default install dialog for mobile.", width="556", height="781" %}
+{% Img src="image/SeARmcA1EicLXagFnVOe0ou9cqK2/yshUdzH27Gm1Rzdj9s8O.png", alt="The  browser default install dialog for mobile.", width="385", height="676" %}
  <figcaption>
     Default install dialog on mobile.
   </figcaption>


### PR DESCRIPTION
- Switch the desktop and mobile images back to the correct position