### PR TITLE
Clarify 'Web Origin' for third party original trail registration.

### DIFF
--- a/site/en/docs/web-platform/third-party-origin-trials/index.md
+++ b/site/en/docs/web-platform/third-party-origin-trials/index.md
@@ -65,6 +65,7 @@ on progress with third-party origin trials.
    trials](https://developers.chrome.com/origintrials/#/trials/active).
 1. On the trial's registration page, enable the option to request a third-party token, if
    available.
+1. For third-party tokens, the Web Origin value should be the origin serveing the script that injects the origin trail token.
 1. Select one of the choices for restricting usage for a third-party token:
    1. Standard Limit: This is the usual limit of
       [0.5% of Chrome page loads](https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md#3-what-happens-if-a-large-site-such-as-a-google-service-starts-depending-on-an-experimental-feature).


### PR DESCRIPTION
Fixes N/A

Changes proposed in this pull request:

This change clarifies 'Web Origin' for third party original trail registration. The current doc is a little bit confusing, it suggests that the token can be used for multiple third-party sites but it doesn't explain why we still need to provide 'Web Origin' in the registration. I found the answer in the [troubleshooting page](https://developer.chrome.com/docs/web-platform/origin-trial-troubleshooting/#origin-third): the web origin should be the origin that serves the script.