### PR TITLE
Update Third-Party Storage Partitioning Deprecation Trials

### DIFF
--- a/site/en/blog/storage-partitioning-deprecation-trial/index.md
+++ b/site/en/blog/storage-partitioning-deprecation-trial/index.md
@@ -97,7 +97,7 @@ Example:
 Sites should audit their usage of unpartitioned storage, service worker, and
 communication APIs in third-party contexts, and, if needed, prepare for
 third-party partitioning before these deprecation trials expire. **The intent is
-to expire these deprecation trials with the release of Chrome 127 on August 6, 2024.**
+to expire these deprecation trials with the release of Chrome 127 on September 3, 2024.**
 
 To instruct the browser to unpartition storage in third-party content embedded
 on its pages, top-level sites need to register for one or both of the

--- a/site/en/blog/storage-partitioning-deprecation-trial/index.md
+++ b/site/en/blog/storage-partitioning-deprecation-trial/index.md
@@ -31,7 +31,7 @@ This trial is available due to a need for some sites to migrate their Firebase
 
 ## Available deprecation trials
 
-Starting in [Chrome 112 Beta](https://chromiumdash.appspot.com/schedule), we'll
+Starting in [Chrome 115](https://chromiumdash.appspot.com/schedule), we'll
 open up two deprecation trials:
 
 1.  [`DisableThirdPartyStoragePartitioning`](/origintrials/#/view_trial/-8517432795264450559):
@@ -113,7 +113,7 @@ The following is a brief overview of how to participate in one or both of the
 deprecation trials. For more detailed instructions, visit
 [Get started with origin trials](/docs/web-platform/origin-trials).
 
-1.  Launch Chrome version 112 (or later) and ensure the
+1.  Launch Chrome version 115 (or later) and ensure the
     [`ThirdPartyStoragePartitioning`](/blog/storage-partitioning-dev-trial/)
     flag is enabled.
 1.  Verify that the behavior of third-party content embedded in your
@@ -130,7 +130,7 @@ deprecation trials. For more detailed instructions, visit
 1.  Add an origin trial token to your page:
     1. For the `DisableThirdPartySessionStoragePartitioningAfterGeneralPartitioning` trial you may add an `Origin-Trial: <DEPRECATION TRIAL TOKEN>` to         your top-level site’s HTTP response header, where `<DEPRECATION TRIAL TOKEN>` contains the token you got when registering for the deprecation             trial. You can also do this via HTML `<meta> tag.
     1. For the `DisableThirdPartyStoragePartitioning` trial, the token must be given via an HTML `<meta>` tag. The HTTP header method is not supported.
-1.  Load your website in Chrome 112 Beta (or later) with
+1.  Load your website in Chrome 115 (or later) with
     `ThirdPartyStoragePartitioning` still enabled and verify that any
     partitioning related issues have been properly mitigated.
 1.  To stop participating in the deprecation trial simply remove the header

--- a/site/en/blog/storage-partitioning-deprecation-trial/index.md
+++ b/site/en/blog/storage-partitioning-deprecation-trial/index.md
@@ -142,7 +142,7 @@ feature, but the third-party script injecting the token must be evaluated in the
 top-level frame before the third-party iframe that won't have partitioning applied
 is loaded. The `DisableThirdPartySessionStoragePartitioningAfterGeneralPartitioning`
 deprecation trial does not support third-party origin trials as the enrollee
-must have been the top-level site at some point in the lifetime of  given tab. The guide to
+must have been the top-level site at some point in the lifetime of the given tab. The guide to
 [troubleshooting Chrome's origin trials](/docs/web-platform/origin-trial-troubleshooting/)
 provides a full checklist for ensuring your token is correctly configured.
 

--- a/site/en/blog/storage-partitioning-deprecation-trial/index.md
+++ b/site/en/blog/storage-partitioning-deprecation-trial/index.md
@@ -7,6 +7,7 @@ authors:
   - arichiv
   - kyraseevers
 date: 2023-03-09
+updated: 2023-05-16
 tags:
   - privacy
 ---
@@ -96,7 +97,7 @@ Example:
 Sites should audit their usage of unpartitioned storage, service worker, and
 communication APIs in third-party contexts, and, if needed, prepare for
 third-party partitioning before these deprecation trials expire. **The intent is
-to expire these deprecation trials with Chrome 123, ending on May 2, 2024.**
+to expire these deprecation trials with the release of Chrome 127 on August 6, 2024.**
 
 To instruct the browser to unpartition storage in third-party content embedded
 on its pages, top-level sites need to register for one or both of the
@@ -135,13 +136,13 @@ deprecation trials. For more detailed instructions, visit
 1.  To stop participating in the deprecation trial simply remove the header
     you added in step 2.
 
-These deprecation trials do not support the
+The `DisableThirdPartyStoragePartitioning` deprecation trial does support the
 [third-party origin trials](/docs/web-platform/third-party-origin-trials/)
-feature. The enrollee must be the top-level site for
-`DisableThirdPartyStoragePartitioning`, and for
-`DisableThirdPartySessionStoragePartitioningAfterGeneralPartitioning` the
-enrollee must have been the top-level site at some point in the lifetime of a
-given tab. The guide to
+feature, but the third-party script injecting the token must be evaluated in the
+top-level frame before the third-party iframe that won't have partitioning applied
+is loaded. The `DisableThirdPartySessionStoragePartitioningAfterGeneralPartitioning`
+deprecation trial does not support third-party origin trials as the engollee
+must have been the top-level site at some point in the lifetime of  given tab. The guide to
 [troubleshooting Chrome's origin trials](/docs/web-platform/origin-trial-troubleshooting/)
 provides a full checklist for ensuring your token is correctly configured.
 

--- a/site/en/blog/storage-partitioning-deprecation-trial/index.md
+++ b/site/en/blog/storage-partitioning-deprecation-trial/index.md
@@ -141,7 +141,7 @@ The `DisableThirdPartyStoragePartitioning` deprecation trial does support the
 feature, but the third-party script injecting the token must be evaluated in the
 top-level frame before the third-party iframe that won't have partitioning applied
 is loaded. The `DisableThirdPartySessionStoragePartitioningAfterGeneralPartitioning`
-deprecation trial does not support third-party origin trials as the engollee
+deprecation trial does not support third-party origin trials as the enrollee
 must have been the top-level site at some point in the lifetime of  given tab. The guide to
 [troubleshooting Chrome's origin trials](/docs/web-platform/origin-trial-troubleshooting/)
 provides a full checklist for ensuring your token is correctly configured.


### PR DESCRIPTION
Both will be extended until the release of Chrome 127 and one now supports third-party origin trial tokens.

Fixes https://bugs.chromium.org/p/chromium/issues/detail?id=1441411
