### PR TITLE
Address feedback on tabCapture documentation.

### DIFF
--- a/site/en/docs/extensions/mv3/screen_capture/index.md
+++ b/site/en/docs/extensions/mv3/screen_capture/index.md
@@ -3,16 +3,16 @@ layout: "layouts/doc-post.njk"
 title: "Audio recording and screen capture"
 seoTitle: "Chrome Extensions: Audio recording and screen capture"
 date: 2023-04-14
-description: How to record audio or video from a tab, window, or screen
+description: How to record audio or video from a tab, window, or screen.
 ---
 
 This guide explains different approaches for recording audio and video from a tab, window, or
 screen using APIs such as [`chrome.tabCapture`][tabcapture] or
 [`getDisplayMedia()`][get-display-media].
 
-## Common use cases
+## Common use cases {: #common-use-cases }
 
-### Screen recording {: #screen-recording}
+### Screen recording {: #screen-recording }
 
 For screen recording, call [`getDisplayMedia()`][get-display-media], which triggers the dialog box
 shown below. This provides the user with the ability to select which tab, window or screen they wish
@@ -33,66 +33,21 @@ If called within a content script, recording will automatically end when the use
 page. To record in the background and across navigations, use an
 [offscreen document][offscreen-documents] with the `DISPLAY_MEDIA` reason.
 
-### Tab capture based on user gesture
+### Tab capture based on user gesture {: #user-gesture }
 
 Calling [`getDisplayMedia()`][get-display-media] results in the browser showing a dialog which asks
 the user what they would like to share. However, in some cases the user has just clicked on the
-action button to invoke your extension for a specific tab, and you would like to immediately start
-capturing the tab without this prompt.
+[action button][action-button] to invoke your extension for a specific tab, and you would like to
+immediately start capturing the tab without this prompt.
 
-#### Audio and video (single page)
-
-If your recording does not need to persist across navigations, encourage the user to open your
-extension's popup to start recording. Then, use
-[chrome.tabCapture.getMediaStreamId][tabcapture-media-stream-id] in the popup to get a stream ID,
-and pass that ID to a content script. Make sure to set the `consumerTabId` property to allow the tab
-to access this stream.
-
-In your popup:
-
-```js
-chrome.tabs.query({ active: true, lastFocusedWindow: true }, ([{ id: tabId }]) => {
-  chrome.tabCapture.getMediaStreamId({ consumerTabId: tabId }, async (id) => {
-    chrome.tabs.sendMessage(tabId, { name: "media-id", data: id });
-  });
-});
-```
-
-In the content script, obtain a stream from the ID:
-
-```js
-chrome.runtime.onMessage.addListener(async (msg) => {
-  if (msg.name === "media-id") {
-    const media = await navigator.mediaDevices.getUserMedia({
-      audio: {
-        mandatory: {
-          chromeMediaSource: "tab",
-          chromeMediaSourceId: msg.data,
-        },
-      },
-      video: {
-        mandatory: {
-          chromeMediaSource: "tab",
-          chromeMediaSourceId: msg.data,
-        },
-      },
-    });
-
-    // Continue to play the captured audio to the user.
-    const output = new AudioContext();
-    const source = output.createMediaStreamSource(media);
-    source.connect(output.destination);
-  }
-});
-```
-
-#### Audio and video (across navigations)
+#### Audio and video {: #audio-and-video }
 
 {% Aside %}
 
 In the future, we may support passing a media stream ID to an
-[offscreen document][offscreen-documents] so recording can more easily persist across navigations.
-We are collecting feedback in the [chromium-extensions mailing list][feedback-mailing-list].
+[offscreen document][offscreen-documents] so recording can happen in the background and more easily
+persist across navigations. We are collecting feedback in the
+[chromium-extensions mailing list][feedback-mailing-list].
 
 {% endAside %}
 
