### PR TITLE
Update PAAPI walkthrough link

### DIFF
--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -79,7 +79,7 @@
             - url: /docs/privacy-sandbox/fledge-api/reports
             - url: /docs/privacy-sandbox/fledge-api/troubleshoot
         - url: /docs/privacy-sandbox/fledge-api/feature-status
-        - url: https://docs.google.com/document/d/16U6nCs5-RTpYDF5nuUVopvUXKzDgH6yDKaYbzY3ouiI/view
+        - url: https://goo.gle/protected-audience-api-walkthrough
           title: i18n.docs.privacy-sandbox.paapi-walkthrough
     - title: i18n.docs.privacy-sandbox.content-selection
       sections:


### PR DESCRIPTION
This PR updates the PAAPI walkthrough link to a shortlink: https://goo.gle/protected-audience-api-walkthrough