### PR TITLE
Add documentation for using Google Analytics with Chrome Web Store

### DIFF
--- a/site/_data/docs/webstore/toc.yml
+++ b/site/_data/docs/webstore/toc.yml
@@ -16,6 +16,7 @@
     - url: /docs/webstore/manage/
     - url: /docs/webstore/update/
     - url: /docs/webstore/review-process/
+    - url: /docs/webstore/google-analytics/
     - url: /docs/webstore/troubleshooting/
     - url: /docs/webstore/branding/
     - url: /docs/webstore/rating/

--- a/site/en/docs/webstore/google-analytics/index.md
+++ b/site/en/docs/webstore/google-analytics/index.md
@@ -95,6 +95,14 @@ act on behalf of the publisher account. This means they can access the Developer
 and publish updates to your extensions. Consequently, access should be shared sparingly. It is not
 currently possible to grant access to just the Analytics property.
 
+### With Looker Studio
+
+Alternatively, you can use [Looker Studio][looker-studio] to create a report based on your
+Google Analytics data. This can be easily shared with any Google account.
+
+Simple choose "Create" and choose the type of file you would like to create. Use the Google
+Analytics connector and add your property under the "Chrome Web Store developer properties" account.
+
 [developer-dashboard]: https://chrome.google.com/webstore/devconsole/
 [ga]: https://analytics.google.com/
 [ga-thresholds]: https://support.google.com/analytics/answer/9383630
@@ -105,3 +113,4 @@ currently possible to grant access to just the Analytics property.
 [ga-custom-events]: https://support.google.com/analytics/answer/12229021
 [extensions-ga4]: /docs/extensions/mv3/tut_analytics/
 [group-publisher]: /docs/webstore/group-publishers/
+[looker-studio]: https://lookerstudio.google.com/

