### PR TITLE
Rename RMSPE to RMSRE

### DIFF
--- a/site/en/docs/privacy-sandbox/summary-reports/design-decisions/index.md
+++ b/site/en/docs/privacy-sandbox/summary-reports/design-decisions/index.md
@@ -588,18 +588,18 @@ Click on the buttons in the top menu to toggle between the two modes (_#1. in th
 
 Noise is added to protect individual user privacy.
 
-A high noise percentage value indicates that buckets/keys are sparse and
+A high noise value indicates that buckets/keys are sparse and
 contain contributions from a limited number of sensitive events. This is done
 automatically by Noise Lab, to allow individuals to "hide in the crowd," or in
 other words, protects these limited individuals' privacy with a larger amount
 of added noise.
 
-A low noise percentage indicates that the data setup was designed in such
+A low noise indicates that the data setup was designed in such
 a way that already allows individuals to "hide in the crowd." This means the
 buckets contain contributions from a sufficient number of events to ensure that
 individual user privacy is protected.
 
-This statement holds true for both the [APE](#ape) (average percentage error) and [RMSPE_T](#rmspe) (root-mean-square percentage error with a threshold).
+This statement holds true for both the [APE](#ape) (average percentage error) and [RMSRE_T](#rmsre) (root-mean-square relative error with a threshold).
 
 #### APE (average percentage error) {: #ape}
 
@@ -635,7 +635,7 @@ In Noise Lab, this is then multiplied by 100 to give a percentage.
 
 ##### Pros and Cons
 
-Buckets with smaller sizes have a disproportionate impact on the final value of APE. That could be misleading when assessing noise. This is why we've added another metric, [RMSPE_T](#rmspe), that is designed to mitigate this limitation of APE. Review the [examples](#noise-examples) for details. 
+Buckets with smaller sizes have a disproportionate impact on the final value of APE. That could be misleading when assessing noise. This is why we've added another metric, [RMSRE_T](#rmsre), that is designed to mitigate this limitation of APE. Review the [examples](#noise-examples) for details. 
 
 ##### Code
 
@@ -643,54 +643,52 @@ Review the [source code](https://github.com/privacysandbox/noise-lab/blob/main/p
 for APE calculation.
 
 
-#### RMSPE_T  (root-mean-square percentage error with a threshold) {: #rmspe}
+#### RMSRE_T  (root-mean-square relative error with a threshold) {: #rmsre}
 
-RMSPE_T (root-mean-square percentage error with a threshold) is another measure for noise.
+RMSRE_T (root-mean-square relative error with a threshold) is another measure for noise.
 
-##### How to interpret RMSPE_T
+##### How to interpret RMSRE_T
 
-Lower RMSPE_T values mean better signal-to-noise ratios. 
+Lower RMSRE_T values mean better signal-to-noise ratios. 
 
-RMSPE_T is typically higher than the average percentage error. For example, if a noise ratio that's acceptable for your use case is 20%, and RMSPE_T is 20%, you can be confident that noise levels fall into your acceptable range.
+For example, if a noise ratio that's acceptable for your use case is 20%, and RMSRE_T is 0.2, you can be confident that noise levels fall into your acceptable range.
 
 {% Aside %}
-What does it mean if RMSPE_T is above 100%?
-The interpretation of  RMSPE_T over 100% is similar to that of an APE over 100% LINK.
+What does it mean if RMSRE_T is above 1?
+The interpretation of  RMSRE_T over 1 is similar to that of an APE over 100%.
 
-RMSPE (Root Mean Square Error) is a common metricused by data scientists. 
-RMSPE_T is a variation of RMSPE. RMSPE_T differs from RMSPE in two ways:
+RMSRE (Root Mean Square Relative Error) is a common metricused by data scientists. 
+RMSRE_T is a variation of RMSRE. RMSRE_T differs from RMSRE in two ways:
 
-1. RMSPE_T uses a percentage error similar to noise-to-signal rate, like noise/true-value. 
-2. RMSPE_T assumes the existence of minimal signal: the percentage looks like noise/max(true, T). 
+1. RMSRE_T uses a relative error similar to noise-to-signal rate, like noise/true-value. 
+2. RMSRE_T assumes the existence of minimal signal: noise/max(true, T). 
 
 {% endAside %}
 
 ##### Formula
 
-For a given summary report, RMSPE_T is calculated as follows:
+For a given summary report, RMSRE_T is calculated as follows:
 
 <figure>
-{% Img src="image/URLGRmk9LjR39BLvmeGDZFZkz3p2/zNE4v707JUoUS8keFVsz.png", alt="Formula for RMSPE_T", width="377", height="59" %}
+{% Img src="image/URLGRmk9LjR39BLvmeGDZFZkz3p2/bBMbb19rTteh3gHkS7w9.png", alt="Formula for RMSRE_T", width="498", height="81" %}
 <figcaption style="text-align:left">
-  The equation for RMSPE_T. Absolute values are required, as noise can be negative.
+  The equation for RMSRE_T. Absolute values are required, as noise can be negative.
 </figcaption>
 </figure>
 
-In Noise Lab, this is then multiplied by 100 to give a percentage.
-
 ##### Pros and cons
 
-RMSPE_T is a bit more complex to grasp than APE. However, it has a few advantages that make it in some cases more suitable than APE for analyzing noise in summary reports:
+RMSRE_T is a bit more complex to grasp than APE. However, it has a few advantages that make it in some cases more suitable than APE for analyzing noise in summary reports:
 
-* **RMSPE_T is more stable.** "T" is a threshold. "T" is used to give less weight in the RMSPE_T calculation to buckets that have less conversions and are therefore more sensitive to noise due to their small size. With T, the metric does not spike on buckets with few conversions. If T is equal to 5, a noise value as small as 1 on a bucket with 0 conversions will not be displayed as way over 100%. Instead, it will be capped at 20%, which is equivalent to 1/5, as T is equal to 5. By giving less weight to smaller buckets which are therefore more sensitive to noise, this metric is more stable, and therefore makes it easier to compare two simulations.
-* **RMSPE_T allows for easy aggregation.** Knowing the RMSPE_T of multiple buckets, together with their true counts, allows you to compute the RMSPE_T of their sum. This also allows you to optimize for RMSPE_T for these combined values.
+* **RMSRE_T is more stable.** "T" is a threshold. "T" is used to give less weight in the RMSRE_T calculation to buckets that have less conversions and are therefore more sensitive to noise due to their small size. With T, the metric does not spike on buckets with few conversions. If T is equal to 5, a noise value as small as 1 on a bucket with 0 conversions will not be displayed as way over 1. Instead, it will be capped at 0.2, which is equivalent to 1/5, as T is equal to 5. By giving less weight to smaller buckets which are therefore more sensitive to noise, this metric is more stable, and therefore makes it easier to compare two simulations.
+* **RMSRE_T allows for easy aggregation.** Knowing the RMSRE_T of multiple buckets, together with their true counts, allows you to compute the RMSRE_T of their sum. This also allows you to optimize for RMSRE_T for these combined values.
 
 While aggregation is possible for APE, the formula is quite complicated as it involves the absolute value of sum of Laplace noises. This makes APE harder to optimize.
 
 
 ##### Code
 
-Review the [source code](https://github.com/privacysandbox/noise-lab/blob/main/public/index.html#L66) for RMSPE_T calculation.
+Review the [source code](https://github.com/privacysandbox/noise-lab/blob/main/public/index.html#L66) for RMSRE_T calculation.
 
 #### Examples {: #noise-examples}
 
@@ -706,9 +704,7 @@ bucket_3 = noise: 20, trueSummaryValue: 200
 
 APE = (0.1 + 0.2 + 0.1) / 3 = **13%**
 
-RMSPE_T = sqrt( ( (10/max(5,100))^2  + (20/max(5,100))^2 + (20/max(5,200))^2) / 3) 
-
-      =  sqrt( (0.01 + 0.04 + 0.01) / 3) =  0.14 =  **14%** 
+RMSRE_T = sqrt( ( (10/max(5,100))^2  + (20/max(5,100))^2 + (20/max(5,200))^2) / 3) =  sqrt( (0.01 + 0.04 + 0.01) / 3) =  **0.14** 
 
 {% endAside %}
 
@@ -725,7 +721,7 @@ bucket_3 = noise: 20, trueSummaryValue: 20
 
 APE = (0.1 + 0.2 + 1) / 3 = **43%**
 
-RMSPE_T = sqrt( ( (10/max(5,100))^2  + (20/max(5,100))^2 + (20/max(5,20))^2) / 3)  =  sqrt( (0.01 + 0.04 + 1.0) / 3) =  0.59 =  **59%**
+RMSRE_T = sqrt( ( (10/max(5,100))^2  + (20/max(5,100))^2 + (20/max(5,20))^2) / 3)  =  sqrt( (0.01 + 0.04 + 1.0) / 3) =  **0.59**
 {% endAside %}
 
 {% Aside 'example' %}
@@ -740,7 +736,7 @@ bucket_3 = noise: 20, trueSummaryValue: 0
 
 APE = (0.1 + 0.2 + Infinity) / 3 = **Infinity**
 
-RMSPE_T = sqrt( ( (10/max(5,100))^2  + (20/max(5,100))^2  + (20/max(5,0))^2) / 3) =  sqrt( (0.01 + 0.04 + 16.0) / 3) =  2.31 =  **231%**
+RMSRE_T = sqrt( ( (10/max(5,100))^2  + (20/max(5,100))^2  + (20/max(5,0))^2) / 3) =  sqrt( (0.01 + 0.04 + 16.0) / 3) =  **2.31**
 {% endAside %}
 
 {% endDetails %}

--- a/site/en/docs/privacy-sandbox/summary-reports/design-decisions/index.md
+++ b/site/en/docs/privacy-sandbox/summary-reports/design-decisions/index.md
@@ -594,7 +594,7 @@ automatically by Noise Lab, to allow individuals to "hide in the crowd," or in
 other words, protects these limited individuals' privacy with a larger amount
 of added noise.
 
-A low noise indicates that the data setup was designed in such
+A low noise value indicates that the data setup was designed in such
 a way that already allows individuals to "hide in the crowd." This means the
 buckets contain contributions from a sufficient number of events to ensure that
 individual user privacy is protected.


### PR DESCRIPTION
Rename RMSPE to RMSRE

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- Rename the metric RMSPE to RMSRE
- Additional changes to reflect this is not a percentage