### PR TITLE
Updates links to mv3 samples and removes deprecated links to mv2 samples

### DIFF
--- a/site/en/docs/extensions/reference/declarativeNetRequest/index.md
+++ b/site/en/docs/extensions/reference/declarativeNetRequest/index.md
@@ -404,6 +404,10 @@ When rules are applied to browsers with pages in the service worker's cached sto
   `h1` was removed by (10), `h2` was set by (10) then appended by (11), and `h3` was appended by
   (10) and (11).
 
+The following example extensions show how to use `declarativeNetRequst`. To try this API,
+install the [declarativeNetRequst samples](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/declarativeNetRequest) from the [chrome-extension-samples](https://github.com/GoogleChrome/chrome-extensions-samples)
+repository.
+
 [1]: /docs/extensions/mv3/manifest
 [2]: /docs/extensions/mv3/declare_permissions
 [3]: #type-Ruleset

--- a/site/en/docs/extensions/reference/declarativeNetRequest/index.md
+++ b/site/en/docs/extensions/reference/declarativeNetRequest/index.md
@@ -404,8 +404,8 @@ When rules are applied to browsers with pages in the service worker's cached sto
   `h1` was removed by (10), `h2` was set by (10) then appended by (11), and `h3` was appended by
   (10) and (11).
 
-The following example extensions show how to use `declarativeNetRequst`. To try this API,
-install the [declarativeNetRequst samples](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/declarativeNetRequest) from the [chrome-extension-samples](https://github.com/GoogleChrome/chrome-extensions-samples)
+To try the `chrome.declarativeNetRequest` API,
+install the [declarativeNetRequest samples](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/declarativeNetRequest) from the [chrome-extension-samples](https://github.com/GoogleChrome/chrome-extensions-samples)
 repository.
 
 [1]: /docs/extensions/mv3/manifest

--- a/site/en/docs/extensions/reference/devtools_inspectedWindow/index.md
+++ b/site/en/docs/extensions/reference/devtools_inspectedWindow/index.md
@@ -92,7 +92,6 @@ chrome.devtools.inspectedWindow.eval(
 );
 ```
 
-You can find more examples that use Developer Tools APIs in [Samples][8].
 
 [1]: /docs/extensions/mv3/devtools
 [2]: #property-tabId
@@ -100,4 +99,4 @@ You can find more examples that use Developer Tools APIs in [Samples][8].
 [4]: /docs/extensions/reference/tabs#method-executeScript
 [5]: https://developers.google.com/web/tools/chrome-devtools/
 [7]: https://www.ietf.org/rfc/rfc6454.txt
-[8]: /docs/extensions/mv3/samples#search:devtools
+[8]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples

--- a/site/en/docs/extensions/reference/devtools_network/index.md
+++ b/site/en/docs/extensions/reference/devtools_network/index.md
@@ -36,7 +36,6 @@ chrome.devtools.network.onRequestFinished.addListener(
 );
 ```
 
-You can find more examples that use this API in [Samples][3].
 
 [1]: /docs/extensions/mv3/devtools
 [2]: https://www.softwareishard.com/blog/har-12-spec/

--- a/site/en/docs/extensions/reference/devtools_panels/index.md
+++ b/site/en/docs/extensions/reference/devtools_panels/index.md
@@ -47,7 +47,6 @@ This screenshot demonstrates the effect the above examples would have on Develop
 
 ![Extension icon panel on DevTools toolbar](devtools-panels.png)
 
-You can find examples that use this API in [Samples][5].
 
 [1]: /docs/extensions/mv3/devtools
 [2]: /docs/extensions/reference/extension/

--- a/site/en/docs/extensions/reference/fontSettings/index.md
+++ b/site/en/docs/extensions/reference/fontSettings/index.md
@@ -59,8 +59,6 @@ chrome.fontSettings.setFont(
 );
 ```
 
-You can find a sample extension using the Font Settings API in the [examples/api/fontSettings][3]
-directory. For other examples and for help in viewing the source code, see [Samples][4].
 
 [1]: /docs/extensions/mv3/manifest
 [2]: https://www.w3.org/TR/CSS21/fonts.html#generic-font-families

--- a/site/en/docs/extensions/reference/input_ime/index.md
+++ b/site/en/docs/extensions/reference/input_ime/index.md
@@ -42,8 +42,6 @@ chrome.input.ime.onKeyEvent.addListener(
 );
 ```
 
-For an example of using this API, see the [basic input.ime sample][2]. For other examples and for
-help in viewing the source code, see [Samples][3].
 
 [1]: /docs/extensions/mv3/manifest
 [2]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/_archive/mv2/api/input.ime/basic/

--- a/site/en/docs/extensions/reference/pageAction/index.md
+++ b/site/en/docs/extensions/reference/pageAction/index.md
@@ -82,10 +82,6 @@ For the best visual impact, follow these guidelines:
   instead.
 - **Don't** constantly animate your icon. That's just annoying.
 
-## Examples
-
-You can find simple examples of using page actions in the [examples/api/pageAction][7] directory.
-For other examples and for help in viewing the source code, see [Samples][8].
 
 [1]: /docs/extensions/browserAction
 [2]: /docs/extensions/mv3/manifest

--- a/site/en/docs/extensions/reference/scripting/index.md
+++ b/site/en/docs/extensions/reference/scripting/index.md
@@ -252,7 +252,7 @@ already been injected.
 
 {% endAside %}
 
-The following example extensions show how to use scripting. To try this API,
+To try the `chrome.scripting` API,
 install the [scripting sample](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/scripting) from the [chrome-extension-samples](https://github.com/GoogleChrome/chrome-extensions-samples)
 repository.
 

--- a/site/en/docs/extensions/reference/scripting/index.md
+++ b/site/en/docs/extensions/reference/scripting/index.md
@@ -252,6 +252,10 @@ already been injected.
 
 {% endAside %}
 
+The following example extensions show how to use scripting. To try this API,
+install the [scripting sample](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/scripting) from the [chrome-extension-samples](https://github.com/GoogleChrome/chrome-extensions-samples)
+repository.
+
 [activetab]: /docs/extensions/mv3/manifest/activeTab/
 [contentscripts]: /docs/extensions/mv3/content_scripts
 [manifest]: /docs/extensions/mv3/manifest

--- a/site/en/docs/extensions/reference/topSites/index.md
+++ b/site/en/docs/extensions/reference/topSites/index.md
@@ -19,9 +19,6 @@ You must declare the "topSites" permission in your [extension's manifest][2] to 
 }
 ```
 
-## Examples
-
-You can find samples of this API in [Samples][1].
 
 [1]: /docs/extensions/mv2/samples#search:topsites
 [2]: /docs/extensions/mv3/manifest

--- a/site/en/docs/extensions/reference/webNavigation/index.md
+++ b/site/en/docs/extensions/reference/webNavigation/index.md
@@ -19,10 +19,6 @@ in the [extension manifest][1]. For example:
 }
 ```
 
-## Examples
-
-You can find simple examples of using the tabs module in the [examples/api/webNavigation][2]
-directory. For other examples and for help in viewing the source code, see [Samples][3].
 
 ## Event order
 

--- a/site/en/docs/extensions/reference/webRequest/index.md
+++ b/site/en/docs/extensions/reference/webRequest/index.md
@@ -371,7 +371,9 @@ chrome.webRequest.onBeforeSendHeaders.addListener(
 );
 ```
 
-For more example code, see the [web request samples][16].
+The following example extensions show how to use scripting. To try this API,
+install the [webRequest sample](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/webRequest/http-auth) from the [chrome-extension-samples](https://github.com/GoogleChrome/chrome-extensions-samples)
+repository.
 
 [1]: /docs/extensions/mv3/manifest
 [2]: /docs/extensions/mv2/declare_permissions

--- a/site/en/docs/extensions/reference/webRequest/index.md
+++ b/site/en/docs/extensions/reference/webRequest/index.md
@@ -371,8 +371,8 @@ chrome.webRequest.onBeforeSendHeaders.addListener(
 );
 ```
 
-The following example extensions show how to use scripting. To try this API,
-install the [webRequest sample](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/webRequest/http-auth) from the [chrome-extension-samples](https://github.com/GoogleChrome/chrome-extensions-samples)
+To try the `chrome.webRequest` API,
+install the [webRequest sample](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/webRequest/) from the [chrome-extension-samples](https://github.com/GoogleChrome/chrome-extensions-samples)
 repository.
 
 [1]: /docs/extensions/mv3/manifest


### PR DESCRIPTION
Fixes: https://github.com/GoogleChromeLabs/Extension-Docs/issues/85