### PR TITLE
Fix typo in Best practices > Stay secure doc

### DIFF
--- a/site/en/docs/extensions/mv3/security/index.md
+++ b/site/en/docs/extensions/mv3/security/index.md
@@ -170,7 +170,7 @@ While [content scripts][11] live in an [isolated world][12], they are not immune
   (e.g., [Spectre][14]), and to being taken over by an attacker if a malicious web page compromises
   the renderer process.
 
-Operations using sensative data (such as a user's private information) or chrome APIs with access to the borwser's functions, should be performed in the extensions's service worker.
+Operations using sensative data (such as a user's private information) or chrome APIs with access to the browser's functions, should be performed in the extensions's service worker.
 Avoid accidentally exposing extension privileges to content scripts:
 
 - Assume that [messages from a content script][16] might have been crafted by an attacker (e.g.

--- a/site/en/docs/extensions/mv3/security/index.md
+++ b/site/en/docs/extensions/mv3/security/index.md
@@ -170,7 +170,7 @@ While [content scripts][11] live in an [isolated world][12], they are not immune
   (e.g., [Spectre][14]), and to being taken over by an attacker if a malicious web page compromises
   the renderer process.
 
-Operations using sensative data (such as a user's private information) or chrome APIs with access to the browser's functions, should be performed in the extensions's service worker.
+Operations using sensitive data (such as a user's private information) or Chrome APIs with access to the browser's functions should be performed in the extensions' service worker.
 Avoid accidentally exposing extension privileges to content scripts:
 
 - Assume that [messages from a content script][16] might have been crafted by an attacker (e.g.


### PR DESCRIPTION
Fixes typo 


Changes proposed in this pull request:

- borwser's > browser's
