### PR TITLE
Use correct term for 'synchronous style', update code to use ES2017

### DIFF
--- a/site/en/docs/extensions/mv3/promises/index.md
+++ b/site/en/docs/extensions/mv3/promises/index.md
@@ -27,7 +27,7 @@ To check whether a method supports promises, look for the "Promise" label in its
 There are many places where using promises results in cleaner, easier-to-maintain code. You
 should consider using promises in situations such as the following:
 
-* Any time you want to clean up your code by using a more "synchronous" invocation style.
+* Any time you want to clean up your code by using [direct style](https://en.wikipedia.org/wiki/Continuation-passing_style).
 * Where error handling would be too difficult using callbacks.
 * When you want a more condensed way to invoke several concurrent methods and gather the results into a single thread of code.
 
@@ -52,13 +52,12 @@ chrome.permissions.request(newPerms, (granted) => {
 {% Compare 'better', 'Promise' %}
 ```js
 const newPerms = { permissions: ['topSites'] };
-chrome.permissions.request(newPerms)
-.then((granted) => {
-  if (granted) {
-    console.log('granted');
-  } else {
-    console.log('not granted');
-  }
+const granted = await chrome.permissions.request(newPerms)
+if (granted) {
+  console.log('granted');
+} else {
+  console.log('not granted');
+}
 });
 
 ```


### PR DESCRIPTION
Changes proposed in this pull request:

- 'synchronous style' can potentially cause confusion, the proper name for direct style is 'direct style'
- Use ES2017 rather than .then() chains.