### PR TITLE
[ext-doc] New SidePanel API documentation

### DIFF
--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -36,7 +36,7 @@ The manifest (`manifest.json`) is the configuration file of a Chrome extension. 
 - The [Chrome API][api-ref] keys and [permissions][doc-perms] that the extension needs.
 - The files assigned as the extension service worker, the popup HTML file, the options page, the content scripts, etc.
 
-The [Manifest keys][doc-manifest] article contains the complete list of default and optional keys. For copy-paste-ready code samples, check out the [Manifest examples][doc-manifest-examples].
+The [Manifest keys][doc-manifest] article contains the complete list of default and optional keys. For ready to use code samples, check out the [Manifest examples][doc-manifest-examples].
 
 ### The extension service worker {: #background_script }
 
@@ -65,9 +65,6 @@ An extension can have different HTML pages depending on the design. All extensio
 
 [The options page][doc-options]
 : The options page (`options.html`) provides a way for users to customize an extension, such as choosing which sites the extension will run on. Users can access the options page in several ways as described in [Finding the options page][doc-options-view].
-
-[Side panels][api-sidepanel]
-: Extensions can also provide UI to appear in the side panel (`sidepanel.html`) to provide additional functionality alongside the main content of a site. Users can open these by opening the side panel in Chrome or by clicking the extension toolbar icon. Side panels can be configured to only be displayed on specific sites.
 
 Other extension HTML pages include [Chrome override pages][doc-override], [sandbox pages][doc-sandbox] or any custom page included for a specific purpose like onboarding the user.
 
@@ -109,7 +106,6 @@ Now that you have completed the [Getting Started guides][doc-gs] and understand 
 - Discover best practices for building [secure extensions][doc-secure] that respect [user privacy][doc-privacy]. 
 
 [api-ref]: /docs/extensions/reference
-[api-sidepanel]: /docs/extensions/reference/sidePanel
 [api-storage]: /docs/extensions/reference/storage
 [cs-isolated]: /docs/extensions/mv3/content_scripts/#isolated_world
 [cws]: https://chrome.google.com/webstore/

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -67,7 +67,7 @@ An extension can have different HTML pages depending on the design. All extensio
 : The options page (`options.html`) provides a way for users to customize an extension, such as choosing which sites the extension will run on. Users can access the options page in several ways as described in [Finding the options page][doc-options-view].
 
 [Side panels][api-sidepanel]
-: Extensions can also use side panels (`sidepanel.html`) to provide additional functionality alongside the main content of a site. Users can open side panels by navigating to Chrome’s built-in sidebar menu or by clicking the extension toolbar icon. Side panels can be displayed only on specific sites.
+: Extensions can also provide UI to appear in the side panel (`sidepanel.html`) to provide additional functionality alongside the main content of a site. Users can open these by opening the side panel in Chrome or by clicking the extension toolbar icon. Side panels can be configured to only be displayed on specific sites.
 
 Other extension HTML pages include [Chrome override pages][doc-override], [sandbox pages][doc-sandbox] or any custom page included for a specific purpose like onboarding the user.
 

--- a/site/en/docs/extensions/mv3/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv3/architecture-overview/index.md
@@ -66,6 +66,9 @@ An extension can have different HTML pages depending on the design. All extensio
 [The options page][doc-options]
 : The options page (`options.html`) provides a way for users to customize an extension, such as choosing which sites the extension will run on. Users can access the options page in several ways as described in [Finding the options page][doc-options-view].
 
+[Side panels][api-sidepanel]
+: Extensions can also use side panels (`sidepanel.html`) to provide additional functionality alongside the main content of a site. Users can open side panels by navigating to Chrome’s built-in sidebar menu or by clicking the extension toolbar icon. Side panels can be displayed only on specific sites.
+
 Other extension HTML pages include [Chrome override pages][doc-override], [sandbox pages][doc-sandbox] or any custom page included for a specific purpose like onboarding the user.
 
 ### Other assets {: #assets }
@@ -106,6 +109,7 @@ Now that you have completed the [Getting Started guides][doc-gs] and understand 
 - Discover best practices for building [secure extensions][doc-secure] that respect [user privacy][doc-privacy]. 
 
 [api-ref]: /docs/extensions/reference
