### PR TITLE
Separate features in FLEDGE feature status

### DIFF
--- a/site/en/docs/privacy-sandbox/fledge-api/feature-status/index.md
+++ b/site/en/docs/privacy-sandbox/fledge-api/feature-status/index.md
@@ -72,7 +72,7 @@ find a list of the scoped FLEDGE features and when they'll be supported.
   </tr>
 </table>
 
-## Additional feature support
+### Additional features
 
 <table class="with-heading-tint with-borders width-full">
   <thead>

--- a/site/en/docs/privacy-sandbox/fledge-api/feature-status/index.md
+++ b/site/en/docs/privacy-sandbox/fledge-api/feature-status/index.md
@@ -21,7 +21,7 @@ availability and approach third-party cookie deprecation in Chrome, you may be
 wondering about the availability of FLEDGE services and features. Here you'll
 find a list of the scoped FLEDGE features and when they'll be supported. 
 
-## Main features
+## Feature availability timeline
 
 <table class="with-heading-tint with-borders width-full">
   <thead>

--- a/site/en/docs/privacy-sandbox/fledge-api/feature-status/index.md
+++ b/site/en/docs/privacy-sandbox/fledge-api/feature-status/index.md
@@ -21,6 +21,8 @@ availability and approach third-party cookie deprecation in Chrome, you may be
 wondering about the availability of FLEDGE services and features. Here you'll
 find a list of the scoped FLEDGE features and when they'll be supported. 
 
+## Main features
+
 <table class="with-heading-tint with-borders width-full">
   <thead>
     <tr>
@@ -54,7 +56,20 @@ find a list of the scoped FLEDGE features and when they'll be supported.
     <td>2023 Q2</td>
     <td>Available for testing in Chrome Stable M112+.</td>
   </tr>
-
+ <tr>
+    <td><a href="https://github.com/WICG/turtledove/blob/main/FLEDGE_k_anonymity_server.md">K-anonymity</a>
+   </td>
+    <td>Later in 2023 Q3
+   </td>
+    <td>For rendering creatives, the k-anonymity threshold of “a crowd of 50 users per creative over 7 days” must be met. 
+   </td>
+  </tr>
+    <tr>
+    <td><a href="/blog/fledge-service-overview/#bidding-auction-service">Bidding and Auction services</a>
+   </td>
+    <td>Targeted for testing in H2 2023.</td>
+    <td>In development.</td>
+  </tr>
 </table>
 
 ## Additional feature support
@@ -103,20 +118,7 @@ find a list of the scoped FLEDGE features and when they'll be supported.
     <td>Later in 2023</td>
     <td>Expected in Chrome for origin trial in Q2 2023</td>
   </tr>
-    <tr>
-    <td><a href="https://github.com/WICG/turtledove/blob/main/FLEDGE_k_anonymity_server.md">K-anonymity</a>
-   </td>
-    <td>Later in 2023 Q3
-   </td>
-    <td>For rendering creatives, the k-anonymity threshold of “a crowd of 50 users per creative over 7 days” must be met. 
-   </td>
-  </tr>
-    <tr>
-    <td><a href="/blog/fledge-service-overview/#bidding-auction-service">Bidding and Auction services</a>
-   </td>
-    <td>Targeted for testing in H2 2023.</td>
-    <td>In development.</td>
-  </tr>
+   
   </table>
 
 ## Event-level auction win reporting

--- a/site/en/docs/privacy-sandbox/fledge-api/feature-status/index.md
+++ b/site/en/docs/privacy-sandbox/fledge-api/feature-status/index.md
@@ -38,11 +38,41 @@ find a list of the scoped FLEDGE features and when they'll be supported.
     </td>
   </tr>
   <tr>
