### PR TITLE
Document EnterpriseHardwarePlatformAPIEnabled policy setting.

### DIFF
--- a/site/en/docs/extensions/reference/enterprise_hardwarePlatform/index.md
+++ b/site/en/docs/extensions/reference/enterprise_hardwarePlatform/index.md
@@ -4,8 +4,11 @@ api: enterprise.hardwarePlatform
 
 {% Aside %}
 
-**Note:** This API is only for **[extensions pre-installed by policy][1]**.
+**Note:** This API is only for **[extensions pre-installed by policy][policy]**. The
+<code>[EnterpriseHardwarePlatformAPIEnabled][enterprise-hardware-platform-policy]</code>
+policy key must also be set.
 
 {% endAside %}
 
-[1]: https://support.google.com/chrome/a/answer/1375694?hl=en
+[policy]: https://support.google.com/chrome/a/answer/1375694?hl=en
+[enterprise-hardware-platform-policy]: https://chromeenterprise.google/policies/?policy=EnterpriseHardwarePlatformAPIEnabled

--- a/site/en/docs/extensions/reference/enterprise_hardwarePlatform/index.md
+++ b/site/en/docs/extensions/reference/enterprise_hardwarePlatform/index.md
@@ -10,5 +10,5 @@ policy key must also be set.
 
 {% endAside %}
 
-[policy]: https://support.google.com/chrome/a/answer/1375694?hl=en
+[policy]: https://cloud.google.com/blog/products/chrome-enterprise/how-to-manage-chrome-extensions-on-windows-and-mac
 [enterprise-hardware-platform-policy]: https://chromeenterprise.google/policies/?policy=EnterpriseHardwarePlatformAPIEnabled


### PR DESCRIPTION
Documents that the `EnterpriseHardwarePlatformAPIEnabled` policy key must be set to be able to use the chrome.enterprise.hardwarePlatform API.