### PR TITLE
Nancy debug toc

### DIFF
--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -93,13 +93,12 @@
           title: i18n.docs.privacy-sandbox.experiment-participate
         - url: /docs/privacy-sandbox/attribution-reporting/chrome-shipping
           title: i18n.docs.privacy-sandbox.attribution-reporting-chrome-shipping
-        - url: /docs/privacy-sandbox/attribution-reporting-debugging
-            - title: i18n.docs.privacy-sandbox.cross-site-federation
-              sections:
-                - url: docs/privacy-sandbox/attribution-reporting-debugging
-                - url: /docs/privacy-sandbox/attribution-reporting-debugging/part-1/
-                - url: /docs/privacy-sandbox/attribution-reporting-debugging/part-2/
-                - url: /docs/privacy-sandbox/attribution-reporting-debugging/part-3/
+        - title: i18n.docs.privacy-sandbox.attribution-reporting-debugging-resources
+          sections:
+            - url: docs/privacy-sandbox/attribution-reporting-debugging
+            - url: /docs/privacy-sandbox/attribution-reporting-debugging/part-1/
+            - url: /docs/privacy-sandbox/attribution-reporting-debugging/part-2/
+            - url: /docs/privacy-sandbox/attribution-reporting-debugging/part-3/
         - url: https://docs.google.com/document/d/1BXchEk-UMgcr2fpjfXrQ3D8VhTR-COGYS1cwK_nyLfg/view?usp=sharing
           title: i18n.docs.privacy-sandbox.attribution-reporting-handbook
         - url: /docs/privacy-sandbox/attribution-reporting-updates

--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -94,17 +94,12 @@
         - url: /docs/privacy-sandbox/attribution-reporting/chrome-shipping
           title: i18n.docs.privacy-sandbox.attribution-reporting-chrome-shipping
         - url: /docs/privacy-sandbox/attribution-reporting-debugging
-          - title: i18n.docs.privacy-sandbox.debugging
-            sections:
-              - url: docs/privacy-sandbox/attribution-reporting-debugging
-                title: debugging 
-              - url: /docs/privacy-sandbox/attribution-reporting-debugging/part-1/
-                title: debugging 1
-              - url: /docs/privacy-sandbox/attribution-reporting-debugging/part-2/
-                title: debugging 2
-              - url: /docs/privacy-sandbox/attribution-reporting-debugging/part-3/
-                title: debugging 3
-
+            - title: i18n.docs.privacy-sandbox.cross-site-federation
+              sections:
+                - url: docs/privacy-sandbox/attribution-reporting-debugging
+                - url: /docs/privacy-sandbox/attribution-reporting-debugging/part-1/
+                - url: /docs/privacy-sandbox/attribution-reporting-debugging/part-2/
+                - url: /docs/privacy-sandbox/attribution-reporting-debugging/part-3/
         - url: https://docs.google.com/document/d/1BXchEk-UMgcr2fpjfXrQ3D8VhTR-COGYS1cwK_nyLfg/view?usp=sharing
           title: i18n.docs.privacy-sandbox.attribution-reporting-handbook
         - url: /docs/privacy-sandbox/attribution-reporting-updates

--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -95,7 +95,6 @@
           title: i18n.docs.privacy-sandbox.attribution-reporting-chrome-shipping
         - title: i18n.docs.privacy-sandbox.attribution-reporting-debugging-resources
           sections:
-            - url: docs/privacy-sandbox/attribution-reporting-debugging
             - url: /docs/privacy-sandbox/attribution-reporting-debugging/part-1/
             - url: /docs/privacy-sandbox/attribution-reporting-debugging/part-2/
             - url: /docs/privacy-sandbox/attribution-reporting-debugging/part-3/

--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -94,7 +94,17 @@
         - url: /docs/privacy-sandbox/attribution-reporting/chrome-shipping
           title: i18n.docs.privacy-sandbox.attribution-reporting-chrome-shipping
         - url: /docs/privacy-sandbox/attribution-reporting-debugging
-          title: i18n.docs.privacy-sandbox.attribution-reporting-debugging
+          - title: i18n.docs.privacy-sandbox.debugging
+            sections:
+              - url: docs/privacy-sandbox/attribution-reporting-debugging
+                title: debugging 
+              - url: /docs/privacy-sandbox/attribution-reporting-debugging/part-1/
+                title: debugging 1
+              - url: /docs/privacy-sandbox/attribution-reporting-debugging/part-2/
+                title: debugging 2
+              - url: /docs/privacy-sandbox/attribution-reporting-debugging/part-3/
+                title: debugging 3
+
         - url: https://docs.google.com/document/d/1BXchEk-UMgcr2fpjfXrQ3D8VhTR-COGYS1cwK_nyLfg/view?usp=sharing
           title: i18n.docs.privacy-sandbox.attribution-reporting-handbook
         - url: /docs/privacy-sandbox/attribution-reporting-updates

--- a/site/_data/i18n/docs/privacy-sandbox.yml
+++ b/site/_data/i18n/docs/privacy-sandbox.yml
@@ -64,6 +64,8 @@ experiment-participate:
   en: 'Experiment and participate'
 attribution-reporting-debugging:
   en: 'Debugging Attribution Reporting'
+attribution-reporting-debugging-resources:
+  en: 'Attribution Reporting Debug Resources'
 attribution-reporting-changing:
   en: 'API updates'
 attribution-reporting-handbook:

--- a/site/_data/i18n/docs/privacy-sandbox.yml
+++ b/site/_data/i18n/docs/privacy-sandbox.yml
@@ -65,7 +65,7 @@ experiment-participate:
 attribution-reporting-debugging:
   en: 'Debugging Attribution Reporting'
 attribution-reporting-debugging-resources:
-  en: 'Attribution Reporting Debug Resources'
+  en: 'Generate debug reports'
 attribution-reporting-changing:
   en: 'API updates'
 attribution-reporting-handbook:

--- a/site/en/_partials/privacy-sandbox/ara-debugging-series-intro.md
+++ b/site/en/_partials/privacy-sandbox/ara-debugging-series-intro.md
@@ -1,6 +1,6 @@
 {% Aside %}
 
-This article is part of a [series](/docs/privacy-sandbox/attribution-reporting-debugging/) on debugging the [Attribution Reporting API](/docs/privacy-sandbox/attribution-reporting/system-overview/).
-This series covers client-side debugging for event-level reports and aggregatable reports. Server-side debugging guidance for summary reports is available [here](https://github.com/privacysandbox/aggregation-service/blob/main/docs/DEBUGGING.md). A handbook for API integration is available [here](https://docs.google.com/document/d/1BXchEk-UMgcr2fpjfXrQ3D8VhTR-COGYS1cwK_nyLfg/edit#).
+This article is part of a series on debugging the [Attribution Reporting API](/docs/privacy-sandbox/attribution-reporting/system-overview/).
+This series covers client-side debugging for event-level reports and aggregatable reports. Server-side debugging guidance for summary reports is [available on GitHub](https://github.com/privacysandbox/aggregation-service/blob/main/docs/DEBUGGING.md). The [Experiment with Attribution Reporting Handbook](https://docs.google.com/document/d/1BXchEk-UMgcr2fpjfXrQ3D8VhTR-COGYS1cwK_nyLfg/edit#) provides additional information.
 
 {% endAside %}


### PR DESCRIPTION
Fixes b/280440508

Changes proposed in this pull request:

- Add three attribution reporting debug pages to left nav in a debug section
- staged https://pr-6204-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/attribution-reporting-debugging/
- staged first page https://pr-6204-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/attribution-reporting-debugging/part-1/