+[api-sidepanel]: /docs/extensions/reference/sidePanel
 [api-storage]: /docs/extensions/reference/storage
 [cs-isolated]: /docs/extensions/mv3/content_scripts/#isolated_world
 [cws]: https://chrome.google.com/webstore/

--- a/site/en/docs/extensions/mv3/user_interface/index.md
+++ b/site/en/docs/extensions/mv3/user_interface/index.md
@@ -7,7 +7,6 @@ updated: 2022-04-27
 description: UI and design guidelines for Chrome Extensions.
 ---
 
-<!-- TODO: Extension sample links need to be updated, once the samples are approved -->
 Like Chrome's user interface (UI), an extension UI should be purposeful and minimal. Extensions
 should allow users to customize or enhance the user's browsing experience without distracting
 from it. 
@@ -241,6 +240,45 @@ chrome.storage.local.get('signed_in', (data) => {
   }
 });
 ```
+
+### Side panel {: #side-panel } 
+
+An extension side panel is an HTML file that provides additional functionality alongside the main content of a webpage. The [side panel dictionary example](TBD) displays the same side panel on every page.
+<!-- TODO: Screenshot of dictionary-->
+The side panel is registered under the `“side_panel”` key:
+
+{% Label %}manifest.json:{% endLabel %}
+
+```json
+{
+  "manifest_version": 3,
+  "name": "1 - BLUE Side panel example",
+  "version": "1.0",
+  "description": "Sidepanel declared only in the manifest visible to all sites",
+  "side_panel": {
+    "default_path": "sidepanel.html"
+  },
+  "permissions": ["sidePanel"]
+}
+```
+<!-- Switch code to dictionary code if simple -->
+{% Label %}sidepanel.html:{% endLabel %}
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>My Sidepanel</title>
+  </head>
+  <body>
+    <h1>All sites sidepanel extension</h1>
+    <p>This side panel is enabled on all sites</p>
+    <script src="sidepanel.js"></script>
+  </body>
+</html>
+```
+
+For more samples and use cases, see the [SidePanel API][api-sidepanel] reference page.
 
 ### Tooltip {: #tooltip }
 
@@ -608,6 +646,7 @@ capabilities.
 [api-messages]: /docs/extensions/mv3/i18n-messages
 [api-notif]: /docs/extensions/reference/notifications
 [api-omnibox]: /docs/extensions/reference/omnibox
+[api-sidepanel]: /docs/extensions/reference/sidePanel
 [commands-oncommand]: /docs/extensions/reference/commands#event-onCommand
 [contextmenu-create]: /docs/extensions/reference/contextMenus#method-create
 [docs-background]: /docs/extensions/mv3/background_pages

--- a/site/en/docs/extensions/mv3/user_interface/index.md
+++ b/site/en/docs/extensions/mv3/user_interface/index.md
@@ -259,7 +259,7 @@ An extension side panel is an HTML file that provides additional functionality a
   </figcaption>
 </figure>
 
-For more samples and use cases, see the [SidePanel API][api-sidepanel] reference page.
+For more samples and use cases, see the [Side Panel API][api-sidepanel] reference page.
 
 ### Tooltip {: #tooltip }
 

--- a/site/en/docs/extensions/mv3/user_interface/index.md
+++ b/site/en/docs/extensions/mv3/user_interface/index.md
@@ -7,6 +7,7 @@ updated: 2022-04-27
 description: UI and design guidelines for Chrome Extensions.
 ---
 
+<!-- TODO: Extension sample links need to be updated, once the samples are approved -->
 Like Chrome's user interface (UI), an extension UI should be purposeful and minimal. Extensions
 should allow users to customize or enhance the user's browsing experience without distracting
 from it. 
