### PR TITLE
Add Chrome Apps label to Chrome Apps titles

### DIFF
--- a/site/en/docs/apps/analytics/index.md
+++ b/site/en/docs/apps/analytics/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Analytics"
+title: "[Chrome Apps] Analytics"
 seoTitle: "Google Analytics for Chrome apps [Deprecated]"
 date: 2013-08-01
 #updated: TODO

--- a/site/en/docs/apps/api_other/index.md
+++ b/site/en/docs/apps/api_other/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Web APIs"
+title: "[Chrome Apps] Web APIs"
 seoTitle: "Web APIs for Chrome Apps [Deprecated]"
 date: 2012-09-17
 updated: 2017-03-01

--- a/site/en/docs/apps/app_bluetooth/index.md
+++ b/site/en/docs/apps/app_bluetooth/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Bluetooth"
+title: "[Chrome Apps] Bluetooth"
 seoTitle: "Chrome Apps Bluetooth [Deprecated]"
 date: 2014-03-11
 updated: 2017-02-18

--- a/site/en/docs/apps/app_external/index.md
+++ b/site/en/docs/apps/app_external/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "External Content"
+title: "[Chrome Apps] External Content"
 seoTitle: "External Content [Deprecated]"
 date: 2012-09-17
 updated: 2018-05-14

--- a/site/en/docs/apps/app_network/index.md
+++ b/site/en/docs/apps/app_network/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Network Communications"
+title: "[Chrome Apps] Network Communications"
 seoTitle: "Chrome Apps - Network Communications [Deprecated]"
 date: 2012-09-17
 updated: 2014-11-13

--- a/site/en/docs/apps/app_storage/index.md
+++ b/site/en/docs/apps/app_storage/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Storage APIs"
+title: "[Chrome Apps] Storage APIs"
 seoTitle: "Chrome Apps - Storage APIs [Deprecated]"
 date: 2012-09-17
 updated: 2014-09-10

--- a/site/en/docs/apps/autoupdate/index.md
+++ b/site/en/docs/apps/autoupdate/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Autoupdating"
+title: "[Chrome Apps] Autoupdating"
 seoTitle: "Chrome Apps - Autoupdating"
 date: 2012-09-17
 updated: 2018-03-19

--- a/site/en/docs/apps/contentSecurityPolicy/index.md
+++ b/site/en/docs/apps/contentSecurityPolicy/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Content Security Policy"
+title: "[Chrome Apps] Content Security Policy"
 seoTitle: "Chrome Apps - Content Security Policy [Deprecated]"
 date: 2012-09-17
 updated: 2018-05-14

--- a/site/en/docs/apps/event_pages/index.md
+++ b/site/en/docs/apps/event_pages/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Update: Event Pages and Background Pages"
+title: "[Chrome Apps] Update: Event Pages and Background Pages"
 seoTitle: "Chrome Apps - Update: Event Pages and Background Pages [Deprecated]"
 #date: TODO
 #updated: TODO

--- a/site/en/docs/apps/manifest/action_handlers/index.md
+++ b/site/en/docs/apps/manifest/action_handlers/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Manifest - Action Handlers"
+title: "[Chrome Apps] Manifest - Action Handlers"
 seoTitle: "Chrome Apps Manifest - Action Handlers [Deprecated]"
 date: 2017-02-03
 #updated: TODO

--- a/site/en/docs/apps/manifest/app/index.md
+++ b/site/en/docs/apps/manifest/app/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Manifest - App"
+title: "[Chrome Apps] Manifest - App"
 seoTitle: "Chrome Apps Manifest - App [Deprecated]"
 date: 2013-05-11
 updated: 2018-04-26

--- a/site/en/docs/apps/manifest/bluetooth/index.md
+++ b/site/en/docs/apps/manifest/bluetooth/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Manifest - Bluetooth"
+title: "[Chrome Apps] Manifest - Bluetooth"
 seoTitle: "Chrome Apps Manifest - Bluetooth [Deprecated]"
 date: 2014-03-11
 updated: 2014-10-31

