### PR TITLE
Show correct platform data for enterprise extension APIs.

### DIFF
--- a/external/build/lib/dts-parse.js
+++ b/external/build/lib/dts-parse.js
@@ -757,9 +757,13 @@ class Transform {
           // we haven't seen any other platforms, this might be chromeOsOnly.
           if (text === 'chromeos' && chromeOsOnly === undefined) {
             chromeOsOnly = true;
+          } else if (text === 'lacros') {
+            // We don't currently have a lacros specific pill, so we don't need
+            // to do much here, but we should avoid falling in to the next case
+            // and unsetting chromeOsOnly.
           } else {
-            // The first time we see a platform that's not chromeos, we know the
-            // feature isn't chromeOsOnly.
+            // The first time we see a platform that's not chromeos or lacros,
+            // we know the feature isn't chromeOsOnly.
             chromeOsOnly = false;
           }
           break;


### PR DESCRIPTION
![Screenshot 2023-04-27 at 13 44 39](https://user-images.githubusercontent.com/6097064/234865531-f129332f-dd7a-4279-88f5-e737ba3e9b5e.png)

Fixes #2941 

We were missing some "ChromeOS only" badges on certain extension APIs. This was happening because they are also supported on lacros, and that was causing us to set the chromeOsOnly flag to false.