### PR TITLE
Add YouTube embed fallback styling

### DIFF
--- a/site/_scss/blocks/_youtube.scss
+++ b/site/_scss/blocks/_youtube.scss
@@ -4,6 +4,19 @@
   width: 100%;
 }
 
+.youtube-fallback {
+  align-items: center;
+  aspect-ratio: 16 / 9;
+  background-color: var(--color-bg-shade);
+  color: var(--color-text);
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+  justify-content: center;
+  padding: 1em;
+  text-decoration: none;
+}
+
 lite-youtube {
   height: 100%;
   left: 50%;


### PR DESCRIPTION
Fixes [#6193](https://github.com/GoogleChrome/developer.chrome.com/issues/6193)

Changes proposed in this pull request:
- Implements some fallback styling for d.c.c. for youtube lite

How to test
1. Clone webdev-infra and checkout branch `6193_youtube_embed_should_show_fallback_link`
2. Clone d.c.c repository and checkout branch 6193_youtube_embed_should_show_fallback_link_when_js_is_disabled
3. Setup a sym link between the webdev-infra and d.c.c repository
4. Navigate to /blog/new-in-chrome-113/ with javascript enabled, you should see the youtube video as expected
5. Disable javascript
6. Refresh the page, you should now see the fallback text in place of the youtube video