### PR TITLE
[ext-doc] Convert XMLHttpRequest to fetch()

### DIFF
--- a/site/en/docs/extensions/mv3/content_scripts/index.md
+++ b/site/en/docs/extensions/mv3/content_scripts/index.md
@@ -711,14 +711,9 @@ All assets must be declared as [Web Accessible Resources][manifest-war] in the `
 
 ## Stay secure {: #security }
 
-{% Aside 'warning' %}
-In Manifest V3, `XMLHttpRequest` is not supported in Service Workers.
-Please consider using its modern replacement, `fetch()`.
-{% endAside %}
-
 While isolated worlds provide a layer of protection, using content scripts can create
 vulnerabilities in an extension and the web page. If the content script receives content from a
-separate website, such as making an [`XMLHttpRequest`][28] or fetch() request, be careful to filter content
+separate website, such as making a fetch() request, be careful to filter content
 [cross-site scripting][29] attacks before injecting it. Only communicate over HTTPS in order to
 avoid ["man-in-the-middle"][30] attacks.
 

--- a/site/en/docs/extensions/mv3/content_scripts/index.md
+++ b/site/en/docs/extensions/mv3/content_scripts/index.md
@@ -711,9 +711,14 @@ All assets must be declared as [Web Accessible Resources][manifest-war] in the `
 
 ## Stay secure {: #security }
 
+{% Aside 'warning' %}
+In Manifest V3, `XMLHttpRequest` is not supported in Service Workers.
+Please consider using its modern replacement, `fetch()`.
+{% endAside %}
+
 While isolated worlds provide a layer of protection, using content scripts can create
 vulnerabilities in an extension and the web page. If the content script receives content from a
-separate website, such as making an [`XMLHttpRequest`][28], be careful to filter content
+separate website, such as making an [`XMLHttpRequest`][28] or fetch() request, be careful to filter content
 [cross-site scripting][29] attacks before injecting it. Only communicate over HTTPS in order to
 avoid ["man-in-the-middle"][30] attacks.
 

--- a/site/en/docs/extensions/mv3/security/index.md
+++ b/site/en/docs/extensions/mv3/security/index.md
@@ -161,27 +161,6 @@ function constructDOM() {
 }
 ```
 
-### eval() {: #eval }
-
-Avoid using `eval()` whenever possible to prevent attacks, as `eval()` will execute any code passed
-into it, which may be malicious.
-
-```js
-const fetchValue = await fetch("https://api.example.com/data.json");
-const jsonData = await fetchValue.json();
-// WARNING! Might be evaluating an evil script!
-const result = eval(jsonData);
-```
-
-Instead, prefer safer, and faster, methods such as `JSON.parse()`
-
-```js
-const fetchValue = await fetch("https://api.example.com/data.json");
-const jsonData = await fetchValue.json();
-// JSON.parse does not evaluate the attacker's scripts.
-const result = JSON.parse(jsonData);
-```
-
 ## Use content scripts carefully {: #content_scripts }
 
 While [content scripts][11] live in an [isolated world][12], they are not immune from attacks:

--- a/site/en/docs/extensions/mv3/security/index.md
+++ b/site/en/docs/extensions/mv3/security/index.md
@@ -167,30 +167,19 @@ Avoid using `eval()` whenever possible to prevent attacks, as `eval()` will exec
 into it, which may be malicious.
 
 ```js
-var xhr = new fetch();
-xhr.open("GET", "https://api.example.com/data.json", true);
-xhr.onreadystatechange = function() {
-  if (xhr.readyState == 4) {
-    // WARNING! Might be evaluating an evil script!
-    var resp = eval("(" + xhr.responseText + ")");
-    ...
-  }
-}
-xhr.send();
+const fetchValue = await fetch("https://api.example.com/data.json");
+const jsonData = await fetchValue.json();
+// WARNING! Might be evaluating an evil script!
+const result = eval(jsonData);
 ```
 
 Instead, prefer safer, and faster, methods such as `JSON.parse()`
 
 ```js
-var xhr = new fetch();
-xhr.open("GET", "https://api.example.com/data.json", true);
-xhr.onreadystatechange = function() {
-  if (xhr.readyState == 4) {
-    // JSON.parse does not evaluate the attacker's scripts.
-    var resp = JSON.parse(xhr.responseText);
-  }
-}
-xhr.send();
+const fetchValue = await fetch("https://api.example.com/data.json");
+const jsonData = await fetchValue.json();
+// JSON.parse does not evaluate the attacker's scripts.
+const result = JSON.parse(jsonData);
 ```
 
 ## Use content scripts carefully {: #content_scripts }

--- a/site/en/docs/extensions/mv3/security/index.md
+++ b/site/en/docs/extensions/mv3/security/index.md
@@ -40,6 +40,11 @@ Limiting an extensions privileges limits what a potential attacker can exploit.
 
 ### Cross-origin fetch() {: #xhr }
 
+{% Aside 'warning' %}
+In Manifest V3, `XMLHttpRequest` is not supported in Service Workers.
+Please consider using its modern replacement, `fetch()`.
+{% endAside %}
+
 An extension can only use `fetch()` or [XMLHttpRequest][6] to get resources from itself and from domains
 specified in the permissions.
 

--- a/site/en/docs/extensions/mv3/security/index.md
+++ b/site/en/docs/extensions/mv3/security/index.md
@@ -38,9 +38,9 @@ websites they depend on. Arbitrary code should be kept to a minimum.
 
 Limiting an extensions privileges limits what a potential attacker can exploit.
 
-### Cross-origin XMLHttpRequest {: #xhr }
+### Cross-origin fetch() {: #xhr }
 
-An extension can only use [XMLHttpRequest][6] to get resources from itself and from domains
+An extension can only use `fetch()` or [XMLHttpRequest][6] to get resources from itself and from domains
 specified in the permissions.
 
 ```json
