### PR TITLE
Improve cookie banner on desktop

### DIFF
--- a/site/_scss/blocks/_cookie-banner.scss
+++ b/site/_scss/blocks/_cookie-banner.scss
@@ -26,18 +26,8 @@
     margin-top: 0;
   }
 
-  @include media-query('md-max') {
-    > button {
-      margin-top: initial;
-    }
-
-    > *:last-child {
-      margin-left: get-size(300);
-    }
-  }
-
   > button {
-    margin-top: get-size(300);
-    min-width: 10rem;
+    margin-bottom: get-size(300);
+    min-width: 8rem;
   }
 }

--- a/site/_scss/blocks/_cookie-banner.scss
+++ b/site/_scss/blocks/_cookie-banner.scss
@@ -26,7 +26,18 @@
     margin-top: 0;
   }
 
-  > *:last-child {
-    margin-left: get-size(300);
+  @include media-query('md-max') {
+    > button {
+      margin-top: initial;
+    }
+
+    > *:last-child {
+      margin-left: get-size(300);
+    }
+  }
+
+  > button {
+    margin-top: get-size(300);
+    min-width: 10rem;
   }
 }


### PR DESCRIPTION
Desktop cookie banner looks a bit poor after #6321 :

<img width="547" alt="image" src="https://github.com/GoogleChrome/developer.chrome.com/assets/10931297/4b213409-e557-4c88-ad15-86dc852f75f9">
