### PR TITLE
Add documentation on recording audio or video from a tab, window or screen in MV3

### DIFF
--- a/site/_data/docs/extensions/toc.yml
+++ b/site/_data/docs/extensions/toc.yml
@@ -64,6 +64,7 @@
     - url: /docs/extensions/mv3/override
     - url: /docs/extensions/mv3/richNotifications
     - url: /docs/extensions/mv3/nativeMessaging
+    - url: /docs/extensions/mv3/screen_capture
 - title: i18n.docs.extensions.quality
   sections:
     - url: /docs/extensions/mv3/user_privacy

--- a/site/en/docs/extensions/mv3/screen_capture/index.md
+++ b/site/en/docs/extensions/mv3/screen_capture/index.md
@@ -7,14 +7,14 @@ updated: 2023-04-14
 description: How to record audio or video from a tab, window or screen
 ---
 
-APIs such as [chrome.tabCapture][tabCapture] and [getDisplayMedia][getDisplayMedia] provide a
+APIs such as [chrome.tabCapture][tabcapture] and [getDisplayMedia][get-display-media] provide a
 variety of ways to monitor and record audio and video from a tab, window or screen.
 
 ## Common Use Cases
 
 ### Screen Recording {: #screen-recording}
 
-For screen recording, use the [getDisplayMedia][getDisplayMedia] API. This provides the user with
+For screen recording, use the [getDisplayMedia][get-display-media] API. This provides the user with
 the ability to select which tab, window or screen they wish to share and provides a clear indication
 that recording is taking place.
 
@@ -35,7 +35,9 @@ asking the user what they would like to share.
 
 #### Audio and video (single page)
 
-If your recording does not need to persist across navigations, use [chrome.tabCapture.getMediaStreamId][tabCapture-media-stream-id] to get a stream ID in the popup, and then pass that ID to a content script. Make sure to set the `consumerTabId` property to allow the tab to access this stream:
+If your recording does not need to persist across navigations, use [chrome.tabCapture.getMediaStreamId][tabcapture-media-stream-id] to get a stream ID in the popup, and then pass that ID to a content script. Make sure to set the `consumerTabId` property to allow the tab to access this stream.
+
+In your popup:
 
 ```js
 chrome.tabs.query({ active: true, lastFocusedWindow: true }, ([{ id: tabId }]) => {
@@ -64,6 +66,11 @@ chrome.runtime.onMessage.addListener(async (msg) => {
         },
       },
     });
+
+    // Continue to play the captured audio to the user.
+    const output = new AudioContext();
+    const source = output.createMediaStreamSource(media);
+    source.connect(output.destination);
   }
 });
 ```
