### PR TITLE
ARA noise docs from handbook

### DIFF
--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -108,8 +108,8 @@
           sections:
             - url: /docs/privacy-sandbox/attribution-reporting/understanding-noise/
             - url: /docs/privacy-sandbox/attribution-reporting/working-with-noise/
-        - url: https://docs.google.com/document/d/1BXchEk-UMgcr2fpjfXrQ3D8VhTR-COGYS1cwK_nyLfg/view?usp=sharing
-          title: i18n.docs.privacy-sandbox.attribution-reporting-handbook        
+            - url: https://docs.google.com/document/d/1BXchEk-UMgcr2fpjfXrQ3D8VhTR-COGYS1cwK_nyLfg/view?usp=sharing
+              title: i18n.docs.privacy-sandbox.attribution-reporting-handbook        
         - url: /docs/privacy-sandbox/attribution-reporting-updates
           title: i18n.docs.privacy-sandbox.attribution-reporting-changing
     - title: i18n.docs.privacy-sandbox.measure-cross-site

--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -108,8 +108,8 @@
           sections:
             - url: /docs/privacy-sandbox/attribution-reporting/understanding-noise/
             - url: /docs/privacy-sandbox/attribution-reporting/working-with-noise/
-            - url: https://docs.google.com/document/d/1BXchEk-UMgcr2fpjfXrQ3D8VhTR-COGYS1cwK_nyLfg/view?usp=sharing
-        - title: i18n.docs.privacy-sandbox.attribution-reporting-handbook
+        - url: https://docs.google.com/document/d/1BXchEk-UMgcr2fpjfXrQ3D8VhTR-COGYS1cwK_nyLfg/view?usp=sharing
+          title: i18n.docs.privacy-sandbox.attribution-reporting-handbook        
         - url: /docs/privacy-sandbox/attribution-reporting-updates
           title: i18n.docs.privacy-sandbox.attribution-reporting-changing
     - title: i18n.docs.privacy-sandbox.measure-cross-site

--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -104,8 +104,12 @@
             - url: /docs/privacy-sandbox/attribution-reporting-debugging/part-1/
             - url: /docs/privacy-sandbox/attribution-reporting-debugging/part-2/
             - url: /docs/privacy-sandbox/attribution-reporting-debugging/part-3/
-        - url: https://docs.google.com/document/d/1BXchEk-UMgcr2fpjfXrQ3D8VhTR-COGYS1cwK_nyLfg/view?usp=sharing
-          title: i18n.docs.privacy-sandbox.attribution-reporting-handbook
+        - title: i18n.docs.privacy-sandbox.attribution-reporting-developer-guide
+          sections:
+            - url: /docs/privacy-sandbox/attribution-reporting/understanding-noise/
+            - url: /docs/privacy-sandbox/attribution-reporting/working-with-noise/
+            - url: https://docs.google.com/document/d/1BXchEk-UMgcr2fpjfXrQ3D8VhTR-COGYS1cwK_nyLfg/view?usp=sharing
+        - title: i18n.docs.privacy-sandbox.attribution-reporting-handbook
         - url: /docs/privacy-sandbox/attribution-reporting-updates
           title: i18n.docs.privacy-sandbox.attribution-reporting-changing
     - title: i18n.docs.privacy-sandbox.measure-cross-site

--- a/site/_data/i18n/docs/privacy-sandbox.yml
+++ b/site/_data/i18n/docs/privacy-sandbox.yml
@@ -70,6 +70,8 @@ attribution-reporting-debugging-resources:
   en: 'Generate debug reports'
 attribution-reporting-changing:
   en: 'API updates'
+attribution-reporting-developer-guide:
+  en: 'Developer guide'
 attribution-reporting-handbook:
   en: 'Developer handbook'
 attribution-reporting_description:

--- a/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
@@ -6,7 +6,7 @@ subhead: >
 description: >
   Learn what noise means, where it is added, and how it impacts your measurement efforts.
 date: 2022-06-23
-updated: 2022-06-23
+updated: 2023-06-24
 authors:
   - maudn
 ---

--- a/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
@@ -11,7 +11,9 @@ authors:
   - maudn
 ---
 