@@ -240,26 +241,6 @@ chrome.storage.local.get('signed_in', (data) => {
   }
 });
 ```
-
-### Side panel {: #side-panel } 
-
-An extension side panel is an HTML file that provides additional functionality alongside the main content of a webpage. The [Dictionary side panel][sample-dictionary-sidepanel] example allows users to right-click on a word and see the definition on the side panel.
-
-<figure>
-  {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/9QJK3CNx71t67M3MlIUY.png", alt="Selecting the Dictionary side panel", width="379", height="386" %}
-  <figcaption>
-    Dictionary side panel extension.
-  </figcaption>
-</figure>
-
-<figure>
-  {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/aC3zkJDPliNLXdvfugeU.png", alt="Dictionary side panel context menu choosing the word extensions", width="800", height="393" %}
-  <figcaption>
-    Dictionary extension to defining the word "Extensions".
-  </figcaption>
-</figure>
-
-For more samples and use cases, see the [Side Panel API][api-sidepanel] reference page.
 
 ### Tooltip {: #tooltip }
 
@@ -627,7 +608,6 @@ capabilities.
 [api-messages]: /docs/extensions/mv3/i18n-messages
 [api-notif]: /docs/extensions/reference/notifications
 [api-omnibox]: /docs/extensions/reference/omnibox
-[api-sidepanel]: /docs/extensions/reference/sidePanel
 [commands-oncommand]: /docs/extensions/reference/commands#event-onCommand
 [contextmenu-create]: /docs/extensions/reference/contextMenus#method-create
 [docs-background]: /docs/extensions/mv3/background_pages
@@ -643,9 +623,7 @@ capabilities.
 [sample-context-menu]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/contextMenus/global_context_search
 [sample-drink]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples/sample.water_alarm_notification
 [sample-new-tab-search]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/omnibox/new-tab-search
-[sample-dictionary-sidepanel]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples/sample.sidepanel-dictionary
 [sample-tab-flipper]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/default_command_override
 [section-onclick]: #click
 [section-popup]: #popup
 [notifications-create]: /docs/extensions/reference/notifications#method-create
-

--- a/site/en/docs/extensions/mv3/user_interface/index.md
+++ b/site/en/docs/extensions/mv3/user_interface/index.md
@@ -243,40 +243,21 @@ chrome.storage.local.get('signed_in', (data) => {
 
 ### Side panel {: #side-panel } 
 
-An extension side panel is an HTML file that provides additional functionality alongside the main content of a webpage. The [side panel dictionary example](TBD) displays the same side panel on every page.
-<!-- TODO: Screenshot of dictionary-->
-The side panel is registered under the `“side_panel”` key:
+An extension side panel is an HTML file that provides additional functionality alongside the main content of a webpage. The [Dictionary side panel][sample-dictionary-sidepanel] example allows users to right-click on a word and see the definition on the side panel.
 
-{% Label %}manifest.json:{% endLabel %}
+<figure>
+  {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/9QJK3CNx71t67M3MlIUY.png", alt="Selecting the Dictionary side panel", width="379", height="386" %}
+  <figcaption>
+    Dictionary side panel extension.
+  </figcaption>
+</figure>
 
-```json
-{
-  "manifest_version": 3,
-  "name": "1 - BLUE Side panel example",
-  "version": "1.0",
-  "description": "Sidepanel declared only in the manifest visible to all sites",
-  "side_panel": {
-    "default_path": "sidepanel.html"
-  },
-  "permissions": ["sidePanel"]
-}
-```
-<!-- Switch code to dictionary code if simple -->
-{% Label %}sidepanel.html:{% endLabel %}
-
-```html
-<!DOCTYPE html>
-<html>
-  <head>
-    <title>My Sidepanel</title>
-  </head>
-  <body>
-    <h1>All sites sidepanel extension</h1>
-    <p>This side panel is enabled on all sites</p>
-    <script src="sidepanel.js"></script>
-  </body>
-</html>
-```
+<figure>
+  {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/aC3zkJDPliNLXdvfugeU.png", alt="Dictionary side panel right-clicking on the word extensions", width="800", height="393" %}
+  <figcaption>
+    Using the Dictionary extension to define the word "Extensions".
+  </figcaption>
+</figure>
 
 For more samples and use cases, see the [SidePanel API][api-sidepanel] reference page.
 
@@ -662,7 +643,9 @@ capabilities.
 [sample-context-menu]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/contextMenus/global_context_search
 [sample-drink]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples/sample.water_alarm_notification
 [sample-new-tab-search]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/omnibox/new-tab-search
+[sample-dictionary-sidepanel]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples/sample.sidepanel-dictionary
 [sample-tab-flipper]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/default_command_override
 [section-onclick]: #click
 [section-popup]: #popup
 [notifications-create]: /docs/extensions/reference/notifications#method-create
+

--- a/site/en/docs/extensions/mv3/user_interface/index.md
+++ b/site/en/docs/extensions/mv3/user_interface/index.md
@@ -253,9 +253,9 @@ An extension side panel is an HTML file that provides additional functionality a
 </figure>
 
 <figure>
-  {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/aC3zkJDPliNLXdvfugeU.png", alt="Dictionary side panel right-clicking on the word extensions", width="800", height="393" %}
+  {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/aC3zkJDPliNLXdvfugeU.png", alt="Dictionary side panel context menu choosing the word extensions", width="800", height="393" %}
   <figcaption>
-    Using the Dictionary extension to define the word "Extensions".
+    Dictionary extension to defining the word "Extensions".
   </figcaption>
 </figure>
 

--- a/site/en/docs/extensions/reference/sidePanel/index.md
+++ b/site/en/docs/extensions/reference/sidePanel/index.md
@@ -2,6 +2,10 @@
 api: sidePanel
 ---
 
+{% Aside 'important' %}
+The Side Panel API will launch on [Chrome 114](https://chromiumdash.appspot.com/schedule), available in stable in late May 2023
+{% endAside %}
+
 ## Overview {: #overview }
 
 Chrome features a built-in side panel that enables users to view more information alongside the main content of a webpage. The Side Panel API allows extensions to display their own UI in the side panel. 

--- a/site/en/docs/extensions/reference/sidePanel/index.md
+++ b/site/en/docs/extensions/reference/sidePanel/index.md
@@ -3,7 +3,7 @@ api: sidePanel
 ---
 
 {% Aside 'important' %}
-The Side Panel API will launch on [Chrome 114](https://chromiumdash.appspot.com/schedule), available in stable in late May 2023
+The Side Panel API will launch in [Chrome 114](https://chromiumdash.appspot.com/schedule), currently in beta and available in stable in late May 2023.
 {% endAside %}
 
 ## Overview {: #overview }

--- a/site/en/docs/extensions/reference/sidePanel/index.md
+++ b/site/en/docs/extensions/reference/sidePanel/index.md
@@ -1,0 +1,124 @@
+---
+api: sidePanel
+---
+
+## Overview {: #overview }
+
+Chrome features a built-in side panel that allows users to view more information alongside the main content of a webpage. The SidePanel API allows extensions to add their own panels to the Chrome browser. Some features include:
+
+- The side panel is displayed on the right side of the page.
+- It remains open when navigating between tabs (if set to do so).
+- The side panel can be enabled only on specific websites.
+- As an extension page, side panels have access to all Chrome APIs.
+
+## Manifest {: #manifest }
+
+In order to use the SidePanel API, you must include the `"sidePanel"` permission in the extension manifest. For example:
+
+{% Label %}manifest.json:{% endLabel %}
+
+```json
+{
+  "name": "My side panel extension",
+  ...
+  "permissions": [
+    "sidePanel"
+  ]
+  ...
+}
+```
+
+The side panel can optionally be set initially from the `“default_path”` property in the `“side_panel”` key of the manifest (See [Display on every site](#every-site)). This should point to a relative path within the extension directory.
+
+## Use cases {: #use-cases }
+
+The following sections demonstrate some common use cases for the SidePanel API.
+
+### Display the same side panel on every site {: #every-site }
+
+You can display the same side panel on every site by declaring the `sidepanel.html` file in the manifest. For this, you will need the following files:
+
+{% Label %}manifest.json:{% endLabel %}
+
+```json
+{
+  "name": "My side panel extension",
+  ...
+  "side_panel": {
+    "default_path": "sidepanel.html"
+  }
+  ...
+}
+ 
+```
+
+{% Label %}sidepanel.html:{% endLabel %}
+
+```html
+//TODO
+```
+
+### Enable a side panel on a specific site {: #by-site }
+
+An extension can enable the side panel when the user is on a specific site by using `sidepanel.setOptions()`. The following example enables the side panel only on www.google.com. 
+
+{% Label %}sidepanel.html:{% endLabel %}
+
+```html
+
+```
+
+
+{% Label %}sidepanel.js:{% endLabel %}
+
+```js
+
+```
+
+When the user navigates to a site where the side panel is not enabled, the side panel will close and not be displayed on the drop-down menu.
+
+### Switch from one panel to another {: #multi-panels }
+
+Another way to switch between different side panels is by using `sidepanel.getOptions()` to retrieve the current side panel. The following example sets a welcome side panel, then when the user navigates to a different tab, it replaces it with the main side panel.
+
+{% Label %}sidepanel.js:{% endLabel %}
+
+```js
+
+```
+
+### Use the action icon to open the side panel {: #open-action-icon } 
+
+{% Label %}manifest.json:{% endLabel %}
+
+```json
+{
+  "name": "My side panel extension",
+  ...
+  "permissions": [
+    "sidePanel"
+  ],
+  "action":{},
+  ...
+}
+```
+
+{% Label %}sidepanel.js:{% endLabel %}
+
+```js
+chrome.sidePanel.setPanelBehavior({openPanelOnActionClick: true})
+```
+
+## How to open a side panel {: #user-experience }
+
+Users can view the available panels on the Side panel menu <image here>. Then they can choose a side panel from the drop-down menu. Chrome displays the built-in side panels first.
+
+Each side panel displays the extension's icon in the side panel menu. Otherwise, it will show a placeholder icon with the first letter of the extension's name. 
+
+Developers can also allow users to open the side panel [using the action icon](#open-action-icon).
+
+## Extension samples
+// TODO: Links to GH repo samples
+
+
+

--- a/site/en/docs/extensions/reference/sidePanel/index.md
+++ b/site/en/docs/extensions/reference/sidePanel/index.md
@@ -4,7 +4,16 @@ api: sidePanel
 
 ## Overview {: #overview }
 
-Chrome features a built-in side panel that enables users to view more information alongside the main content of a webpage. The Side Panel API allows extensions to add their own panels to the Chrome browser. Some features include:
+Chrome features a built-in side panel that enables users to view more information alongside the main content of a webpage. The Side Panel API allows extensions to display their own UI in the side panel. 
+
+<figure>
+  {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/2uFG8qxM7cqyMuXWlD9R.png", alt="Side panel drop-down menu", width="291", height="366" %}
+  <figcaption>
+    Chrome browser side panel UI.
+  </figcaption>
+</figure>
+
+Some features include:
 
 - The side panel remains open when navigating between tabs (if set to do so).
 - It can be available only on specific websites.

--- a/site/en/docs/extensions/reference/sidePanel/index.md
+++ b/site/en/docs/extensions/reference/sidePanel/index.md
@@ -8,7 +8,7 @@ The Side Panel API will launch in [Chrome 114](https://chromiumdash.appspot.com/
 
 ## Overview {: #overview }
 
-Chrome features a built-in side panel that enables users to view more information alongside the main content of a webpage. The Side Panel API allows extensions to display their own UI in the side panel. 
+Chrome features a built-in side panel that enables users to view more information alongside the main content of a webpage. The Side Panel API allows extensions to display their own UI in the side panel, enabling persistent experiences that complement the user's browsing journey. 
 
 <figure>
   {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/2uFG8qxM7cqyMuXWlD9R.png", alt="Side panel drop-down menu", width="291", height="366" %}

--- a/site/en/docs/extensions/reference/sidePanel/index.md
+++ b/site/en/docs/extensions/reference/sidePanel/index.md
@@ -3,7 +3,7 @@ api: sidePanel
 ---
 
 {% Aside 'important' %}
-The Side Panel API will launch in [Chrome 114](https://chromiumdash.appspot.com/schedule), currently in beta and available in stable in late May 2023.
+The Side Panel API is currently available in [Chrome Canary](https://www.google.com/chrome/canary/).
 {% endAside %}
 
 ## Overview {: #overview }

--- a/site/en/docs/extensions/reference/sidePanel/index.md
+++ b/site/en/docs/extensions/reference/sidePanel/index.md
@@ -47,13 +47,21 @@ The side panel can optionally be set initially from the `“default_path”` pro
   }
   ...
 }
- 
 ```
 
 {% Label %}sidepanel.html:{% endLabel %}
 
 ```html
-//TODO
+<!DOCTYPE html>
+<html>
+<head>
+  <title>My Sidepanel</title>
+</head>
+<body>
+  <h1>Global side panel extension</h1>
+  <p>This side panel is enabled on all sites</p>
+  </body>
+</html>
 ```
 
 ### Enable a side panel on a specific site {: #by-site }
