### PR TITLE
Custom Tabs: clarify Android App Link support

### DIFF
--- a/site/en/docs/android/custom-tabs/guide-get-started/index.md
+++ b/site/en/docs/android/custom-tabs/guide-get-started/index.md
@@ -21,7 +21,7 @@ dependencies {
 Checkout the [Android Custom Tab Sample app on Github](https://github.com/GoogleChrome/android-browser-helper/tree/dc788207822576f6c867ff28d470ec51ad06d178/demos/custom-tabs-example-app) for a working example.
 {% endAside %}
 
-## Open a link in a custom tab
+## Open a link in a Custom Tab
 
 With the `androidx.browser/browser` library  installed, you can use the [`CustomTabsIntent.Builder`](https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsIntent.Builder) to create a [`CustomTabsIntent`](https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsIntent) and launch the Custom Tab by calling [`launchUrl()`](https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsIntent#launchUrl(android.content.Context,android.net.Uri)) and passing an [Uri](https://developer.android.com/reference/android/net/Uri):
 
@@ -39,5 +39,11 @@ This will open a fullscreen Custom Tab activity as seen on the following screens
 {% Aside 'gotchas' %}
 What happens if the user's default browser does not support Custom Tabs? Custom Tabs are supported by most Android browsers, but if no browser that supports Custom Tabs is installed, the `CustomTabIntent` will open the user's default browser instead. This works, as the `CustomTabsIntent` uses the [`ACTION\_VIEW` Intent](https://developer.android.com/reference/android/content/Intent#ACTION_VIEW) with `Extras` key to customize the UI.
 {% endAside %}
+
+## Supporting Android App Links 
+
+By default, Custom Tabs support [Android App Links](https://developer.android.com/training/app-links/verify-android-applinks). This means, if the YouTube app is installed, launching a `CustomTabsIntent` with a YouTube video URL will open the YouTube app instead of the browser.
+
+However, [passing a `CustomTabsSession` to a `CustomTabIntent`](/docs/android/custom-tabs/guide-warmup-prefetch/) will force open the link in a Custom Tab, even if the corresponding native app is installed. If you want to keep the default behavior of opening web links in native apps, you need to additionally follow our [guide on how to check if a link can be handled by an installed native app](/docs/android/custom-tabs/howto-custom-tab-native-apps/).
 
 Next up: [learn how to customize the look and feel of your Custom Tab.](/docs/android/custom-tabs/guide-ui-customization/).

--- a/site/en/docs/android/custom-tabs/guide-warmup-prefetch/index.md
+++ b/site/en/docs/android/custom-tabs/guide-warmup-prefetch/index.md
@@ -18,11 +18,13 @@ The required steps are:
     a. Warmup the browser process via [`CustomTabsClient.warmup()`](https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsClient#warmup(long)).
     b. Create a new [`CustomTabsSession`](https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsSession) via [`CustomTabsClient.newSession()`](https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsClient#newSession(androidx.browser.customtabs.CustomTabsCallback,int)).
 3. Optionally, prefetch web pages the user is likely to visit via [`CustomTabsSession.mayLaunchUrl()`](https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsSession#mayLaunchUrl(android.net.Uri,android.os.Bundle,java.util.List%3Candroid.os.Bundle%3E)).
-4. When launching a new Custom Tab, pass the [`CustomTabsSession`](https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsSession) to the [CustomTabsIntent.Builder](https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsIntent.Builder) via the constructor `new CustomTabsIntent.Builder(session)`.
+4. When launching a new Custom Tab, pass the [`CustomTabsSession`](https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsSession) to the [CustomTabsIntent.Builder](https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsIntent.Builder) via the constructor `new CustomTabsIntent.Builder(session)`. 
 
 {% Aside 'important' %}
-When targeting API level 30, [`CustomTabsClient`](https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsClient).[`getPackageName()`](https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsClient#getPackageName(android.content.Context,java.util.List%3Cjava.lang.String%3E)) requires you to add a queries section to your Android Manifest, declaring an intent-filter that matches browsers with Custom Tabs support.
+Passing a session to a `CustomTabIntent` will force open the link in a Custom Tab, even if the corresponding native app is installed. If you want to keep the default behavior of opening web links in native apps, you need to additionally follow our [guide on how to check if a link can be handled by an installed native app](/docs/android/custom-tabs/howto-custom-tab-native-apps/).
 {% endAside %}
+
+If your app targets **Android API level 30**, [`CustomTabsClient`](https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsClient).[`getPackageName()`](https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsClient#getPackageName(android.content.Context,java.util.List%3Cjava.lang.String%3E)) requires you to add a queries section to your Android Manifest, declaring an intent-filter that matches browsers with Custom Tabs support.
 
 ```xml
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"


### PR DESCRIPTION
The behavior differs based on whether there is a CustomTabsSession passed to the CustomTabsIntent.Builder or not.
