### PR TITLE
updating chrome apps deprecation announcement

### DIFF
--- a/site/_data/docs/apps/toc.yml
+++ b/site/_data/docs/apps/toc.yml
@@ -1,3 +1,4 @@
+- url: /docs/apps/migration
 - title: i18n.docs.apps.concepts
   sections:
     - url: /docs/apps/overview

--- a/site/en/docs/apps/index.md
+++ b/site/en/docs/apps/index.md
@@ -4,6 +4,8 @@ description: >
   Chrome Apps provided Chrome-specific APIs on top of 
   standardized web technologies to enable you to create experiences that
   had more access to the underlying operating system. They were
-  deprecated in 2020. Support for all platforms will end in June 2022.
+  deprecated in 2020. They are supported only for ChromeOS until Jan 2025.
+  [**Read the announcement**](https://blog.chromium.org/2021/10/extending-chrome-app-support-on-chrome.html) and learn
+more about [**migrating your app**](/apps/migration).
 layout: 'layouts/project-landing.njk'
 ---

--- a/site/en/docs/apps/index.md
+++ b/site/en/docs/apps/index.md
@@ -1,11 +1,12 @@
 ---
 title: Chrome Apps
 description: >
-  Chrome Apps provided Chrome-specific APIs on top of 
+  Chrome Apps provided Chrome-specific APIs on top of
   standardized web technologies to enable you to create experiences that
   had more access to the underlying operating system. They were
-  deprecated in 2020. They are supported only for ChromeOS until Jan 2025.
-  [**Read the announcement**](https://blog.chromium.org/2021/10/extending-chrome-app-support-on-chrome.html) and learn
-more about [**migrating your app**](/apps/migration).
+  deprecated in 2020. They are supported only for ChromeOS until Jan 2025. [**Read the announcement**][1] and learn more about [**migrating your app**][2].
 layout: 'layouts/project-landing.njk'
 ---
+
+[1]: https://blog.chromium.org/2021/10/extending-chrome-app-support-on-chrome.html
+[2]: /apps/migration

--- a/site/en/docs/apps/index.md
+++ b/site/en/docs/apps/index.md
@@ -4,9 +4,6 @@ description: >
   Chrome Apps provided Chrome-specific APIs on top of
   standardized web technologies to enable you to create experiences that
   had more access to the underlying operating system. They were
-  deprecated in 2020. They are supported only for ChromeOS until Jan 2025. [**Read the announcement**][1] and learn more about [**migrating your app**][2].
+  deprecated in 2020. They are supported only for ChromeOS until Jan 2025.
 layout: 'layouts/project-landing.njk'
 ---
-
-[1]: https://blog.chromium.org/2021/10/extending-chrome-app-support-on-chrome.html
-[2]: /apps/migration


### PR DESCRIPTION
Got a request to update the notice for the ChromeOS exception (it will support chrome apps until Jan 2025, not June 2022) and also to add a link to the transition documentation on the home page. (added as the first link)