@@ -75,7 +83,7 @@ An extension can enable the side panel when the user is on a specific site by us
 
 When the user navigates to a site where the side panel is not enabled, the side panel will close and not be displayed on the drop-down menu.
 
-### Switch from one panel to another {: #multi-panels }
+### Switch to a different panel {: #multi-panels }
 
 Another way to switch between different side panels is by using `sidepanel.getOptions()` to retrieve the current side panel. The following example sets a welcome side panel, then when the user navigates to a different tab, it replaces it with the main side panel.
 
@@ -84,6 +92,8 @@ Another way to switch between different side panels is by using `sidepanel.getOp
 ```js
 
 ```
+
+Download the [complete extension](TBD) in the GitHub samples-repo.
 
 ### Use the action icon to open the side panel {: #open-action-icon } 
 
@@ -115,7 +125,7 @@ Each side panel displays the extension's icon in the side panel menu. Otherwise,
 
 Developers can also allow users to open the side panel [using the action icon](#open-action-icon).
 
-## Extension samples
+## Extension samples {: #examples }
 // TODO: Links to GH repo samples
 
 

--- a/site/en/docs/extensions/reference/sidePanel/index.md
+++ b/site/en/docs/extensions/reference/sidePanel/index.md
@@ -9,7 +9,7 @@ Chrome features a built-in side panel that enables users to view more informatio
 - The side panel remains open when navigating between tabs (if set to do so).
 - It can be available only on specific websites.
 - As an extension page, side panels have access to all Chrome APIs.
-- Users can choose which side to display the panel under Chrome settings.
+- Users can choose which side to display the panel on within Chrome's settings.
 
 ## Manifest {: #manifest }
 
@@ -33,7 +33,7 @@ The following sections demonstrate some common use cases for the Side Panel API.
 
 ### Display the same side panel on every site {: #every-site }
 
-The side panel can be set initially from the `“default_path”` property in the `“side_panel”` key of the manifest to display the same side panel on every site. This should point to a relative path within the extension directory.
+The side panel can be set initially from the `"default_path"` property in the `"side_panel"` key of the manifest to display the same side panel on every site. This should point to a relative path within the extension directory.
 
 {% Label %}manifest.json:{% endLabel %}
 
@@ -65,7 +65,7 @@ The side panel can be set initially from the `“default_path”` property in th
 
 ### Enable a side panel on a specific site {: #by-site }
 
-An extension can use [`sidepanel.setOptions()`][sidepanel-setoptions] to enable a side panel on a specific site. This example uses [`chrome.tabs.onUpdated()`][tabs-onupdated] to listen for any updates made to the tab. It checks if the URL is [www.google.com](https://www.google.com) and enables the side panel. Otherwise, it disables it. 
+An extension can use [`sidepanel.setOptions()`][sidepanel-setoptions] to enable a side panel on a specific tab. This example uses [`chrome.tabs.onUpdated()`][tabs-onupdated] to listen for any updates made to the tab. It checks if the URL is [www.google.com](https://www.google.com) and enables the side panel. Otherwise, it disables it. 
 
 {% Label %}service-worker.js:{% endLabel %}
 
@@ -92,9 +92,11 @@ chrome.tabs.onUpdated.addListener((tabId, info, tab) => {
 });
 ```
 
