### PR TITLE
Update index.md

### DIFF
--- a/site/en/docs/android/custom-tabs/guide-warmup-prefetch/index.md
+++ b/site/en/docs/android/custom-tabs/guide-warmup-prefetch/index.md
@@ -56,7 +56,7 @@ private CustomTabsServiceConnection mConnection = new CustomTabsServiceConnectio
         mSession = mClient.newSession(new CustomTabsCallback());
         // Pre-render pages the user is likely to visit
         // you can do this any time while the service is connected
-        mSession.mayLaunchUrl("https://developers.android.com", null, null);
+        mSession.mayLaunchUrl(Uri.parse("https://developers.android.com"), null, null);
     }
 
     @Override


### PR DESCRIPTION
Added "Uri.parse()" to the mSession.mayLaunchUrl() method. Required parameter is of type "Uri", but supplied parameter is of type "String".

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- Added "Uri.parse()" to the mSession.mayLaunchUrl() method. Required parameter is of type "Uri", but supplied parameter is of type "String".
-
-