### PR TITLE
Add breaking changes information for PAA

### DIFF
--- a/site/en/_partials/privacy-sandbox/timeline/private-aggregation.md
+++ b/site/en/_partials/privacy-sandbox/timeline/private-aggregation.md
@@ -1,10 +1,10 @@
 {% Aside 'update' %}
 The Private Aggregation API will contain the following breaking changes in the M115 Beta and Stable releases:
-1. The `sendHistogramReport()` function is renamed to `contributeToHistogram()`
-2. The `reportContributionForEvent()` function is renamed to `contributeToHistogramOnEvent()`
+1. The `sendHistogramReport()` function is renamed to `contributeToHistogram()`.
+2. The `reportContributionForEvent()` function is renamed to `contributeToHistogramOnEvent()`.
 3. `enableDebugMode()`’s `debug_key` parameter is renamed to `debugKey`.
-4. The reporting endpoint is renamed from `/.well-known/private-aggregation/report-fledge` to `/.well-known/private-aggregation/report-protected-audience`
-5. The `api` property value of the aggregatable report payload is renamed from `fledge` to `protected-audience` 
+4. The reporting endpoint is renamed from `/.well-known/private-aggregation/report-fledge` to `/.well-known/private-aggregation/report-protected-audience`.
+5. The `api` property value of the aggregatable report payload is renamed from `fledge` to `protected-audience`. 
 
 You must update your code to ensure that the Private Aggregation API continues to work with the Protected Audience API. Users in an outdated Chrome instance will still send their report to the legacy endpoint, so you should ensure backward compatibility to collect all reports. We recommend using feature detection with `if ('contributeToHistogram' in privateAggregation))`.
 

--- a/site/en/_partials/privacy-sandbox/timeline/private-aggregation.md
+++ b/site/en/_partials/privacy-sandbox/timeline/private-aggregation.md
@@ -1,11 +1,14 @@
 {% Aside 'update' %}
