### PR TITLE
Fix a typo and correct the next version number in index.md

### DIFF
--- a/site/en/blog/new-in-chrome-114/index.md
+++ b/site/en/blog/new-in-chrome-114/index.md
@@ -20,7 +20,7 @@ Here's what you need to know:
 
 * CSS [`text-wrap: balance`] (#text-wrap-balance) is available to improve text layouts.
 * Cookies partitioned by top level site ([CHIPS](#chips)) are here.
-* Popovers are easier than even with the [Popover API](#popover-api).
+* Popovers are easier than ever with the [Popover API](#popover-api).
 * And there’s plenty [more](#more).
 
 I’m Adriana Jara. Let’s dive in and see what’s new for developers in Chrome 114.
@@ -110,5 +110,5 @@ To stay up to date, [subscribe](https://goo.gl/6FP1a5) to the
 [Chrome Developers YouTube channel](https://www.youtube.com/user/ChromeDevelopers/),
 and you'll get an email notification whenever we launch a new video.
 
-Yo soy Adriana Jara, and as soon as Chrome 114 is released, I'll be right here to
+Yo soy Adriana Jara, and as soon as Chrome 115 is released, I'll be right here to
 tell you what's new in Chrome!


### PR DESCRIPTION
Changes proposed in this pull request:

- Change "even" in "easier than even with the Popover API" with "ever"
- Change "114" in "and as soon as Chrome 114 is released" with "115"