+    <td><a href="https://github.com/privacysandbox/fledge-docs/blob/main/trusted_services_overview.md#trusted-execution-environment">Trusted Execution Environment (TEE)</a> usage for Key/Value service</td>
+    <td>Now</td>
+    <td>Required no sooner than Q3 2025.</td>
+  </tr>
+  <tr>
+    <td><a href="/docs/privacy-sandbox/fenced-frame/">Fenced frames</a>
+   </td>
+    <td>Now
+   </td>
+    <td>Required no sooner than 2026.</td>
+  </tr>
+  <tr>
+    <td>Improved FLEDGE + <a href="/docs/privacy-sandbox/attribution-reporting/">Attribution Reporting</a> integration.</td>
+    <td>2023 Q2</td>
+    <td>Available for testing in Chrome Stable M112+.</td>
+  </tr>
+
+</table>
+
+## Additional feature support
+
+<table class="with-heading-tint with-borders width-full">
+  <thead>
+    <tr>
+      <th>Feature</th>
+      <th>Available for testing</th>
+      <th>Status</th>
+    </tr>
+  </thead>
+    <tr>
     <td>Event-level user bidding signals for modeling (<a href="https://github.com/WICG/turtledove/issues/435">Github Issue</a>)</td>
     <td>Later in 2023</td>
     <td>Expected in Chrome for origin trial in Q2 2023.</td>
   </tr>
-  <tr>
+    <tr>
     <td><a href="https://github.com/WICG/turtledove/issues/299">Per-Buyer Latency Reporting</a></td>
     <td>Later in 2023</td>
     <td>Expected in Chrome for origin trial in Q1 2023</td>
@@ -57,7 +87,7 @@ find a list of the scoped FLEDGE features and when they'll be supported.
     <td>Later in 2023</td>
     <td>Expected in Chrome for origin trial in Q2 2023.</td>
   </tr>
-  <tr>
+    <tr>
     <td><a href="https://github.com/WICG/turtledove/issues/441">Direct seller destination support</a></td>
     <td>Later in 2023</td>
     <td>Expected in Chrome for origin trial in Q1 2023.</td>
@@ -73,19 +103,7 @@ find a list of the scoped FLEDGE features and when they'll be supported.
     <td>Later in 2023</td>
     <td>Expected in Chrome for origin trial in Q2 2023</td>
   </tr>
-  <tr>
-    <td><a href="https://github.com/privacysandbox/fledge-docs/blob/main/trusted_services_overview.md#trusted-execution-environment">Trusted Execution Environment (TEE)</a> usage for Key/Value service</td>
-    <td>Now</td>
-    <td>Required no sooner than Q3 2025.</td>
-  </tr>
-  <tr>
-    <td><a href="/docs/privacy-sandbox/fenced-frame/">Fenced frames</a>
-   </td>
-    <td>Now
-   </td>
-    <td>Required no sooner than 2026.</td>
-  </tr>
-  <tr>
+    <tr>
     <td><a href="https://github.com/WICG/turtledove/blob/main/FLEDGE_k_anonymity_server.md">K-anonymity</a>
    </td>
     <td>Later in 2023 Q3
@@ -93,18 +111,13 @@ find a list of the scoped FLEDGE features and when they'll be supported.
     <td>For rendering creatives, the k-anonymity threshold of “a crowd of 50 users per creative over 7 days” must be met. 
    </td>
   </tr>
-  <tr>
-    <td>Improved FLEDGE + <a href="/docs/privacy-sandbox/attribution-reporting/">Attribution Reporting</a> integration.</td>
-    <td>2023 Q2</td>
-    <td>Available for testing in Chrome Stable M112+.</td>
-  </tr>
-  <tr>
+    <tr>
     <td><a href="/blog/fledge-service-overview/#bidding-auction-service">Bidding and Auction services</a>
    </td>
     <td>Targeted for testing in H2 2023.</td>
     <td>In development.</td>
   </tr>
-</table>
+  </table>
 
 ## Event-level auction win reporting
 


### PR DESCRIPTION
Fixes b/276776494

Changes proposed in this pull request:

- Separate the larger features from supporting features in FLEDGE feature status
- staged: https://pr-6111-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/fledge-api/feature-status/
- oops! ready for review