### PR TITLE
Mv3 reference page sample links

### DIFF
--- a/site/en/docs/extensions/reference/bookmarks/index.md
+++ b/site/en/docs/extensions/reference/bookmarks/index.md
@@ -67,12 +67,12 @@ chrome.bookmarks.create({
 });
 ```
 
-For an example of using this API, see the [basic bookmarks sample][5]. For other examples and for
-help in viewing the source code, see [Samples][6].
+To try this API, install the [Bookmarks API example][6] from the [chrome-extension-samples][5]
+repository.
 
 [1]: /docs/extensions/mv3/manifest
 [2]: #type-BookmarkTreeNode
 [3]: #method-create
 [4]: #type-BookmarkTreeNode
-[5]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/master/_archive/mv2/api/bookmarks/basic/
-[6]: /docs/extensions/mv2/samples
+[5]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples
+[6]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/bookmarks

--- a/site/en/docs/extensions/reference/bookmarks/index.md
+++ b/site/en/docs/extensions/reference/bookmarks/index.md
@@ -67,7 +67,7 @@ chrome.bookmarks.create({
 });
 ```
 
-To try this API. Install the [Bookmarks API example][6] from the [chrome-extension-samples][5]
+To try this API, install the [Bookmarks API example][6] from the [chrome-extension-samples][5]
 repository.
 
 [1]: /docs/extensions/mv3/manifest

--- a/site/en/docs/extensions/reference/bookmarks/index.md
+++ b/site/en/docs/extensions/reference/bookmarks/index.md
@@ -67,7 +67,7 @@ chrome.bookmarks.create({
 });
 ```
 
-To try this API, install the [Bookmarks API example][6] from the [chrome-extension-samples][5]
+To try this API. Install the [Bookmarks API example][6] from the [chrome-extension-samples][5]
 repository.
 
 [1]: /docs/extensions/mv3/manifest

--- a/site/en/docs/extensions/reference/browsingData/index.md
+++ b/site/en/docs/extensions/reference/browsingData/index.md
@@ -170,8 +170,10 @@ extension removes data on their behalf.
 
 ## Examples
 
-Samples for the `browsingData` API are available [on the samples page][3].
+To try this API, install the [browsingData API example][4] from the [chrome-extension-samples][3]
+repository.
 
 [1]: /docs/extensions/mv3/manifest
 [2]: https://chrome.google.com/webstore/detail/aknpkdffaafgjchaibgeefbgmgeghloj
-[3]: /docs/extensions/mv2/samples#search:browsingData
+[3]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples
+[4]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/browsingData

--- a/site/en/docs/extensions/reference/contentSettings/index.md
+++ b/site/en/docs/extensions/reference/contentSettings/index.md
@@ -96,11 +96,13 @@ across plugin updates.
 
 ## Examples
 
-You can find samples of this API on the [sample page][6].
+To try this API, install the [contentSettings API example][6] from the [chrome-extension-samples][7]
+repository.
 
 [1]: /docs/extensions/mv2/match_patterns
 [2]: #property-notifications
 [3]: #property-cookies
 [4]: #property-plugins
 [5]: #method-ContentSetting-getResourceIdentifiers
-[6]: /docs/extensions/mv2/samples#search:contentSettings
+[6]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/contentSettings
+[7]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples

--- a/site/en/docs/extensions/reference/contextMenus/index.md
+++ b/site/en/docs/extensions/reference/contextMenus/index.md
@@ -34,6 +34,8 @@ you should specify a 16x16-pixel icon for display next to your menu item. For ex
 
 ## Examples
 
-You can find samples of this API on the [sample page][1].
+To try this API, install the [contextMenus API example][1] from the [chrome-extension-samples][2]
+repository.
 
-[1]: /docs/extensions/mv2/samples#search:contextMenus
+[1]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/contextMenus
+[2]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples

--- a/site/en/docs/extensions/reference/debugger/index.md
+++ b/site/en/docs/extensions/reference/debugger/index.md
@@ -33,7 +33,9 @@ You must declare the "debugger" permission in your extension's manifest to use t
 
 ## Examples
 
-You can find samples of this API in [Samples][debugger-samples].
+To try this API, install the [debugger API example](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/debugger) from the [chrome-extension-samples](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples)
+repository.
+
 
 [audits]: https://chromedevtools.github.io/devtools-protocol/tot/Audits
 [dom]: https://chromedevtools.github.io/devtools-protocol/tot/DOM

--- a/site/en/docs/extensions/reference/devtools_inspectedWindow/index.md
+++ b/site/en/docs/extensions/reference/devtools_inspectedWindow/index.md
@@ -92,11 +92,9 @@ chrome.devtools.inspectedWindow.eval(
 );
 ```
 
