### PR TITLE
DevTools Tips 24: Source maps in DevTools

### DIFF
--- a/site/_data/docs/devtools/toc.yml
+++ b/site/_data/docs/devtools/toc.yml
@@ -81,6 +81,7 @@
 - url: /docs/devtools/css/animations/
 - url: /docs/devtools/changes/
 - url: /docs/devtools/coverage/
+- url: /docs/devtools/developer-resources/
 - url: /docs/devtools/css-overview/
 - url: /docs/devtools/issues/
 - url: /docs/devtools/media-panel/

--- a/site/en/blog/devtools-tips-24/index.md
+++ b/site/en/blog/devtools-tips-24/index.md
@@ -1,0 +1,34 @@
+---
+title: >
+  DevTools Tips: Source maps in DevTools
+description: >
+  Use source maps in DevTools to debug your original code instead of deployed.
+layout: 'layouts/blog-post.njk'
+date: 2023-04-26
+authors:
+  - sofiayem
+hero: 'image/NJdAV9UgKuN8AhoaPBquL7giZQo1/uTEJAPTsoLQgB3ZLpKEw.png'
+alt: >
+  DevTools Tips hero logo
+tags:
+  - devtools
+  - devtools-tips
+---
+
+[Source maps](https://web.dev/source-maps/) let you keep your code readable and debuggable even after you've combined and minified it, without impacting performance. To learn how source maps work, see the [previous DevTools Tips video](https://www.youtube.com/watch?v=FIYkjjFYvoI).
+
+{% YouTube id='SkUcO4ML5U0' %}
+
+Watch this video to learn how to:
+
+- [Enable source maps](/docs/devtools/javascript/source-maps/#enable_source_maps_in_settings).
+- Use [**Developer Resources**](/docs/devtools/developer-resources/) drawer tab to check if source maps loaded successfully.
+- If required, [load source maps manually](/docs/devtools/developer-resources/#load).
+- [Debug your (mapped) original code](/docs/devtools/javascript/source-maps/#debugging_with_source_maps) instead of deployed as you normally would.
+- [Group the files you author](/docs/devtools/javascript/reference/#group-authored-and-deployed) to navigate the file tree in **Sources** easier.
+
+To learn more, see:
+
+- [What are source maps?](https://web.dev/source-maps/)
+- [Debug your original code instead of deployed with source maps](/docs/devtools/javascript/source-maps/)
+- [Developer Resources: View and manually load source maps](/docs/devtools/developer-resources/)

--- a/site/en/blog/devtools-tips-24/index.md
+++ b/site/en/blog/devtools-tips-24/index.md
@@ -19,7 +19,7 @@ tags:
 
 {% YouTube id='SkUcO4ML5U0' %}
 
-Watch this video to learn how to:
+Watch this video to learn how to work with source maps in DevTools:
 
 - [Enable source maps](/docs/devtools/javascript/source-maps/#enable_source_maps_in_settings).
 - Use [**Developer Resources**](/docs/devtools/developer-resources/) tab to check if source maps loaded successfully.

--- a/site/en/blog/devtools-tips-24/index.md
+++ b/site/en/blog/devtools-tips-24/index.md
@@ -22,7 +22,7 @@ tags:
 Watch this video to learn how to:
 
 - [Enable source maps](/docs/devtools/javascript/source-maps/#enable_source_maps_in_settings).
-- Use [**Developer Resources**](/docs/devtools/developer-resources/) drawer tab to check if source maps loaded successfully.
+- Use [**Developer Resources**](/docs/devtools/developer-resources/) tab to check if source maps loaded successfully.
 - If required, [load source maps manually](/docs/devtools/developer-resources/#load).
 - [Debug your (mapped) original code](/docs/devtools/javascript/source-maps/#debugging_with_source_maps) instead of deployed as you normally would.
 - [Group the files you author](/docs/devtools/javascript/reference/#group-authored-and-deployed) to navigate the file tree in **Sources** easier.

--- a/site/en/docs/devtools/developer-resources/index.md
+++ b/site/en/docs/devtools/developer-resources/index.md
@@ -1,14 +1,14 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Developer Resources: View and load source maps manually"
+title: "Developer Resources: View and manually load source maps"
 authors:
   - sofiayem
 date: 2023-04-26
 #updated: YYYY-MM-DD
-description: "Check if source maps load successfully and, if required, load them manually."
+description: "Use the Developer Resources drawer tab to check if source maps load successfully and load them manually."
 ---
 
-Use the **Developer Resources** drawer panel to check if DevTools loads source maps successfully. If required, you can load them manually.
+Use the **Developer Resources** drawer tab to check if DevTools loads source maps successfully. If required, you can load them manually.
 
 {% YouTube id='SkUcO4ML5U0' %}
 
@@ -20,24 +20,50 @@ When you open DevTools, it attempts to load source maps, if any. In case of fail
 
 {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/wbVBOGD7jn0wQeYnvaRE.png", alt="The source map load error in the Console.", width="800", height="495" %}
 
-In the **Developer Resources** drawer tab, you can view the source map load status and even load a source maps manually. 
+In the **Developer Resources** drawer tab, you can view the source map load status and even load source maps manually. 
 
 ## Open Developer Resources and check status {: #open-developer-resources }
 
 To check the load statuses of source maps:
 
-1. Open {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/N5Lkpdwpaz4YqRGFr2Ks.svg", alt="Three-dot menu.", width="22", height="22" %} > **More tools** > **Developer Resources**.
+1. [Open DevTools](/docs/devtools/open/), make sure to [enable source maps](/docs/devtools/javascript/source-maps/#enable_source_maps_in_settings), and navigate to {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/N5Lkpdwpaz4YqRGFr2Ks.svg", alt="Three-dot menu.", width="22", height="22" %} > **More tools** > **Developer Resources**.
 1. In the table, check the values in the following columns:
 
-   - **Status** to see if the source map load resulted in success or failure.
-   - **Error** to read the error message.
+   - **Status** to see if the source map loading was a success or failure.
+   - **Error** to read the error message, if any.
 
 {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/vYeuYDIasIImzGs1Y6hw.png", alt="The Status and Error columns.", width="800", height="495" %}
 
 ## Filter resources by URL or Error {: #filter-resources }
 
+To focus on source maps that interest you, enter text in the textbox at the top to filter out source maps that don't contain this text in URLs or error messages.
 
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/y1VcNVAkSuNp0ofvaD3q.png", alt="Filtering out source maps that don't contain 'js' in URL.", width="800", height="553" %}
+
+## Troubleshoot {: #troubleshoot }
+
+By default, DevTools requests source maps rather than the website. Such requests may be treated as [cross-origin](https://developer.mozilla.org/docs/Web/HTTP/CORS) and might not get through.
+
+To make the website request source maps first, in the top right corner of **Developer Resources**, check {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/hmp8j3HiLMCcqPArD9yt.svg", alt="Checkbox.", width="24", height="24" %} **Enable loading through target**.
+
+If you still have issues with loading source maps, try to load them manually as described next.
 
 ## Load a source map manually {: #load }
 
+If you encounter load failures or, for example, want to [debug your original code](/docs/devtools/javascript/source-maps/) on a website in production that lacks source maps, you can load them manually:
 
+1. [Generate source maps using tools that support them](/docs/devtools/javascript/source-maps/#use_a_supported_preprocessor).
+1. Host the source maps locally.
+1. [Open DevTools](/docs/devtools/open/) on your page and make sure to [enable source maps](/docs/devtools/javascript/source-maps/#enable_source_maps_in_settings).
+1. Open the deployed (processed) file in **Sources**, right-click it in the **Editor**, and select **Add source map** from the menu.
+
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/snRTwnA88ziEz5MslUBJ.png", alt="Selecting 'Add source maps' from the menu.", width="800", height="553" %}
+1. In the textbox, specify the source map URL and click **Add**.
+
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/W8gjE6hv8zPdzT4OfUup.png", alt="Specifying the source map URL.", width="800", height="553" %}
+
+1. Check if the source map appeared in **Developer Resources** and the original file (mapped from the deployed one) in the file tree.
+
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/bKZ5xtima2U1z6RSHJ3B.png", alt="A manually loaded source map makes the original file appear in the file tree.", width="800", height="553" %}
+
+1. Proceed to [debug your original file](/docs/devtools/javascript/source-maps/#debugging_with_source_maps).

--- a/site/en/docs/devtools/developer-resources/index.md
+++ b/site/en/docs/devtools/developer-resources/index.md
@@ -1,0 +1,43 @@
+---
+layout: "layouts/doc-post.njk"
+title: "Developer Resources: View and load source maps manually"
+authors:
+  - sofiayem
+date: 2023-04-26
+#updated: YYYY-MM-DD
+description: "Check if source maps load successfully and, if required, load them manually."
+---
+
+Use the **Developer Resources** drawer panel to check if DevTools loads source maps successfully. If required, you can load them manually.
+
+{% YouTube id='SkUcO4ML5U0' %}
+
+{% Aside 'important' %}
+To learn how source maps can make debugging easier for you, see [Debug your original code instead of deployed with source maps](/docs/devtools/javascript/source-maps/).
+{% endAside %}
+
+When you open DevTools, it attempts to load source maps, if any. In case of failure, the **Console** logs an error similar to the following.
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/wbVBOGD7jn0wQeYnvaRE.png", alt="The source map load error in the Console.", width="800", height="495" %}
+
+In the **Developer Resources** drawer tab, you can view the source map load status and even load a source maps manually. 
+
+## Open Developer Resources and check status {: #open-developer-resources }
+
+To check the load statuses of source maps:
+
+1. Open {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/N5Lkpdwpaz4YqRGFr2Ks.svg", alt="Three-dot menu.", width="22", height="22" %} > **More tools** > **Developer Resources**.
+1. In the table, check the values in the following columns:
+
+   - **Status** to see if the source map load resulted in success or failure.
+   - **Error** to read the error message.
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/vYeuYDIasIImzGs1Y6hw.png", alt="The Status and Error columns.", width="800", height="495" %}
+
+## Filter resources by URL or Error {: #filter-resources }
+
+
+
+## Load a source map manually {: #load }
+
+

--- a/site/en/docs/devtools/developer-resources/index.md
+++ b/site/en/docs/devtools/developer-resources/index.md
@@ -8,7 +8,7 @@ date: 2023-04-26
 description: "Use the Developer Resources drawer tab to check if source maps load successfully and load them manually."
 ---
 
-Use the **Developer Resources** drawer tab to check if DevTools loads source maps successfully. If required, you can load them manually.
+Use the **Developer Resources** tab to check if DevTools loads source maps successfully. If required, you can load them manually.
 
 {% YouTube id='SkUcO4ML5U0' %}
 

--- a/site/en/docs/devtools/developer-resources/index.md
+++ b/site/en/docs/devtools/developer-resources/index.md
@@ -10,7 +10,7 @@ description: "Use the Developer Resources drawer tab to check if source maps loa
 
 Use the **Developer Resources** tab to check if DevTools loads source maps successfully. If required, you can load them manually.
 
-{% YouTube id='SkUcO4ML5U0' %}
+{% YouTube id='SkUcO4ML5U0', startTime=139 %}
 
 {% Aside 'important' %}
 To learn how source maps can make debugging easier for you, see [Debug your original code instead of deployed with source maps](/docs/devtools/javascript/source-maps/).

--- a/site/en/docs/devtools/javascript/source-maps/index.md
+++ b/site/en/docs/devtools/javascript/source-maps/index.md
@@ -62,7 +62,7 @@ With source maps [ready](#use_a_supported_preprocessor) and [enabled](#enable_so
 1. [Open your website's sources](/docs/devtools/javascript/#sources-ui) in the **Sources** panel.
 1. To focus only on the code you author, [group authored and deployed files in the file tree](/docs/devtools/javascript/reference/#group-authored-and-deployed). Then expand the {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/KIgoYfQUdaCtgDLdYKSE.svg", alt="Authored.", width="24", height="24" %} **Authored** section and open your original source file in the **Editor**.
 
-   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/RjxMoAjP106QbqZziwaZ.png", alt="The original file opened in the Authored section.", width="800", height="450" %}
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/aMQH5hz1wtyvZ6m9iwIS.png", alt="The original file opened in the Authored section.", width="800", height="467" %}
 
 1. [Set a breakpoint](/docs/devtools/javascript/breakpoints/) as you normally would. For example, a [logpoint](/docs/devtools/javascript/breakpoints/#log-loc). Then run the code.
 

--- a/site/en/docs/devtools/javascript/source-maps/index.md
+++ b/site/en/docs/devtools/javascript/source-maps/index.md
@@ -13,6 +13,8 @@ description: "Keep your client-side code readable and debuggable even after you'
 Keep your client-side code readable and debuggable even after you've combined, minified or compiled
 it. Use source maps to map your source code to your compiled code in the **Sources** panel.
 
+{% YouTube id='SkUcO4ML5U0' %}
+
 ## Get started with preprocessors {: #get_started_with_preprocessors }
 
 Source maps from preprocessors cause DevTools to load your original files in addition to your minified ones.
@@ -44,6 +46,10 @@ In {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/9gzXiTYY0nZzBxGI6KrV.svg", alt
 {% Aside %}
 You might also want to check {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/hmp8j3HiLMCcqPArD9yt.svg", alt="Checkbox.", width="22", height="22" %} **Enable CSS source maps**.
 {% endAside %}
+
+## Check if source maps load sucessfully {: #developer-resources }
+
+See [Developer Resources: View and load source maps manually](/docs/devtools/developer-resources).
 
 ## Debugging with source maps {: #debugging_with_source_maps }
 


### PR DESCRIPTION
Fixes #5674

Changes proposed in this pull request:

- [x] Documented missing Developer Resources drawer tab
- [x] Promo post for DTT 24

Publish on Apr 26.