### PR TITLE
link fix

### DIFF
--- a/site/en/blog/background-fetch/index.md
+++ b/site/en/blog/background-fetch/index.md
@@ -108,7 +108,7 @@ navigator.serviceWorker.ready.then(async (swReg) => {
 
 {% Aside %}
 Many examples in this article use async functions. If you aren't familiar with them, [check
-out the guide](https://web.dev/javascript-async-functions/).
+out the guide](https://web.dev/async-functions/).
 {% endAside %}
 
 `backgroundFetch.fetch` takes three arguments:


### PR DESCRIPTION
changed [/javascript-async-functions](https://web.dev/javascript-async-functions/) to [/async-functions](https://web.dev/async-functions/ )
former link 404's. It's the same article, checked wayback machine.
