### PR TITLE
#3930 - Fix unique redirect handler

### DIFF
--- a/server/handlers/redirects/uniqueRedirect.js
+++ b/server/handlers/redirects/uniqueRedirect.js
@@ -231,7 +231,12 @@ async function buildMatcher(source = 'dist/', avoidDirs = defaultAvoidDirs) {
     if (scope === path.dirname(p)) {
       force = true;
     }
-    insertRoot(scope, p, key, force);
+
+    try {
+      insertRoot(scope, p, key, force);
+    } catch (e) {
+      console.error(`Error: Failed to insert '${p}' into '${scope}': ${e}`);
+    }
   }
 
   // Look at all redirs in avoided directories, and move them to the root only if possible. This basically

--- a/site/_collections/tags.js
+++ b/site/_collections/tags.js
@@ -38,8 +38,6 @@ module.exports = function (collections) {
     .reverse()
     .filter(filterOutDrafts);
 
-  // console.log(allSorted[0]);
-
   // The i18n for this file exposes top-level object keys of valid tags.
   const supportedTags = /** @type {{[tag: string]: unknown}} */ (
     YAML.load(

--- a/site/_collections/tags.js
+++ b/site/_collections/tags.js
@@ -38,6 +38,8 @@ module.exports = function (collections) {
     .reverse()
     .filter(filterOutDrafts);
 
+  // console.log(allSorted[0]);
+
   // The i18n for this file exposes top-level object keys of valid tags.
   const supportedTags = /** @type {{[tag: string]: unknown}} */ (
     YAML.load(
@@ -62,11 +64,23 @@ module.exports = function (collections) {
   allSortedForLoop: for (const item of allSorted) {
     // If there are no tags or the tags isn't a string or array, skip the post.
     /** @type {string[]} */
-    const allTags = [item.data.tags ?? []].flat();
+    let allTags = [item.data.tags ?? []].flat();
     if (!allTags.length) {
       delete item.data.tags;
       continue allSortedForLoop;
     }
+
+    // rewrite chromeX to chrome-X
+    const chromeXRegex = /^chrome(\d+)$/;
+    allTags = allTags.map(tag => {
+      chromeXRegex.lastIndex = 0;
+      const match = tag.match(chromeXRegex);
+      if (match) {
+        return `chrome-${match[1]}`;
+      }
+
+      return tag;
+    });
 
     // Ensure that tags on the front matter is an array.
     item.data.tags = allTags;


### PR DESCRIPTION
Fixes #3930

Changes proposed in this pull request:

- continue uniqueHandler build even if an individual redirect entry errors
- interpret "chromeX" (e.g. chrome110) as chrome-X (e.g. chrome-110) to prevent unintentional duplicate tags