### PR TITLE
Aside background no longer overlaps other elements

### DIFF
--- a/site/_scss/blocks/_aside.scss
+++ b/site/_scss/blocks/_aside.scss
@@ -1,4 +1,5 @@
 .aside {
+  display: flow-root;
   --link-color: var(--color-blue-darkest);
   --link-visited-color: var(--color-blue-darkest);
   --link-rgb-background: var(--rgb-blue-darkest);


### PR DESCRIPTION
Fixes #6782 

-on file "_aside.scss": Added "display:flow-root;" to aside elements so the colored background doesn't collide with elements on the right.

Signed CLA as Jose Francisco Arana Buelna