### PR TITLE
[ext-doc] Update sidePanel aside

### DIFF
--- a/site/en/docs/extensions/reference/sidePanel/index.md
+++ b/site/en/docs/extensions/reference/sidePanel/index.md
@@ -3,7 +3,7 @@ api: sidePanel
 ---
 
 {% Aside 'important' %}
-The Side Panel API is currently available in [Chrome Canary](https://www.google.com/chrome/canary/).
+The Side Panel API is currently available in [Chrome Beta 114](https://www.google.com/chrome/beta/).
 {% endAside %}
 
 ## Overview {: #overview }


### PR DESCRIPTION
The `"side_panel"` manifest key is now working on Chrome 114. This PR updates the aside.