@@ -76,13 +83,37 @@ In the future, we may support passing a media stream ID to an [offscreen documen
 
 {% endAside %}
 
-To record audio and video across navigations, you can open an extension page in a new tab or window, and directly obtain a stream. Set the `targetTabId` property to capture the correct tab:
+To record audio and video across navigations, you can open an extension page in a new tab or window, and directly obtain a stream. Set the `targetTabId` property to capture the correct tab.
+
+In your popup:
 
 ```js
-chrome.tabs.query({ active: true, lastFocusedWindow: true }, ([{ id: tabId }]) => {
-  chrome.tabCapture.getMediaStreamId({ targetTabId: tabId }, async (id) => {
-    chrome.tabs.sendMessage(tabId, { name: "media-id", data: id });
+chrome.windows.create({ url: chrome.runtime.getURL("recorder.html") });
+```
+
+Then, in your extension page:
+
+```js
+chrome.tabCapture.getMediaStreamId({ targetTabId: tabId }, async (id) => {
+  const media = await navigator.mediaDevices.getUserMedia({
+    audio: {
+      mandatory: {
+        chromeMediaSource: "tab",
+        chromeMediaSourceId: id,
+      },
+    },
+    video: {
+      mandatory: {
+        chromeMediaSource: "tab",
+        chromeMediaSourceId: id,
+      },
+    },
   });
+
+  // Continue to play the captured audio to the user.
+  const output = new AudioContext();
+  const source = output.createMediaStreamSource(media);
+  source.connect(output.destination);
 });
 ```
 
@@ -90,7 +121,7 @@ Alternatively, consider using the [screen recording](#screen-recording) approach
 
 #### Audio only
 
-If you only need to record audio, you can directly obtain a stream in the extension popup using [chrome.tabCapture.capture][tabCapture-capture]. When the popup closes, recording will be stopped.
+If you only need to record audio, you can directly obtain a stream in the extension popup using [chrome.tabCapture.capture][tabcapture-capture]. When the popup closes, recording will be stopped.
 
 ```js
 chrome.tabCapture.capture({ audio: true }, (stream) => {
@@ -107,11 +138,10 @@ chrome.tabCapture.capture({ audio: true }, (stream) => {
 
 For more information on how to record a stream, see the [MediaRecorder][media-recorder] API.
 
-[tabCapture]: /docs/extensions/reference/tabCapture
-[tabCapture-focus-bug]: https://bugs.chromium.org/p/chromium/issues/detail?id=1434258
-[tabCapture-capture]: /docs/extensions/reference/tabCapture/#method-capture
-[tabCapture-media-stream-id]: /docs/extensions/reference/tabCapture/#method-getMediaStreamId
-[getDisplayMedia]: https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia
+[tabcapture]: /docs/extensions/reference/tabCapture
+[tabcapture-capture]: /docs/extensions/reference/tabCapture/#method-capture
+[tabcapture-media-stream-id]: /docs/extensions/reference/tabCapture/#method-getMediaStreamId
+[get-display-media]: https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia
 [offscreen-documents]: /blog/Offscreen-Documents-in-Manifest-v3/
 [feedback-mailing-list]: https://groups.google.com/a/chromium.org/g/chromium-extensions/c/Ef08XtOOyoI/m/L5HM7yPsBAAJ
-[media-recorder]: https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder
+[media-recorder]: https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorders

--- a/site/en/docs/extensions/mv3/screen_capture/index.md
+++ b/site/en/docs/extensions/mv3/screen_capture/index.md
@@ -1,0 +1,117 @@
+---
+layout: "layouts/doc-post.njk"
+title: "Audio recording and screen capture"
+seoTitle: "Chrome Extensions: Audio recording and screen capture"
+date: 2023-04-14
+updated: 2023-04-14
+description: How to record audio or video from a tab, window or screen
+---
+
+APIs such as [chrome.tabCapture][tabCapture] and [getDisplayMedia][getDisplayMedia] provide a
+variety of ways to monitor and record audio and video from a tab, window or screen.
+
+## Common Use Cases
+
+### Screen Recording {: #screen-recording}
+
+For screen recording, use the [getDisplayMedia][getDisplayMedia] API. This provides the user with
+the ability to select which tab, window or screen they wish to share and provides a clear indication
+that recording is taking place.
+
+```js
+// User will be prompted to select what they would like to share.
+const stream = await navigator.mediaDevices.getDisplayMedia({ audio: true, video: true });
+```
+
+If called within a content script, recording will automatically end when the user navigates to a new
+page. To record in the background and across navigations, use an
+[offscreen document][offscreen-documents] with the <code>DISPLAY_MEDIA</code> reason.
+
+### Tab capture based on user gesture
+
+Some use cases need to capture the current tab following a user interaction
+with the extension's action icon. In these cases, it is not desirable to show a secondary dialog
+asking the user what they would like to share.
+
+#### Audio and video (single page)
+
+If your recording does not need to persist across navigations, use [chrome.tabCapture.getMediaStreamId][tabCapture-media-stream-id] to get a stream ID in the popup, and then pass that ID to a content script. Make sure to set the `consumerTabId` property to allow the tab to access this stream:
+
+```js
+chrome.tabs.query({ active: true, lastFocusedWindow: true }, ([{ id: tabId }]) => {
+  chrome.tabCapture.getMediaStreamId({ consumerTabId: tabId }, async (id) => {
+    chrome.tabs.sendMessage(tabId, { name: "media-id", data: id });
+  });
+});
+```
+
+Then, in the content script, obtain a stream from the ID:
+
+```js
+chrome.runtime.onMessage.addListener(async (msg) => {
+  if (msg.name === "media-id") {
+    const media = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        mandatory: {
+          chromeMediaSource: "tab",
+          chromeMediaSourceId: msg.data,
+        },
+      },
+      video: {
+        mandatory: {
+          chromeMediaSource: "tab",
+          chromeMediaSourceId: msg.data,
+        },
+      },
+    });
+  }
+});
+```
+
+#### Audio and video (across navigations)
+
+{% Aside %}
+
+In the future, we may support passing a media stream ID to an [offscreen document][offscreen-documents] so recording can more easily persist across navigations. We are collecting feedback in the [chromium-extensions mailing list][feedback-mailing-list].
+
+{% endAside %}
+
+To record audio and video across navigations, you can open an extension page in a new tab or window, and directly obtain a stream. Set the `targetTabId` property to capture the correct tab:
+
+```js
+chrome.tabs.query({ active: true, lastFocusedWindow: true }, ([{ id: tabId }]) => {
+  chrome.tabCapture.getMediaStreamId({ targetTabId: tabId }, async (id) => {
+    chrome.tabs.sendMessage(tabId, { name: "media-id", data: id });
+  });
+});
+```
+
+Alternatively, consider using the [screen recording](#screen-recording) approach which allows you to record in the background using an offscreen document.
+
+#### Audio only
+
+If you only need to record audio, you can directly obtain a stream in the extension popup using [chrome.tabCapture.capture][tabCapture-capture]. When the popup closes, recording will be stopped.
+
+```js
+chrome.tabCapture.capture({ audio: true }, (stream) => {
+  // Continue to play the captured audio to the user.
+  const output = new AudioContext();
+  const source = output.createMediaStreamSource(stream);
+  source.connect(output.destination);
+
+  // TODO: Do something with the stream (e.g record it)
+});
+```
+
+## Other Considerations
+
+For more information on how to record a stream, see the [MediaRecorder][media-recorder] API.
+
+[tabCapture]: /docs/extensions/reference/tabCapture
+[tabCapture-focus-bug]: https://bugs.chromium.org/p/chromium/issues/detail?id=1434258
+[tabCapture-capture]: /docs/extensions/reference/tabCapture/#method-capture
+[tabCapture-media-stream-id]: /docs/extensions/reference/tabCapture/#method-getMediaStreamId
+[getDisplayMedia]: https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia
+[offscreen-documents]: /blog/Offscreen-Documents-in-Manifest-v3/
+[feedback-mailing-list]: https://groups.google.com/a/chromium.org/g/chromium-extensions/c/Ef08XtOOyoI/m/L5HM7yPsBAAJ
+[media-recorder]: https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder

--- a/site/en/docs/extensions/reference/tabCapture/index.md
+++ b/site/en/docs/extensions/reference/tabCapture/index.md
@@ -7,12 +7,12 @@ has_warning: This permission <a href="/docs/extensions/mv3/permission_warnings/#
 
 The chrome.tabCapture API allows you to access a [MediaStream][media-stream] containing video and
 audio of the current tab. It can only be called after the user invokes an extension, similar to the
-behavior of the [activeTab][activeTab] permission.
+behavior of the [activeTab][active-tab] permission.
 
 ## Preserving system audio
 
 When a [MediaStream][media-stream] is obtained for a tab, audio playing in that tab will no longer
-be played to the user. This is similar to the behavior of the [getDisplayMedia][getDisplayMedia] API
+be played to the user. This is similar to the behavior of the [get-display-media][getDisplayMedia] API
 when the <code>[suppressLocalAudioPlayback][supress-playback]</code> flag is set to true.
 
 To continue playing audio to the user, use the following:
@@ -28,7 +28,7 @@ destination.
 
 ## Stream IDs
 
-Calling [chrome.tabCapture.getMediaStreamId][getMediaStreamId] will return a stream ID. To later
+Calling [chrome.tabCapture.getMediaStreamId][get-media-stream-id] will return a stream ID. To later
 access a [MediaStream][media-stream] from the ID, use the following:
 
 ```js
