### PR TITLE
docs imply that you can get the value in the storage.set promise fulfillment. you can't.

### DIFF
--- a/site/en/docs/extensions/reference/storage/index.md
+++ b/site/en/docs/extensions/reference/storage/index.md
@@ -84,7 +84,7 @@ The following samples demonstrate the `local`, `sync`, and
 
   ```js
   chrome.storage.local.set({ key: value }).then(() => {
-    console.log("Value is set to " + value);
+    console.log("Value is set");
   });
 
   chrome.storage.local.get(["key"]).then((result) => {
@@ -97,7 +97,7 @@ The following samples demonstrate the `local`, `sync`, and
 
   ```js
   chrome.storage.sync.set({ key: value }).then(() => {
-    console.log("Value is set to " + value);
+    console.log("Value is set");
   });
 
   chrome.storage.sync.get(["key"]).then((result) => {
@@ -110,7 +110,7 @@ The following samples demonstrate the `local`, `sync`, and
 
   ```js
   chrome.storage.session.set({ key: value }).then(() => {
-    console.log("Value is set to " + value);
+    console.log("Value was set");
   });
 
   chrome.storage.session.get(["key"]).then((result) => {


### PR DESCRIPTION
[docs](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/set#return_value). `Value`, as currently used, is `undefined`