### PR TITLE
Remove a redundant calc() from popover explainer

### DIFF
--- a/site/en/blog/introducing-popover-api/index.md
+++ b/site/en/blog/introducing-popover-api/index.md
@@ -224,7 +224,7 @@ You set up an anchor by giving it an `id` (in this example, `#menu-toggle`), and
 
 ```css
 #menu-items {
-  bottom: calc(anchor(bottom));
+  bottom: anchor(bottom);
   left: anchor(center);
   translate: -50% 0;
 }


### PR DESCRIPTION
Remove a redundant calc() from popover explainer

@una 