### PR TITLE
Add further comments re Early Hints support

### DIFF
--- a/site/en/blog/early-hints/index.md
+++ b/site/en/blog/early-hints/index.md
@@ -157,9 +157,9 @@ If you are using one of the following CDNs or platforms, you may not need to man
 
 Informational HTTP responses in the 100 range are part of the HTTP standard, but some older clients or bots may struggle with these because, prior to the launch of 103 Early Hints, they were rarely used for general web browsing.
 
-Only emitting 103 Early Hints in response to clients that send a `sec-fetch-mode: navigate` HTTP request header has should ensure such hints are only sent for newer clients that understand to wait for the subsequent response. Additionally, since Early Hints are only supported on navigation requests (see [Current limitations](#current-limitations)), this has the added benefit of avoiding needlessly sending these on other requests.
+Only emitting 103 Early Hints in response to clients that send a `sec-fetch-mode: navigate` HTTP request header has should ensure such hints are only sent for newer clients that understand to wait for the subsequent response. Additionally, since Early Hints are only supported on navigation requests (see [current limitations](#current-limitations)), this has the added benefit of avoiding needlessly sending these on other requests.
 
-In addition [Early Hints are recommended to only be sent over HTTP/2 or HTTP/3 connections](https://www.rfc-editor.org/rfc/rfc8297.html#section-3).
+In addition, [Early Hints are recommended to only be sent over HTTP/2 or HTTP/3 connections](https://www.rfc-editor.org/rfc/rfc8297.html#section-3).
 
 ## Advanced pattern
 

--- a/site/en/blog/early-hints/index.md
+++ b/site/en/blog/early-hints/index.md
@@ -156,7 +156,7 @@ If you are using one of the following CDNs or platforms, you may not need to man
 
 Informational HTTP responses in the 100 range are part of the HTTP standard, but some older clients or bots may struggle with these because, prior to the launch of 103 Early Hints, they were rarely used for general web browsing.
 
-Only emitting 103 Early Hints in response to clients that send a `sec-fetch-mode: navigate` HTTP request header has should ensure such hints are only sent for clients that understand to wait for the subsequent response. Additionally, since Early Hints are only supported on navigation requests anyway (see [Current Limitations](#current-limitations)), this has the added benefit of avoiding needlessly sending these on other requests.
+Only emitting 103 Early Hints in response to clients that send a `sec-fetch-mode: navigate` HTTP request header has should ensure such hints are only sent for newer clients that understand to wait for the subsequent response. Additionally, since Early Hints are only supported on navigation requests (see [Current limitations](#current-limitations)), this has the added benefit of avoiding needlessly sending these on other requests.
 
 ## Advanced pattern
 

--- a/site/en/blog/early-hints/index.md
+++ b/site/en/blog/early-hints/index.md
@@ -7,7 +7,7 @@ description: >
 subhead: >
   Find out how your server can send hints to the browser about critical sub-resources.
 date: 2022-06-23
-updated: 2023-06-09
+updated: 2023-06-10
 authors:
   - kenjibaheux
 tags:
@@ -154,7 +154,9 @@ If you are using one of the following CDNs or platforms, you may not need to man
 
 ## Avoiding issues for clients that do not support Early Hints
 
-Informational HTTP responses in the 100 range are part of the HTTP standard, but some older clients or bots may struggle with these because, prior to the launch of 103 Early Hints, they were rarely used for general web browsing. Only emitting 103 Early Hints in response to clients that send a `sec-fetch-mode=navigate` HTTP request header should ensure such hints are only sent for clients that understand to wait for the subsequent response.
+Informational HTTP responses in the 100 range are part of the HTTP standard, but some older clients or bots may struggle with these because, prior to the launch of 103 Early Hints, they were rarely used for general web browsing.
+
+Only emitting 103 Early Hints in response to clients that send a `sec-fetch-mode: navigate` HTTP request header has should ensure such hints are only sent for clients that understand to wait for the subsequent response. Additionally, since Early Hints are only supported on navigation requests anyway (see [Current Limitations](#current-limitations)), this has the added benefit of avoiding needlessly sending these on other requests.
 
 ## Advanced pattern
 

--- a/site/en/blog/early-hints/index.md
+++ b/site/en/blog/early-hints/index.md
@@ -10,6 +10,7 @@ date: 2022-06-23
 updated: 2023-06-10
 authors:
   - kenjibaheux
+  - tunetheweb
 tags:
   - css
 hero: 'image/kheDArv5csY6rvQUJDbWRscckLr1/GDoM9e3pHadjogCPqB4r.jpg'
@@ -157,6 +158,8 @@ If you are using one of the following CDNs or platforms, you may not need to man
 Informational HTTP responses in the 100 range are part of the HTTP standard, but some older clients or bots may struggle with these because, prior to the launch of 103 Early Hints, they were rarely used for general web browsing.
 
 Only emitting 103 Early Hints in response to clients that send a `sec-fetch-mode: navigate` HTTP request header has should ensure such hints are only sent for newer clients that understand to wait for the subsequent response. Additionally, since Early Hints are only supported on navigation requests (see [Current limitations](#current-limitations)), this has the added benefit of avoiding needlessly sending these on other requests.
+
+In addition [Early Hints are recommended to only be sent over HTTP/2 or HTTP/3 connections](https://www.rfc-editor.org/rfc/rfc8297.html#section-3).
 
 ## Advanced pattern
 


### PR DESCRIPTION
See: https://twitter.com/tunetheweb/status/1667421606186999808?s=20

Changes proposed in this pull request:

- Update `sec-fetch-mode=navigate` to `sec-fetch-mode: navigate` to more accurately reflect how HTTP header and values are typically written.
- Add additional benefit of setting Early Hints only on `sec-fetch-mode: navigate` requests.

CC: @lpardue @tvereecke @kenjibaheux