-Data in aggregatable reports is _noised_; in other words, for a small percentage of cases, random data is sent instead of real reports/data. This practice preserves user privacy by preventing the joining of user identity across sites. 
+Summary reports are the result of the aggregation of _aggregatable reports_. 
+When aggregatable reports are batched by a collector and processed by the aggregation service, noise—a random amount of data—is added to the resulting summary reports. 
+Noise is added to protect user privacy. The goal of this mechanism is to have a framework which can support [differentially private](https://github.com/WICG/conversion-measurement-api/blob/main/AGGREGATE.md#differential-privacy) measurement.
 
 
 ## Understanding noise in general

--- a/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
@@ -69,7 +69,7 @@ Noise is drawn from the [Laplace distribution](https://en.wikipedia.org/wiki/Lap
 
 -   A *mean* (`μ`) of 0. This means that the most likely noise value is 0 (no noise added), and that the noisy value is as likely to be smaller than the original as it is to be larger (this is sometimes called *unbiased*).
 -   A *scale parameter* of` b = CONTRIBUTION_BUDGET` / `epsilon`.
-    -   `CONTRIBUTION_BUDGET` is defined in the browser.
+    -   `CONTRIBUTION_BUDGET` is defined in the browser. <!-- liink to contribution budget -->
     -   `epsilon` is fixed in the aggregation server.
 
 

--- a/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
@@ -32,7 +32,7 @@ What you will want to do is configure your API usage in such a way that:
 1. The answer to the question above is yes.
 1. Noise is managed in a way that doesn't significantly impact your ability to make a decision based on certain data. You can approach this as follows: for an expected minimum number of conversions, you want to keep the noise in the collected metric below a certain %.
 
-In this section and the following, we'll outline strategies for option 2.
+In this section and the following, we'll outline strategies to achieve 2.
 
 ## Core concepts
 

--- a/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
@@ -11,7 +11,7 @@ authors:
   - maudn
 ---
 
-Data in event-level and summary reports is _noised_; in other words, for a small percentage of cases, random data is sent instead of real reports/data. This practice preserves user privacy by preventing the joining of user identity across sites. 
+Data in aggregatable reports is _noised_; in other words, for a small percentage of cases, random data is sent instead of real reports/data. This practice preserves user privacy by preventing the joining of user identity across sites. 
 
 
 ## Understanding noise in general
@@ -57,7 +57,7 @@ All the elements that impact noise rely on two primary concepts.
 
     Therefore, noise is likely to have a lower impact on the $20,000 aggregated purchase value than on the $200 value. Relatively speaking, $20,000 is likely to be less noisy, that is it's likely to have a higher signal-to-noise ratio.
 
-    {% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/qSSm2ahrags6PyX0uumm.png", alt="ALT_TEXT_HERE", width="800", height="453" %}
+    {% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/qSSm2ahrags6PyX0uumm.png", alt="Higher aggregated values have relatively lower noise impact.", width="800", height="453" %}
 
     This has a few important practical implications that are outlined in the next section. This mechanism is part of the API design, and the practical implications are long-term. They will continue to play an important role when ad techs design and evaluate various aggregation strategies.
 
@@ -78,10 +78,11 @@ Noise is drawn from the [Laplace distribution](https://en.wikipedia.org/wiki/Lap
     -   `CONTRIBUTION_BUDGET` is [defined in the browser](https://docs.google.com/document/d/1BRFl9x21rEI1xmZhomPxbzkYBBoM7TF4aEBVr9p0ZzI/edit#heading=h.pcbjmxqyvd83).
     -   `epsilon` is fixed in the aggregation server.
 
+
+The following diagram shows the probability density function for a Laplace distribution with μ=0, b = 20:
+
 {% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/FsWhm3xQ2zrEVZL5AmmN.png", alt="Probability density function for a Laplace distribution with μ=0, b = 20", width="512", height="330" %}
-<figcaption>
-Probability density function for a Laplace distribution with μ=0, b = 20 
-</figcaption>
+
 
 #### Random noise values, one noise distribution
 
@@ -99,19 +100,16 @@ This illustrates that the noise values all come from the same distribution, and 
 
 Noise is applied to every summary value—including empty ones (0).
 
-{% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/qKiM3ozD6OZhkr113Sr7.png", alt="ALT_TEXT_HERE", width="256", height="173" %}
+{% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/qKiM3ozD6OZhkr113Sr7.png", alt="Even empty summary values are subject to noise.", width="256", height="173" %}
 
-##### Example
-
-Even if the true summary value for a given key is 0, the noisy summary value you'll see in the summary report for this key will (most likely) not be 0.
+For example, even if the true summary value for a given key is 0, the noisy summary value you'll see in the summary report for this key will (most likely) not be 0.
 
 Noise can be either a positive or a negative number.
 
-{% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/bKwhviKHyHc6r7u0KIY5.png", alt="ALT_TEXT_HERE", width="512", height="204" %}
+{% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/bKwhviKHyHc6r7u0KIY5.png", alt="Examples of positive and negative noise.", width="512", height="204" %}
 
-##### Example
 
-For a pre-noise purchase amount of 327,000, noise may be +6,000 or -6,000 (these are arbitrary example values).
+For example, for a pre-noise purchase amount of 327,000, noise may be +6,000 or -6,000 (these are arbitrary example values).
 
 ### Evaluating noise
 

--- a/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
@@ -1,0 +1,148 @@
+---
+layout: 'layouts/doc-post.njk'
+title: 'Understanding noise'
+subhead: >
+  What noise means, where it is added, and how it impacts your measurement efforts.
+description: >
+  What noise means, where it is added, and how it impacts your measurement efforts.
+date: 2022-03-01
+updated: 2023-03-14
+authors:
+  - maudn
+---
+
+Data in event-level and summary reports is _noised_; in other words, for a small percentage of cases, random data is sent instead of real reports/data. This practice preserves user privacy by preventing the joining of user identity across sites. 
+
+
+## Understanding noise in general
+
+While adding noise isn’t usually a part of ads measurement today, in many cases the noise added won’t substantially change how you interpret your results. 
+
+
+It may help to think about it in the following way:
+Would you be confident taking a certain decision based on certain data if that data wasn't noisy? 
+
+
+For example, would an advertiser be confident in changing their campaign strategy or budgets, based on the fact that Campaign A had 15 conversions and Campaign B had 16? 
+
+
+If the answer is no, noise is irrelevant. You would design your data collection in a way that enables you to answer yes to the question above. 
+
+
+What you will want to do is configure your API usage in such a way that:
+
+1. The answer to the question above is yes.
+1. Noise is managed in a way that doesn't significantly impact your ability to make a decision based on certain data. You can approach this as follows: for an expected minimum number of conversions, you want to keep the noise in the collected metric below a certain %.
+
+
+In this section and the following, we'll outline strategies for option 2.
+
+
+## Core concepts
+
+The aggregation service adds noise once to each summary value—that is, once per key—every time a summary report is requested.
+
+These noise values are randomly drawn from a [specific probability distribution](#how-noise-is-applied), discussed below.
+
+All the elements that impact noise rely on two primary concepts.
+
+1. The noise distribution ([details below](#how-noise-is-applied)) is the same regardless of the summary value, low or high. Therefore, the higher the summary value, the less impact the noise is likely to have, relative to this value.
+
+   For example, assume both a total aggregated purchase value of $20,000 and a total aggregated purchase value of $200 are subject to noise selected from the same distribution. 
+
+   Let's assume noise from this distribution varies roughly between -100 and +100.
+
+    - For the summary purchase value of $20,000, noise varies between 0 and 100/20,000=**0.5%**.
+    - For the summary purchase value of $200, noise varies between 0 and 100/200=**50%**.
+
+    Therefore, noise is likely to have a lower impact on the $20,000 aggregated purchase value than on the $200 value. Relatively speaking, $20,000 is likely to be less noisy, that is it's likely to have a higher signal-to-noise ratio.
+
+    {% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/qSSm2ahrags6PyX0uumm.png", alt="ALT_TEXT_HERE", width="800", height="453" %}
+
+    This has a few important practical implications that are outlined in the next section. This mechanism is part of the API design, and the practical implications are long-term. They will continue to play an important role when ad techs design and evaluate various aggregation strategies.
+
+1. While the noise is drawn from the same distribution regardless of the summary value, that distribution depends on several parameters. One of these parameters, [epsilon](https://en.wikipedia.org/wiki/Differential_privacy#%CE%B5-differential_privacy), can be altered by ad techs during the origin trial to evaluate various utility/privacy adjustments. Consider the ability to tweak epsilon as temporary. We welcome your feedback on your use-cases and the values of epsilon that work well.
+
+While an ad tech company is not in direct control of the ways noise is added, it can influence the impact of noise on its measurement data. In the next sections, we'll dive into how noise can be influenced in practice. 
+
+Before we do, let's take a closer look at the way noise is applied.
+
+### Zooming in: how noise is applied {: #how-noise-is-applied}
+
+#### One noise distribution
+
+Noise is drawn from the [Laplace distribution](https://en.wikipedia.org/wiki/Laplace_distribution), with the following parameters:
+
+-   A *mean* (`μ`) of 0. This means that the most likely noise value is 0 (no noise added), and that the noisy value is as likely to be smaller than the original as it is to be larger (this is sometimes called *unbiased*).
+-   A *scale parameter* of` b = CONTRIBUTION_BUDGET` / `epsilon`.
+    -   `CONTRIBUTION_BUDGET` is [defined in the browser](https://docs.google.com/document/d/1BRFl9x21rEI1xmZhomPxbzkYBBoM7TF4aEBVr9p0ZzI/edit#heading=h.pcbjmxqyvd83).
+    -   `epsilon` is fixed in the aggregation server.
+
+{% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/FsWhm3xQ2zrEVZL5AmmN.png", alt="Probability density function for a Laplace distribution with μ=0, b = 20", width="512", height="330" %}
+<figcaption>
+Probability density function for a Laplace distribution with μ=0, b = 20 
+</figcaption>
+
+#### Random noise values, one noise distribution
+
+Let's assume that an ad tech requests summary reports for two aggregation keys, key1 and key2.
+
+The aggregation service selects two noise values x1 and x2, following the [same noise distribution](#one-noise-distribution). x1 is added to the summary value for key1, and x2 is added to the summary value for key2.
+
+In the diagrams, we'll represent noise values as identical.
+
+This is a simplification; in reality, noise values will vary, as they're drawn randomly from the distribution.
+
+This illustrates that the noise values all come from the same distribution, and are independent from the summary value they're applied to.
+
+#### Other properties of noise
+
+Noise is applied to every summary value—including empty ones (0).
+
+{% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/qKiM3ozD6OZhkr113Sr7.png", alt="ALT_TEXT_HERE", width="256", height="173" %}
+
+##### Example
+
+Even if the true summary value for a given key is 0, the noisy summary value you'll see in the summary report for this key will (most likely) not be 0.
+
+Noise can be either a positive or a negative number.
+
+{% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/bKwhviKHyHc6r7u0KIY5.png", alt="ALT_TEXT_HERE", width="512", height="204" %}
+
+##### Example
+
+For a pre-noise purchase amount of 327,000, noise may be +6,000 or -6,000 (these are arbitrary example values).
+
+### Evaluating noise
+
+#### Calculating the standard deviation of the noise
+
+The standard deviation of the noise is:
+
+```text
+b*sqrt(2) = (`CONTRIBUTION_BUDGET` / epsilon)*sqrt(2)
+```
+
+##### Example
+
+With epsilon = 10, the standard deviation of the noise is:
+
+```text
+b*sqrt(2) = (CONTRIBUTION_BUDGET / epsilon)*sqrt(2) = (65,536/10)*sqrt(2) = 9,267.
+```
+
+#### Evaluating when measurement differences are significant
+
+Because you will know the [standard deviation](#evaluating-noise) of the noise added to each value output by the aggregation service, you can determine appropriate thresholds for comparison to determine whether differences observed could be due to noise. 
+
+For example, if the noise added to a value is approximately +/- 10 (accounting for [scaling](#heading=h.683u7t2q1xk2)) and the difference in the value between two campaigns is over 100, it's likely safe to conclude that the difference in the value measured between each campaign is not due to noise alone.
+
+{% Aside 'caution' %}
+Do not rely on report counts or data available only via debug reports as a source of truth in your designs. In the future, the data available in debug reports will change and noisy reports will be generated alongside real reports, so these signals should be used only to validate your implementation and testing strategy.</th>
+{% endAside %}
+
+{% Partial 'privacy-sandbox/ar-engage.njk' %}
+
+## Next steps
+
+* [Working with noise](/docs/privacy-sandbox/attribution-reporting/working-with-noise/).

--- a/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
@@ -141,4 +141,6 @@ Do not rely on report counts or data available only via debug reports as a sourc
 
 ## Next steps
 
-* [Working with noise](/docs/privacy-sandbox/attribution-reporting/working-with-noise/).
+- To see what variables you can control to improve the signal to noise ratio, refer to [Working with noise](/docs/privacy-sandbox/attribution-reporting/working-with-noise/).
+- Review [Experiment with summary report design decisions](/docs/privacy-sandbox/summary-reports/design-decisions/#quick-tour).
+- Try out the [Noise lab](https://noise-lab.uc.r.appspot.com/?mode=simple).

--- a/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
@@ -25,7 +25,7 @@ Would you be confident taking a decision based on a certain piece of data if tha
 
 For example, would an advertiser be confident in changing their campaign strategy or budgets, based on the fact that Campaign A had 15 conversions and Campaign B had 16? 
 
-If the answer is no, noise is irrelevant. You would design your data collection in a way that enables you to answer yes to the question above. 
+If the answer is no, noise is irrelevant.
 
 What you will want to do is configure your API usage in such a way that:
 

--- a/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
@@ -15,6 +15,7 @@ Summary reports are the result of the aggregation of _aggregatable reports_.
 When aggregatable reports are batched by a collector and processed by the aggregation service, noise—a random amount of data—is added to the resulting summary reports. 
 Noise is added to protect user privacy. The goal of this mechanism is to have a framework which can support [differentially private](https://github.com/WICG/conversion-measurement-api/blob/main/AGGREGATE.md#differential-privacy) measurement.
 
+{% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/FclMA9IFcNr3A3dwIG6T.png", alt="Noise is added in the final summary report.", width="800", height="313" %}
 
 ## Introduction to noise in summary reports
 

--- a/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
@@ -90,9 +90,7 @@ Let's assume that an ad tech requests summary reports for two aggregation keys, 
 
 The aggregation service selects two noise values x1 and x2, following the [same noise distribution](#one-noise-distribution). x1 is added to the summary value for key1, and x2 is added to the summary value for key2.
 
-In the diagrams, we'll represent noise values as identical.
-
-This is a simplification; in reality, noise values will vary, as they're drawn randomly from the distribution.
+In the diagrams, we'll represent noise values as identical. This is a simplification; in reality, noise values will vary, as they're drawn randomly from the distribution.
 
 This illustrates that the noise values all come from the same distribution, and are independent from the summary value they're applied to.
 

--- a/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
@@ -16,7 +16,7 @@ When aggregatable reports are batched by a collector and processed by the aggreg
 Noise is added to protect user privacy. The goal of this mechanism is to have a framework which can support [differentially private](https://github.com/WICG/conversion-measurement-api/blob/main/AGGREGATE.md#differential-privacy) measurement.
 
 
-## Understanding noise in general
+## Introduction to noise in summary reports
 
 While adding noise isn’t usually a part of ads measurement today, in many cases the noise added won’t substantially change how you interpret your results. 
 

--- a/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
@@ -1,6 +1,6 @@
 ---
 layout: 'layouts/doc-post.njk'
-title: 'Understanding noise'
+title: 'Understanding noise in summary reports'
 subhead: >
   What noise means, where it is added, and how it impacts your measurement efforts.
 description: >

--- a/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
@@ -5,8 +5,8 @@ subhead: >
   What noise means, where it is added, and how it impacts your measurement efforts.
 description: >
   What noise means, where it is added, and how it impacts your measurement efforts.
-date: 2022-03-01
-updated: 2023-03-14
+date: 2022-06-23
+updated: 2022-06-23
 authors:
   - maudn
 ---

--- a/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
@@ -110,7 +110,7 @@ For example, for a pre-noise purchase amount of 327,000, noise may be +6,000 or 
 The standard deviation of the noise is:
 
 ```text
-b*sqrt(2) = (`CONTRIBUTION_BUDGET` / epsilon)*sqrt(2)
+b*sqrt(2) = (CONTRIBUTION_BUDGET / epsilon)*sqrt(2)
 ```
 
 ##### Example

--- a/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
@@ -21,7 +21,7 @@ Noise is added to protect user privacy. The goal of this mechanism is to have a 
 While adding noise isn’t usually a part of ads measurement today, in many cases the noise added won’t substantially change how you interpret your results. 
 
 It may help to think about it in the following way:
-Would you be confident taking a certain decision based on certain data if that data wasn't noisy? 
+Would you be confident taking a decision based on a certain piece of data if that data wasn't noisy? 
 
 For example, would an advertiser be confident in changing their campaign strategy or budgets, based on the fact that Campaign A had 15 conversions and Campaign B had 16? 
 

--- a/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
@@ -75,7 +75,7 @@ Noise is drawn from the [Laplace distribution](https://en.wikipedia.org/wiki/Lap
 
 -   A *mean* (`μ`) of 0. This means that the most likely noise value is 0 (no noise added), and that the noisy value is as likely to be smaller than the original as it is to be larger (this is sometimes called *unbiased*).
 -   A *scale parameter* of` b = CONTRIBUTION_BUDGET` / `epsilon`.
-    -   `CONTRIBUTION_BUDGET` is [defined in the browser](https://docs.google.com/document/d/1BRFl9x21rEI1xmZhomPxbzkYBBoM7TF4aEBVr9p0ZzI/edit#heading=h.pcbjmxqyvd83).
+    -   `CONTRIBUTION_BUDGET` is defined in the browser.
     -   `epsilon` is fixed in the aggregation server.
 
 
@@ -131,7 +131,7 @@ b*sqrt(2) = (CONTRIBUTION_BUDGET / epsilon)*sqrt(2) = (65,536/10)*sqrt(2) = 9,26
 
 Because you will know the [standard deviation](#evaluating-noise) of the noise added to each value output by the aggregation service, you can determine appropriate thresholds for comparison to determine whether differences observed could be due to noise. 
 
-For example, if the noise added to a value is approximately +/- 10 (accounting for [scaling](#heading=h.683u7t2q1xk2)) and the difference in the value between two campaigns is over 100, it's likely safe to conclude that the difference in the value measured between each campaign is not due to noise alone.
+For example, if the noise added to a value is approximately +/- 10 (accounting for scaling) and the difference in the value between two campaigns is over 100, it's likely safe to conclude that the difference in the value measured between each campaign is not due to noise alone.
 
 {% Aside 'caution' %}
 Do not rely on report counts or data available only via debug reports as a source of truth in your designs. In the future, the data available in debug reports will change and noisy reports will be generated alongside real reports, so these signals should be used only to validate your implementation and testing strategy.</th>

--- a/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
@@ -2,9 +2,9 @@
 layout: 'layouts/doc-post.njk'
 title: 'Understanding noise in summary reports'
 subhead: >
-  What noise means, where it is added, and how it impacts your measurement efforts.
+  Learn what noise means, where it is added, and how it impacts your measurement efforts.
 description: >
-  What noise means, where it is added, and how it impacts your measurement efforts.
+  Learn what noise means, where it is added, and how it impacts your measurement efforts.
 date: 2022-06-23
 updated: 2022-06-23
 authors:

--- a/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
@@ -18,25 +18,19 @@ Data in aggregatable reports is _noised_; in other words, for a small percentage
 
 While adding noise isn’t usually a part of ads measurement today, in many cases the noise added won’t substantially change how you interpret your results. 
 
-
 It may help to think about it in the following way:
 Would you be confident taking a certain decision based on certain data if that data wasn't noisy? 
 
-
 For example, would an advertiser be confident in changing their campaign strategy or budgets, based on the fact that Campaign A had 15 conversions and Campaign B had 16? 
 
-
 If the answer is no, noise is irrelevant. You would design your data collection in a way that enables you to answer yes to the question above. 
-
 
 What you will want to do is configure your API usage in such a way that:
 
 1. The answer to the question above is yes.
 1. Noise is managed in a way that doesn't significantly impact your ability to make a decision based on certain data. You can approach this as follows: for an expected minimum number of conversions, you want to keep the noise in the collected metric below a certain %.
 
-
 In this section and the following, we'll outline strategies for option 2.
-
 
 ## Core concepts
 
@@ -83,7 +77,6 @@ The following diagram shows the probability density function for a Laplace distr
 
 {% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/FsWhm3xQ2zrEVZL5AmmN.png", alt="Probability density function for a Laplace distribution with μ=0, b = 20", width="512", height="330" %}
 
-
 #### Random noise values, one noise distribution
 
 Let's assume that an ad tech requests summary reports for two aggregation keys, key1 and key2.
@@ -105,7 +98,6 @@ For example, even if the true summary value for a given key is 0, the noisy summ
 Noise can be either a positive or a negative number.
 
 {% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/bKwhviKHyHc6r7u0KIY5.png", alt="Examples of positive and negative noise.", width="512", height="204" %}
-
 
 For example, for a pre-noise purchase amount of 327,000, noise may be +6,000 or -6,000 (these are arbitrary example values).
 

--- a/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
@@ -142,5 +142,5 @@ Do not rely on report counts or data available only via debug reports as a sourc
 ## Next steps
 
 - To see what variables you can control to improve the signal to noise ratio, refer to [Working with noise](/docs/privacy-sandbox/attribution-reporting/working-with-noise/).
-- Review [Experiment with summary report design decisions](/docs/privacy-sandbox/summary-reports/design-decisions/#quick-tour).
+- Review [Experiment with summary report design decisions](/docs/privacy-sandbox/summary-reports/design-decisions/#quick-tour) for help with planning your aggregation reporting strategies.
 - Try out the [Noise lab](https://noise-lab.uc.r.appspot.com/?mode=simple).

--- a/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/understanding-noise/index.md
@@ -119,7 +119,7 @@ b*sqrt(2) = (CONTRIBUTION_BUDGET / epsilon)*sqrt(2)
 With epsilon = 10, the standard deviation of the noise is:
 
 ```text
-b*sqrt(2) = (CONTRIBUTION_BUDGET / epsilon)*sqrt(2) = (65,536/10)*sqrt(2) = 9,267.
+b*sqrt(2) = (CONTRIBUTION_BUDGET / epsilon)*sqrt(2) = (65,536/10)*sqrt(2) = 9,267
 ```
 
 #### Evaluating when measurement differences are significant

--- a/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
@@ -20,7 +20,7 @@ Before proceeding, for an in-depth understanding of what noise is, and its impac
 
 ### Scale up to contribution budget
 
-We've seen that the [noise applied to the summary value](/docs/privacy-sandbox/attribution-reporting/understanding-noise/#evaluating-noise) for each key is based on the 0-65,536 scale (0-`CONTRIBUTION_BUDGET`).
+As explained in [Understanding noise](/docs/privacy-sandbox/attribution-reporting/understanding-noise/#evaluating-noise), noise applied to the summary value for each key is based on the 0-65,536 scale (0-`CONTRIBUTION_BUDGET`).
 
 {% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/ODm7VrPRfwRm3hh8lWZg.png", alt="Noise distribution is based on budget.", width="512", height="147" %}
 

--- a/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
@@ -1,0 +1,154 @@
+---
+layout: 'layouts/doc-post.njk'
+title: 'Working with noise'
+subhead: >
+  How to work with, account for, and reduce the impact of noise in your aggregatable reports.
+description: >
+  How to work with, account for, and reduce the impact of noise in your aggregatable reports.
+date: 2022-03-01
+updated: 2023-03-14
+authors:
+  - maudn
+---
+
+## Before you begin
+
+Before proceeding, for an in-depth understanding of what noise is, and its impact, refer to [Understanding noise](/docs/privacy-sandbox/attribution-reporting/understanding-noise/).
+
+
+## Your controls on noise
+
+### Scale up to contribution budget
+
+We've seen that the [noise applied to the summary value](/docs/privacy-sandbox/attribution-reporting/understanding-noise/#evaluating-noise) for each key is based on the 0-65,536 scale (0-`CONTRIBUTION_BUDGET`).
+
+{% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/ODm7VrPRfwRm3hh8lWZg.png", alt="ALT_TEXT_HERE", width="512", height="147" %}
+
+Due to this, to maximize signal relative to noise, you should *scale up* each value before setting it as an aggregatable value—that is, multiply each value by a certain factor (while ensuring it stays within the contribution budget).
+
+{% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/P28EJ3mddaen0x7gLA0g.png", alt="ALT_TEXT_HERE", width="512", height="404" %}
+
+#### Scaling factor
+
+The *scaling factor* represents how much you want to scale a given aggregatable value.
+Its value should be the contribution budget divided by the maximum aggregatable value for a certain key.
+
+{% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/8ykXLb19ztwGLFeP1UXY.png", alt="ALT_TEXT_HERE", width="512", height="363" %}
+
+#### Example
+
+Let's assume advertisers want to know the total purchase value. You know that the maximum expected purchase value of any individual purchase is $2,000, except for a few outliers that you decide to ignore:
+
+-   **Calculate the scaling factor**:
+    -   To maximize the signal-to-noise ratio, you need to scale this value to 65,536 (the contribution budget).
+    -   This results in a 65,536 / 2,000 an approximately **32_x_** scaling factor. In practice, you may round this factor up or down.
+-   **Scale up your values before aggregation**. For every **$1** of purchase, increment the tracked metric by **32**. For example, for a purchase of **$120**, set an aggregatable value of *120*32 = 3,840**.
+-   **Scale down your values after aggregation**. Once you receive the summary report that contains the purchase value summed across multiple users, scale down the summary value using the scaling factor you used before aggregation. In our example, we've used a scaling factor of 32 pre-aggregation, so we need to divide the summary value received in the summary report by 32. Therefore, if the summary purchase value for a given key in the summary report is 76,800, the summary purchase value (with noise) is 76,800/32 = $2,400.
+
+#### Split up your budget
+
+If you have several measurement goals&mdash;for example, purchase count and purchase value&mdash;you may want to split your budget across these goals.
+
+In this case, your scaling factors will be different for different aggregatable values, depending on the expected maximum of a given aggregatable value.
+
+
+{% Aside %}
+You may decide to allocate the budget equally between two measurement goals, or you can choose to prioritize different measurement goals by allocating more budget to certain goals and less to others.
+{% endAside %}
+
+
+#### Example
+
+Let's assume you're tracking both the purchase count and the purchase value, and that you decide to allocate your budget equally.
+
+65,536 / 2 = 32,768 can be allocated per measurement type and per source.
+
+-   Purchase count:
+    -   You're only tracking one purchase, so the maximum number of purchases for a given conversion is 1.
+    -   Therefore, you decide to set your scaling factor for purchase count to 32,768 / 1 = 32,768.
+-   Purchase value:
+    -   Let's assume the maximum expected purchase value of any individual purchase is $2,000.
+    -   Therefore, you decide to set your scaling factor for purchase value to 32,768 / 2,000 = 16.384 or approximately 16.
+
+### Coarser aggregation keys improve signal-to-noise ratio
+
+Since coarse keys catch more conversion events than granular keys, coarse keys generally lead to higher summary values. 
+
+Higher summary values are less impacted by noise than lower values; noise on these values is likely to be lower, relative to this value.
+
+Values collected with coarser keys are likely to be relatively less noisy than values collected with more granular keys.
+
+#### Example
+
+All else held equal, a key that tracks purchase value globally (summed across all countries) will lead to a higher summary purchase value (and a higher summary conversion count) than a key that tracks conversions at a country's level. 
+
+Therefore, the relative noise on the total purchase value for a specific country will be higher than the relative noise on the total purchase value for all countries.
+
+Similarly, all else held equal, the total purchase value for shoes is lower than the total purchase value for all items (including shoes). 
+
+Therefore, the relative noise on the total purchase value for shoes will be higher than the relative noise on the total purchase value for all items.
+
+{% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/fEMnK3PlbIxRCWduHsp6.png", alt="ALT_TEXT_HERE", width="800", height="615" %}
+
+### Summing up summary values (rollups) also sums their noise
+
+By summing up yourself summary values from summary reports to access higher-level data, you also sum the noise from these summary values.
+
+{% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/xvdO0HpvwkvppLv1Pv0O.png", alt="ALT_TEXT_HERE", width="800", height="1058" %}
+
+#### Example
+
+Let's look at two different approaches:
+-   **Approach A**: you include a Geography ID in your keys. Summary reports expose geo-ID-level keys, each associated with the summary purchase value at a specific Geo ID's level.
+-   **Approach B**: you don't include geography ID in your keys. Summary reports directly expose the summary purchase value for all geography IDs / locations.
+
+To access country-level purchase value:
+-   With approach A, you sum geo-ID-level summary values and hence also sum their noise. This is likely to cause more noise added to the final geo-ID-level purchase value.
+-   With approach B, you directly look at the data exposed in summary reports. Noise has been added only once to that data.
+
+Therefore, the summary purchase value for a given geo ID is likely to be more noisy with approach A.
+
+Similarly, including a zipcode-level dimension in your keys will likely lead to more noisy results than using coarser keys with a region-level dimension.
+
+### Aggregating over longer time periods increases signal-to-noise ratio
+
+Requesting summary reports less often means that each summary value will likely be higher than if you requested reports more often; more conversions are likely to happen in longer time spans.
+
+As mentioned earlier, the higher the summary value is, the lower the relative noise is likely to be. Therefore, requesting summary reports less frequently leads to a higher (better) signal to noise ratio.
+
+{% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/2VZyQbx2weKGTfA3QdA0.png", alt="Requesting summary reports less frequently leads to a higher signal to noise ratio", width="512", height="315" %}
+
+#### Example
+
+-   If you're requesting hourly summary reports over 24 hours and then summing the summary value from each hourly report to access day-level data, noise is added 24 times.
+-   In one daily summary report, noise is added in only once.
+
+### Higher epsilon, lower noise
+
+The higher the epsilon value, the lower the noise and the lower the privacy protection.
+
+### Leveraging filtering and deduplication
+
+An important part of allocating budget between different keys is understanding how many times a given event can occur. For example, an advertiser may only care about one purchase for each click, but might be interested in up to 3 “product page view” conversions. To support these use-cases,you may also want to leverage the following API features that enable you to control how many reports are generated, and which conversions are counted:
+
+<!-- Filtering and Deduplication links needed later -->
+
+
+### Experimenting with epsilon 
+
+Lower values of epsilon provide greater privacy protection.
+
+During the origin trial, ad tech companies can choose epsilon within a given range. We recommend you start with epsilon=10. 
+
+Epsilon can be set to any value between 0 and 64: 0 < epsilon ≤ 64. 
+
+This range is wide enough to allow for flexible testing.
+
+#### Recommendations to experiment
+
+We recommend the following:
+- Start with epsilon = 10.
+- In case this causes notable utility issues, increase epsilon incrementally. 
+- Share your feedback about specific inflection points you may find with regards to data usability.
+
+{% Partial 'privacy-sandbox/ar-engage.njk' %}

--- a/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
@@ -145,5 +145,5 @@ We recommend the following:
 
 ## Next steps
 
-- Review [Experiment with summary report design decisions](/docs/privacy-sandbox/summary-reports/design-decisions/#quick-tour).
+- For more information on factors that influence reporting, such as campaign variables, batching frequency, dimension granularity, refer to [Experiment with summary report design decisions](/docs/privacy-sandbox/summary-reports/design-decisions/#quick-tour) .
 - Try out the [Noise lab](https://noise-lab.uc.r.appspot.com/?mode=simple).

--- a/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
@@ -26,7 +26,7 @@ As explained in Understanding noise, [noise applied to the summary value](/docs/
 
 {% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/ODm7VrPRfwRm3hh8lWZg.png", alt="Noise distribution is based on budget.", width="512", height="147" %}
 
-Due to this, to maximize signal relative to noise, you should *scale up* each value before setting it as an aggregatable value—that is, multiply each value by a certain factor (while ensuring it stays within the contribution budget).
+Due to this, to maximize signal relative to noise, you should *scale up* each value before setting it as an aggregatable value—that is, multiply each value by a certain factor, the _scaling factor_, while ensuring it stays within the contribution budget.
 
 {% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/P28EJ3mddaen0x7gLA0g.png", alt="Relative noise with and without scaling.", width="512", height="404" %}
 

--- a/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
@@ -145,5 +145,5 @@ We recommend the following:
 
 ## Next steps
 
-- For more information on factors that influence reporting, such as campaign variables, batching frequency, dimension granularity, refer to [Experiment with summary report design decisions](/docs/privacy-sandbox/summary-reports/design-decisions/#quick-tour) .
+- For more information on factors that influence reporting, such as campaign variables, batching frequency, and dimension granularity, refer to [Experiment with summary report design decisions](/docs/privacy-sandbox/summary-reports/design-decisions/#quick-tour) .
 - Try out the [Noise lab](https://noise-lab.uc.r.appspot.com/?mode=simple).

--- a/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
@@ -5,8 +5,8 @@ subhead: >
   How to work with, account for, and reduce the impact of noise in your aggregatable reports.
 description: >
   How to work with, account for, and reduce the impact of noise in your aggregatable reports.
-date: 2022-03-01
-updated: 2023-03-14
+date: 2022-06-23
+updated: 2022-06-23
 authors:
   - maudn
 ---

--- a/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
@@ -22,27 +22,26 @@ Before proceeding, for an in-depth understanding of what noise is, and its impac
 
 We've seen that the [noise applied to the summary value](/docs/privacy-sandbox/attribution-reporting/understanding-noise/#evaluating-noise) for each key is based on the 0-65,536 scale (0-`CONTRIBUTION_BUDGET`).
 
-{% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/ODm7VrPRfwRm3hh8lWZg.png", alt="ALT_TEXT_HERE", width="512", height="147" %}
+{% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/ODm7VrPRfwRm3hh8lWZg.png", alt="Noise distribution is based on budget.", width="512", height="147" %}
 
 Due to this, to maximize signal relative to noise, you should *scale up* each value before setting it as an aggregatable value—that is, multiply each value by a certain factor (while ensuring it stays within the contribution budget).
 
-{% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/P28EJ3mddaen0x7gLA0g.png", alt="ALT_TEXT_HERE", width="512", height="404" %}
+{% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/P28EJ3mddaen0x7gLA0g.png", alt="Relative noise with and without scaling.", width="512", height="404" %}
 
 #### Scaling factor
 
 The *scaling factor* represents how much you want to scale a given aggregatable value.
 Its value should be the contribution budget divided by the maximum aggregatable value for a certain key.
 
-{% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/8ykXLb19ztwGLFeP1UXY.png", alt="ALT_TEXT_HERE", width="512", height="363" %}
+{% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/8ykXLb19ztwGLFeP1UXY.png", alt="Determining the scaling factor based on contribution budget.", width="512", height="363" %}
 
-#### Example
 
-Let's assume advertisers want to know the total purchase value. You know that the maximum expected purchase value of any individual purchase is $2,000, except for a few outliers that you decide to ignore:
+For example, let's assume advertisers want to know the total purchase value. You know that the maximum expected purchase value of any individual purchase is $2,000, except for a few outliers that you decide to ignore:
 
 -   **Calculate the scaling factor**:
     -   To maximize the signal-to-noise ratio, you need to scale this value to 65,536 (the contribution budget).
     -   This results in a 65,536 / 2,000 an approximately **32_x_** scaling factor. In practice, you may round this factor up or down.
--   **Scale up your values before aggregation**. For every **$1** of purchase, increment the tracked metric by **32**. For example, for a purchase of **$120**, set an aggregatable value of *120*32 = 3,840**.
+-   **Scale up your values before aggregation**. For every **$1** of purchase, increment the tracked metric by **32**. For example, for a purchase of **$120**, set an aggregatable value of 120*32 = 3,840.
 -   **Scale down your values after aggregation**. Once you receive the summary report that contains the purchase value summed across multiple users, scale down the summary value using the scaling factor you used before aggregation. In our example, we've used a scaling factor of 32 pre-aggregation, so we need to divide the summary value received in the summary report by 32. Therefore, if the summary purchase value for a given key in the summary report is 76,800, the summary purchase value (with noise) is 76,800/32 = $2,400.
 
 #### Split up your budget
@@ -56,10 +55,7 @@ In this case, your scaling factors will be different for different aggregatable 
 You may decide to allocate the budget equally between two measurement goals, or you can choose to prioritize different measurement goals by allocating more budget to certain goals and less to others.
 {% endAside %}
 
-
-#### Example
-
-Let's assume you're tracking both the purchase count and the purchase value, and that you decide to allocate your budget equally.
+For example, let's assume you're tracking both the purchase count and the purchase value, and that you decide to allocate your budget equally.
 
 65,536 / 2 = 32,768 can be allocated per measurement type and per source.
 
@@ -88,15 +84,14 @@ Similarly, all else held equal, the total purchase value for shoes is lower than
 
 Therefore, the relative noise on the total purchase value for shoes will be higher than the relative noise on the total purchase value for all items.
 
-{% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/fEMnK3PlbIxRCWduHsp6.png", alt="ALT_TEXT_HERE", width="800", height="615" %}
+{% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/fEMnK3PlbIxRCWduHsp6.png", alt="Noise impact with granular versus coarse keys.", width="800", height="615" %}
 
 ### Summing up summary values (rollups) also sums their noise
 
-By summing up yourself summary values from summary reports to access higher-level data, you also sum the noise from these summary values.
+By summing up your summary values from summary reports to access higher-level data, you also sum the noise from these summary values.
 
-{% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/xvdO0HpvwkvppLv1Pv0O.png", alt="ALT_TEXT_HERE", width="800", height="1058" %}
+{% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/xvdO0HpvwkvppLv1Pv0O.png", alt="The degree of noise with granular keys with rollups versus coarse keys with no rollups", width="800", height="1058" %}
 
-#### Example
 
 Let's look at two different approaches:
 -   **Approach A**: you include a Geography ID in your keys. Summary reports expose geo-ID-level keys, each associated with the summary purchase value at a specific Geo ID's level.
@@ -118,7 +113,7 @@ As mentioned earlier, the higher the summary value is, the lower the relative no
 
 {% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/2VZyQbx2weKGTfA3QdA0.png", alt="Requesting summary reports less frequently leads to a higher signal to noise ratio", width="512", height="315" %}
 
-#### Example
+Here's an example to illustrate:
 
 -   If you're requesting hourly summary reports over 24 hours and then summing the summary value from each hourly report to access day-level data, noise is added 24 times.
 -   In one daily summary report, noise is added in only once.

--- a/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
@@ -128,7 +128,7 @@ The higher the epsilon value, the lower the noise and the lower the privacy prot
 
 An important part of allocating budget between different keys is understanding how many times a given event can occur. For example, an advertiser may only care about one purchase for each click, but might be interested in up to 3 “product page view” conversions. To support these use-cases, you may also want to leverage the following API features that enable you to control how many reports are generated, and which conversions are counted:
 
--   Filtering. [Read more about filtering](https://docs.google.com/document/d/1BXchEk-UMgcr2fpjfXrQ3D8VhTR-COGYS1cwK_nyLfg/edit#bookmark=id.qdq6jtxqf6ia).
+-   Filtering. [Read more about filtering](https://docs.google.com/document/d/1BXchEk-UMgcr2fpjfXrQ3D8VhTR-COGYS1cwK_nyLfg/edit#bookmark=kix.h4a74yd4tm8e).
 -   Deduplication. [Read more about deduplication](https://docs.google.com/document/d/1BXchEk-UMgcr2fpjfXrQ3D8VhTR-COGYS1cwK_nyLfg/edit#heading=h.o45jud4u6whw).
 
 <!-- Filtering and Deduplication links needed later -->

--- a/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
@@ -6,7 +6,7 @@ subhead: >
 description: >
   Learn how to work with, account for, and reduce the impact of noise in your aggregatable reports.
 date: 2022-06-23
-updated: 2022-06-23
+updated: 2023-06-24
 authors:
   - maudn
 ---

--- a/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
@@ -18,9 +18,11 @@ Before proceeding, for an in-depth understanding of what noise is, and its impac
 
 ## Your controls on noise
 
+While you can't directly control the noise added to your aggregatable reports, there are steps you can take to minimize the effects. The following sections explain these strategies.
+
 ### Scale up to contribution budget
 
-As explained in [Understanding noise](/docs/privacy-sandbox/attribution-reporting/understanding-noise/#evaluating-noise), noise applied to the summary value for each key is based on the 0-65,536 scale (0-`CONTRIBUTION_BUDGET`).
+As explained in Understanding noise, [noise applied to the summary value](/docs/privacy-sandbox/attribution-reporting/understanding-noise/#evaluating-noise) for each key is based on the 0-65,536 scale (0-`CONTRIBUTION_BUDGET`).
 
 {% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/ODm7VrPRfwRm3hh8lWZg.png", alt="Noise distribution is based on budget.", width="512", height="147" %}
 
@@ -49,7 +51,6 @@ For example, let's assume advertisers want to know the total purchase value. You
 If you have several measurement goals&mdash;for example, purchase count and purchase value&mdash;you may want to split your budget across these goals.
 
 In this case, your scaling factors will be different for different aggregatable values, depending on the expected maximum of a given aggregatable value.
-
 
 {% Aside %}
 You may decide to allocate the budget equally between two measurement goals, or you can choose to prioritize different measurement goals by allocating more budget to certain goals and less to others.
@@ -91,7 +92,6 @@ Therefore, the relative noise on the total purchase value for shoes will be high
 By summing up your summary values from summary reports to access higher-level data, you also sum the noise from these summary values.
 
 {% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/xvdO0HpvwkvppLv1Pv0O.png", alt="The degree of noise with granular keys with rollups versus coarse keys with no rollups", width="800", height="1058" %}
-
 
 Let's look at two different approaches:
 -   **Approach A**: you include a Geography ID in your keys. Summary reports expose geo-ID-level keys, each associated with the summary purchase value at a specific Geo ID's level.

--- a/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
@@ -30,7 +30,7 @@ Due to this, to maximize signal relative to noise, you should *scale up* each va
 
 {% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/P28EJ3mddaen0x7gLA0g.png", alt="Relative noise with and without scaling.", width="512", height="404" %}
 
-#### Scaling factor
+#### Calculating a scaling factor
 
 The scaling factor represents how much you want to scale a given aggregatable value.
 Its value should be the contribution budget divided by the maximum aggregatable value for a certain key.

--- a/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
@@ -32,7 +32,7 @@ Due to this, to maximize signal relative to noise, you should *scale up* each va
 
 #### Scaling factor
 
-The *scaling factor* represents how much you want to scale a given aggregatable value.
+The scaling factor represents how much you want to scale a given aggregatable value.
 Its value should be the contribution budget divided by the maximum aggregatable value for a certain key.
 
 {% Img src="image/RtQlPaM9wdhEJGVKR8boMPkWf443/8ykXLb19ztwGLFeP1UXY.png", alt="Determining the scaling factor based on contribution budget.", width="512", height="363" %}

--- a/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
@@ -2,9 +2,9 @@
 layout: 'layouts/doc-post.njk'
 title: 'Working with noise'
 subhead: >
-  How to work with, account for, and reduce the impact of noise in your aggregatable reports.
+  Learn how to work with, account for, and reduce the impact of noise in your aggregatable reports.
 description: >
-  How to work with, account for, and reduce the impact of noise in your aggregatable reports.
+  Learn how to work with, account for, and reduce the impact of noise in your aggregatable reports.
 date: 2022-06-23
 updated: 2022-06-23
 authors:

--- a/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
@@ -52,6 +52,8 @@ If you have several measurement goals&mdash;for example, purchase count and purc
 
 In this case, your scaling factors will be different for different aggregatable values, depending on the expected maximum of a given aggregatable value.
 
+Read details in the [complete example](https://docs.google.com/document/d/1bU0a_njpDcRd9vDR0AJjwJjrf3Or8vAzyfuK8JZDEfo/view#heading=h.duini3m1xb4y).
+
 {% Aside %}
 You may decide to allocate the budget equally between two measurement goals, or you can choose to prioritize different measurement goals by allocating more budget to certain goals and less to others.
 {% endAside %}
@@ -124,7 +126,10 @@ The higher the epsilon value, the lower the noise and the lower the privacy prot
 
 ### Leveraging filtering and deduplication
 
-An important part of allocating budget between different keys is understanding how many times a given event can occur. For example, an advertiser may only care about one purchase for each click, but might be interested in up to 3 “product page view” conversions. To support these use-cases,you may also want to leverage the following API features that enable you to control how many reports are generated, and which conversions are counted:
+An important part of allocating budget between different keys is understanding how many times a given event can occur. For example, an advertiser may only care about one purchase for each click, but might be interested in up to 3 “product page view” conversions. To support these use-cases, you may also want to leverage the following API features that enable you to control how many reports are generated, and which conversions are counted:
+
+-   Filtering. [Read more about filtering](https://docs.google.com/document/d/1BXchEk-UMgcr2fpjfXrQ3D8VhTR-COGYS1cwK_nyLfg/edit#bookmark=id.qdq6jtxqf6ia).
+-   Deduplication. [Read more about deduplication](https://docs.google.com/document/d/1BXchEk-UMgcr2fpjfXrQ3D8VhTR-COGYS1cwK_nyLfg/edit#heading=h.o45jud4u6whw).
 
 <!-- Filtering and Deduplication links needed later -->
 

--- a/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
@@ -142,3 +142,8 @@ We recommend the following:
 - Share your feedback about specific inflection points you may find with regards to data usability.
 
 {% Partial 'privacy-sandbox/ar-engage.njk' %}
+
+## Next steps
+
+- Review [Experiment with summary report design decisions](/docs/privacy-sandbox/summary-reports/design-decisions/#quick-tour).
+- Try out the [Noise lab](https://noise-lab.uc.r.appspot.com/?mode=simple).

--- a/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
@@ -13,7 +13,7 @@ authors:
 
 ## Before you begin
 
-Before proceeding, for an in-depth understanding of what noise is, and its impact, refer to [Understanding noise](/docs/privacy-sandbox/attribution-reporting/understanding-noise/).
+Before proceeding, for an in-depth understanding of what noise is, and its impact, refer to [Understanding noise in summary reports](/docs/privacy-sandbox/attribution-reporting/understanding-noise/).
 
 
 ## Your controls on noise

--- a/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
@@ -128,7 +128,6 @@ An important part of allocating budget between different keys is understanding h
 
 <!-- Filtering and Deduplication links needed later -->
 
-
 ### Experimenting with epsilon 
 
 Lower values of epsilon provide greater privacy protection.

--- a/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
@@ -133,11 +133,7 @@ An important part of allocating budget between different keys is understanding h
 
 Lower values of epsilon provide greater privacy protection.
 
-During the origin trial, ad tech companies can choose epsilon within a given range. We recommend you start with epsilon=10. 
-
-Epsilon can be set to any value between 0 and 64: 0 < epsilon ≤ 64. 
-
-This range is wide enough to allow for flexible testing.
+During the origin trial, ad tech companies can choose epsilon within a given range. We recommend you start with epsilon=10. Epsilon can be set to any value between 0 and 64: 0 < epsilon ≤ 64. This range is wide enough to allow for flexible testing.
 
 #### Recommendations to experiment
 


### PR DESCRIPTION
Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- Convert ARA noise sections from handbook and tips docs for DCC
- note: since this is existing content, what dates do we want for created and updated. Dates currently in the files are the actual created and updated dates of the source doc: https://docs.google.com/document/d/1bU0a_njpDcRd9vDR0AJjwJjrf3Or8vAzyfuK8JZDEfo/edit#
- https://pr-6556-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/attribution-reporting/understanding-noise/
- https://pr-6556-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/attribution-reporting/working-with-noise/