### PR TITLE
Removes mention of event page and erroneous information in storage manifest key page

### DIFF
--- a/site/en/docs/extensions/mv3/manifest/storage/index.md
+++ b/site/en/docs/extensions/mv3/manifest/storage/index.md
@@ -35,8 +35,7 @@ schema.
 ```
 
 Chrome will then load these policies from the underlying operating system and from Google Apps for
-signed-in users. The [storage.onChanged][4] event is fired whenever a policy change is detected,
-including while the browser wasn't running if the extension uses [event pages][5]. You can verify
+signed-in users. The [storage.onChanged][4] event is fired whenever a policy change is detected.
 the policies that Chrome loaded at [chrome://policy][6].
 
 ## Schema format {: #format }

--- a/site/en/docs/extensions/mv3/manifest/storage/index.md
+++ b/site/en/docs/extensions/mv3/manifest/storage/index.md
@@ -36,7 +36,7 @@ schema.
 
 Chrome will then load these policies from the underlying operating system and from Google Apps for
 signed-in users. The [storage.onChanged][4] event is fired whenever a policy change is detected.
-the policies that Chrome loaded at [chrome://policy][6].
+You can verify the policies that Chrome loaded at [chrome://policy][6].
 
 ## Schema format {: #format }
 


### PR DESCRIPTION
Fixes #https://github.com/GoogleChromeLabs/Extension-Docs/issues/112