### PR TITLE
Add warning about animation shorthand resetting animation-timeline to its initial value

### DIFF
--- a/site/en/articles/scroll-driven-animations/index.md
+++ b/site/en/articles/scroll-driven-animations/index.md
@@ -163,6 +163,8 @@ Example:
 }
 ```
 
+{% Aside %} The `animation-timeline` longhand property is not part of the `animation` shorthand and must be declared separately. Furthermore, `animation-timeline` must be declared after the `animation` shorthand as the shorthand will reset non-included longhands to their initial value. {% endAside %}
+
 The `scroll()` function accepts a `<scroller>` and an `<axis>` argument.
 
 Accepted values for the `<scroller>` argument are the following:


### PR DESCRIPTION
This is an important detail I underlined at CSS Day during my talk, yet some folks pointed me out this info is not included in the post. This PR corrects that.