### PR TITLE
Update offscreen documents docs to use runtime.getContexts

### DIFF
--- a/site/en/docs/extensions/reference/offscreen/index.md
+++ b/site/en/docs/extensions/reference/offscreen/index.md
@@ -28,7 +28,7 @@ Pages loaded as offscreen documents are handled differently from other types of 
 * Offscreen documents cannot have their `opener` property set using the [`chrome.windows` API][api-windows] method `windows.setSelfAsOpener()`.
 * An extension can only have one offscreen document open at a time. If the extension is running in split mode with an active incognito profile, both the normal and incognito profiles can each have one offscreen document. 
 
-Use [`chrome.offscreen.createDocument()`](#method-createDocument) and [`chrome.offscreen.closeDocument()`](#method-closeDocument) for creating and closing an offscreen document. Only a single Document can be open at a time. `createDocument` requires besides the document's `url`, reason and justification:
+Use [`chrome.offscreen.createDocument()`](#method-createDocument) and [`chrome.offscreen.closeDocument()`](#method-closeDocument) for creating and closing an offscreen document. Only a single Document can be open at a time. `createDocument()` requires the document's `url`, a reason, and a justification:
 
 ```js
 chrome.offscreen.createDocument({

--- a/site/en/docs/extensions/reference/offscreen/index.md
+++ b/site/en/docs/extensions/reference/offscreen/index.md
@@ -34,7 +34,7 @@ Reasons, listed [below][offscreen-reason], are set upon document creation to det
 | AUDIO_PLAYBACK    | Closed after 30 seconds without audio playing. |
 | All other reasons | Not currently limited                          |
 
-## Example
+## Example: open and close an offscreen document
 
 Use `chrome.offscreen.createDocument()` and `chrome.offscreen.closeDocument()` for creating and closing an offscreen document. Only a single Document can be open at a time. 
 
@@ -49,21 +49,6 @@ chrome.offscreen.closeDocument()
 ```
 
 The following example shows how to ensure that the offscreen document has already been created. The `setupOffscreenDocument()` function calls [`runtime.getContexts()`][runtime-get-contexts] to find the existing offscreen document or creates it if it doesn't already exist. Note that an extension can only have one offscreen document.
-
-{% Aside 'gotchas' %}
-[`runtime.getContexts()`][runtime-get-contexts] was added in Chrome 116. In earlier versions of
-Chrome, you can check for the existence of the offscreen document using [`clients.matchAll()`](https://developer.mozilla.org/docs/Web/API/Clients/matchAll):
-
-```js
-const matchedClients = await clients.matchAll();
-
-for (const client of matchedClients) {
-  if (client.url === offscreenUrl) {
-    return;
-  }
-}
-```
-{% endAside %}
 
 ```js
 let creating; // A global promise to avoid concurrency issues
@@ -111,6 +96,25 @@ chrome.action.onClicked.addListener(async () => {
 ```
 
 For complete examples, see the [offscreen-clipboard][gh-offscreen-clipboard] and [offscreen-dom][gh-offscreen-dom] demos on GitHub.
+
+### Before Chrome 116: check if an offscreen document is open
+
+[`runtime.getContexts()`][runtime-get-contexts] was added in Chrome 116. In earlier versions of
+Chrome, you can check for the existence of the offscreen document using [`clients.matchAll()`](https://developer.mozilla.org/docs/Web/API/Clients/matchAll):
+
+```js
+async function hasOffscreenDocument(offscreenUrl) {
+    const matchedClients = await clients.matchAll();
+
+    for (const client of matchedClients) {
+      if (client.url === offscreenUrl) {
+        return true;
+      }
+    }
+    return false;
+}
+```
+
 
  [api-runtime]: /docs/extensions/reference/runtime/
  [api-windows]: /docs/extensions/reference/windows/

--- a/site/en/docs/extensions/reference/offscreen/index.md
+++ b/site/en/docs/extensions/reference/offscreen/index.md
@@ -38,6 +38,8 @@ chrome.offscreen.createDocument({
 });
 ```
 
+### Reasons
+
 Find all valid reasons listed [below][offscreen-reason]. Reasons are set upon document creation to determine the document's lifespan: 
 
 

--- a/site/en/docs/extensions/reference/offscreen/index.md
+++ b/site/en/docs/extensions/reference/offscreen/index.md
@@ -52,7 +52,17 @@ The following example shows how to ensure that the offscreen document has alread
 
 {% Aside 'gotchas' %}
 [`runtime.getContexts()`][runtime-get-contexts] was added in Chrome 116. In earlier versions of
-Chrome, you can check for the existence of the offscreen document using [`clients.matchAll()`](https://developer.mozilla.org/docs/Web/API/Clients/matchAll).
+Chrome, you can check for the existence of the offscreen document using [`clients.matchAll()`](https://developer.mozilla.org/docs/Web/API/Clients/matchAll):
+
+```js
+const matchedClients = await clients.matchAll();
+
+for (const client of matchedClients) {
+  if (client.url === offscreenUrl) {
+    return;
+  }
+}
+```
 {% endAside %}
 
 ```js

--- a/site/en/docs/extensions/reference/offscreen/index.md
+++ b/site/en/docs/extensions/reference/offscreen/index.md
@@ -40,7 +40,7 @@ chrome.offscreen.createDocument({
 
 ### Reasons
 
-Find all valid reasons listed [below][offscreen-reason]. Reasons are set upon document creation to determine the document's lifespan: 
+Find all valid reasons listed [below][offscreen-reason]. Reasons are set on document creation to determine the document's lifespan: 
 
 
 | Reason            | Offscreen Document Lifetime                    |

--- a/site/en/docs/extensions/reference/offscreen/index.md
+++ b/site/en/docs/extensions/reference/offscreen/index.md
@@ -18,6 +18,9 @@ You must declare the `"offscreen"` permission in the [extension manifest][doc-ma
   ...
 }
 ```
+
+## Usage
+
 Pages loaded as offscreen documents are handled differently from other types of extension pages. The extension's permissions carry over to offscreen documents, but extension API access is heavily limited. Currently, an offscreen document can only use the [`chrome.runtime`][api-runtime] APIs to send and receive messages; all other extension APIs are not exposed. Other notable differences between offscreen documents and normal pages are as follows:
 
 * An offscreen document's URL must be a static HTML file bundled with the extension.
@@ -25,18 +28,7 @@ Pages loaded as offscreen documents are handled differently from other types of 
 * Offscreen documents cannot have their `opener` property set using the [`chrome.windows` API][api-windows] method `windows.setSelfAsOpener()`.
 * An extension can only have one offscreen document open at a time. If the extension is running in split mode with an active incognito profile, both the normal and incognito profiles can each have one offscreen document. 
 
-## Reasons
-
-Reasons, listed [below][offscreen-reason], are set upon document creation to determine the document's lifespan.
-
-| Reason            | Offscreen Document Lifetime                    |
-|-------------------|------------------------------------------------|
-| AUDIO_PLAYBACK    | Closed after 30 seconds without audio playing. |
-| All other reasons | Not currently limited                          |
-
-## Example: open and close an offscreen document
-
-Use `chrome.offscreen.createDocument()` and `chrome.offscreen.closeDocument()` for creating and closing an offscreen document. Only a single Document can be open at a time. 
+Use [`chrome.offscreen.createDocument()`](#method-createDocument) and [`chrome.offscreen.closeDocument()`](#method-closeDocument) for creating and closing an offscreen document. Only a single Document can be open at a time. `createDocument` requires besides the document's `url`, reason and justification:
 
 ```js
 chrome.offscreen.createDocument({
@@ -44,9 +36,17 @@ chrome.offscreen.createDocument({
   reasons: ['CLIPBOARD'],
   justification: 'reason for needing the document',
 });
-
-chrome.offscreen.closeDocument()
 ```
+
+Find all valid reasons listed [below][offscreen-reason]. Reasons are set upon document creation to determine the document's lifespan: 
+
+
+| Reason            | Offscreen Document Lifetime                    |
+|-------------------|------------------------------------------------|
+| AUDIO_PLAYBACK    | Closed after 30 seconds without audio playing. |
+| All other reasons | Not currently limited                          |
+
+## Example: maintaining the lifecycle of an offscreen document
 
 The following example shows how to ensure that the offscreen document has already been created. The `setupOffscreenDocument()` function calls [`runtime.getContexts()`][runtime-get-contexts] to find the existing offscreen document or creates it if it doesn't already exist. Note that an extension can only have one offscreen document.
 


### PR DESCRIPTION
Updates our offscreen documents docs to use runtime.getContexts, which is available starting in Chrome 116. I'm unsure if we should merge this until that is closer to beta but happy either way.

Fixes https://github.com/GoogleChromeLabs/Extension-Docs/issues/75