@@ -135,7 +90,14 @@ Alternatively, consider using the [screen recording](#screen-recording) approach
 record in the background using an offscreen document, but shows the user a dialog to select a tab,
 window or screen to record from.
 
-#### Audio only
+#### Audio only {: #audio-only }
+
+{% Aside 'caution' %}
+
+This approach only works for audio, as attempting to capture video from the popup causes
+focus to move and the popup to close.
+
+{% endAside %}
 
 If you only need to record audio, you can directly obtain a stream in the extension popup using
 [chrome.tabCapture.capture][tabcapture-capture]. When the popup closes, recording will be stopped.
@@ -151,7 +113,7 @@ chrome.tabCapture.capture({ audio: true }, (stream) => {
 });
 ```
 
-## Other considerations
+## Other considerations {: #other-considerations }
 
 For more information on how to record a stream, see the [MediaRecorder][media-recorder] API.
 
@@ -162,3 +124,4 @@ For more information on how to record a stream, see the [MediaRecorder][media-re
 [offscreen-documents]: /blog/Offscreen-Documents-in-Manifest-v3/
 [feedback-mailing-list]: https://groups.google.com/a/chromium.org/g/chromium-extensions/c/Ef08XtOOyoI/m/L5HM7yPsBAAJ
 [media-recorder]: https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder
+[action-button]: /docs/extensions/mv3/user_interface/#action

--- a/site/en/docs/extensions/reference/tabCapture/index.md
+++ b/site/en/docs/extensions/reference/tabCapture/index.md
@@ -3,14 +3,14 @@ api: tabCapture
 has_warning: This permission <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">triggers a warning</a>.
 ---
 
-## Overview
+## Overview {: #overview }
 
 The chrome.tabCapture API allows you to access a [MediaStream][media-stream] containing video and
 audio of the current tab. It can only be called after the user invokes an extension, such as by
-clicking the extension's action button. This is similar to the behavior of the
+clicking the extension's [action button][action-button]. This is similar to the behavior of the
 [activeTab][active-tab] permission.
 
-## Preserving system audio
+## Preserving system audio {: #preserving-system-audio }
 
 When a [MediaStream][media-stream] is obtained for a tab, audio in that tab will no longer be played
 to the user. This is similar to the behavior of the [`getDisplayMedia()`][get-display-media] function when
@@ -27,7 +27,7 @@ source.connect(output.destination);
 This creates a new `AudioContext` and connects the audio of the tab's `MediaStream` to the default
 destination.
 
-## Stream IDs
+## Stream IDs {: #stream-ids }
 
 Calling [chrome.tabCapture.getMediaStreamId][get-media-stream-id] will return a stream ID. To later
 access a [MediaStream][media-stream] from the ID, use the following:
@@ -49,7 +49,7 @@ navigator.mediaDevices.getUserMedia({
 });
 ```
 
-## Learn more
+## Learn more {: #learn-more }
 
 To learn more about how to use the `chrome.tabCapture` API, see
 [Audio recording and screen capture][audio-recording-screen-capture]. This demonstrates how to use
@@ -61,3 +61,4 @@ To learn more about how to use the `chrome.tabCapture` API, see
 [get-display-media]: https://developer.mozilla.org/docs/Web/API/MediaDevices/getDisplayMedia
 [supress-playback]: https://developer.mozilla.org/docs/Web/API/MediaTrackSupportedConstraints/suppressLocalAudioPlayback
 [audio-recording-screen-capture]: /docs/extensions/mv3/screen_capture/
+[action-button]: /docs/extensions/mv3/user_interface/#action


### PR DESCRIPTION
Addresses some general feedback on the tabCapture documentation. In addition:

- I've removed the suggestion to use a content script. Devlin pointed out that this increases risk (since the page can now access the MediaStream) and is less useful now we are looking in to supporting tabCapture from an offscreen document. I've updated the callout to mention that we are actively considering work here.
- I've added a new callout in the audio section to make it clearer that this does not work for video.