### PR TITLE
fix: typo

### DIFF
--- a/site/en/docs/android/trusted-web-activity/quick-start/index.md
+++ b/site/en/docs/android/trusted-web-activity/quick-start/index.md
@@ -58,7 +58,7 @@ npm i -g @bubblewrap/cli
 ### Setting up the Environment
 
 When running Bubblewrap for the first time, it will offer to automatically download and install the
-required external dependencies. We recommend allowing the tool do do this, as it guarantees that
+required external dependencies. We recommend allowing the tool to do this, as it guarantees that
 the dependencies are configured correctly. Check the [Bubblewrap documentation][1] to use an
 existing Java Development Kit (JDK) or Android command line tools installation.
 


### PR DESCRIPTION
Changes proposed in this pull request:

- fix typo ~do do~ to `to do`