### PR TITLE
Add Protected Audience API walkthrough doc 

### DIFF
--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -74,6 +74,8 @@
             - url: /docs/privacy-sandbox/fledge-api/reports
             - url: /docs/privacy-sandbox/fledge-api/troubleshoot
         - url: /docs/privacy-sandbox/fledge-api/feature-status
+        - url: https://docs.google.com/document/d/16U6nCs5-RTpYDF5nuUVopvUXKzDgH6yDKaYbzY3ouiI/view
+          title: i18n.docs.privacy-sandbox.paapi-walkthrough
     - title: i18n.docs.privacy-sandbox.content-selection
       sections:
         - url: /docs/privacy-sandbox/shared-storage/content-selection

--- a/site/_data/i18n/docs/privacy-sandbox.yml
+++ b/site/_data/i18n/docs/privacy-sandbox.yml
@@ -125,3 +125,5 @@ fenced-frame:
   en: 'Fenced Frames'
 fledge-api:
   en: 'Developer guide'
+paapi-walkthrough:
+  en: 'Protected Audience API walkthrough'


### PR DESCRIPTION
This PR adds the Protected Audience API walkthrough doc to the sidebar menu for Privacy Sandbox

Preview link: https://pr-6368-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/#show-relevant-content