### PR TITLE
Retain video aspect ratio when both width and height are set

### DIFF
--- a/site/_scss/_global.scss
+++ b/site/_scss/_global.scss
@@ -29,3 +29,7 @@ main:focus {
 video {
   width: 100%;
 }
+
+video[width][height] {
+  height: auto;
+}


### PR DESCRIPTION
In the CSS of DCC, the width of a `video` element is set to `100%`. This does not play nice with video elements that have both a `width` and a `height` attribute set: the width will be sized to `100%` with CSS, yet the specified height (via the `height` attribute) will be used. This can lead to videos being stretched out / not having the correct aspect ratio. 

By setting the `height` to `auto` in CSS as well, this can be fixed.

Compare these two screenshots below. The video is square (800px by 800px). In the before version it is not a square: the available width is less than 800px so the CSS shrinks it, yet the height remains 800px. This results in a white space added below the video (and obscured by the controls here). In the after version, the height is adjusted too, respecting the original aspect ratio as derived from the width/height attributes.

| before | after |
|-|-|
| <img width="792" alt="Screenshot 2023-05-03 at 22 56 32" src="https://user-images.githubusercontent.com/213073/236048528-e7d806b8-0b69-430f-a354-9595de9f9435.png"> | <img width="764" alt="Screenshot 2023-05-03 at 22 56 43" src="https://user-images.githubusercontent.com/213073/236048719-398abefd-0d1b-48d1-9424-dd9d9b4ec425.png"> |

The adjusted CSS is written in a defensive way so that only applies to videos that have both the `width` and `height` attributes set.
