### PR TITLE
Align hero image width with content on large screens

### DIFF
--- a/site/_scss/blocks/_hero-image.scss
+++ b/site/_scss/blocks/_hero-image.scss
@@ -1,6 +1,6 @@
 .hero-image {
-  max-height: 480px;
-  max-width: 960px;
+  max-height: calc(480px + 1.5em);
+  max-width: calc(960px + 3em);
   width: 100%;
 
   @media (min-width: 960px) {


### PR DESCRIPTION
On large screens, the hero image does not align properly with the content column. This because of an extra padding of 1.5em on the inline axis that is added to the content. I’m not sure if this is intentional or not, but I can’t help but notice it and think it’s off.

This PR makes it so that the hero image becomes as wide as the content column.

Compare this before and after:

| before | after |
|-|-|
| <img width="1552" alt="Screenshot 2023-05-03 at 14 52 57" src="https://user-images.githubusercontent.com/213073/236046547-7dd113ae-70d0-427e-8789-9b06b4d9e83b.png"> | <img width="1552" alt="Screenshot 2023-05-03 at 14 53 00" src="https://user-images.githubusercontent.com/213073/236046792-51f5cc71-8017-47f2-9e70-c29999bc5831.png"> |

If your OCD is not as bad as mine is, then feel free to discard.