### PR TITLE
WNDT 114 backfill: Web Vitals track removed

### DIFF
--- a/site/en/blog/new-in-devtools-114/index.md
+++ b/site/en/blog/new-in-devtools-114/index.md
@@ -139,7 +139,7 @@ Additionally, the ID of the interaction has been moved from the tooltip to **Sum
 
 Chromium issues: [1432512](https://crbug.com/1432512), [1432509](https://crbug.com/1432509).
 
-### Web Vitals moved to Timings {: #web-vitals }
+### Web Vitals updates {: #web-vitals }
 
 The **Performance** panel has removed the following tracks:
 

--- a/site/en/blog/new-in-devtools-114/index.md
+++ b/site/en/blog/new-in-devtools-114/index.md
@@ -146,21 +146,17 @@ The **Performance** panel has removed the following tracks:
 - The **Web Vitals** track. Instead, see the relevant timings in the **Timings** track on hover.
 - The **Long Tasks** subtrack. You can already find such tasks in the [**Main** track](/docs/devtools/performance/reference/#long-tasks) shaded [in red and with a red triangle](/blog/new-in-devtools-83/#long-tasks).
 
-Both the **Web Vitals** and **Long Tasks** tracks included information that was duplicated elsewhere. They were also non-interactive compared to their more fully-featured alternatives which provide more detailed information when clicked on.
+Both the **Web Vitals** and **Long Tasks** tracks contained information duplicated elsewhere. They were also non-interactive compared to their more fully featured alternatives which provide more detailed information when clicked.
 
 {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Wu4ePOcdvtKHyvy0PK96.png", alt="Before and after moving the Web Vitals to the Timings track.", width="800", height="613" %}
 
+Additionally, the **Experiences** track was renamed to **Layout Shifts** to more accurately reflect its usage.
+
 Learn more about [Web Vitals](https://web.dev/vitals/).
 
-{# https://chromium-review.googlesource.com/q/Ib6f7a8788298187a70bdb44820ce452c6d8db1f1 #}
+{# https://chromium.googlesource.com/devtools/devtools-frontend/+/41b7043de413b2a87f6a8dc8a90ac1a744912400 #}
+{# https://chromium.googlesource.com/devtools/devtools-frontend/+/26306da9622791b255b12c9c0deeac0a0d4a07b8 #}
 
-Chromium issue: [1430844](https://crbug.com/1430844).
-
-The Experiences track was renamed to Layout Shifts to more accurately reflect it's usage.
-
-{# https://chromium-review.googlesource.com/q/26306da9622791b255b12c9c0deeac0a0d4a07b8 #}
-
-Chromium issue: [4403716](https://crbug.com/1428522).
 ## JavaScript Profiler deprecation: Phase three {: #js-profiler }
 
 As early as [Chrome 58](/blog/devtools-javascript-cpu-profile-migration-2/), the DevTools team planned to eventually deprecate the **JavaScript Profiler** and have Node.js and Deno developers use the **Performance** panel for profiling JavaScript CPU performance.

--- a/site/en/blog/new-in-devtools-114/index.md
+++ b/site/en/blog/new-in-devtools-114/index.md
@@ -154,6 +154,11 @@ Learn more about [Web Vitals](https://web.dev/vitals/).
 
 Chromium issue: [1430844](https://crbug.com/1430844).
 
+The Experiences track was renamed to Layout Shifts to more accurately reflect it's usage.
+
+{# https://chromium-review.googlesource.com/q/26306da9622791b255b12c9c0deeac0a0d4a07b8 #}
+
+Chromium issue: [4403716](https://crbug.com/1428522).
 ## JavaScript Profiler deprecation: Phase three {: #js-profiler }
 
 As early as [Chrome 58](/blog/devtools-javascript-cpu-profile-migration-2/), the DevTools team planned to eventually deprecate the **JavaScript Profiler** and have Node.js and Deno developers use the **Performance** panel for profiling JavaScript CPU performance.

--- a/site/en/blog/new-in-devtools-114/index.md
+++ b/site/en/blog/new-in-devtools-114/index.md
@@ -139,6 +139,21 @@ Additionally, the ID of the interaction has been moved from the tooltip to **Sum
 
 Chromium issues: [1432512](https://crbug.com/1432512), [1432509](https://crbug.com/1432509).
 
+### Web Vitals moved to Timings {: #web-vitals }
+
+The **Performance** panel gets rid of the following redundancies:
+
+- Non-interactable **Web Vitals** track. Instead, see the relevant timings in the **Timings** track on hover.
+- The **Long Tasks** subtrack. You can already find such tasks in the [**Main** track](/docs/devtools/performance/reference/#long-tasks) shaded [in red and with a red triangle](/blog/new-in-devtools-83/#long-tasks).
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Wu4ePOcdvtKHyvy0PK96.png", alt="Before and after moving the Web Vitals to the Timings track.", width="800", height="613" %}
+
+Learn more about [Web Vitals](https://web.dev/vitals/).
+
+{# https://chromium-review.googlesource.com/q/Ib6f7a8788298187a70bdb44820ce452c6d8db1f1 #}
+
+Chromium issue: [1430844](https://crbug.com/1430844).
+
 ## JavaScript Profiler deprecation: Phase three {: #js-profiler }
 
 As early as [Chrome 58](/blog/devtools-javascript-cpu-profile-migration-2/), the DevTools team planned to eventually deprecate the **JavaScript Profiler** and have Node.js and Deno developers use the **Performance** panel for profiling JavaScript CPU performance.

--- a/site/en/blog/new-in-devtools-114/index.md
+++ b/site/en/blog/new-in-devtools-114/index.md
@@ -141,10 +141,12 @@ Chromium issues: [1432512](https://crbug.com/1432512), [1432509](https://crbug.c
 
 ### Web Vitals moved to Timings {: #web-vitals }
 
-The **Performance** panel gets rid of the following redundancies:
+The **Performance** panel has removed the following tracks:
 
-- Non-interactable **Web Vitals** track. Instead, see the relevant timings in the **Timings** track on hover.
+- The **Web Vitals** track. Instead, see the relevant timings in the **Timings** track on hover.
 - The **Long Tasks** subtrack. You can already find such tasks in the [**Main** track](/docs/devtools/performance/reference/#long-tasks) shaded [in red and with a red triangle](/blog/new-in-devtools-83/#long-tasks).
+
+Both the **Web Vitals** and **Long Tasks** tracks included information that was duplicated elsewhere. They were also non-interactive compared to their more fully-featured alternatives which provide more detailed information when clicked on.
 
 {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Wu4ePOcdvtKHyvy0PK96.png", alt="Before and after moving the Web Vitals to the Timings track.", width="800", height="613" %}
 

--- a/site/en/docs/devtools/performance/reference/index.md
+++ b/site/en/docs/devtools/performance/reference/index.md
@@ -412,7 +412,7 @@ The **Interactions** track also shows [Interaction to Next Paint (INP)](https://
 
 {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/wrFaZ26nYCuprtCSNB5C.png", alt="The INP warning.", width="800", height="685" %}
 
-Interactions over 200 milliseconds also have the part of the interaction above 200 milliseconds shaded in red—in the same way that [long tasks in the Main thread section](#main:~:text=Long%20tasks%20are%20also%20highlighted) also have the part over the 50 millisecond long task threshold shaded in red. In this example, 353.77 milliseconds out of the 553.77 milliseconds is shaded in red.
+Interactions over 200 milliseconds also have the part of the interaction above 200 milliseconds shaded in red—in the same way that [long tasks in the Main thread section](#long-tasks) also have the part over the 50 millisecond long task threshold shaded in red. In this example, 353.77 milliseconds out of the 553.77 milliseconds is shaded in red.
 
 ### View GPU activity {: #gpu }
 

--- a/site/en/docs/devtools/performance/reference/index.md
+++ b/site/en/docs/devtools/performance/reference/index.md
@@ -244,6 +244,8 @@ A `click` event caused a function call in `script_foot_closure.js` on line 53. B
 
 DevTools assigns scripts random colors to break up the flame chart and make it more readable. In the example above, function calls from one script are colored light green. Calls from another script are colored beige. The darker yellow represents scripting activity, and the purple event represents rendering activity. These darker yellow and purple events are consistent across all recordings.
 
+{: #long-tasks }
+
 [Long tasks are also highlighted](/blog/new-in-devtools-83/#long-tasks) with a red triangle, and with the part over 50 milliseconds shaded in red:
 
 {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/zB1QLni239q7xxTYqUhP.png", alt="The Long Task UI", width="800", height="568" %}


### PR DESCRIPTION
Added the missing section about the removal of Web Vitals track. Didn't yet mention the Layout Shifts track because of [crbug.com/1454082](https://crbug.com/1454082).