-<<<<<<< Updated upstream
-=======
 To try this API, install the [devtools API examples](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/devtools) from the [chrome-extension-samples](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples)
 repository.
->>>>>>> Stashed changes
+
 
 [1]: /docs/extensions/mv3/devtools
 [2]: #property-tabId

--- a/site/en/docs/extensions/reference/devtools_inspectedWindow/index.md
+++ b/site/en/docs/extensions/reference/devtools_inspectedWindow/index.md
@@ -92,6 +92,11 @@ chrome.devtools.inspectedWindow.eval(
 );
 ```
 
+<<<<<<< Updated upstream
+=======
+To try this API, install the [devtools API examples](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/devtools) from the [chrome-extension-samples](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples)
+repository.
+>>>>>>> Stashed changes
 
 [1]: /docs/extensions/mv3/devtools
 [2]: #property-tabId

--- a/site/en/docs/extensions/reference/devtools_network/index.md
+++ b/site/en/docs/extensions/reference/devtools_network/index.md
@@ -36,6 +36,12 @@ chrome.devtools.network.onRequestFinished.addListener(
 );
 ```
 
+<<<<<<< Updated upstream
+=======
+To try this API, install the [devtools API examples](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/devtools) from the [chrome-extension-samples](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples)
+repository.
+
+>>>>>>> Stashed changes
 
 [1]: /docs/extensions/mv3/devtools
 [2]: https://www.softwareishard.com/blog/har-12-spec/

--- a/site/en/docs/extensions/reference/devtools_network/index.md
+++ b/site/en/docs/extensions/reference/devtools_network/index.md
@@ -36,12 +36,9 @@ chrome.devtools.network.onRequestFinished.addListener(
 );
 ```
 
-<<<<<<< Updated upstream
-=======
 To try this API, install the [devtools API examples](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/devtools) from the [chrome-extension-samples](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples)
 repository.
 
->>>>>>> Stashed changes
 
 [1]: /docs/extensions/mv3/devtools
 [2]: https://www.softwareishard.com/blog/har-12-spec/

--- a/site/en/docs/extensions/reference/devtools_panels/index.md
+++ b/site/en/docs/extensions/reference/devtools_panels/index.md
@@ -47,11 +47,8 @@ This screenshot demonstrates the effect the above examples would have on Develop
 
 ![Extension icon panel on DevTools toolbar](devtools-panels.png)
 
-<<<<<<< Updated upstream
-=======
 To try this API, install the [devtools panels API example][5] from the [chrome-extension-samples][6]
 repository.
->>>>>>> Stashed changes
 
 [1]: /docs/extensions/mv3/devtools
 [2]: /docs/extensions/reference/extension/

--- a/site/en/docs/extensions/reference/devtools_panels/index.md
+++ b/site/en/docs/extensions/reference/devtools_panels/index.md
@@ -47,9 +47,15 @@ This screenshot demonstrates the effect the above examples would have on Develop
 
 ![Extension icon panel on DevTools toolbar](devtools-panels.png)
 
+<<<<<<< Updated upstream
+=======
+To try this API, install the [devtools panels API example][5] from the [chrome-extension-samples][6]
+repository.
+>>>>>>> Stashed changes
 
 [1]: /docs/extensions/mv3/devtools
 [2]: /docs/extensions/reference/extension/
 [3]: /docs/extensions/mv3/overview#contentScripts
 [4]: /docs/extensions/reference/devtools_panels#method-setOpenResourceHandler
-[5]: https://github.com/GoogleChrome/chrome-extensions-samples
+[5]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/devtools/panels
+[6]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples

--- a/site/en/docs/extensions/reference/fontSettings/index.md
+++ b/site/en/docs/extensions/reference/fontSettings/index.md
@@ -59,11 +59,8 @@ chrome.fontSettings.setFont(
 );
 ```
 
-<<<<<<< Updated upstream
-=======
 To try this API, install the [fontSettings API example](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/fontSettings) from the [chrome-extension-samples](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples)
 repository.
->>>>>>> Stashed changes
 
 [1]: /docs/extensions/mv3/manifest
 [2]: https://www.w3.org/TR/CSS21/fonts.html#generic-font-families