--- a/site/en/docs/apps/manifest/default_locale/index.md
+++ b/site/en/docs/apps/manifest/default_locale/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Manifest - Default Locale"
+title: "[Chrome Apps] Manifest - Default Locale"
 seoTitle: "chrome Apps Manifest - Default Locale [Deprecated]"
 #date: TODO
 #updated: TODO

--- a/site/en/docs/apps/manifest/description/index.md
+++ b/site/en/docs/apps/manifest/description/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Manifest - Description"
+title: "[Chrome Apps] Manifest - Description"
 seoTitle: "Chrome Apps Manifest - Description [Deprecated]"
 #date: TODO
 #updated: TODO

--- a/site/en/docs/apps/manifest/externally_connectable/index.md
+++ b/site/en/docs/apps/manifest/externally_connectable/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "externally_connectable"
+title: "[Chrome Apps] externally_connectable"
 seoTitle: "Chrome Apps externally_connectable [Deprecated]"
 #date: TODO
 #updated: TODO

--- a/site/en/docs/apps/manifest/file_handlers/index.md
+++ b/site/en/docs/apps/manifest/file_handlers/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Manifest - File Handlers"
+title: "[Chrome Apps] Manifest - File Handlers"
 seoTitle: "Chrome Apps Manifest - File Handlers [Deprecated]"
 date: 2013-05-11
 updated: 2016-04-19

--- a/site/en/docs/apps/manifest/icons/index.md
+++ b/site/en/docs/apps/manifest/icons/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Manifest - Icons"
+title: "[Chrome Apps] Manifest - Icons"
 seoTitle: "Chrome Apps Manifest - Icons [Deprecated]"
 #date: TODO
 #updated: TODO

--- a/site/en/docs/apps/manifest/index.md
+++ b/site/en/docs/apps/manifest/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Manifest File Format"
+title: "[Chrome Apps] Manifest File Format"
 seoTitle: "Chrome Apps Manifest File Format [Deprecated]"
 #date: TODO
 #updated: TODO

--- a/site/en/docs/apps/manifest/key/index.md
+++ b/site/en/docs/apps/manifest/key/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Manifest - Key"
+title: "[Chrome Apps] Manifest - Key"
 seoTitle: "Chrome Apps Manifest - Key [Deprecated]"
 #date: TODO
 #updated: TODO

--- a/site/en/docs/apps/manifest/kiosk_enabled/index.md
+++ b/site/en/docs/apps/manifest/kiosk_enabled/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Kiosk Apps"
+title: "[Chrome Apps] Kiosk Apps"
 seoTitle: "Kiosk Chrome Apps [Deprecated]"
 date: 2013-05-11
 updated: 2014-07-18

--- a/site/en/docs/apps/manifest/manifest_version/index.md
+++ b/site/en/docs/apps/manifest/manifest_version/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Manifest Version"
+title: "[Chrome Apps] Manifest Version"
 seoTitle: "Chrome Apps Manifest Version [Deprecated]"
 #date: TODO
 #updated: TODO

--- a/site/en/docs/apps/manifest/minimum_chrome_version/index.md
+++ b/site/en/docs/apps/manifest/minimum_chrome_version/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Manifest - Minimum Chrome Version"
+title: "[Chrome Apps] Manifest - Minimum Chrome Version"
 seoTitle: "Chrome Apps Manifest - Minimum Chrome Version [Deprecated]"
 #date: TODO
 #updated: TODO

--- a/site/en/docs/apps/manifest/nacl_modules/index.md
+++ b/site/en/docs/apps/manifest/nacl_modules/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Manifest - Nacl Modules"
+title: "[Chrome Apps] Manifest - Nacl Modules"
 seoTitle: "Chrome Apps Manifest - Nacl Modules [Deprecated]"
 #date: TODO
 #updated: TODO

--- a/site/en/docs/apps/manifest/name/index.md
+++ b/site/en/docs/apps/manifest/name/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Manifest - Name and Short Name"
+title: "[Chrome Apps] Manifest - Name and Short Name"
 seoTitle: "Chrome Apps Manifest - Name and Short Name [Deprecated]"
 #date: TODO
 #updated: TODO

