### PR TITLE
fix: improve regex to block 'parallel' search queries

### DIFF
--- a/site/_js/web-components/search-box.js
+++ b/site/_js/web-components/search-box.js
@@ -32,7 +32,7 @@ const index = client.initIndex('prod_developer_chrome');
 const blockedQueries = [
   /add? ?bloc?k?/,
   /d(a|o|u)w?nl?o?/,
-  /p(a|e)r?r(a|e)?/,
+  /^p(a|e)r+(l|al|el)/,
   /automate be/,
   /roblox/,
   /ublock/,


### PR DESCRIPTION
While the existing regular expression catches all wild "parallel" spellings it's a little to eager and also catches "permission" which is a valid search term.

Updated it to be less eager, available to test with https://regex101.com/ and `^p(a|e)r+(l|al|el)`

```
pala
pall
paller
panel
par
para
para 
para download 
para downloading
paradownloading
paral
parala
paralal
parale
paralel
paralel 
paralel do
paralel download
paralel download 
paralell
parall
parall download 
paralla
parallal
paralle
paralle 
paralle downloading
paralled
parallel
parallel 
parallel d
parallel daw
parallel do
parallel doe
parallel donl
parallel dow
parallel dowl
parallel dowlo
parallel down
parallel downl
parallel downlo
parallel downloa
parallel download
parallel download 
parallel downloadin
parallel downloading
parallel downloading 
parallel downloads
parallel downloads 
parallel downlodi
parallel downloding
parallel downloding 
parallele downloading
parallell
parallels 
paraller
paraller download 
pare
parel
parell
parellal
parelle
parellel
parl
parla
parlal
parlar
parle
parlel
parlell
parll
parlla
parllal
parlle
parllel
parr
parra
parral
parralel
parrall
parralle
parrallel
parre
parrel
parrell
parrl
password
pat
path
payload
pdf
pe
per
pera
peral
perall
perallel
performance
perll
permission
permissions
```