### PR TITLE
Fix HTML rendering of title in post navigation

### DIFF
--- a/site/_includes/partials/post-navigation.njk
+++ b/site/_includes/partials/post-navigation.njk
@@ -17,7 +17,7 @@
       {% if previousPost %}
         <a href="{{ previousPost.url }}" class="post-navigation__link">
           <span class="post-navigation__label">{{ 'i18n.common.back' | i18n(locale) }}</span>
-          <p class="post-navigation__title">{{previousPost.data.title}}</p>
+          <p class="post-navigation__title">{{ previousPost.data.title | safe }}</p>
         </a>
       {% endif %}
     </div>
@@ -26,7 +26,7 @@
       {% if nextPost %}
        <a href="{{ nextPost.url }}" class="post-navigation__link">
         <span class="post-navigation__label">{{ 'i18n.common.next' | i18n(locale) }}</span>
-        <p class="post-navigation__title">{{nextPost.data.title}}</p>
+        <p class="post-navigation__title">{{ nextPost.data.title | safe }}</p>
           </a>
       {% endif %}
     </div>


### PR DESCRIPTION
This PR fixes an issue with HTML rendering of post titles in bottom page navigation. See live example at https://developer.chrome.com/blog/topics-enhancements/#:~:text=Back

![image](https://github.com/GoogleChrome/developer.chrome.com/assets/634478/d0f1cc42-2aa8-4fd4-af7d-01a227f86d1e)
