### PR TITLE
Add ePAA availability and API renaming status

### DIFF
--- a/site/en/_partials/privacy-sandbox/timeline/private-aggregation.md
+++ b/site/en/_partials/privacy-sandbox/timeline/private-aggregation.md
@@ -17,7 +17,7 @@ These changes will be possible for testing from the week of Monday, May 22nd in 
     * The `contributeToHistogram()` function is available in Chrome Canary, Dev, Beta, and Stable M115+
     * The `contributeToHistogramOnEvent()` function is available in Chrome Canary, Dev, Beta, and Stable M115+
   * Legacy function names 
-    * The below function names will be deprecated in M115
+    * The following function names will be deprecated in M115
     * The `sendHistogramReport()` function is available in 
       * Chrome Canary, Dev, and Beta M107+
       * Chrome Stable M112+

--- a/site/en/_partials/privacy-sandbox/timeline/private-aggregation.md
+++ b/site/en/_partials/privacy-sandbox/timeline/private-aggregation.md
@@ -13,11 +13,16 @@ These changes will be possible for testing from the week of Monday, May 22nd in 
 
 * The [Private Aggregation API](https://github.com/patcg-individual-drafts/private-aggregation-api/) has entered [public discussion](https://github.com/patcg-individual-drafts/private-aggregation-api/issues).
 * The Private Aggregation API is available for testing in the [Privacy Sandbox Unified Origin Trial](/docs/privacy-sandbox/unified-origin-trial/).
-  * The `sendHistogramReport()` function is available in 
-    * Chrome Canary, Dev, and Beta M107+
-    * Chrome Stable M112+
-  * The `reportContributionForEvent()` function is available in
-    * Chrome Canary and Dev M113+
+  * New function names
+    * The `contributeToHistogram()` function is available in Chrome Canary, Dev, Beta, and Stable M115+
+    * The `contributeToHistogramOnEvent()` function is available in Chrome Canary, Dev, Beta, and Stable M115+
+  * Legacy function names 
+    * The below function names will be deprecated in M115
+    * The `sendHistogramReport()` function is available in 
+      * Chrome Canary, Dev, and Beta M107+
+      * Chrome Stable M112+
+    * The `reportContributionForEvent()` function is available in
+      * Chrome Canary and Dev M113+
   * Supplying a context ID via Shared Storage for report verification is available in
     * Chrome Canary, Dev, Beta, and Stable M114+
   * See the [Privacy Sandbox origin trial](/docs/privacy-sandbox/unified-origin-trial/#status) page to see the latest traffic allocation

--- a/site/en/docs/privacy-sandbox/private-aggregation/index.md
+++ b/site/en/docs/privacy-sandbox/private-aggregation/index.md
@@ -8,7 +8,7 @@ description: >
    Generate aggregate data reports using data from Protected Audience and cross-site
    data from Shared Storage.
 date: 2022-10-11
-updated: 2023-06-01
+updated: 2023-06-29
 authors:
    - kevinkiklee
 ---


### PR DESCRIPTION
This PR adds the status update for extended Private Aggregation availability in M115, and function renaming. 

Preview link: https://pr-6715-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/private-aggregation/#implementation-status