### PR TITLE
[ext-doc] Fix code block for SW basics article

### DIFF
--- a/site/en/docs/extensions/mv3/service_workers/basics/index.md
+++ b/site/en/docs/extensions/mv3/service_workers/basics/index.md
@@ -27,7 +27,7 @@ To register an extension service worker, specify it in the `"background"` field 
 
 There are two methods of importing scripts into a service worker: the [`import`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/import) statement and the [`importScripts()`](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/importScripts) method. Note that [`import()`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/import), often called a dynamic import, is not supported.
 
-To use the `import` statement, add the `"type" field to your manifest and specify `"module"`. For example:
+To use the `import` statement, add the `"type"` field to your manifest and specify `"module"`. For example:
 
 ```json/2
   "background": {


### PR DESCRIPTION
Fixes #6195

Changes proposed in this pull request:

- Fixed the code block overflow article at https://developer.chrome.com/docs/extensions/mv3/service_workers/basics/.
- Please find below the screenshots.

Before Fix           |  After Fix
:-------------------------:|:-------------------------:
<img width="1507" alt="before_fix" src="https://github.com/GoogleChrome/developer.chrome.com/assets/59731841/cbeb1873-9787-4b08-b361-1773eaf39f02">)  |  <img width="1507" alt="after_fix" src="https://github.com/GoogleChrome/developer.chrome.com/assets/59731841/a13812b7-4ba7-4222-bfa2-8a88a354705e">

 


