### PR TITLE
Update tabCapture documentation to use offscreen documents.

### DIFF
--- a/site/en/docs/extensions/mv3/screen_capture/index.md
+++ b/site/en/docs/extensions/mv3/screen_capture/index.md
@@ -121,7 +121,7 @@ are requirements for the approach above.
 Instead, you can open an extension page in a new tab or window, and directly obtain a stream. Set
 the `targetTabId` property to capture the correct tab.
 
-In your popup:
+Start by opening an extension page (perhaps in your popup or service worker):
 
 ```js
 chrome.windows.create({ url: chrome.runtime.getURL("recorder.html") });
@@ -180,8 +180,8 @@ chrome.tabCapture.capture({ audio: true }, (stream) => {
 });
 ```
 
-If you need the recording to persist across navigations, consider using the approach in the
-[previous section](#audio-and-video).
+If you need the recording to persist across navigations, consider using the approach described
+in the [previous section](#audio-and-video-offscreen-doc).
 
 ## Other considerations {: #other-considerations }
 

--- a/site/en/docs/extensions/mv3/screen_capture/index.md
+++ b/site/en/docs/extensions/mv3/screen_capture/index.md
@@ -82,30 +82,30 @@ Then, in your offscreen document:
 
 ```js
 chrome.runtime.onMessage.addListener(async (message) => {
-  if (message.target === 'offscreen') {
-    if (message.type === 'start-recording') {
-      const media = await navigator.mediaDevices.getUserMedia({
-        audio: {
-          mandatory: {
-            chromeMediaSource: "tab",
-            chromeMediaSourceId: message.data,
-          },
+  if (message.target !== 'offscreen') return;
+  
+  if (message.type === 'start-recording') {
+    const media = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        mandatory: {
+          chromeMediaSource: "tab",
+          chromeMediaSourceId: message.data,
         },
-        video: {
-          mandatory: {
-            chromeMediaSource: "tab",
-            chromeMediaSourceId: message.data,
-          },
+      },
+      video: {
+        mandatory: {
+          chromeMediaSource: "tab",
+          chromeMediaSourceId: message.data,
         },
-      });
+      },
+    });
 
-      // Continue to play the captured audio to the user.
-      const output = new AudioContext();
-      const source = output.createMediaStreamSource(media);
-      source.connect(output.destination);
+    // Continue to play the captured audio to the user.
+    const output = new AudioContext();
+    const source = output.createMediaStreamSource(media);
+    source.connect(output.destination);
 
-      // TODO: Do something to recording the MediaStream.
-    }
+    // TODO: Do something to recording the MediaStream.
   }
 });
 ```

--- a/site/en/docs/extensions/mv3/screen_capture/index.md
+++ b/site/en/docs/extensions/mv3/screen_capture/index.md
@@ -10,9 +10,7 @@ This guide explains different approaches for recording audio and video from a ta
 screen using APIs such as [`chrome.tabCapture`][tabcapture] or
 [`getDisplayMedia()`][get-display-media].
 
-## Common use cases {: #common-use-cases }
-
-### Screen recording {: #screen-recording }
+## Screen recording {: #screen-recording }
 
 For screen recording, call [`getDisplayMedia()`][get-display-media], which triggers the dialog box
 shown below. This provides the user with the ability to select which tab, window or screen they wish
@@ -33,16 +31,14 @@ If called within a content script, recording will automatically end when the use
 page. To record in the background and across navigations, use an
 [offscreen document][offscreen-documents] with the `DISPLAY_MEDIA` reason.
 
-### Tab capture based on user gesture {: #user-gesture }
+## Tab capture based on user gesture {: #user-gesture }
 
 Calling [`getDisplayMedia()`][get-display-media] results in the browser showing a dialog which asks
 the user what they would like to share. However, in some cases the user has just clicked on the
 [action button][action-button] to invoke your extension for a specific tab, and you would like to
 immediately start capturing the tab without this prompt.
 
-#### Audio and video {: #audio-and-video }
-
-##### In an offscreen document {: #audio-and-video-offscreen-doc }
+### Recording audio and video in the background {: #audio-and-video-offscreen-doc }
 
 Starting in Chrome 116, you can call the [`chrome.tabCapture`][tabcapture] API in a service worker
 to obtain a stream ID following user gesture. This can then be passed to an offscreen document to
@@ -116,7 +112,7 @@ chrome.runtime.onMessage.addListener(async (message) => {
 
 For a full example, see the [Tab Capture - Recorder][recorder-sample] sample.
 
-##### In a new tab {: #audio-and-video-new-tab }
+### Recording audio and video in a new tab {: #audio-and-video-new-tab }
 
 Prior to Chrome 116, it was not possible to use the [`chrome.tabCapture`][tabcapture] API in a
 service worker or to consume a stream ID created by that API in an offscreen document. Both of these
@@ -161,7 +157,7 @@ Alternatively, consider using the [screen recording](#screen-recording) approach
 record in the background using an offscreen document, but shows the user a dialog to select a tab,
 window or screen to record from.
 
-#### Audio only {: #audio-only }
+### Recording audio in a popup {: #audio-only }
 
 {% Aside 'caution' %}
 

--- a/site/en/docs/extensions/reference/tabCapture/index.md
+++ b/site/en/docs/extensions/reference/tabCapture/index.md
@@ -49,7 +49,7 @@ navigator.mediaDevices.getUserMedia({
 });
 ```
 
-### Usage Restrictions {: #usage-restrictions }
+### Usage restrictions {: #usage-restrictions }
 
 After calling [`getMediaStreamId()`][get-media-stream-id], there are restrictions on where the
 returned stream ID can be used:

--- a/site/en/docs/extensions/reference/tabCapture/index.md
+++ b/site/en/docs/extensions/reference/tabCapture/index.md
@@ -49,6 +49,20 @@ navigator.mediaDevices.getUserMedia({
 });
 ```
 
+### Usage Restrictions {: #usage-restrictions }
+
+After calling [`getMediaStreamId()`][get-media-stream-id], there are restrictions on where the
+returned stream ID can be used:
+
+- If `consumerTabId` is specified, the ID can be used by a `getUserMedia()` call in any frame in the
+given tab which has the same security origin.
+- When this is not specified, begininning in Chrome 116, the ID can be used in any frame with the
+same security origin in the same render process as the caller. This means that a stream ID obtained
+in a service worker can be used in an [offscreen document][offscreen-document].
+
+Prior to Chrome 116, when a `consumerTabId` was not specified, the stream ID was restricted to both
+the security origin, render process and render frame of the caller.
+
 ## Learn more {: #learn-more }
 
 To learn more about how to use the `chrome.tabCapture` API, see
@@ -62,3 +76,4 @@ To learn more about how to use the `chrome.tabCapture` API, see
 [supress-playback]: https://developer.mozilla.org/docs/Web/API/MediaTrackSupportedConstraints/suppressLocalAudioPlayback
 [audio-recording-screen-capture]: /docs/extensions/mv3/screen_capture/
 [action-button]: /docs/extensions/mv3/user_interface/#action
+[offscreen-document]: /docs/extensions/reference/offscreen/


### PR DESCRIPTION
Shows how to capture the active tab using an offscreen document starting in Chrome 116. This relates to the changes made in https://bugs.chromium.org/p/chromium/issues/detail?id=1400269.

Related: https://github.com/GoogleChrome/chrome-extensions-samples/pull/974
Related: https://github.com/GoogleChromeLabs/Extension-Docs/issues/100