### PR TITLE
Update Web Manifest id blog post

### DIFF
--- a/site/en/blog/pwa-manifest-id/index.md
+++ b/site/en/blog/pwa-manifest-id/index.md
@@ -55,7 +55,7 @@ is to check the value calculated by Chrome.
 1. Add an `id` property to the web app manifest using the `id` value shown in
    the note.
 
-{% Img src="image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/7vo2XUpQxz0RWfWBuLDa.png", class="screenshot", alt="Tooltip showing 'id' value.", width="800", height="175" %}
+{% Img src="image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/7vo2XUpQxz0RWfWBuLDa.png", class="screenshot", alt="Note showing 'id' value.", width="800", height="175" %}
 
 ```json
 {

--- a/site/en/blog/pwa-manifest-id/index.md
+++ b/site/en/blog/pwa-manifest-id/index.md
@@ -38,9 +38,9 @@ that matches the already installed PWA, it will treat that as the installed PWA.
 
 ## Browser support
 
-Support for the `id` property is expected to land in desktop Chromium-based
-browsers starting with version 96. Support for mobile (which currently uses
-the manifest url as the unique id) should land in the first half of 2022.
+Starting with version 96, the `id` property is supported on desktop and
+mobile Chromium-based browsers and on Firefox beginning with version 95.
+{% BrowserCompat 'html.manifest.id' %}
 
 ## What should I do today?
 
@@ -86,7 +86,7 @@ DevTools.
 browser will generate an `id` if there is not one in the manifest. On desktop,
 it will be calculated based on the `start_url` in the web app manifest.
 
-In the future, adding an `id`  to the web app manifest will make it possible
+In the future, adding an `id` to the web app manifest will make it possible
 to change the `start_url` and the manifest path, because the browser will
 identify the PWA based on the specified `id`, rather than the `start_url` or
 manifest path.
@@ -115,9 +115,9 @@ these steps:
 
 ## Additional resources
 
-* [Explainer][explainer]
-* [Design doc][design-doc]
-* [`id` property in Editor's draft of the Manifest spec][draft-spec]
+- [Explainer][explainer]
+- [Design doc][design-doc]
+- [`id` property in Editor's draft of the Manifest spec][draft-spec]
 
 [draft-spec]: https://w3c.github.io/manifest/#id-member
 [explainer]: https://github.com/philloooo/pwa-unique-id/blob/main/explainer.md

--- a/site/en/blog/pwa-manifest-id/index.md
+++ b/site/en/blog/pwa-manifest-id/index.md
@@ -49,12 +49,11 @@ is to check the value calculated by Chrome.
 
 1. Using Chrome 96 or higher, open the **Manifest** pane of the **Application**
    panel in DevTools.
-1. Hover your mouse over the `(!)` icon next to the **App Id** property. The
-   `(!)` tooltip icon will only appear when the `id` is **not** specified in
-   the web app manifest file.
-1. Note the `id` value shown in the tooltip (see screenshot below).
+1. Check the **Note** below the **Computed App Id** property. The note will
+   only appear when the `id` is **not** specified in the web app manifest file.
+1. Check the suggested `id` value shown in the note (see screenshot below).
 1. Add an `id` property to the web app manifest using the `id` value shown in
-   the tooltip.
+   the note.
 
 {% Img src="image/0g2WvpbGRGdVs0aAPc6ObG7gkud2/7vo2XUpQxz0RWfWBuLDa.png", class="screenshot", alt="Tooltip showing 'id' value.", width="800", height="175" %}
 
@@ -76,7 +75,7 @@ DevTools.
 ## What if I don't set an `id`?
 
 **Don't worry, nothing will break**. Starting in Chrome 96 on desktop, the
-browser will generate an `id` if there is not one in the manifest. On desktop,
+browser generates an `id` if there is not one in the manifest. On desktop,
 it will be calculated based on the `start_url` in the web app manifest.
 
 Adding an `id` to the web app manifest makes it possible to change the

--- a/site/en/blog/pwa-manifest-id/index.md
+++ b/site/en/blog/pwa-manifest-id/index.md
@@ -42,13 +42,6 @@ Starting with version 96, the `id` property is supported on desktop and
 mobile Chromium-based browsers and on Firefox beginning with version 95.
 {% BrowserCompat 'html.manifest.id' %}
 
-## What should I do today?
-
-Today, there is **nothing you need to do**, and nothing will break if you
-don't add an `id` to your web app manifest (as long as the `start_url` and
-the manifest path remains the same). To future-proof your PWA, you can add
-an `id` property to your web app manifest.
-
 ## How do I determine and set my `id`? {: #determine-id }
 
 The safest, and the most accurate, way to determine the `id` for a PWA

--- a/site/en/blog/pwa-manifest-id/index.md
+++ b/site/en/blog/pwa-manifest-id/index.md
@@ -76,7 +76,7 @@ DevTools.
 
 **Don't worry, nothing will break**. Starting in Chrome 96 on desktop, the
 browser generates an `id` if there is not one in the manifest. On desktop,
-it will be calculated based on the `start_url` in the web app manifest.
+it is calculated based on the `start_url` in the web app manifest.
 
 Adding an `id` to the web app manifest makes it possible to change the
 `start_url` and the manifest path, because the browser identifies the PWA

--- a/site/en/blog/pwa-manifest-id/index.md
+++ b/site/en/blog/pwa-manifest-id/index.md
@@ -85,12 +85,9 @@ based on the specified `id`, rather than the `start_url` or manifest path.
 
 ## How do I test this?
 
-To test the behaviour before Chrome 96 is available as stable, follow
-these steps:
+To test the behaviour, follow these steps:
 
-1. Using Chrome 96 or later (currently Chrome Canary), enable the
-   `#enable-desktop-pwas-manifest-id` flag, then restart the browser.
-1. Install the PWA.
+1. Open Chrome 96 or later and install the PWA.
 1. Open `about://web-app-internals/` and check the `unhashed_app_id` and
    `start_url` property for the installed PWA.
 1. Add an `id` property to your web app manifest following the steps in