@@ -54,9 +54,9 @@ To learn more about how to use the chrome.tabCapture API, see
 [Audio recording and screen capture][audio-recording-screen-capture]. This demonstrates how to use
 tabCapture and other related APIs to solve a number of common use cases.
 
-[getMediaStreamId]: #method-getMediaStreamId
-[activeTab]: /docs/extensions/mv3/manifest/activeTab/
+[get-media-stream-id]: #method-getMediaStreamId
+[active-tab]: /docs/extensions/mv3/manifest/activeTab/
 [media-stream]: https://developer.mozilla.org/docs/Web/API/MediaStream
-[getDisplayMedia]: https://developer.mozilla.org/docs/Web/API/MediaDevices/getDisplayMedia
+[get-display-media]: https://developer.mozilla.org/docs/Web/API/MediaDevices/getDisplayMedia
 [supress-playback]: https://developer.mozilla.org/docs/Web/API/MediaTrackSupportedConstraints/suppressLocalAudioPlayback
 [audio-recording-screen-capture]: /docs/extensions/mv3/screen_capture/

--- a/site/en/docs/extensions/reference/tabCapture/index.md
+++ b/site/en/docs/extensions/reference/tabCapture/index.md
@@ -3,4 +3,60 @@ api: tabCapture
 has_warning: This permission <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">triggers a warning</a>.
 ---
 
