### PR TITLE
Fix (again) typo

### DIFF
--- a/site/en/articles/nfc/index.md
+++ b/site/en/articles/nfc/index.md
@@ -440,7 +440,7 @@ document.querySelector("#abortButton").onclick = event => {
 
 ### Read after write
 
-Using `write()` then `scan()` with the [`AbortController`]
+Using `write()` then `scan()` with the <code>[AbortController]</code>
 primitive makes it possible to read an NFC tag after writing a message to it.
 The example below shows you how to write a text message to an NFC tag and read
 the new message in the NFC tag. It stops scanning after three seconds.


### PR DESCRIPTION
Following https://github.com/GoogleChrome/developer.chrome.com/pull/6174 and https://github.com/GoogleChrome/developer.chrome.com/pull/6171#discussion_r1182520288, I'm reverting to original formatting as it's the only way to make it work with URL in foot notes.

@rachelandrew Please review and merge.