--- a/site/en/blog/pwa-manifest-id/index.md
+++ b/site/en/blog/pwa-manifest-id/index.md
@@ -47,12 +47,12 @@ mobile Chromium-based browsers and on Firefox beginning with version 95.
 The safest, and the most accurate, way to determine the `id` for a PWA
 is to check the value calculated by Chrome.
 
-1. Using Chrome 96 or higher (currently available as Chrome Canary), open the
-   **Manifest** pane of the **Application** panel in DevTools.
+1. Using Chrome 96 or higher, open the **Manifest** pane of the **Application**
+   panel in DevTools.
 1. Hover your mouse over the `(!)` icon next to the **App Id** property. The
    `(!)` tooltip icon will only appear when the `id` is **not** specified in
    the web app manifest file.
-1. Note the `id` value shown in the tool tip (see screenshot below).
+1. Note the `id` value shown in the tooltip (see screenshot below).
 1. Add an `id` property to the web app manifest using the `id` value shown in
    the tooltip.
 

--- a/site/en/blog/pwa-manifest-id/index.md
+++ b/site/en/blog/pwa-manifest-id/index.md
@@ -79,10 +79,9 @@ DevTools.
 browser will generate an `id` if there is not one in the manifest. On desktop,
 it will be calculated based on the `start_url` in the web app manifest.
 
-In the future, adding an `id` to the web app manifest will make it possible
-to change the `start_url` and the manifest path, because the browser will
-identify the PWA based on the specified `id`, rather than the `start_url` or
-manifest path.
+Adding an `id` to the web app manifest makes it possible to change the
+`start_url` and the manifest path, because the browser identifies the PWA
+based on the specified `id`, rather than the `start_url` or manifest path.
 
 ## How do I test this today?
 

--- a/site/en/blog/pwa-manifest-id/index.md
+++ b/site/en/blog/pwa-manifest-id/index.md
@@ -83,7 +83,7 @@ Adding an `id` to the web app manifest makes it possible to change the
 `start_url` and the manifest path, because the browser identifies the PWA
 based on the specified `id`, rather than the `start_url` or manifest path.
 
-## How do I test this today?
+## How do I test this?
 
 To test the behaviour before Chrome 96 is available as stable, follow
 these steps:

--- a/site/en/blog/pwa-manifest-id/index.md
+++ b/site/en/blog/pwa-manifest-id/index.md
@@ -38,8 +38,8 @@ that matches the already installed PWA, it will treat that as the installed PWA.
 
 ## Browser support
 
-Starting with version 96, the `id` property is supported on desktop and
-mobile Chromium-based browsers and on Firefox beginning with version 95.
+The `id` property is supported on desktop and mobile Chromium-based browsers
+starting with version 96 and on Firefox starting with version 95.
 {% BrowserCompat 'html.manifest.id' %}
 
 ## How do I determine and set my `id`? {: #determine-id }


### PR DESCRIPTION
Changes proposed in this pull request:

- Update Web Manifest ID browser support section in [this](https://developer.chrome.com/blog/pwa-manifest-id) blogpost.
- Mention Firefox.
- Add Browser compatibility widget.
- Update phrases like `id` _will_ be available in Chrome 96.
- Remove Chrome Canary usage suggestions.
- Update "How do I test this today?" section. (I'm not quite sure, maybe it is no longer actual and should be deleted?)