@@ -162,7 +162,7 @@ Avoid using `eval()` whenever possible to prevent attacks, as `eval()` will exec
 into it, which may be malicious.
 
 ```js
-var xhr = new XMLHttpRequest();
+var xhr = new fetch();
 xhr.open("GET", "https://api.example.com/data.json", true);
 xhr.onreadystatechange = function() {
   if (xhr.readyState == 4) {
@@ -177,7 +177,7 @@ xhr.send();
 Instead, prefer safer, and faster, methods such as `JSON.parse()`
 
 ```js
-var xhr = new XMLHttpRequest();
+var xhr = new fetch();
 xhr.open("GET", "https://api.example.com/data.json", true);
 xhr.onreadystatechange = function() {
   if (xhr.readyState == 4) {

--- a/site/en/docs/extensions/mv3/security/index.md
+++ b/site/en/docs/extensions/mv3/security/index.md
@@ -46,8 +46,7 @@ Use its modern replacement, `fetch()`.
 {% endAside %}
 
 An extension can only use `fetch()` or [XMLHttpRequest][6] to get resources from itself and from domains
-specified in the permissions.
-
+specified in the permissions, as both API's use the same [fetch handler][27] in the service worker.
 ```json
 {
   "name": "Very Secure Extension",
@@ -251,4 +250,4 @@ function sanitizeInput(input) {
 [24]: /docs/extensions/reference/runtime#type-MessageSender
 [25]: /docs/extensions/mv3/content_scripts
 [26]: /docs/extensions/mv3/security#avoid
-
+[27]: https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent/handled

--- a/site/en/docs/extensions/mv3/security/index.md
+++ b/site/en/docs/extensions/mv3/security/index.md
@@ -41,8 +41,8 @@ Limiting an extensions privileges limits what a potential attacker can exploit.
 ### Cross-origin fetch() {: #xhr }
 
 {% Aside 'warning' %}
-In Manifest V3, `XMLHttpRequest` is not supported in Service Workers.
-Please consider using its modern replacement, `fetch()`.
+`XMLHttpRequest()` is not supported in Service Workers.
+Use its modern replacement, `fetch()`.
 {% endAside %}
 
 An extension can only use `fetch()` or [XMLHttpRequest][6] to get resources from itself and from domains

--- a/site/en/docs/extensions/reference/webRequest/index.md
+++ b/site/en/docs/extensions/reference/webRequest/index.md
@@ -180,7 +180,7 @@ permissions][9]. Moreover, only the following schemes are accessible: `http://`,
 `chrome-extension://`. In addition, even certain requests with URLs using one of the above schemes
 are hidden. These include `chrome-extension://other_extension_id` where `other_extension_id` is not
 the ID of the extension to handle the request, `https://www.google.com/chrome`, and other sensitive
-requests core to browser functionality. Also synchronous `fetch()` requests from your extension are
+requests core to browser functionality. Also synchronous XMLHttpRequests from your extension are
 hidden from blocking event handlers in order to prevent deadlocks. Note that for some of the
 supported schemes the set of available events might be limited due to the nature of the
 corresponding protocol. For example, for the file: scheme, only `onBeforeRequest`,

--- a/site/en/docs/extensions/reference/webRequest/index.md
+++ b/site/en/docs/extensions/reference/webRequest/index.md
@@ -180,7 +180,7 @@ permissions][9]. Moreover, only the following schemes are accessible: `http://`,
 `chrome-extension://`. In addition, even certain requests with URLs using one of the above schemes
 are hidden. These include `chrome-extension://other_extension_id` where `other_extension_id` is not
 the ID of the extension to handle the request, `https://www.google.com/chrome`, and other sensitive
-requests core to browser functionality. Also synchronous XMLHttpRequests from your extension are
+requests core to browser functionality. Also synchronous `fetch()` requests from your extension are
 hidden from blocking event handlers in order to prevent deadlocks. Note that for some of the
 supported schemes the set of available events might be limited due to the nature of the
 corresponding protocol. For example, for the file: scheme, only `onBeforeRequest`,


### PR DESCRIPTION
Fixes (https://github.com/GoogleChromeLabs/Extension-Docs/issues/45)

Changes proposed in this pull request:

- Replaces the use of XMLHttpRequest to fetch() in sample code blocks.