### PR TITLE
Add report verification information for Private Aggregation

### DIFF
--- a/site/en/_partials/privacy-sandbox/timeline/private-aggregation.md
+++ b/site/en/_partials/privacy-sandbox/timeline/private-aggregation.md
@@ -5,5 +5,7 @@
     * Chrome Stable M112+
   * The `reportContributionForEvent()` function is available in
     * Chrome Canary and Dev M113+
+  * Supplying a context ID via Shared Storage for report verification is available in
+    * Chrome Canary, Dev, Beta, and Stable M114+
   * See the [Privacy Sandbox origin trial](/docs/privacy-sandbox/unified-origin-trial/#status) page to see the latest traffic allocation
 * See the [Chrome platform status page](https://chromestatus.com/feature/5743412790689792) page to see the API’s current stage.

--- a/site/en/_partials/privacy-sandbox/timeline/shared-storage-features.md
+++ b/site/en/_partials/privacy-sandbox/timeline/shared-storage-features.md
@@ -21,6 +21,6 @@
     <td>Prevent invalid Private Aggregation API reports with report verification for Shared Storage</br>
       <a href="https://github.com/patcg-individual-drafts/private-aggregation-api/blob/main/report_verification.md">Explainer</a>
     </td>
-    <td>Expected in Chrome for origin trial in Q2 2023</td>
+    <td>Available for origin trial in Q2 2023</td>
   </tr>
 </table>

--- a/site/en/docs/privacy-sandbox/private-aggregation/index.md
+++ b/site/en/docs/privacy-sandbox/private-aggregation/index.md
@@ -193,6 +193,11 @@ privateAggregation.enableDebugMode({ debug_key: BigInt(1234) });
 
 Within FLEDGE worklets only, we provide a trigger-based mechanism for sending a report only if a certain event occurs. This function also allows for the bucket and value to depend on signals that are not yet available at that point in the auction (for example, the value of the winning bid in `generateBid()`). More detail is available in the [explainer](https://github.com/WICG/turtledove/blob/main/FLEDGE_extended_PA_reporting.md).
 
+## Report verification
+For Shared Storage, you can verify the aggregatable reports you received are legitimate by [adding a context ID](https://github.com/patcg-individual-drafts/private-aggregation-api/blob/main/report_verification.md#shared-storage) to the shared storage operation call.  The ID will be attached to the sent report, and at a later time, you can use that ID to verify that the report was sent from your shared storage operation. The feature is available for testing in Chrome M114+. Report verification for the Protected Audience API is not yet available for testing, 
+
+To learn more, see the [report verification explainer](https://github.com/patcg-individual-drafts/private-aggregation-api/blob/main/report_verification.md#shared-storage). 
+
 ## Engage and share feedback
 
 The Private Aggregation API proposal is under active discussion and subject to change in the future. If you try this API and have feedback, we'd love to hear it.

--- a/site/en/docs/privacy-sandbox/private-aggregation/index.md
+++ b/site/en/docs/privacy-sandbox/private-aggregation/index.md
@@ -194,7 +194,10 @@ privateAggregation.enableDebugMode({ debug_key: BigInt(1234) });
 Within FLEDGE worklets only, we provide a trigger-based mechanism for sending a report only if a certain event occurs. This function also allows for the bucket and value to depend on signals that are not yet available at that point in the auction (for example, the value of the winning bid in `generateBid()`). More detail is available in the [explainer](https://github.com/WICG/turtledove/blob/main/FLEDGE_extended_PA_reporting.md).
 
 ## Report verification
-For Shared Storage, you can verify the aggregatable reports you received are legitimate by [adding a context ID](https://github.com/patcg-individual-drafts/private-aggregation-api/blob/main/report_verification.md#shared-storage) to the shared storage operation call.  The ID will be attached to the sent report, and at a later time, you can use that ID to verify that the report was sent from your shared storage operation. The feature is available for testing in Chrome M114+. Report verification for the Protected Audience API is not yet available for testing, 
+
+For Shared Storage, you can verify the aggregatable reports you received are legitimate by [adding a context ID](https://github.com/patcg-individual-drafts/private-aggregation-api/blob/main/report_verification.md#shared-storage) to the shared storage operation call. The ID will be attached to the sent report, and at a later time, you can use that ID to verify that the report was sent from your shared storage operation.
+
+The feature is available for testing in Chrome M114+. Report verification for the Protected Audience API is not yet available for testing.
 
 To learn more, see the [report verification explainer](https://github.com/patcg-individual-drafts/private-aggregation-api/blob/main/report_verification.md#shared-storage). 
 


### PR DESCRIPTION
This PR adds the information about context ID in Private Aggregation which can be used to verify a report.

Preview links: 
* Private aggregation: https://pr-6320-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/private-aggregation#report-verification
* Private aggregation status: https://pr-6320-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/status/#private-aggregation-api
* Shared storage status: https://pr-6320-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/status/#shared-storage