-To reflect the [Protected Audience name change](https://privacysandbox.com/intl/en_us/news/protected-audience-api-our-new-name-for-fledge), the Private Aggregation API will contain the following breaking changes in the M115 Stable release:
-1. The reporting endpoint is changed from `/.well-known/private-aggregation/report-fledge` to `/.well-known/private-aggregation/report-protected-audience`
-2. The `api` property value of the aggregatable report payload is changed from `fledge` to `protected-audience`
+The Private Aggregation API will contain the following breaking changes in the M115 Beta and Stable releases:
+1. The `sendHistogramReport()` function is renamed to `contributeToHistogram()`
+2. The `reportContributionForEvent()` function is renamed to `contributeToHistogramOnEvent()`
+3. `enableDebugMode()`’s `debug_key` parameter is renamed to `debugKey`.
+4. The reporting endpoint is renamed from `/.well-known/private-aggregation/report-fledge` to `/.well-known/private-aggregation/report-protected-audience`
+5. The `api` property value of the aggregatable report payload is renamed from `fledge` to `protected-audience` 
 
-You must update your code to ensure that the Private Aggregation API continues to work with the Protected Audience API. Users in an outdated Chrome instance will still send their report to the legacy endpoint, so you should ensure backward compatibility to collect all reports. 
+You must update your code to ensure that the Private Aggregation API continues to work with the Protected Audience API. Users in an outdated Chrome instance will still send their report to the legacy endpoint, so you should ensure backward compatibility to collect all reports. We recommend using feature detection with `if ('contributeToHistogram' in privateAggregation))`.
 
-The new endpoint and `api` property value will be available for testing on Monday, May 22nd in M115 Canary and Dev channels.
+These changes will be possible for testing during the week of Monday, May 22nd in Canary and Dev channels. 
 {% endAside %}
 
 * The [Private Aggregation API](https://github.com/patcg-individual-drafts/private-aggregation-api/) has entered [public discussion](https://github.com/patcg-individual-drafts/private-aggregation-api/issues).

--- a/site/en/_partials/privacy-sandbox/timeline/private-aggregation.md
+++ b/site/en/_partials/privacy-sandbox/timeline/private-aggregation.md
@@ -8,7 +8,7 @@ The Private Aggregation API will contain the following breaking changes in the M
 
 You must update your code to ensure that the Private Aggregation API continues to work with the Protected Audience API. Users in an outdated Chrome instance will still send their report to the legacy endpoint, so you should ensure backward compatibility to collect all reports. We recommend using feature detection with `if ('contributeToHistogram' in privateAggregation))`.
 
-These changes will be possible for testing during the week of Monday, May 22nd in Canary and Dev channels. 
+These changes will be possible for testing from the week of Monday, May 22nd in Canary and Dev channels. 
 {% endAside %}
 
 * The [Private Aggregation API](https://github.com/patcg-individual-drafts/private-aggregation-api/) has entered [public discussion](https://github.com/patcg-individual-drafts/private-aggregation-api/issues).

--- a/site/en/docs/privacy-sandbox/private-aggregation/index.md
+++ b/site/en/docs/privacy-sandbox/private-aggregation/index.md
@@ -8,7 +8,7 @@ description: >
    Generate aggregate data reports using data from Protected Audience and cross-site
    data from Shared Storage.
 date: 2022-10-11
-updated: 2023-03-14
+updated: 2023-05-26
 authors:
    - kevinkiklee
 ---
@@ -112,9 +112,9 @@ From a Protected Audience API worklet, you can aggregate your data directly usin
 
 The following functions are available in the `privateAggregation` object available in Shared Storage and Protected Audience API worklets. To learn how to run your code in a worklet, refer to the [Shared Storage code samples](/docs/privacy-sandbox/use-shared-storage/). 
 
-### sendHistogramReport()
+### contributeToHistogram()
 
-You can call `privateAggregation.sendHistogramReport({ bucket: <bucket>, value: <value> })`, where the aggregation key is `bucket` and the aggregatable value as `value`. For the `bucket` parameter, a `BigInt` is required. For the `value` parameter, an integer Number is required.
+You can call `privateAggregation.contributeToHistogram({ bucket: <bucket>, value: <value> })`, where the aggregation key is `bucket` and the aggregatable value as `value`. For the `bucket` parameter, a `BigInt` is required. For the `value` parameter, an integer Number is required.
 
 Here is an example of how it may be called in Shared Storage for reach measurement: 
 
@@ -165,7 +165,7 @@ class ReachMeasurementOperation {
     // Set the aggregation key in `bucket`
     // Bucket examples: 54153254n or BigInt(54153254)
     // Set the scaled aggregatable value in `value`
-    privateAggregation.sendHistogramReport({
+    privateAggregation.contributeToHistogram({
       bucket: convertContentIdToBucket(data.contentId), 
       value: 1 * SCALE_FACTOR 
     });
@@ -186,17 +186,17 @@ While third-party cookies are still available, we'll provide a temporary mechani
 
 Calling `privateAggregation.enableDebugMode()` in the worklet enables the debug mode which causes aggregatable reports to include the unencrypted (cleartext) payload. You can then process these payloads with the Aggregation Service [local testing tool](https://github.com/google/trusted-execution-aggregation-service#set-up-local-testing). 
 
-You can also set the debug key by calling `privateAggregation.enableDebugMode({ <debug_key: debug_key> })` where a BigInt can be used as a debug key. The debug key can be used to associate data from a cookie-based measurement and data from Private Aggregation measurement. These can be called only once per context. Any subsequent calls will be ignored.
+You can also set the debug key by calling `privateAggregation.enableDebugMode({ <debugKey: debugKey> })` where a `BigInt` can be used as a debug key. The debug key can be used to associate data from a cookie-based measurement and data from Private Aggregation measurement. These can be called only once per context. Any subsequent calls will be ignored.
 
 ```js
 // Enables debug mode
 privateAggregation.enableDebugMode();
 
 // Enables debug mode and sets a debug key
-privateAggregation.enableDebugMode({ debug_key: BigInt(1234) });
+privateAggregation.enableDebugMode({ debugKey: BigInt(1234) });
 ```
 
-### reportContributionForEvent()
+### contributeToHistogramOnEvent()
 
 Within Protected Audience API worklets only, we provide a trigger-based mechanism for sending a report only if a certain event occurs. This function also allows for the bucket and value to depend on signals that are not yet available at that point in the auction (for example, the value of the winning bid in `generateBid()`). More detail is available in the [explainer](https://github.com/WICG/turtledove/blob/main/FLEDGE_extended_PA_reporting.md).
 

--- a/site/en/docs/privacy-sandbox/private-aggregation/index.md
+++ b/site/en/docs/privacy-sandbox/private-aggregation/index.md
@@ -8,7 +8,7 @@ description: >
    Generate aggregate data reports using data from Protected Audience and cross-site
    data from Shared Storage.
 date: 2022-10-11
-updated: 2023-05-26
+updated: 2023-05-30
 authors:
    - kevinkiklee
 ---


### PR DESCRIPTION
This PR contains the breaking changes that are being introduced for the Private Aggregation API. 

Preview link: https://pr-6433-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/private-aggregation/#implementation-status