### PR TITLE
Add note about restricting 103 Early Hints to clients that can handle them

### DIFF
--- a/site/en/blog/early-hints/index.md
+++ b/site/en/blog/early-hints/index.md
@@ -7,7 +7,7 @@ description: >
 subhead: >
   Find out how your server can send hints to the browser about critical sub-resources.
 date: 2022-06-23
-updated: 2023-05-23
+updated: 2023-06-09
 authors:
   - kenjibaheux
 tags:
@@ -150,7 +150,11 @@ Here is a quick summary of the level of support for Early Hints among popular OS
 If you are using one of the following CDNs or platforms, you may not need to manually implement Early Hints. Refer to your solution provider's online documentation to find out if it supports Early Hints, or refer to the non-exhaustive list here:
 
 - [Early Hints at Cloudflare](https://developers.cloudflare.com/cache/about/early-hints/)
-- [Early Hints at Fastly](https://www.google.com/url?q=https://www.fastly.com/blog/beyond-server-push-experimenting-with-the-103-early-hints-status-code%23:~:text%3Dabout%2520this%2520feature.-,Sending%2520103%2520Early%2520Hints,in%2520VCL%252C%2520like%2520this%253A&sa=D&source=docs&ust=1655290700718877&usg=AOvVaw07p23rkLcV4vplasZJBjEx).
+- [Early Hints at Fastly](https://www.fastly.com/blog/beyond-server-push-experimenting-with-the-103-early-hints-status-code#:~:text=about%20this%20feature.-,Sending%20103%20Early%20Hints,in%20VCL%2C%20like%20this%3A).
+
+## Avoiding issues for clients that do not support Early Hints
+
+Informational HTTP responses in the 100 range are part of the HTTP standard, but some older clients or bots may struggle with these as, prior to the launch of 103 Early Hints they were rarely used for general web browsing. Only emitting 103 Early Hints for clients that send a `sec-fetch-mode=navigate` HTTP header in the request should ensure these are only sent for clients that understand to wait for the subsequent response.
 
 ## Advanced pattern
 


### PR DESCRIPTION
See:
- https://www.linkedin.com/feed/update/urn:li:activity:7072444645087047681/
- https://www.linkedin.com/feed/update/urn:li:activity:7072869355666976769/
- https://www.linkedin.com/feed/update/urn:li:activity:7072444645087047681?commentUrn=urn%3Ali%3Acomment%3A%28activity%3A7072444645087047681%2C7072625262080729088%29

Changes proposed in this pull request:

- Add note about only sending 103 responses when client indicates it will understand how to process them
- Correct Fastly link