### PR TITLE
Fix the basic syntax to include // and port between HOST and URI

### DIFF
--- a/site/en/docs/multidevice/android/intents/index.md
+++ b/site/en/docs/multidevice/android/intents/index.md
@@ -26,8 +26,8 @@ including the ability to pass extra information into the app via [Intent Extras]
 The basic syntax for an intent-based URI is as follows:
 
 ```text
-intent:  
-   HOST/URI-path // Optional host  
+intent://  
+   HOST[:PORT]/URI-path // Optional host  
    #Intent;  
       package=\[string\];  
       action=\[string\];  


### PR DESCRIPTION
The intent uri syntax misses "//", while the examples does include them. Also introducing the PORT between HOST and URI as an optional string.

Changes proposed in this pull request:

-
-
-