### PR TITLE
Add tomac@‘s blog to authorsData.json

### DIFF
--- a/site/_data/authorsData.json
+++ b/site/_data/authorsData.json
@@ -873,6 +873,11 @@
         "label": "web.dev",
         "type": "rss",
         "url": "https://web.dev/authors/thomassteiner/feed.xml"
+      },
+      {
+        "label": "Blogccasion",
+        "type": "rss",
+        "url": "https://blog.tomayac.com/feed/feed.xml"
       }
     ]
   },


### PR DESCRIPTION

Changes proposed in this pull request:

- Add tomac@‘s blog to authorsData.json

