### PR TITLE
Fix inconsistency in reference to Hello Extensions icon in tutorial

### DIFF
--- a/site/en/docs/extensions/mv3/getstarted/development-basics/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/development-basics/index.md
@@ -77,8 +77,7 @@ To load an unpacked extension in developer mode:
       </figcaption>
     </figure>
 
-Ta-da! The extension has been successfully installed. Because no extension icons were included in
-the manifest, a generic icon will be created for the extension.
+Ta-da! The extension has been successfully installed.
 
 ## Pinning the extension {: #pin }
 


### PR DESCRIPTION
In the "Loading an unpacked extension" section it mentions a generic icon is generated because there is no icon specified in the manifest; this is incorrect, as the previous sections of this page instruct the reader to save a linked icon and includes a reference to it in the provided manifest. This commit removes the sentence referencing creation of a generic icon.

Fixes #6558 

Changes proposed in this pull request:

- Remove the sentence in the [Loading an Unpacked Extension](https://developer.chrome.com/docs/extensions/mv3/getstarted/development-basics/#load-unpacked) section referencing creation of a generic icon.
- I would also suggest changing the screenshot to show the icon from the previous section, but I don't know how to propose that change off the top of my head, so it is not included in this PR.