### PR TITLE
Rename @initial to @starting-style

### DIFF
--- a/site/en/blog/whats-new-css-ui-2023/index.md
+++ b/site/en/blog/whats-new-css-ui-2023/index.md
@@ -595,13 +595,13 @@ In order for all of this to transition popovers in and out smoothly, the web nee
 
 As a part of the work to enable nice transitions for popovers, selectmenus, and even existing elements like dialogs or custom components, browsers are enabling new plumbing to support these animations.
 
-The following popover demo, animates popovers in and out using `:popover-open` for the open state, `@initial` for the before-open state, and applies a transform value to the element directly for the after-open-is-closed state. To make this all work with display, it needs adding to the `transition` property, like so:
+The following popover demo, animates popovers in and out using `:popover-open` for the open state, `@starting-style` for the before-open state, and applies a transform value to the element directly for the after-open-is-closed state. To make this all work with display, it needs adding to the `transition` property, like so:
 
 ```css
 .settings-popover {
   &:popover-open {
     /*   0. before-change   */
-    @initial {
+    @starting-style {
       transform: translateY(20px);
       opacity: 0;
     }
@@ -630,10 +630,6 @@ The following popover demo, animates popovers in and out using `:popover-open` f
   height: 500,
   tab: 'result'
 } %}
-
-{% Aside 'caution' %}
-This is currently an experimental API, and the syntax for `@initial` might change before going stable.
-{% endAside %}
 
 ## Interactions
 


### PR DESCRIPTION
The CSSWG is [as good as resolved](https://github.com/w3c/csswg-drafts/issues/8174#issuecomment-1558702524) on renaming `@initial` to `@starting-style`. Chrome Canary [landed the rename just yesterday](https://chromium-review.googlesource.com/c/chromium/src/+/4474048).

This seems like a good time to update the blog post as well, to have it reflect what is available in Chrome Canary. The embedded demo has been updated too.