### PR TITLE
Duplication clean up from tutorial

### DIFF
--- a/site/en/docs/webstore/program-policies/best-practices/index.md
+++ b/site/en/docs/webstore/program-policies/best-practices/index.md
@@ -5,10 +5,10 @@ date: 2022-11-01
 updated: 2023-05-30
 ---
 
-1.	Research and understand the Chrome Web Store policies. Before developing a Chrome extension, it is important to review the Chrome Web Store Developer Program Policies and ensure your extension complies with all guidelines and requirements.
+1.	Research and understand the [Chrome Web Store policies][cws-policy]. Before developing a Chrome extension, it is important to review the Chrome Web Store Developer Program Policies and ensure your extension complies with all guidelines and requirements.
 1.	Extensions should add value to the Chrome Web Store. If your extension is not particularly useful or unique, it doesn’t belong on the Chrome Web Store.
 1.	No cheating. If you attempt to scam the system (for example, by misleading users, circumventing enforcement, copying the work of other developers, or manipulating your extension’s reviews or ratings) you will be banned from the Chrome Web Store.
-1.	Developers must strictly adhere to the follow strict guidelines regarding the collection, use, and disclosure of user data, and must obtain user consent for any data collection or usage. Apps that access sensitive user data such as financial information, health information, or personal information must comply with additional policies and guidelines.
+1.	Developers must strictly adhere to [strict guidelines][user-privacy] regarding the collection, use, and disclosure of user data, and must obtain user consent for any data collection or usage. Apps that access sensitive user data such as financial information, health information, or personal information must comply with additional policies and guidelines.
 1.	Ensure that all of your extension’s information and metadata are up to date and accurate.
 1.	Test your extensions for crashes, broken features, and bugs prior to submission.
 1.	Verify that your contact information is correct to ensure you receive important communications for the Chrome Web Store.
@@ -16,3 +16,5 @@ updated: 2023-05-30
 1.	Provide meaningful customer support for your extension.
 1.	Chrome Web Store policies are subject to change. Google may update the policies at any time, and developers are responsible for keeping up-to-date with any changes and complying with the updated policies. Updates to our policies will be announced via email to the address listed in your developer account. 
 
+[cws-policy]: /docs/webstore/program-policies/
+[user-privacy]: /docs/webstore/program-policies/#protecting-user-privacy


### PR DESCRIPTION
Tutorial contained duplicate paragraphs both conveying same message, this change cleans up them.