### PR TITLE
Fix code typo in index.md

### DIFF
--- a/site/en/docs/extensions/migrating/api-calls/index.md
+++ b/site/en/docs/extensions/migrating/api-calls/index.md
@@ -195,7 +195,7 @@ The methods and properties listed below need to change in Manifest V3.
 | `chrome.extension.onRequest`          | `chrome.runtime.onRequest`                           |
 | `chrome.extension.onRequestExternal`  | `chrome.runtime.onMessageExternal`                   |
 | `chrome.extension.sendMessage()`      | `chrome.runtime.sendMessage()`                       |
-| `chrome.extension.sendNativeMessage() | `chrome.runtime.sendNativeMessage()                  |
+| `chrome.extension.sendNativeMessage()` | `chrome.runtime.sendNativeMessage()`                  |
 | `chrome.extension.sendRequest()`      | `chrome.runtime.sendMessage()`                       |
 | `chrome.runtime.onSuspend` (background scripts) | Not supported in extension service workers. Use the [`beforeunload`](https://developer.mozilla.org/docs/Web/API/Window/beforeunload_event) document event instead. |
 | `chrome.tabs.getAllInWindow()`        | `chrome.tabs.query()`                                |


### PR DESCRIPTION
chrome.extension.sendNativeMessage tab cell has no ending `.