### PR TITLE
Remove incorrect description of close() method including flush().

### DIFF
--- a/site/en/blog/sync-methods-for-accesshandles/index.md
+++ b/site/en/blog/sync-methods-for-accesshandles/index.md
@@ -47,7 +47,7 @@ are **synchronous as of Chromium&nbsp;108**.
 - `getSize()`: Returns the size of the file associated with the access handle in bytes.
 - `flush()`: Ensures that the contents of the file associated with the access handle contain all the
   modifications done through `write()`.
-- `close()`: Flushes the access handle and then closes it. Closing an access handle disables any
+- `close()`: Closing an access handle disables any
   further operations on it and releases the lock on the entry associated with the access handle.
 
 ```js


### PR DESCRIPTION
The spec for close() does not guarantee a flush. From https://fs.spec.whatwg.org/#dom-filesystemsyncaccesshandle-close

> Note: This method does not guarantee that all file modifications will be immediately reflected in the underlying storage device. Call the flush() method first if you require this guarantee.

- Remove the text that implies that `close()` will `flush()`.
