### PR TITLE
DevTools 116: Stylesheet debugging + moved linear easing support

### DIFF
--- a/site/en/docs/devtools/css/reference/index.md
+++ b/site/en/docs/devtools/css/reference/index.md
@@ -601,27 +601,36 @@ To change shadows with the **Shadow Editor**:
 
 ### Edit animation and transition timings with the Easing Editor {: #edit-easing }
 
-The **Easing Editor** provides a GUI for changing the easing values of [`transition-timing-function`][36] and [`animation-timing-function`][37].
+The **Easing Editor** provides a GUI for changing the values of [`transition-timing-function`][36] and [`animation-timing-function`][37].
 
-To change the values with the **Easing Editor**:
+To open the **Easing Editor**:
 
 1. [Select an element][27] with a timing function declaration, like the `<body>` element on this page.
-1. In the **Styles** tab, find the purple {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/U0vVF9a5jrj948Gegu6o.png", alt="Ease.", width="22", height="22" %} icon next to the `transition-timing-function` or `animation-timing-function` declarations.
-   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/ulG0cDcH3SnYS13kJbuB.png", alt="Ease icon.", width="800", height="434" %}
+1. In the **Styles** tab, find the purple {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/U0vVF9a5jrj948Gegu6o.png", alt="Ease.", width="22", height="22" %} icon next to the `transition-timing-function`, `animation-timing-function` declarations, or the `transition` shorthand property.
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/H1aAwZxrVvJvjwpoOxN5.png", alt="The Easing Editor icon.", width="800", height="463" %}
 1. Click the icon to open the **Easing Editor**:
-   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/JujOC1By7NK2YzfHT7lD.png", alt="The Easing Editor.", width="800", height="584" %}
-1. To set a [keyword value][38], click one of the picker buttons:
+   {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/IPbaYo0rCjI4NaczFoyN.png", alt="The Easing Editor.", width="800", height="726" %}
+
+### Use presets to adjust timings {: #presets }
+
+To adjust timings with a click, use the presets in the **Easing Editor**:
+
+1. In the **Easing Editor**, to set a [keyword value][38], click one of the picker buttons:
+   - **linear** {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Z9pH2ZrmGkZpaHtdSIUg.png", alt="The linear button.", width="24", height="24" %}
    - **ease-in-out** {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/a0WRju7wMXvxVXiCqFuc.png", alt="The ease-in-out button.", width="24", height="24" %}
    - **ease-in** {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/3kjLNBHixVNDmxarpnqF.png", alt="The ease-in button.", width="24", height="24" %}
    - **ease-out** {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/jlueFxpe3WZ05X2lxp20.png", alt="The ease-out button.", width="24", height="24" %}
 1. In the **Presets switcher**, click {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/79O9ggoDdHGLL73Q1tdG.svg", alt="Left.", width="24", height="24" %} or {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/19mp1EDARktd9LnrvI5L.svg", alt="Right.", width="24", height="24" %} buttons to pick one of the following presets:
 
+  - Linear presets: `elastic`, `bounce`, or `emphasized`.
+  - [Cubic Bezier](https://developer.mozilla.org/docs/Glossary/Bezier_curve) presets:
+
 <table>
 <thead>
   <tr>
-    <th>Easing type</th>
+    <th>Timing keyword</th>
     <th>Preset</th>
-    <th>Bezier equivalent</th>
+    <th>Cubic Bezier</th>
   </tr>
 </thead>
 <tbody>
@@ -691,9 +700,17 @@ To change the values with the **Easing Editor**:
 </tbody>
 </table>
 
-Alternatively, in the **Curve editor**, drag the purple circles to set a custom [`cubic-bezier(x1,y1,x2,y2)`](https://developer.mozilla.org/docs/Glossary/Bezier_curve) value.
+### Configure custom timings {: #custom-timings }
 
-{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/RrpIeYlQURppXdbUXV6C.png", alt="Curve editor.", width="800", height="584" %}
+To set custom values for timing functions, use the control points on the lines:
+
+- For linear functions, click anywhere on the line to add a control point and drag it. Double-click to remove the point.
+
+  {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/sy89NLWDhT7oHgVLnnaF.png", alt="Dragging a control point of a linear function.", width="800", height="720" %}
+
+- For Cubic Bezier functions, drag one of the control points.
+
+  {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/Y6ZAZfS5jZYwifaFfzRD.png", alt="Dragging the control points of a Cubic Bezier function.", width="800", height="720" %}
 
 Any change triggers a ball animation in the **Preview** at the top of editor.
 

--- a/site/en/docs/devtools/issues/index.md
+++ b/site/en/docs/devtools/issues/index.md
@@ -19,7 +19,7 @@ content.
 
 {% Aside %}
 
-Starting from Chrome 92, the **Issues** tab supports the following types of issues:
+Starting from Chrome 116, the **Issues** tab supports the following types of issues:
 
 - [Cookie problems][1]
 - [Mixed content][2]
@@ -28,6 +28,7 @@ Starting from Chrome 92, the **Issues** tab supports the following types of issu
 - [Quirks mode issues][7]
 - (Preview) [Low-contrast issues][8]
 - [Trusted Web Activity issues][9]
+- [Stylesheet loading issues](/blog/new-in-devtools-116/#stylesheets)
 
 Future versions of Chrome will support more issue types.
 

--- a/site/en/docs/devtools/sources/index.md
+++ b/site/en/docs/devtools/sources/index.md
@@ -53,7 +53,7 @@ Note that the **Page** pane lists only the loaded and deployed stylesheets.
 
 Use the **Editor** pane to edit CSS and JavaScript. DevTools updates the page to run your new code.
 
-The **Editor** also helps you debug. For example, it underlines and shows inline error tooltips next to syntax errors and other issues, such as failed CSS `@import` and `url()` statements, and HTML `href` attribtues with invalid URLs.
+The **Editor** also helps you debug. For example, it underlines and shows inline error tooltips next to syntax errors and other issues, such as failed CSS `@import` and `url()` statements, and HTML `href` attributes with invalid URLs.
 
 {% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/bC8AE6UACgxtXXkNMAkL.png", alt="An inline syntax error tooltip.", width="800", height="550" %}
 

--- a/site/en/docs/devtools/sources/index.md
+++ b/site/en/docs/devtools/sources/index.md
@@ -45,20 +45,26 @@ of file. For images, you see a preview of the image.
 
 {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/ByErR7HFeQ7zOVjF4Wyp.png", alt="Viewing a file in the Editor pane.", width="800", height="530" %}
 
+{% Aside %}
+Note that the **Page** pane lists only the loaded and deployed stylesheets.
+{% endAside %}
+
 ## Edit CSS and JavaScript {: #edit }
 
 Use the **Editor** pane to edit CSS and JavaScript. DevTools updates the page to run your new code.
-For example, if you edit the `background-color` of an element, you'll see that change take effect
+
+The **Editor** also helps you debug. For example, it underlines and shows inline error tooltips next to syntax errors and other issues, such as failed CSS `@import` and `url()` statements, and HTML `href` attribtues with invalid URLs.
+
+{% Img src="image/NJdAV9UgKuN8AhoaPBquL7giZQo1/bC8AE6UACgxtXXkNMAkL.png", alt="An inline syntax error tooltip.", width="800", height="550" %}
+
+If you edit the `background-color` of an element, you'll see that the change takes effect
 immediately.
 
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/p0sdJ5tx5yQx1cuOLimO.gif", alt="Editing CSS in the Editor pane", width="800", height="461" %}
+{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/p0sdJ5tx5yQx1cuOLimO.gif", alt="Editing CSS in the Editor pane.", width="800", height="461", class="screenshot" %}
 
-CSS changes take effect immediately, no save needed. For JavaScript changes to take effect, press
-Command+S (Mac) or Control+S (Windows, Linux). DevTools doesn't re-run a script, so the only
-JavaScript changes that take effect are those that you make inside of functions. For example, note
- how `console.log('A')` doesn't run, whereas `console.log('B')` does.
+For JavaScript changes to take effect, press <kbd>Command</kbd>+<kbd>S</kbd> (Mac) or <kbd>Control</kbd>+<kbd>S</kbd> (Windows, Linux). DevTools doesn't re-run a script, so the only JavaScript changes that take effect are those that you make inside of functions. For example, note how `console.log('A')` doesn't run, whereas `console.log('B')` does.
 
-{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/vtNDAWnzXAV5H0cjkZdT.gif", alt="Editing JavaScript in the Editor pane.", width="800", height="461" %}
+{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/vtNDAWnzXAV5H0cjkZdT.gif", alt="Editing JavaScript in the Editor pane.", width="800", height="461", class="screenshot" %}
 
 If DevTools re-ran the entire script after making the change, then the text `A` would have been logged to the
 **Console**.


### PR DESCRIPTION
Documented https://developer.chrome.com/blog/new-in-devtools-116/#stylesheets

Moved "Linear support in the Easing Editor" from 115 to 116 (https://developer.chrome.com/blog/new-in-devtools-116/#linear)

Publish on Aug 15