### PR TITLE
fix: replace broken url with correct url

### DIFF
--- a/site/en/blog/richer-install-ui-desktop/index.md
+++ b/site/en/blog/richer-install-ui-desktop/index.md
@@ -47,7 +47,7 @@ To display the Richer Install UI dialog developers need to add at least one scre
 
 For example developers can use the `description` field to highlight the app’s features that incentivize the user to keep it in their devices. With the `screenshots` they can present the look and feel of the web app as a standalone, with all the easy access that platform apps have.
 
-For a detailed specification and a guide to add them to your app visit the [Richer Install UI pattern](https://web.dev/patterns/advanced-apps/richer-install-ui/).
+For a detailed specification and a guide to add them to your app visit the [Richer Install UI pattern](https://web.dev/patterns/web-apps/richer-install-ui/).
 
 The older style of install prompt provided little information and context. This didn't match users' expectations of what installation means and could leave them confused about what happened. Many declined the install request entirely, which was also bad for the businesses that built them.
 

--- a/site/en/blog/richer-pwa-installation/index.md
+++ b/site/en/blog/richer-pwa-installation/index.md
@@ -91,7 +91,7 @@ To display the richer install UI dialog developers need to add at least one scre
 
 For example developers can use the `description` field to highlight the app’s features that incentivize the user to keep it in their devices, and with the `screenshots`  they can present the look and feel of the web app as a standalone, with all the easy access that platform apps have.
 
-For a detailed specification and a guide to add them to your app visit the [Richer Install UI pattern](https://web.dev/patterns/advanced-apps/richer-install-ui).
+For a detailed specification and a guide to add them to your app visit the [Richer Install UI pattern](https://web.dev/patterns/web-apps/richer-install-ui/).
 
 
 ## Feedback


### PR DESCRIPTION
Fixes #6678 

Changes proposed in this pull request:

- I have updated the broken link in the documentation located at [Richer PWA installation UI](https://developer.chrome.com/blog/richer-pwa-installation/) and [Richer UI install available for desktop](https://developer.chrome.com/blog/richer-install-ui-desktop/)
- I replaced the incorrect URL [404 Not Found Richer Install UI pattern ](https://web.dev/patterns/advanced-apps/richer-install-ui) with the correct URL [How to add Richer Install UI](https://web.dev/patterns/web-apps/richer-install-ui/)  
- This change ensures that users can access the relevant resource for the "Richer Install UI pattern" without encountering a "Page Not Found" error.
- Verified that the new URL leads to the accurate documentation page for the "Richer Install UI pattern".
- Tested the updated link to confirm that it resolves the "Page Not Found" error.
- Submitted this pull request to address issue #6678 raised by myself.

Requesting a review from the maintainers to ensure the correctness of the proposed change.