-When the user navigates to a site where the side panel is not enabled, the side panel will close and not be available on the side panel drop-down menu.
+When a user temporarily switches to a tab where the side panel is not enabled, the side panel will be hidden. It will automatically show again when the user switches to a tab where it was previously open.
 
-For a complete example, see the[Tab-specific side panel][sample-sp-google] sample. 
+When the user navigates to a site where the side panel is not enabled, the side panel will close and the extension will not show in the side panel drop-down menu.
+
+For a complete example, see the [Tab-specific side panel][sample-sp-google] sample. 
 
 ### Enable the action icon to open the side panel {: #open-action-icon } 
 

--- a/site/en/docs/extensions/reference/sidePanel/index.md
+++ b/site/en/docs/extensions/reference/sidePanel/index.md
@@ -22,7 +22,7 @@ Some features include:
 - The side panel remains open when navigating between tabs (if set to do so).
 - It can be available only on specific websites.
 - As an extension page, side panels have access to all Chrome APIs.
-- Users can choose which side to display the panel on within Chrome's settings.
+- Within Chrome's settings, users can specify which side the panel should be displayed on.
 
 ## Manifest {: #manifest }
 

--- a/site/en/docs/extensions/reference/sidePanel/index.md
+++ b/site/en/docs/extensions/reference/sidePanel/index.md
@@ -28,15 +28,13 @@ In order to use the SidePanel API, you must include the `"sidePanel"` permission
 }
 ```
 
-The side panel can optionally be set initially from the `“default_path”` property in the `“side_panel”` key of the manifest (See [Display on every site](#every-site)). This should point to a relative path within the extension directory.
-
 ## Use cases {: #use-cases }
 
-The following sections demonstrate some common use cases for the SidePanel API.
+The following sections demonstrate some common use cases for the SidePanel API. For complete extension samples, skip to [examples](#examples).
 
 ### Display the same side panel on every site {: #every-site }
 
-You can display the same side panel on every site by declaring the `sidepanel.html` file in the manifest. For this, you will need the following files:
+The side panel can optionally be set initially from the `“default_path”` property in the `“side_panel”` key of the manifest to display the same side panel on every site. This should point to a relative path within the extension directory.
 
 {% Label %}manifest.json:{% endLabel %}
 

--- a/site/en/docs/extensions/reference/sidePanel/index.md
+++ b/site/en/docs/extensions/reference/sidePanel/index.md
@@ -4,7 +4,7 @@ api: sidePanel
 
 ## Overview {: #overview }
 
-Chrome features a built-in side panel that enables users to view more information alongside the main content of a webpage. The SidePanel API allows extensions to add their own panels to the Chrome browser. Some features include:
+Chrome features a built-in side panel that enables users to view more information alongside the main content of a webpage. The Side Panel API allows extensions to add their own panels to the Chrome browser. Some features include:
 
 - The side panel remains open when navigating between tabs (if set to do so).
 - It can be available only on specific websites.
@@ -13,7 +13,7 @@ Chrome features a built-in side panel that enables users to view more informatio
 
 ## Manifest {: #manifest }
 
-To use the SidePanel API, add the `"sidePanel"` permission in the extension [manifest][doc-manifest] file:
+To use the Side Panel API, add the `"sidePanel"` permission in the extension [manifest][doc-manifest] file:
 
 {% Label %}manifest.json:{% endLabel %}
 
@@ -29,7 +29,7 @@ To use the SidePanel API, add the `"sidePanel"` permission in the extension [man
 
 ## Use cases {: #use-cases }
 
-The following sections demonstrate some common use cases for the SidePanel API. See [Extension samples](#examples) for complete extension examples.
+The following sections demonstrate some common use cases for the Side Panel API. See [Extension samples](#examples) for complete extension examples.
 
 ### Display the same side panel on every site {: #every-site }
 
@@ -70,13 +70,13 @@ An extension can use [`sidepanel.setOptions()`][sidepanel-setoptions] to enable 
 {% Label %}service-worker.js:{% endLabel %}
 
 ```js
