### PR TITLE
Updated prerender experiment to use prerender instead of prefetch

### DIFF
--- a/site/_includes/layouts/base.njk
+++ b/site/_includes/layouts/base.njk
@@ -61,7 +61,8 @@
                 }
               }
             ]
-          }
+          },
+          "eagerness": "moderate"
         }
       ]
     }

--- a/site/_includes/layouts/base.njk
+++ b/site/_includes/layouts/base.njk
@@ -17,7 +17,7 @@
     <link rel="preload" as="font" crossorigin href="/fonts/google-sans-v2003/regular/latin.woff2">
     <link rel="preload" as="font" crossorigin href="/fonts/google-sans-v2003/medium/latin.woff2">
 
-    
+
     {% block css %}{% endblock %}
 
     <script type="module" src="{{ helpers.hashForProd('/js/main.js') }}"></script>
@@ -46,7 +46,7 @@
     {# Exclude the /articles/ section as a control #}
     <script type="speculationrules">
     {
-      "prefetch": [
+      "prerender": [
         {
           "source": "document",
           "where": {


### PR DESCRIPTION
We are currently running an origin trial added in #5216 to test documentation rules to prefetch next navigations for performance reasons. We have collected data over the last few months and now want to do a full prerender, instead of just a prefetch, and collect more data on that.

We're also set the `eagerness` to `moderate` to allow it to happen on `hover` as well as `mousedown`. 

We have #5247 open to remind us to remove this origin trail after the experiment finishes (or the feature reaches stable - [currently scheduled for Chrome 115](https://chromestatus.com/feature/5112150536749056)).

Note: I'll be opening a similar request for web.dev