### PR TITLE
Commands reference page mv2 cleanup

### DIFF
--- a/site/en/docs/extensions/reference/commands/index.md
+++ b/site/en/docs/extensions/reference/commands/index.md
@@ -134,8 +134,7 @@ chrome.commands.onCommand.addListener((command) => {
 
 ### Action commands
 
-The `_execute_action` command is reserved for triggering your action,
-it does not dispatch [`command.onCommand`][event-oncommand] events as do standard commands.
+The `_execute_action` (Manifest V3), `_execute_browser_action` (Manifest V2), and `_execute_page_action` (Manifest V2) commands are reserved for the action of trigger your action, browser action, or page action respectively. These commands do not dispatch [command.onCommand][event-oncommand] events like standard commands.
 
 If you need to take action based on your popup opening, consider listening for a
 [DOMContentLoaded][html-dcl] event inside your popup's JavaScript.

--- a/site/en/docs/extensions/reference/commands/index.md
+++ b/site/en/docs/extensions/reference/commands/index.md
@@ -94,6 +94,8 @@ Key combinations that involve `Ctrl+Alt` are not permitted in order to avoid con
 
 ### Handling command events
 
+{% Label %}manifest.json:{% endLabel %}
+
 ```json
 {
   "name": "My extension",
@@ -121,6 +123,8 @@ Key combinations that involve `Ctrl+Alt` are not permitted in order to avoid con
 
 In your service worker, you can bind a handler to each of the commands defined in the manifest
 using `onCommand.addListener`. For example:
+
+{% Label %}service-worker.js:{% endLabel %}
 
 ```js
 chrome.commands.onCommand.addListener((command) => {
@@ -158,6 +162,8 @@ at `chrome://extensions/shortcuts`.
 
 Example:
 
+{% Label %}manifest.json:{% endLabel %}
+
 ```json
 {
   "name": "My extension",
@@ -185,8 +191,9 @@ Commands allow extensions to map logic to keyboard shortcuts that can be invoked
 most basic, a command only requires a command declaration in the extension's manifest and a listener
 registration as shown in the following example.
 
+{% Label %}manifest.json:{% endLabel %}
+
 ```json
-// manifest.json
 {
   "name": "Command demo - basic",
   "version": "1.0",
@@ -203,8 +210,9 @@ registration as shown in the following example.
 }
 ```
 
+{% Label %}service-worker.js:{% endLabel %}
+
 ```js
-// service-worker.js
 chrome.commands.onCommand.addListener((command) => {
   console.log(`Command "${command}" triggered`);
 });
@@ -217,8 +225,9 @@ action. The following example injects a content script that shows an
 alert on the current page when the user either clicks the extension's action or triggers the
 keyboard shortcut.
 
+{% Label %}manifest.json:{% endLabel %}
+
 ```json
-// manifest.json
 {
   "name": "Commands demo - action invocation",
   "version": "1.0",
@@ -238,9 +247,9 @@ keyboard shortcut.
   }
 }
 ```
+{% Label %}service-worker.js:{% endLabel %}
 
 ```js
-// service-worker.js
 chrome.action.onClicked.addListener((tab) => {
   chrome.scripting.executeScript({
     target: {tabId: tab.id},
@@ -272,8 +281,9 @@ of commands returned by `commands.getAll()`.
 
 {% endAside %}
 
+{% Label %}service-worker.js:{% endLabel %}
+
 ```js
-// service-worker.js
 chrome.runtime.onInstalled.addListener((reason) => {
   if (reason === chrome.runtime.OnInstalledReason.INSTALL) {
     checkCommandShortcuts();

--- a/site/en/docs/extensions/reference/commands/index.md
+++ b/site/en/docs/extensions/reference/commands/index.md
@@ -213,7 +213,7 @@ chrome.commands.onCommand.addListener((command) => {
 ### Action command
 
 As described in the [Usage][header-usage] section, you can also map a command to an extension's
-action, browser action, or page action. The following example injects a content script that shows an
+action. The following example injects a content script that shows an
 alert on the current page when the user either clicks the extension's action or triggers the
 keyboard shortcut.
 

--- a/site/en/docs/extensions/reference/commands/index.md
+++ b/site/en/docs/extensions/reference/commands/index.md
@@ -135,7 +135,7 @@ chrome.commands.onCommand.addListener((command) => {
 ### Action commands
 
 The `_execute_action` command is reserved for triggering your action,
-it does not dispatch [`command.onCommand`][event-oncommand] events like standard commands.
+it does not dispatch [`command.onCommand`][event-oncommand] events as do standard commands.
 
 If you need to take action based on your popup opening, consider listening for a
 [DOMContentLoaded][html-dcl] event inside your popup's JavaScript.

--- a/site/en/docs/extensions/reference/commands/index.md
+++ b/site/en/docs/extensions/reference/commands/index.md
@@ -2,10 +2,6 @@
 api: commands
 ---
 
-## Manifest
-
-You must have a `"manifest_version"` of at least `2` to use this API.
-
 ## Usage
 
 The Commands API allows extension developers to define specific commands, and bind them to a default
@@ -123,7 +119,7 @@ Key combinations that involve `Ctrl+Alt` are not permitted in order to avoid con
 }
 ```
 
-In your background page, you can bind a handler to each of the commands defined in the manifest
+In your service worker, you can bind a handler to each of the commands defined in the manifest
 using `onCommand.addListener`. For example:
 
 ```js
@@ -134,10 +130,8 @@ chrome.commands.onCommand.addListener((command) => {
 
 ### Action commands
 
-The `_execute_action` (Manifest V3), `_execute_browser_action` (Manifest V2), and
-`_execute_page_action` (Manifest V2) commands are reserved for the action of trigger your action,
-browser action, or page action respectively. These commands do not dispatch
-[command.onCommand][event-oncommand] events like standard commands.
+The `_execute_action` command is reserved for triggering your action,
+it does not dispatch [command.onCommand][event-oncommand] events like standard commands.
 
 If you need to take action based on your popup opening, consider listening for a
 [DOMContentLoaded][html-dcl] event inside your popup's JavaScript.
@@ -198,7 +192,7 @@ registration as shown in the following example.
   "version": "1.0",
   "manifest_version": 3,
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "service-worker.js"
   },
   "commands": {
     "inject-script": {
@@ -210,7 +204,7 @@ registration as shown in the following example.
 ```
 
 ```js
-// background.js
+// service-worker.js
 chrome.commands.onCommand.addListener((command) => {
   console.log(`Command "${command}" triggered`);
 });
@@ -230,7 +224,7 @@ keyboard shortcut.
   "version": "1.0",
   "manifest_version": 3,
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "service-worker.js"
   },
   "permissions": ["activeTab", "scripting"],
   "action": {},
@@ -246,7 +240,7 @@ keyboard shortcut.
 ```
 
 ```js
-// background.js
+// service-worker.js
 chrome.action.onClicked.addListener((tab) => {
   chrome.scripting.executeScript({
     target: {tabId: tab.id},
@@ -279,7 +273,7 @@ of commands returned by `commands.getAll()`.
 {% endAside %}
 
 ```js
-// background.js
+// service-worker.js
 chrome.runtime.onInstalled.addListener((reason) => {
   if (reason === chrome.runtime.OnInstalledReason.INSTALL) {
     checkCommandShortcuts();

--- a/site/en/docs/extensions/reference/commands/index.md
+++ b/site/en/docs/extensions/reference/commands/index.md
@@ -131,7 +131,7 @@ chrome.commands.onCommand.addListener((command) => {
 ### Action commands
 
 The `_execute_action` command is reserved for triggering your action,
-it does not dispatch [command.onCommand][event-oncommand] events like standard commands.
+it does not dispatch [`command.onCommand`][event-oncommand] events like standard commands.
 
 If you need to take action based on your popup opening, consider listening for a
 [DOMContentLoaded][html-dcl] event inside your popup's JavaScript.

--- a/site/en/docs/extensions/reference/commands/index.md
+++ b/site/en/docs/extensions/reference/commands/index.md
@@ -134,7 +134,10 @@ chrome.commands.onCommand.addListener((command) => {
 
 ### Action commands
 
-The `_execute_action` (Manifest V3), `_execute_browser_action` (Manifest V2), and `_execute_page_action` (Manifest V2) commands are reserved for the action of trigger your action, browser action, or page action respectively. These commands do not dispatch [command.onCommand][event-oncommand] events like standard commands.
+The `_execute_action` (Manifest V3), `_execute_browser_action` (Manifest V2), and
+`_execute_page_action` (Manifest V2) commands are reserved for the action of trigger your action,
+browser action, or page action respectively. These commands do not dispatch
+[command.onCommand][event-oncommand] events like standard commands.
 
 If you need to take action based on your popup opening, consider listening for a
 [DOMContentLoaded][html-dcl] event inside your popup's JavaScript.


### PR DESCRIPTION
Fixes https://github.com/GoogleChromeLabs/Extension-Docs/issues/84

Changes proposed in this pull request:

- Modernizes mv2 terminology out of the commands reference page.