### PR TITLE
Append What's New in WebGPU list to existing posts

### DIFF
--- a/site/_data/i18n/tags.yml
+++ b/site/_data/i18n/tags.yml
@@ -141,6 +141,9 @@ media:
 webgpu:
   en: WebGPU
 
+new-in-webgpu:
+  en: What's New in WebGPU
+
 new-in-chrome:
   en: New in Chrome
   es: Qué hay de nuevo en Chrome

--- a/site/_data/supportedTags.json
+++ b/site/_data/supportedTags.json
@@ -74,6 +74,9 @@
   "webgpu": {
     "title": "i18n.tags.webgpu"
   },
+  "new-in-webgpu": {
+    "title": "i18n.tags.new-in-webgpu"
+  },
   "new-in-chrome": {
     "title": "i18n.tags.new-in-chrome"
   },

--- a/site/en/_partials/webgpu/whats-new.md
+++ b/site/en/_partials/webgpu/whats-new.md
@@ -1,0 +1,25 @@
+## What's New in WebGPU {: #whats-new }
+
+A list of everything that has been covered in the [What's New in WebGPU](/tags/new-in-webgpu/) series.
+
+
+### Chrome 115 {: #chrome115 }
+
+* [Supported WGSL language extensions](/blog/new-in-webgpu-115/#supported-wgsl-language-extensions)
+* [Unset vertex buffer](/blog/new-in-webgpu-115/#unset-vertex-buffer)
+* [Experimental support for Direct3D 11](/blog/new-in-webgpu-115/#experimental-support-for-direct3d-11)
+* [Get discrete GPU by default on AC power](/blog/new-in-webgpu-115/#get-discrete-gpu-by-default-on-ac-power)
+* [Improving developer experience](/blog/new-in-webgpu-115/#improving-developer-experience)
+* [Dawn updates](/blog/new-in-webgpu-115/#dawn-updates)
+
+### Chrome 114 {: #chrome114 }
+
+* [Optimizing JavaScript](/blog/new-in-webgpu-114/#optimizing-javascript)
+* [getCurrentTexture() on unconfigured canvas throws InvalidStateError](/blog/new-in-webgpu-114/#getcurrenttexture-on-unconfigured-canvas-throws-invalidstateerror)
+* [WGSL updates](/blog/new-in-webgpu-114/#wgsl-updates)
+* [Dawn updates](/blog/new-in-webgpu-114/#dawn-updates)
+
+### Chrome 113 {: #chrome113 }
+
+* [Use WebCodecs VideoFrame source in importExternalTexture()](/blog/new-in-webgpu-113/#use-webcodecs-videoframe-source-in-importexternaltexture)
+

--- a/site/en/blog/new-in-webgpu-113/index.md
+++ b/site/en/blog/new-in-webgpu-113/index.md
@@ -9,6 +9,7 @@ date: 2023-04-26
 authors:
   - beaufortfrancois
 tags:
+  - new-in-webgpu
   - webgpu
   - chrome-113
   - media
@@ -49,3 +50,5 @@ const texture = device.importExternalTexture({ source: videoFrame });
 ```
 
 Check out the [Video Uploading with WebCodecs](https://webgpu.github.io/webgpu-samples/samples/videoUploadingWebCodecs) experimental sample to play with it.
+
+{% Partial 'webgpu/whats-new.md' %}

--- a/site/en/blog/new-in-webgpu-114/index.md
+++ b/site/en/blog/new-in-webgpu-114/index.md
@@ -9,6 +9,7 @@ date: 2023-05-31
 authors:
   - beaufortfrancois
 tags:
+  - new-in-webgpu
   - webgpu
   - chrome-114
 ---
@@ -52,3 +53,5 @@ Descriptor labels for invalid objects are not being dropped anymore so that you 
 ### Add missing APIs for Node.js
 
 The `GPUAdapter::requestAdapterInfo()` and `GPUBuffer::getMapState()` methods are now implemented for Node.js. See [issue dawn:1761](https://bugs.chromium.org/p/dawn/issues/detail?id=1761).
+
+{% Partial 'webgpu/whats-new.md' %}

--- a/site/en/blog/new-in-webgpu-115/index.md
+++ b/site/en/blog/new-in-webgpu-115/index.md
@@ -9,6 +9,7 @@ updated: 2023-06-26
 authors:
   - beaufortfrancois
 tags:
+  - new-in-webgpu
   - webgpu
   - chrome-115
 ---
@@ -120,3 +121,5 @@ auto transientTexture = device.CreateTexture(&desc);
 ### Building without `depot_tools`
 
 A new `DAWN_FETCH_DEPENDENCIES` CMake option allows you to fetch Dawn dependencies using a Python script that reads DEPS files instead of requiring the installation of [`depot_tools`](http://commondatastorage.googleapis.com/chrome-infra-docs/flat/depot_tools/docs/html/depot_tools_tutorial.html#_setting_up) by all projects that depend on it. See [change 131750](https://dawn-review.googlesource.com/c/dawn/+/131750).
+
+{% Partial 'webgpu/whats-new.md' %}


### PR DESCRIPTION
Following existing [pattern](https://developer.chrome.com/blog/new-in-devtools-116/#whats-new) used by "New in DevTools", this PR appends list of everything that has been covered in the What's New in WebGPU series to existing New in WebGPU posts. It also adds a dedicated RSS tag.

@rachelandrew Please review.