### PR TITLE
Fix broken link to Structured Headers spec

### DIFF
--- a/site/en/articles/user-agent-client-hints/index.md
+++ b/site/en/articles/user-agent-client-hints/index.md
@@ -167,7 +167,7 @@ Sec-CH-UA-Platform: "macOS"
 
 {% Aside 'caution' %}
 These properties are more complex than just a single value, so [Structured
-Headers](https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html)
+Headers](https://httpwg.org/specs/rfc8941.html)
 are used for representing lists and booleans.
 {% endAside %}
 


### PR DESCRIPTION
Fixes #6770 

Changes proposed in this pull request:

- Fix broken link to Structured Headers specification in '[Improving user privacy and developer experience with User-Agent Client Hints](https://developer.chrome.com/articles/user-agent-client-hints/)'