### PR TITLE
Embed relevant Google I/O session in linear() article

### DIFF
--- a/site/en/articles/css-linear-easing-function/index.md
+++ b/site/en/articles/css-linear-easing-function/index.md
@@ -15,6 +15,8 @@ tags:
   - chrome-113
 ---
 
+{% YouTube id="oDcb3fvtETs", startTime="704" %}
+
 ## Easings in CSS
 
 When animating or transitioning elements in CSS, you control the rate at which a value changes with an easing function using the `animation-timing-function` and `transition-timing-function` properties.


### PR DESCRIPTION
Uh, forgot to add the relevant video to [the `linear()` article](https://developer.chrome.com/articles/css-linear-easing-function/): https://www.youtube.com/watch?v=oDcb3fvtETs&t=704s