--- a/site/en/docs/extensions/reference/fontSettings/index.md
+++ b/site/en/docs/extensions/reference/fontSettings/index.md
@@ -59,6 +59,11 @@ chrome.fontSettings.setFont(
 );
 ```
 
+<<<<<<< Updated upstream
+=======
+To try this API, install the [fontSettings API example](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/fontSettings) from the [chrome-extension-samples](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples)
+repository.
+>>>>>>> Stashed changes
 
 [1]: /docs/extensions/mv3/manifest
 [2]: https://www.w3.org/TR/CSS21/fonts.html#generic-font-families

--- a/site/en/docs/extensions/reference/history/index.md
+++ b/site/en/docs/extensions/reference/history/index.md
@@ -31,8 +31,8 @@ The following table describes each transition type.
 
 ## Examples
 
-For examples of using this API, see the [history sample directory][8] and the [history API test
-directory][9]. For other examples and for help in viewing the source code, see [Samples][10].
+To try this API, install the [history API example](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/history) from the [chrome-extension-samples](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples)
+repository.
 
 [1]: /docs/extensions/mv3/manifest
 [2]: #tt_generated

--- a/site/en/docs/extensions/reference/omnibox/index.md
+++ b/site/en/docs/extensions/reference/omnibox/index.md
@@ -43,7 +43,8 @@ example, the [context menus API][2] also uses a 16x16-pixel icon, but it is disp
 
 ## Examples
 
-You can find samples of this API on the [sample page][3].
+To try this API, install the [omnibox API example](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/omnibox) from the [chrome-extension-samples](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples)
+repository.
 
 [1]: /docs/extensions/mv3/manifest
 [2]: /docs/extensions/contextMenus

--- a/site/en/docs/extensions/reference/privacy/index.md
+++ b/site/en/docs/extensions/reference/privacy/index.md
@@ -94,7 +94,8 @@ chrome.privacy.services.autofillEnabled.onChange.addListener(
 
 ## Examples
 
-For example code, see the [Privacy API samples][4].
+To try this API, install the [privacy API example](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/privacy) from the [chrome-extension-samples](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples)
+repository.
 
 [1]: https://www.google.com/intl/en/landing/chrome/google-chrome-privacy-whitepaper.pdf
 [2]: /docs/extensions/mv3/manifest

--- a/site/en/docs/extensions/reference/topSites/index.md
+++ b/site/en/docs/extensions/reference/topSites/index.md
@@ -18,7 +18,10 @@ You must declare the "topSites" permission in your [extension's manifest][2] to 
   ...
 }
 ```
+## Examples
 
+To try this API, install the [topSites API example](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/topSites) from the [chrome-extension-samples](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples)
+repository.
 
 [1]: /docs/extensions/mv2/samples#search:topsites
 [2]: /docs/extensions/mv3/manifest

--- a/site/en/docs/extensions/reference/webNavigation/index.md
+++ b/site/en/docs/extensions/reference/webNavigation/index.md
@@ -119,6 +119,11 @@ The following transition qualifiers exist:
 
 <table><tbody><tr><th>Transition qualifier</th><th>Description</th></tr><tr><td>"client_redirect"</td><td>One or more redirects caused by JavaScript or meta refresh tags on the page happened during the navigation.</td></tr><tr><td>"server_redirect"</td><td>One or more redirects caused by HTTP headers sent from the server happened during the navigation.</td></tr><tr><td>"forward_back"</td><td>The user used the Forward or Back button to initiate the navigation.</td></tr><tr><td>"from_address_bar"</td><td>The user initiated the navigation from the address bar (aka Omnibox).</td></tr></tbody></table>
 
+## Examples
+
+To try this API, install the [webNavigation API example](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/webNavigation) from the [chrome-extension-samples](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples)
+repository.
+
 [1]: /docs/extensions/mv3/manifest/
 [2]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/_archive/mv2/api/webNavigation/
 [3]: /docs/extensions/mv2/samples

--- a/site/en/docs/extensions/reference/windows/index.md
+++ b/site/en/docs/extensions/reference/windows/index.md
@@ -35,9 +35,8 @@ window. Under some circumstances, there may be no current window for background 
 
 ![Two windows, each with one tab](windows.png)
 
-You can find simple examples of using the windows module in the [examples/api/windows][11]
-directory. Another example is in the [tabs_api.html][12] file of the [inspector][13] example. For
-other examples and for help in viewing the source code, see [Samples][14].
+To try this API, install the [windows API example](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/windows) from the [chrome-extension-samples](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples)
+repository.
 
 [1]: #type-Window
 [2]: /docs/extensions/reference/tabs#type-Tab


### PR DESCRIPTION
Fixes: https://github.com/GoogleChromeLabs/Extension-Docs/issues/65

Changes proposed in this pull request:

- Adds links to MV3 samples on API reference pages.