--- a/site/en/docs/webstore/google-analytics/index.md
+++ b/site/en/docs/webstore/google-analytics/index.md
@@ -1,0 +1,107 @@
+---
+layout: "layouts/doc-post.njk"
+title: "Using your Google Analytics account with the Chrome Web Store"
+seoTitle: "Using your Google Analytics account with the Chrome Web Store"
+date: 2023-07-11
+description: How to use your Google Analytics account with the Chrome Web Store
+---
+
+The Chrome Web Store offers integration with Google Analytics. This allows you to see analytics for
+your Chrome Web Store listing as an alternative to the view offered in the Developer Dashboard.
+
+If you’re instead looking to track usage of your extension, see
+[Using Google Analytics 4][extensions-ga4].
+
+## Opt-in to Google Analytics
+
+When viewing your item in the [Developer Dashboard][developer-dashboard], find the Additional
+metrics section on the Store listing page. Click "Opt in to Google Analytics".
+
+{% Img src="image/wVNVUJS8Z8O04i1tJKSdsp6nkRQ2/AVqhwuRqmI00g7AVkIDc.png", alt="Opt in UI for Google Analytics in Developer Dashboard", width="800", height="161" %}
+
+Then, head to [https://analytics.google.com/][ga]. You should have access to a new property which
+has been named with your extension ID.
+
+## Limits
+
+Some limits are in place which can not be changed. These include:
+
+- Data retention is set to two months.
+- Data de-identification is enabled, which limits access to non aggregated data to prevent tracking
+an individual user. For example, data may be withheld if it does not meet system-defined
+[thresholds][ga-thresholds].
+
+## Page views {: #page-views }
+
+Each time a user visits your extension listing, you will see a page view for the following URL: `/webstore/detail/ext/free/EXTENSION_ID/EXTENSION_NAME`
+
+When a user installs your extension, the web store also generates a page view for a fake
+`/track_install` URL.
+
+## Events
+
+The Chrome Web Store also sends a number of events to your property:
+
+- [`page_view`][ga-pageview], [`session_start`][ga-sessionstart], [`first_visit`][ga-firstvisit] and
+[`user_engagement`][ga-userengagement]
+- `install`: This is a [custom event][ga-custom-events] sent when a user installs your extension, at
+the same time as the `track_install` page view (see [above](#page-views)). It is only sent if the
+user actually installs your extension (not if they dismiss the permission dialog for example).
+
+## Monitoring ad performance
+
+### Connecting to Google Ads or other services
+
+It is not currently possible to link your Google Analytics property to other services like Google
+Ads. We recommend periodically checking the data in Google Analytics to understand ad performance
+and make decisions about how to optimize campaigns.
+
+### Using UTM parameters
+
+A common use case for developers is monitoring advertising performance. In these cases, it is useful
+to know which ads led to views of your item’s store listing or which resulted in conversions.
+
+You can use the `utm_medium`, `utm_source` and `utm_campaign` parameters for this which are all
+forwarded to Google Analytics. For example, an ad could direct users to the following URL:
+
+[https://chrome.google.com/webstore/detail/action-api-demo/ljjhjaakmncibonnjpaoglbhcjeolhkk?utm_source=ad&utm_medium=cpc&utm_campaign=summer-ad-campaign](https://chrome.google.com/webstore/detail/action-api-demo/ljjhjaakmncibonnjpaoglbhcjeolhkk?utm_source=ad&utm_medium=cpc&utm_campaign=summer-ad-campaign)
+
+You will see the following for the corresponding `page_view` and `install` events:
+
+- Session source: `ad`
+- Session medium: `cpc`
+- Session campaign: `summer-ad-campaign`
+
+The corresponding first user medium/first user campaign/first user source fields will also be set if
+this is the first time the user has visited your extension listing.
+
+{% Aside 'warning' %}
+Note: It can take between 24-48 hours for data to be finalized. Before then, you may see events
+reported with a blank entry for these fields. This will be corrected as the data is finalized.
+{% endAside %}
+
+## Tracking conversions
+
+The install event generated when a user installs your extension can be marked as a conversion event.
+Go to "Admin > Conversions" and choose "New Conversion Event". Enter "install" and click save. The
+event will now appear as a Conversion across your Google Analytics dashboard.
+
+## Giving other accounts access to Google Analytics
+
+To give other Google accounts access to your Google Analytics property, set up a
+[Group Publisher][group-publisher]. Members of this group will be automatically granted access to
+the Google Analytics property. Note that granting access to the linked group means those users can
+act on behalf of the publisher account. This means they can access the Developer Dashboard and edit
+and publish updates to your extensions. Consequently, access should be shared sparingly. It is not
+currently possible to grant access to just the Analytics property.
+
+[developer-dashboard]: https://chrome.google.com/webstore/devconsole/
+[ga]: https://analytics.google.com/
+[ga-thresholds]: https://support.google.com/analytics/answer/9383630
+[ga-pageview]: https://support.google.com/analytics/answer/9234069#page_view
+[ga-sessionstart]: https://support.google.com/analytics/answer/9234069#session_start
+[ga-firstvisit]: https://support.google.com/analytics/answer/9234069#first_visit
+[ga-userengagement]: https://support.google.com/analytics/answer/9234069#user_engagement
+[ga-custom-events]: https://support.google.com/analytics/answer/12229021
+[extensions-ga4]: /docs/extensions/mv3/tut_analytics/
+[group-publisher]: /docs/webstore/group-publishers/

--- a/site/en/docs/webstore/google-analytics/index.md
+++ b/site/en/docs/webstore/google-analytics/index.md
@@ -12,7 +12,7 @@ your Chrome Web Store listing as an alternative to the view offered in the Devel
 If you’re instead looking to track usage of your extension, see
 [Using Google Analytics 4][extensions-ga4].
 
-## Opt-in to Google Analytics
+## Opt-in to Google Analytics {: #opt-in }
 
 When viewing your item in the [Developer Dashboard][developer-dashboard], find the Additional
 metrics section on the Store listing page. Click "Opt in to Google Analytics".
@@ -22,7 +22,7 @@ metrics section on the Store listing page. Click "Opt in to Google Analytics".
 Then, head to [https://analytics.google.com/][ga]. You should have access to a new property which
 has been named with your extension ID.
 
-## Limits
+## Limits {: #limits }
 
 Some limits are in place which can not be changed. These include:
 
@@ -38,7 +38,7 @@ Each time a user visits your extension listing, you will see a page view for the
 When a user installs your extension, the web store also generates a page view for a fake
 `/track_install` URL.
 
-## Events
+## Events {: #events }
 
 The Chrome Web Store also sends a number of events to your property:
 
@@ -48,15 +48,15 @@ The Chrome Web Store also sends a number of events to your property:
 the same time as the `track_install` page view (see [above](#page-views)). It is only sent if the
 user actually installs your extension (not if they dismiss the permission dialog for example).
 
-## Monitoring ad performance
+## Monitoring ad performance {: #monitor-performance }
 
-### Connecting to Google Ads or other services
+### Connecting to Google Ads or other services {: #connect-other-services }
 
 It is not currently possible to link your Google Analytics property to other services like Google
 Ads. We recommend periodically checking the data in Google Analytics to understand ad performance
 and make decisions about how to optimize campaigns.
 
-### Using UTM parameters
+### Using UTM parameters {: #utm-params }
 
 A common use case for developers is monitoring advertising performance. In these cases, it is useful
 to know which ads led to views of your item’s store listing or which resulted in conversions.
@@ -80,13 +80,13 @@ Note: It can take between 24-48 hours for data to be finalized. Before then, you
 reported with a blank entry for these fields. This will be corrected as the data is finalized.
 {% endAside %}
 
-## Tracking conversions
+## Tracking conversions {: #track-conversions }
 
 The install event generated when a user installs your extension can be marked as a conversion event.
 Go to "Admin > Conversions" and choose "New Conversion Event". Enter "install" and click save. The
 event will now appear as a Conversion across your Google Analytics dashboard.
 
-## Giving other accounts access to Google Analytics
+## Giving other accounts access to Google Analytics {: #grant-access }
 
 To give other Google accounts access to your Google Analytics property, set up a
 [Group Publisher][group-publisher]. Members of this group will be automatically granted access to

--- a/site/en/docs/webstore/google-analytics/index.md
+++ b/site/en/docs/webstore/google-analytics/index.md
@@ -7,7 +7,7 @@ description: How to use your Google Analytics account with the Chrome Web Store
 ---
 
 The Chrome Web Store offers integration with Google Analytics. This allows you to see analytics for
-your Chrome Web Store listing as an alternative to the view offered in the Developer Dashboard.
+your Chrome Web Store listing in addition to the view offered in the Developer Dashboard.
 
 If you’re instead looking to track usage of your extension, see
 [Using Google Analytics 4][extensions-ga4].

--- a/site/en/docs/webstore/google-analytics/index.md
+++ b/site/en/docs/webstore/google-analytics/index.md
@@ -3,8 +3,7 @@ layout: "layouts/doc-post.njk"
 title: "Using your Google Analytics account with the Chrome Web Store"
 seoTitle: "Using your Google Analytics account with the Chrome Web Store"
 date: 2023-07-11
-description: The Chrome Web Store offers integration with Google Analytics, which allows you to see analytics for
-your Chrome Web Store listing in addition to the view offered in the Developer Dashboard.
+description: The Chrome Web Store offers integration with Google Analytics, which allows you to see analytics for your Chrome Web Store listing in addition to the view offered in the Developer Dashboard.
 ---
 
 The Chrome Web Store offers integration with Google Analytics. This allows you to see analytics for
@@ -34,6 +33,8 @@ Some limits apply in your Google Analytics property. These include:
 - Data de-identification is enabled, which limits access to non aggregated data to prevent tracking
 an individual user. For example, data may be withheld if it does not meet system-defined
 [thresholds][ga-thresholds].
+- Additional users can only be added by syncing with a Group Publisher (see
+[below](#group-publisher)).
 
 ## Page views {: #page-views }
 
@@ -53,12 +54,6 @@ The Chrome Web Store also sends a number of events to your property:
 the same time as the `track_install` page view (see [above](#page-views)). 
 
 ## Monitoring ad performance {: #monitor-performance }
-
-### Connecting to Google Ads or other services {: #connect-other-services }
-
-It is not currently possible to link your Google Analytics property to other services like Google
-Ads. We recommend periodically checking the data in Google Analytics to understand ad performance
-and make decisions about how to optimize campaigns.
 
 ### Using UTM parameters {: #utm-params }
 
@@ -84,6 +79,12 @@ It can take between 24 and 48 hours for data to be finalized. Before then, you m
 reported with a blank entry for these fields. This will be corrected as the data is finalized.
 {% endAside %}
 
+### Connecting to Google Ads or other services {: #connect-other-services }
+
+It is not currently possible to link your Google Analytics property to other services like Google
+Ads. We recommend periodically checking the data in Google Analytics to understand ad performance
+and make decisions about how to optimize campaigns.
+
 ## Tracking conversions {: #track-conversions }
 
 The install event generated when a user installs your extension can be marked as a conversion event.
@@ -92,14 +93,15 @@ event will now appear as a Conversion across your Google Analytics dashboard.
 
 ## Giving other accounts access to Google Analytics {: #grant-access }
 
+### Using a Group Publisher {: #group-publisher }
+
 To give other Google accounts access to your Google Analytics property, set up a
 [Group Publisher][group-publisher]. Members of this group will be automatically granted access to
 the Google Analytics property. Note that granting access to the linked group means those users can
 act on behalf of the publisher account. This means they can access the Developer Dashboard and edit
-and publish updates to your extensions. Consequently, access should be shared sparingly. It is not
-currently possible to grant access to just the Analytics property.
+and publish updates to your extensions. Consequently, access should be shared sparingly.
 
-### With Looker Studio
+### With Looker Studio {: #looker-studio }
 
 Alternatively, you can use [Looker Studio][looker-studio] to create a report based on your
 Google Analytics data. This can be easily shared with any Google account.

--- a/site/en/docs/webstore/google-analytics/index.md
+++ b/site/en/docs/webstore/google-analytics/index.md
@@ -40,18 +40,14 @@ an individual user. For example, data may be withheld if it does not meet system
 
 Each time a user visits your extension listing, you will see a page view for the following URL: `/webstore/detail/ext/free/EXTENSION_ID/EXTENSION_NAME`
 
-When a user installs your extension, the web store also generates a page view for a fake
-`/track_install` URL. This is only sent if a user accepts the permission prompt to complete the
-install.
-
 ## Events {: #events }
 
 The Chrome Web Store also sends a number of events to your property:
 
 - [`page_view`][ga-pageview], [`session_start`][ga-sessionstart], [`first_visit`][ga-firstvisit] and
 [`user_engagement`][ga-userengagement]
-- `install`: A [custom event][ga-custom-events] sent when a user installs your extension, at
-the same time as the `track_install` page view (see [above](#page-views)). 
+- `install`: A [custom event][ga-custom-events] sent when a user installs your extension. This is
+only sent if a user accepts the permission prompt to complete the install.
 
 ## Monitoring ad performance {: #monitor-performance }
 

--- a/site/en/docs/webstore/google-analytics/index.md
+++ b/site/en/docs/webstore/google-analytics/index.md
@@ -28,7 +28,7 @@ has been named with your extension ID.
 
 ## Limits {: #limits }
 
-Some limits are in place which can not be changed. These include:
+Some limits apply in your Google Analytics property. These include:
 
 - Data retention is set to two months.
 - Data de-identification is enabled, which limits access to non aggregated data to prevent tracking

--- a/site/en/docs/webstore/google-analytics/index.md
+++ b/site/en/docs/webstore/google-analytics/index.md
@@ -39,7 +39,8 @@ an individual user. For example, data may be withheld if it does not meet system
 Each time a user visits your extension listing, you will see a page view for the following URL: `/webstore/detail/ext/free/EXTENSION_ID/EXTENSION_NAME`
 
 When a user installs your extension, the web store also generates a page view for a fake
-`/track_install` URL.
+`/track_install` URL. This is only sent if a user accepts the permission prompt to complete the
+install.
 
 ## Events {: #events }
 
@@ -48,8 +49,7 @@ The Chrome Web Store also sends a number of events to your property:
 - [`page_view`][ga-pageview], [`session_start`][ga-sessionstart], [`first_visit`][ga-firstvisit] and
 [`user_engagement`][ga-userengagement]
 - `install`: A [custom event][ga-custom-events] sent when a user installs your extension, at
-the same time as the `track_install` page view (see [above](#page-views)). It is only sent if the
-user actually installs your extension (not if they dismiss the permission dialog for example).
+the same time as the `track_install` page view (see [above](#page-views)). 
 
 ## Monitoring ad performance {: #monitor-performance }
 

--- a/site/en/docs/webstore/google-analytics/index.md
+++ b/site/en/docs/webstore/google-analytics/index.md
@@ -3,7 +3,8 @@ layout: "layouts/doc-post.njk"
 title: "Using your Google Analytics account with the Chrome Web Store"
 seoTitle: "Using your Google Analytics account with the Chrome Web Store"
 date: 2023-07-11
-description: How to use your Google Analytics account with the Chrome Web Store
+description: The Chrome Web Store offers integration with Google Analytics, which allows you to see analytics for
+your Chrome Web Store listing in addition to the view offered in the Developer Dashboard.
 ---
 
 The Chrome Web Store offers integration with Google Analytics. This allows you to see analytics for
@@ -17,8 +18,10 @@ If you’re instead looking to track usage of your extension, see
 When viewing your item in the [Developer Dashboard][developer-dashboard], find the Additional
 metrics section on the Store listing page. Click "Opt in to Google Analytics".
 
-{% Img src="image/wVNVUJS8Z8O04i1tJKSdsp6nkRQ2/AVqhwuRqmI00g7AVkIDc.png", alt="Opt in UI for Google Analytics in Developer Dashboard", width="800", height="161" %}
-
+<figure>
+  {% Img src="image/wVNVUJS8Z8O04i1tJKSdsp6nkRQ2/AVqhwuRqmI00g7AVkIDc.png", alt="Opt in UI for Google Analytics in Developer Dashboard", width="800", height="161" %}
+  <figcaption>Opt in UI for Google Analytics in Developer Dashboard.</figcaption>
+</figure>
 Then, head to [https://analytics.google.com/][ga]. You should have access to a new property which
 has been named with your extension ID.
 
@@ -44,7 +47,7 @@ The Chrome Web Store also sends a number of events to your property:
 
 - [`page_view`][ga-pageview], [`session_start`][ga-sessionstart], [`first_visit`][ga-firstvisit] and
 [`user_engagement`][ga-userengagement]
-- `install`: This is a [custom event][ga-custom-events] sent when a user installs your extension, at
+- `install`: A [custom event][ga-custom-events] sent when a user installs your extension, at
 the same time as the `track_install` page view (see [above](#page-views)). It is only sent if the
 user actually installs your extension (not if they dismiss the permission dialog for example).
 
@@ -61,7 +64,7 @@ and make decisions about how to optimize campaigns.
 A common use case for developers is monitoring advertising performance. In these cases, it is useful
 to know which ads led to views of your item’s store listing or which resulted in conversions.
 
-You can use the `utm_medium`, `utm_source` and `utm_campaign` parameters for this which are all
+You can use the `utm_source`, `utm_medium`, and `utm_campaign` parameters for this which are all
 forwarded to Google Analytics. For example, an ad could direct users to the following URL:
 
 [https://chrome.google.com/webstore/detail/action-api-demo/ljjhjaakmncibonnjpaoglbhcjeolhkk?utm_source=ad&utm_medium=cpc&utm_campaign=summer-ad-campaign](https://chrome.google.com/webstore/detail/action-api-demo/ljjhjaakmncibonnjpaoglbhcjeolhkk?utm_source=ad&utm_medium=cpc&utm_campaign=summer-ad-campaign)
@@ -72,18 +75,18 @@ You will see the following for the corresponding `page_view` and `install` event
 - Session medium: `cpc`
 - Session campaign: `summer-ad-campaign`
 
-The corresponding first user medium/first user campaign/first user source fields will also be set if
-this is the first time the user has visited your extension listing.
+If this is the first time the user has visited your extension listing the "first user
+medium", "first user campaign", and "first user source" fields will also be set.
 
-{% Aside 'warning' %}
-Note: It can take between 24-48 hours for data to be finalized. Before then, you may see events
+{% Aside %}
+It can take between 24 and 48 hours for data to be finalized. Before then, you may see events
 reported with a blank entry for these fields. This will be corrected as the data is finalized.
 {% endAside %}
 
 ## Tracking conversions {: #track-conversions }
 
 The install event generated when a user installs your extension can be marked as a conversion event.
-Go to "Admin > Conversions" and choose "New Conversion Event". Enter "install" and click save. The
+Go to **Admin**, then **Conversions** and choose **New Conversion Event**. Enter "install" and click **Save**. The
 event will now appear as a Conversion across your Google Analytics dashboard.
 
 ## Giving other accounts access to Google Analytics {: #grant-access }

--- a/site/en/docs/webstore/google-analytics/index.md
+++ b/site/en/docs/webstore/google-analytics/index.md
@@ -22,6 +22,7 @@ metrics section on the Store listing page. Click "Opt in to Google Analytics".
   {% Img src="image/wVNVUJS8Z8O04i1tJKSdsp6nkRQ2/AVqhwuRqmI00g7AVkIDc.png", alt="Opt in UI for Google Analytics in Developer Dashboard", width="800", height="161" %}
   <figcaption>Opt in UI for Google Analytics in Developer Dashboard.</figcaption>
 </figure>
+
 Then, head to [https://analytics.google.com/][ga]. You should have access to a new property which
 has been named with your extension ID.
 

--- a/site/en/docs/webstore/manage/index.md
+++ b/site/en/docs/webstore/manage/index.md
@@ -211,6 +211,8 @@ To track store item metrics, you can opt in to Google Analytics 4 by clicking **
 The Chrome Web Store manages the account for you and makes the data available in Google Analytics. Chrome Web Store grants you access only to non user-level data. For group publishers, all developers within the group, regardless of their role within the group, are granted access to data for items owned by the group.
 {% Img src="image/sQ51XsLqKMgSQMCZjIN0B7hlBO02/etCDPbAFMIeOcKvAW4rN.png", alt="Where to opt in to Google Analytics", width="713", height="123" %}
 
+Learn more [here][analytics].
+
 [cws-review]: /docs/webstore/review-process/
 [cws-support]: https://support.google.com/chrome_webstore/contact/dev_account_transfer
 [dev-dashboard]: https://chrome.google.com/webstore/devconsole
@@ -219,3 +221,4 @@ The Chrome Web Store manages the account for you and makes the data available in
 [support-tab]: #user-support-tab
 [troubleshooting]: /docs/webstore/troubleshooting/
 [whats-new]: /docs/extensions/whatsnew/
+[analytics]: /docs/webstore/google-analytics/


### PR DESCRIPTION
Adds documentation for using Google Analytics with Chrome Web Store.

Fixes https://github.com/GoogleChromeLabs/Extension-Docs/issues/95