### PR TITLE
Update typo in brower-support/index.md

### DIFF
--- a/site/en/docs/android/custom-tabs/browser-support/index.md
+++ b/site/en/docs/android/custom-tabs/browser-support/index.md
@@ -534,7 +534,7 @@ Set whether the url bar should hide as the user scrolls down on the page.
 
 ### setEngagementSignalsCallback()
 
-Sets an `[EngagementSignalsCallback](https://developer.android.com//reference/androidx/browser/customtabs/EngagementSignalsCallback)` to receive callbacks for events related to the user's engagement with webpage within the tab.
+Sets an [`EngagementSignalsCallback`](https://developer.android.com//reference/androidx/browser/customtabs/EngagementSignalsCallback) to receive callbacks for events related to the user's engagement with webpage within the tab.
 
 {% AndroidBrowserSupportTable
  _method="setEngagementSignalsCallback",


### PR DESCRIPTION
I also found that there's a tiny bitty error for the documentation for the image being used for https://developer.chrome.com/docs/android/custom-tabs/browser-support/#setclosebuttonposition (mistakenly used the same image as the previous) but not sure how I should change it.

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:
* Fix the markdown format for the link to EngagementSignalsCallback
-
-
-