-<!-- Intentionally blank -->
+## Overview
+
+The chrome.tabCapture API allows you to access a [MediaStream][media-stream] containing video and
+audio of the current tab. It can only be called after the user invokes an extension, similar to the
+behavior of the [activeTab][activeTab] permission.
+
+## Preserving system audio
+
+When a [MediaStream][media-stream] is obtained for a tab, audio playing in that tab will no longer
+be played to the user. This is similar to the behavior of the [getDisplayMedia][getDisplayMedia] API
+when the <code>[suppressLocalAudioPlayback][supress-playback]</code> flag is set to true.
+
+To continue playing audio to the user, use the following:
+
+```js
+const output = new AudioContext();
+const source = output.createMediaStreamSource(stream);
+source.connect(output.destination);
+```
+
+This creates a new AudioContext and connects the audio of the tab's MediaStream to the default
+destination.
+
+## Stream IDs
+
+Calling [chrome.tabCapture.getMediaStreamId][getMediaStreamId] will return a stream ID. To later
+access a [MediaStream][media-stream] from the ID, use the following:
+
+```js
+navigator.mediaDevices.getUserMedia({
+  audio: {
+    mandatory: {
+      chromeMediaSource: "tab",
+      chromeMediaSourceId: id,
+    },
+  },
+  video: {
+    mandatory: {
+      chromeMediaSource: "tab",
+      chromeMediaSourceId: id,
+    },
+  },
+});
+```
+
+## Learn More
+
+To learn more about how to use the chrome.tabCapture API, see
+[Audio recording and screen capture][audio-recording-screen-capture]. This demonstrates how to use
+tabCapture and other related APIs to solve a number of common use cases.
+
+[getMediaStreamId]: #method-getMediaStreamId
+[activeTab]: /docs/extensions/mv3/manifest/activeTab/
+[media-stream]: https://developer.mozilla.org/docs/Web/API/MediaStream
+[getDisplayMedia]: https://developer.mozilla.org/docs/Web/API/MediaDevices/getDisplayMedia
+[supress-playback]: https://developer.mozilla.org/docs/Web/API/MediaTrackSupportedConstraints/suppressLocalAudioPlayback
+[audio-recording-screen-capture]: /docs/extensions/mv3/screen_capture/


### PR DESCRIPTION
![Screenshot 2023-04-28 at 18 51 35](https://user-images.githubusercontent.com/6097064/235218683-f2a9a0d2-d9fb-4511-9eab-f3e5956c838a.png)

Adds documentation on recording audio or video from a tab, window or screen in MV3. Additionally, some additional information has been added to the API reference for the chrome.tabCapture API to explain some common issues when working with that API and how to resolve them.

In one place I mention that we may make changes in a future version of Chrome and link to the chromium-extensions mailing list. I think this is a slightly new thing for the docs, but I feel pretty strongly that it's worth doing. This documentation exists for the sole purpose of helping developers to migrate and if we can tell them our thinking and where APIs might be improving in the future we can help them to build in a way that will make it easier for us to move the platform forward in the future.