--- a/site/en/docs/apps/manifest/offline_enabled/index.md
+++ b/site/en/docs/apps/manifest/offline_enabled/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Manifest - Offline Enabled"
+title: "[Chrome Apps] Manifest - Offline Enabled"
 seoTitle: "Chrome Apps Manifest - Offline Enabled [Deprecated]"
 #date: TODO
 #updated: TODO

--- a/site/en/docs/apps/manifest/requirements/index.md
+++ b/site/en/docs/apps/manifest/requirements/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Manifest - Requirements"
+title: "[Chrome Apps] Manifest - Requirements"
 seoTitle: "Chrome Apps Manifest - Requirements [Deprecated]"
 #date: TODO
 #updated: TODO

--- a/site/en/docs/apps/manifest/sandbox/index.md
+++ b/site/en/docs/apps/manifest/sandbox/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Manifest - Sandbox"
+title: "[Chrome Apps] Manifest - Sandbox"
 seoTitle: "Chrome Apps Manifest - Sandbox [Deprecated]"
 #date: TODO
 #updated: TODO

--- a/site/en/docs/apps/manifest/sockets/index.md
+++ b/site/en/docs/apps/manifest/sockets/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "sockets"
+title: "[Chrome Apps] sockets"
 seoTitle: "Chrome Apps - sockets [Deprecated]"
 date: 2014-01-08
 updated: 2014-10-31

--- a/site/en/docs/apps/manifest/storage/index.md
+++ b/site/en/docs/apps/manifest/storage/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Manifest for storage areas"
+title: "[Chrome Apps] Manifest for storage areas"
 seoTitle: "Chrome Apps Manifest for storage areas [Deprecated]"
 #date: TODO
 #updated: TODO

--- a/site/en/docs/apps/manifest/url_handlers/index.md
+++ b/site/en/docs/apps/manifest/url_handlers/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "url_handlers"
+title: "[Chrome Apps] url_handlers"
 seoTitle: "Chrome Apps url_handlers [Deprecated]"
 date: 2013-09-11
 updated: 2014-05-21

--- a/site/en/docs/apps/manifest/usb_printers/index.md
+++ b/site/en/docs/apps/manifest/usb_printers/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Manifest - USB Printers"
+title: "[Chrome Apps] Manifest - USB Printers"
 seoTitle: "Chrome Apps Manifest - USB Printers [Deprecated]"
 date: 2015-05-07
 #updated: TODO

--- a/site/en/docs/apps/manifest/version/index.md
+++ b/site/en/docs/apps/manifest/version/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Manifest - Version"
+title: "[Chrome Apps] Manifest - Version"
 seoTitle: "Chrome Apps Manifest - Version [Deprecated]"
 #date: TODO
 #updated: TODO

--- a/site/en/docs/apps/manifestVersion/index.md
+++ b/site/en/docs/apps/manifestVersion/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Manifest Version"
+title: "[Chrome Apps] Manifest Version"
 seoTitle: "Chrome Apps Manifest Version [Deprecated]"
 date: 2012-09-17
 updated: 2019-08-12

--- a/site/en/docs/apps/nativeMessaging/index.md
+++ b/site/en/docs/apps/nativeMessaging/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Native Messaging"
+title: "[Chrome Apps] Native Messaging"
 seoTitle: "Chrome Apps - Native Messaging Deprecated]"
 date: 2014-12-15
 updated: 2018-05-14

--- a/site/en/docs/apps/overview/index.md
+++ b/site/en/docs/apps/overview/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "What Are Chrome Apps?"
+title: "[Chrome Apps] What Are Chrome Apps?"
 seoTitle: "What Are Chrome Apps? [Deprecated]"
 date: 2012-09-17
 updated: 2018-04-26

--- a/site/en/docs/apps/publish_app/index.md
+++ b/site/en/docs/apps/publish_app/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Publish Your App"
+title: "[Chrome Apps] Publish Your App"
 seoTitle: "Publish Your Chrome App [Deprecated]"
 date: 2012-09-17
 updated: 2013-10-21


### PR DESCRIPTION
Fixes #https://github.com/GoogleChromeLabs/Extension-Docs/issues/136

Changes proposed in this pull request:

- Adds [Chrome apps] to the pages that have an extension equivalent.
