### PR TITLE
Remove `inert` polyfill as no longer required

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -100,8 +100,7 @@
         "test-listen": "1.1.0",
         "tmp": "^0.2.1",
         "unified-lint-rule": "^1.0.6",
-        "unist-util-visit": "^2.0.3",
-        "wicg-inert": "^3.0.3"
+        "unist-util-visit": "^2.0.3"
       },
       "engines": {
         "node": ">=14"
@@ -26570,12 +26569,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/wicg-inert": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/wicg-inert/-/wicg-inert-3.1.2.tgz",
-      "integrity": "sha512-Ba9tGNYxXwaqKEi9sJJvPMKuo063umUPsHN0JJsjrs2j8KDSzkWLMZGZ+MH1Jf1Fq4OWZ5HsESJID6nRza2ang==",
-      "dev": true
-    },
     "node_modules/widest-line": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
@@ -47247,12 +47240,6 @@
         "has-tostringtag": "^1.0.0",
         "is-typed-array": "^1.1.10"
       }
-    },
-    "wicg-inert": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/wicg-inert/-/wicg-inert-3.1.2.tgz",
-      "integrity": "sha512-Ba9tGNYxXwaqKEi9sJJvPMKuo063umUPsHN0JJsjrs2j8KDSzkWLMZGZ+MH1Jf1Fq4OWZ5HsESJID6nRza2ang==",
-      "dev": true
     },
     "widest-line": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -145,8 +145,7 @@
     "test-listen": "1.1.0",
     "tmp": "^0.2.1",
     "unified-lint-rule": "^1.0.6",
-    "unist-util-visit": "^2.0.3",
-    "wicg-inert": "^3.0.3"
+    "unist-util-visit": "^2.0.3"
   },
   "volta": {
     "node": "16.14.2"

--- a/site/_js/actions/search.js
+++ b/site/_js/actions/search.js
@@ -15,7 +15,6 @@
  */
 
 import {store} from '../store';
-import 'wicg-inert';
 
 export const activateSearch = store.action(() => {
   // Scroll the window to the top of the page.

--- a/site/_js/actions/side-nav.js
+++ b/site/_js/actions/side-nav.js
@@ -15,7 +15,6 @@
  */
 
 import {store} from '../store';
-import 'wicg-inert';
 
 export const expandSideNav = store.action(() => {
   document.querySelectorAll('[data-side-nav-inert').forEach(item => {


### PR DESCRIPTION
With all major browsers now supporting `inert` natively let's remove this polyfill and reduce the JS on our site as much as possible to improve our INP scores.
