### PR TITLE
Add event-level reporting status for shared storage

### DIFF
--- a/site/en/_partials/privacy-sandbox/timeline/shared-storage-features.md
+++ b/site/en/_partials/privacy-sandbox/timeline/shared-storage-features.md
@@ -6,6 +6,10 @@
     </tr>
   </thead>
   <tr>
+    <td><a href="https://github.com/WICG/shared-storage#event-level-reporting">Event-level reporting</a> for Content Selection (<code>selectURL()</code>)</td>
+    <td>Available until at least 2026</td>
+  </tr>
+  <tr>
     <td>Support for debug mode and testing of Aggregation Service with the local testing tool</br>
       <a href="/docs/privacy-sandbox/private-aggregation/#enabledebugmode">Private Aggregation API documentation</a></td>
     <td>Available in Chrome for origin trial in Q2 2023</td>


### PR DESCRIPTION
This PR adds event-level reporting status for Shared Storage. 

Preview link: https://pr-6528-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/shared-storage/#implementation-status