### PR TITLE
[ext-doc] Removes aside in Side Panel API

### DIFF
--- a/site/en/docs/extensions/reference/sidePanel/index.md
+++ b/site/en/docs/extensions/reference/sidePanel/index.md
@@ -2,10 +2,6 @@
 api: sidePanel
 ---
 
-{% Aside 'important' %}
-The Side Panel API is currently available in [Chrome Beta 114](https://www.google.com/chrome/beta/).
-{% endAside %}
-
 ## Overview {: #overview }
 
 Chrome features a built-in side panel that enables users to view more information alongside the main content of a webpage. The Side Panel API allows extensions to display their own UI in the side panel, enabling persistent experiences that complement the user's browsing journey. 


### PR DESCRIPTION
Now that the Side Panel API is available in Chrome 114 Stable, this aside warning is no longer needed.
