### PR TITLE
Include an example of affected cookies for First-Party Sets

### DIFF
--- a/site/en/docs/privacy-sandbox/first-party-sets-integration/index.md
+++ b/site/en/docs/privacy-sandbox/first-party-sets-integration/index.md
@@ -125,7 +125,7 @@ Refreshing, reloading, or otherwise recreating the iframe will require requestin
 
 ### Cookie requirements
 
-rSA only provides access for cookies that are already specified for cross-site contexts, meaning that they must specify both the `SameSite=None` and `Secure` attributes. Cookies intended for first-party use only, as in those specifying `SameSite=Lax`, `SameSite=Strict`, or without a `SameSite` attribute will **never** be shared in a cross-site context regardless of rSA.
+rSA only [provides access for cookies that are already marked for use in cross-site contexts](https://privacycg.github.io/storage-access/#cookies), meaning that they must specify both the `SameSite=None` and `Secure` attributes. Cookies intended for first-party use only, as in those specifying `SameSite=Lax`, `SameSite=Strict`, or without a `SameSite` attribute will **never** be shared in a cross-site context regardless of rSA.
 
 ### Security
 

--- a/site/en/docs/privacy-sandbox/first-party-sets-integration/index.md
+++ b/site/en/docs/privacy-sandbox/first-party-sets-integration/index.md
@@ -123,6 +123,10 @@ Each new frame will need to request storage access individually and it will auto
 
 Refreshing, reloading, or otherwise recreating the iframe will require requesting access again.
 
+### Cookie requirements
+
+rSA only provides access for cookies that are already specified for cross-site contexts, meaning that they must specify both the `SameSite=None` and `Secure` attributes. Cookies intended for first-party use only, as in those specifying `SameSite=Lax`, `SameSite=Strict`, or without a `SameSite` attribute will **never** be shared in a cross-site context regardless of rSA.
+
 ### Security
 
 For rSAFor, subresource requests require [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/docs/Web/HTTP/CORS) headers or `crossorigin` attribute on the resources, ensuring explicit opt-in.

--- a/site/en/docs/privacy-sandbox/first-party-sets-integration/index.md
+++ b/site/en/docs/privacy-sandbox/first-party-sets-integration/index.md
@@ -125,7 +125,9 @@ Refreshing, reloading, or otherwise recreating the iframe will require requestin
 
 ### Cookie requirements
 
-rSA only [provides access for cookies that are already marked for use in cross-site contexts](https://privacycg.github.io/storage-access/#cookies), meaning that they must specify both the `SameSite=None` and `Secure` attributes. Cookies intended for first-party use only, as in those specifying `SameSite=Lax`, `SameSite=Strict`, or without a `SameSite` attribute will **never** be shared in a cross-site context regardless of rSA.
+Cookies must specify both the `SameSite=None` and `Secure` attributes as rSA only [provides access for cookies that are already marked for use in cross-site contexts](https://privacycg.github.io/storage-access/#cookies). 
+
+Cookies with `SameSite=Lax`, `SameSite=Strict`, or without a `SameSite` attribute are for first-party use only and will **never** be shared in a cross-site context regardless of rSA.
 
 ### Security
 


### PR DESCRIPTION
Adds an explicit statement of requiring `SameSite=None` for First-Party Sets where it was previously just implicit in referencing cross-site / third-party cookies. Also makes a callout that `Lax` and `Strict` cookies are unaffected.