-const googleURL = 'https://www.google.com';
+const GOOGLE_ORIGIN = 'https://www.google.com';
 
 chrome.tabs.onUpdated.addListener((tabId, info, tab) => {
   if (!tab.url) return;
   const url = new URL(tab.url);
   // Enables the side panel on google.com
-  if (url.origin === googleURL) {
+  if (url.origin === GOOGLE_ORIGIN) {
     chrome.sidePanel.setOptions({
       tabId,
       path: 'sidepanel.html',
@@ -118,7 +118,7 @@ Now, let's add this functionality to the previous example:
 {% Label %}service-worker.js:{% endLabel %}
 
 ```js/3-3
-const googleURL = 'https://www.google.com';
+const GOOGLE_ORIGIN = 'https://www.google.com';
 
 // Allows users to open the side panel by clicking on the action toolbar icon
 chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
@@ -178,7 +178,7 @@ Using a keyboard shortcut
 
 ## Extension samples {: #examples }
 
-For more SidePanel API extensions demos, explore any of the following extensions:
+For more Side Panel API extensions demos, explore any of the following extensions:
 
 - [Site-specific side panel][sample-sp-google].
 - [Multiple side panels][sample-sp-multiple].
@@ -191,7 +191,7 @@ For more SidePanel API extensions demos, explore any of the following extensions
 [runtime-oninstalled]: /docs/extensions/reference/runtime/#event-onInstalled
 [sample-sp-dictionary]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples/sample.sidepanel-dictionary
 [sample-sp-global]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples/cookbook.sidepanel-global
-[sample-sp-google]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples/cookbook.sidepanel-action
+[sample-sp-google]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples/cookbook.sidepanel-site-specific
 [sample-sp-multiple]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples/cookbook.sidepanel-multiple
 [sidepanel-getoptions]:#method-getOptions
 [sidepanel-set-behavior]: #method-setPanelBehavior

--- a/site/en/docs/extensions/reference/sidePanel/index.md
+++ b/site/en/docs/extensions/reference/sidePanel/index.md
@@ -85,19 +85,19 @@ An extension can use [`sidepanel.setOptions()`][sidepanel-setoptions] to enable 
 ```js
 const GOOGLE_ORIGIN = 'https://www.google.com';
 
-chrome.tabs.onUpdated.addListener((tabId, info, tab) => {
+chrome.tabs.onUpdated.addListener(async (tabId, info, tab) => {
   if (!tab.url) return;
   const url = new URL(tab.url);
   // Enables the side panel on google.com
   if (url.origin === GOOGLE_ORIGIN) {
-    chrome.sidePanel.setOptions({
+    await chrome.sidePanel.setOptions({
       tabId,
       path: 'sidepanel.html',
       enabled: true
     });
-  // Disables the side panel on all other sites
   } else {
-    chrome.sidePanel.setOptions({
+    // Disables the side panel on all other sites
+    await chrome.sidePanel.setOptions({
       tabId,
       enabled: false
     });
@@ -132,11 +132,13 @@ Now, let's add this functionality to the previous example:
 
 {% Label %}service-worker.js:{% endLabel %}
 
-```js/3-3
+```js
 const GOOGLE_ORIGIN = 'https://www.google.com';
 
 // Allows users to open the side panel by clicking on the action toolbar icon
-chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
+chrome.sidePanel
+  .setPanelBehavior({ openPanelOnActionClick: true })
+  .catch((error) => console.error(error));
 ...
 ```
 


### PR DESCRIPTION
## Description:
This PR introduces a new SidePanel API reference page, as well as updates to our Extensions architecture and Extension UI articles.

The SidePanel API provides developers with a way to implement customizable side panels in their extension. The new reference page includes detailed documentation on how to use this API, use cases and links to complete extension examples in the extension-samples repo.

**NOTE**
This is an MVP. We will be adding more details and companion documentation later.
The goal is to merge by **Cinco de Mayo** (5/5) 😄 

## Pending tasks
- [x] Merge extension samples [#890](https://github.com/GoogleChrome/chrome-extensions-samples/pull/890)
