### PR TITLE
Add shared storage mailing list

### DIFF
--- a/site/en/docs/privacy-sandbox/events/index.md
+++ b/site/en/docs/privacy-sandbox/events/index.md
@@ -22,6 +22,7 @@ Subscribe to the following mailing lists to be notified of other events:
 * [Attribution Reporting](https://groups.google.com/u/2/a/chromium.org/g/attribution-reporting-api-dev)
 * [FLEDGE](https://groups.google.com/u/2/a/chromium.org/g/fledge-api-announce)
 * [Topics](https://groups.google.com/u/2/a/chromium.org/g/topics-api-announce)
+* [Shared Storage](https://groups.google.com/a/chromium.org/g/shared-storage-api-announcements)
 
 ## Ongoing events
 


### PR DESCRIPTION
Fixes b/281511375

Changes proposed in this pull request:

- Add shared storage mailing list to the list on PS events page
- staged: https://pr-6223-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/events/
-