### PR TITLE
Remove purpose: "any maskable" recommendation in Lighthouse PWA Audit docs

### DIFF
--- a/site/en/docs/lighthouse/pwa/maskable-icon-audit/index.md
+++ b/site/en/docs/lighthouse/pwa/maskable-icon-audit/index.md
@@ -38,7 +38,7 @@ In order to pass the audit:
 
 1. Use [Maskable.app Editor][editor] to convert an existing icon to a maskable icon.
 1. Add the `purpose` property to one of the `icons` objects in your [web app manifest][manifest].
-   Set the value of `purpose` to `maskable` or `any maskable`. See [Values][values].
+   Set the value of `purpose` to `maskable`. See [Values][values].
 
    ```json/8
    {
@@ -49,7 +49,7 @@ In order to pass the audit:
          "src": "path/to/maskable_icon.png",
          "sizes": "196x196",
          "type": "image/png",
-         "purpose": "any maskable"
+         "purpose": "maskable"
        }
      ]
      …


### PR DESCRIPTION
Chrome DevTools now shows a warning in the "Manifest" section when `purpose` value is `any maskable`.

The [web.dev article](https://web.dev/maskable-icon/) on Maskable Icon also advises against it (quote at the end of article).

> While you can specify multiple space-separated purposes such as "any maskable", in practice you shouldn't. Using "maskable" icons as "any" icons is suboptimal as the icon is going to be used as-is, resulting in excess padding, making the core icon content smaller. 

Wouldn't it be better to not recommend `any maskable` altogether going forward?