### PR TITLE
Corrected information on FAQ page

### DIFF
--- a/site/en/docs/extensions/mv3/faq/index.md
+++ b/site/en/docs/extensions/mv3/faq/index.md
@@ -156,8 +156,10 @@ popup. There is no way to keep the popup open after the user has clicked away.
 ### Can extensions be notified when they are installed/uninstalled? {: #faq-lifecycle-events }
 
 You can listen to the [runtime.onInstalled][48] event to be notified when your extension is
-installed or updated, or when Chrome itself is updated. There is no corresponding event for when
-your extension is uninstalled.
+installed or updated, or when Chrome itself is updated. While there is no event listener
+for uninstalling an extension, a URL can be set via the `setUninstallUrl()` API to open when
+the extension is uninstalled. This allows for some final functionality without access to any extension APIs,
+like clean up server-side data, do analytics, and implement surveys.
 
 ## Development {: #development2 }
 


### PR DESCRIPTION
Fixes https://github.com/GoogleChromeLabs/Extension-Docs/issues/85

- Corrects the FAQ page to mention runtime.setUninstallURL in the lifecycle events section.