### PR TITLE
Add PAA rename information for Protected Audience

### DIFF
--- a/site/en/_partials/privacy-sandbox/timeline/private-aggregation.md
+++ b/site/en/_partials/privacy-sandbox/timeline/private-aggregation.md
@@ -1,3 +1,13 @@
+{% Aside 'update' %}
+To reflect the [Protected Audience name change](https://privacysandbox.com/intl/en_us/news/protected-audience-api-our-new-name-for-fledge), the Private Aggregation API will contain the following breaking changes in the M115 Stable release:
+1. The reporting endpoint is changed from `/.well-known/private-aggregation/report-fledge` to `/.well-known/private-aggregation/report-protected-audience`
+2. The `api` property value of the aggregatable report payload is changed from `fledge` to `protected-audience`
+
+You must update your code to ensure that the Private Aggregation API continues to work with the Protected Audience API. Users in an outdated Chrome instance will still send their report to the legacy endpoint, so you should ensure backward compatibility to collect all reports. 
+
+The new endpoint and `api` property value will be available for testing on Monday, May 22nd in M115 Canary and Dev channels.
+{% endAside %}
+
 * The [Private Aggregation API](https://github.com/patcg-individual-drafts/private-aggregation-api/) has entered [public discussion](https://github.com/patcg-individual-drafts/private-aggregation-api/issues).
 * The Private Aggregation API is available for testing in the [Privacy Sandbox Unified Origin Trial](/docs/privacy-sandbox/unified-origin-trial/).
   * The `sendHistogramReport()` function is available in 

--- a/site/en/docs/privacy-sandbox/private-aggregation-fundamentals/index.md
+++ b/site/en/docs/privacy-sandbox/private-aggregation-fundamentals/index.md
@@ -162,11 +162,11 @@ For testing purposes, the “Send Selected Reports” button can be used to send
 The browser sends the aggregatable reports to the origin of the worklet containing the call to the Private Aggregation API, using the listed well-known path:
 
 *   For Shared Storage: `/.well-known/private-aggregation/report-shared-storage`
-*   For FLEDGE: `/.well-known/private-aggregation/report-fledge`
+*   For Protected Audience: `/.well-known/private-aggregation/report-protected-audience`
 
 At these endpoints, you will need to operate a server — acting as a collector — that receives the aggregatable reports sent from the clients.
 
-The server should then batch reports and send the batch to the Aggregation Service.  Create batches based on the information available in the unencrypted payload of the aggregatable report, such as the `shared\_info` field. Ideally, the batches should contain 100 or more reports per batch. 
+The server should then batch reports and send the batch to the Aggregation Service.  Create batches based on the information available in the unencrypted payload of the aggregatable report, such as the `shared_info` field. Ideally, the batches should contain 100 or more reports per batch. 
 
 You may decide to batch on a daily or weekly basis. This strategy is flexible, and you can change your batching strategy for specific events where you expect more volume—for example, days of the year when more impressions are expected. Batches should include reports from the same API version, reporting origin, and schedule report time. 
 

--- a/site/ja/docs/privacy-sandbox/private-aggregation-fundamentals/index.md
+++ b/site/ja/docs/privacy-sandbox/private-aggregation-fundamentals/index.md
@@ -138,7 +138,7 @@ Private Aggregation API に対する各呼び出しは*コントリビューシ�
 ブラウザーは、リスト化された well-known パスを使用して Private Aggregation API への呼び出しを含むワークレットのオリジンへと集計可能なレポートを送信します。
 
 - 共有ストレージの場合: `/.well-known/private-aggregation/report-shared-storage`
-- FLEDGE の場合: `/.well-known/private-aggregation/report-fledge`
+- Protected Audience の場合: `/.well-known/private-aggregation/report-protected-audience`
 
 これらのエンドポイントでは、クライアントから送信された集計可能なレポートを受信する (コレクターとして機能する) サーバーを運用する必要があります。
 


### PR DESCRIPTION
This PR lets the users know that PAA will be updated with the following changes: 
* the reporting endpoint will be updated from `fledge` to `protected-audience`
* the `api` property value will be updated from `fledge` to `protected-audience`

Preview: 
* Link: https://pr-6336-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/private-aggregation/#implementation-status