### PR TITLE
`OpfsDb` lives under `oo1`.

### DIFF
--- a/site/en/blog/sqlite-wasm-in-the-browser-backed-by-the-origin-private-file-system/index.md
+++ b/site/en/blog/sqlite-wasm-in-the-browser-backed-by-the-origin-private-file-system/index.md
@@ -169,8 +169,8 @@ const start = function (sqlite3) {
   const oo = sqlite3.oo1; /*high-level OO API*/
   log('sqlite3 version', capi.sqlite3_libversion(), capi.sqlite3_sourceid());
   let db;
-  if (sqlite3.opfs) {
-    db = new sqlite3.opfs.OpfsDb('/mydb.sqlite3');
+  if ('opfs' in sqlite3) {
+    db = new oo.OpfsDb('/mydb.sqlite3');
     log('The OPFS is available.');
   } else {
     db = new oo.DB('/mydb.sqlite3', 'ct');


### PR DESCRIPTION
Changes proposed in this pull request:
Fixes the code example of initializing Opfs SQLite db.
it seems in recent versions, the `OpfsDb` lives under `oo1` and not under `opfs` object.
check https://github.com/tomayac/sqlite-wasm#in-a-worker-with-opfs-if-available