### PR TITLE
Remove initialAspectRatio

### DIFF
--- a/site/en/docs/web-platform/document-picture-in-picture/index.md
+++ b/site/en/docs/web-platform/document-picture-in-picture/index.md
@@ -127,7 +127,7 @@ pipButton.addEventListener('click', async () => {
 
 ### Set the size of the Picture-in-Picture window
 
-To set the size of the Pictire-in-Picture window, set the `width` and `height` options of `documentPictureInPicture.requestWindow()` to the desired Picture-in-Picture window size. Chrome may clamp those options values if they are too large or too small to fit a user-friendly window size.
+To set the size of the Picture-in-Picture window, set the `width` and `height` options of `documentPictureInPicture.requestWindow()` to the desired Picture-in-Picture window size. Chrome may clamp the option values if they are too large or too small to fit a user-friendly window size.
 
 ```js
 pipButton.addEventListener("click", async () => {

--- a/site/en/docs/web-platform/document-picture-in-picture/index.md
+++ b/site/en/docs/web-platform/document-picture-in-picture/index.md
@@ -6,7 +6,7 @@ description: >
 authors:
   - beaufortfrancois
 date: 2023-02-02
-updated: 2023-02-22
+updated: 2023-05-11
 hero: image/vvhSqZboQoZZN9wBvoXq72wzGAf1/l8xW8V85N60e4dmwUwmE.jpg
 alt: Person holding outdoor lounge chairs.
 tags:
@@ -81,9 +81,6 @@ Research has shown that users need more ways to be productive on the web. Docume
   The promise rejects if it's called without a user gesture.
   The `options` dictionary contains the optional following members:
 
-  `initialAspectRatio`
-  : Sets the initial aspect ratio of the Picture-in-Picture window.
-
   `width`
   : Sets the initial width of the Picture-in-Picture window.
 
@@ -130,30 +127,21 @@ pipButton.addEventListener('click', async () => {
 
 ### Set the size of the Picture-in-Picture window
 
-To set an aspect ratio, set the `initialAspectRatio` option of `documentPictureInPicture.requestWindow()` to the desired Picture-in-Picture window aspect ratio.
+To set the size of the Pictire-in-Picture window, set the `width` and `height` options of `documentPictureInPicture.requestWindow()` to the desired Picture-in-Picture window size. Chrome may clamp those options values if they are too large or too small to fit a user-friendly window size.
 
 ```js
 pipButton.addEventListener("click", async () => {
   const player = document.querySelector("#player");
 
-  // Open a Picture-in-Picture window whose aspect ratio is
+  // Open a Picture-in-Picture window whose size is
   // the same as the player's.
   const pipWindow = await documentPictureInPicture.requestWindow({
-    initialAspectRatio: player.clientWidth / player.clientHeight,
+    width: player.clientWidth,
+    height: player.clientHeight,
   });
 
   // Move the player to the Picture-in-Picture window.
   pipWindow.document.body.append(player);
-});
-```
-
-The `width` and `height` options can also be used to set the desired Picture-in-Picture window size. Chrome may clamp those options values if they are too large or too small to fit a user-friendly window size.
-
-```js
-// Set player's width and height as the Picture-in-Picture window size.
-const pipWindow = await documentPictureInPicture.requestWindow({
-  width: player.clientWidth,
-  height: player.clientHeight,
 });
 ```
 


### PR DESCRIPTION
Since we don't currently support locking the aspect ratio, having `initialAspectRatio` as an option doesn't really make sense, so we should remove it.

Spec PR: https://github.com/WICG/document-picture-in-picture/pull/36
Chromium CL: https://chromium-review.googlesource.com/c/chromium/src/+/4518212


FYI @steimelchrome @liberato-at-chromium