### PR TITLE
Update aside in MV2 articles

### DIFF
--- a/site/en/_partials/extensions/mv2-legacy-page.md
+++ b/site/en/_partials/extensions/mv2-legacy-page.md
@@ -1,4 +1,3 @@
 {% Aside 'warning' %}
-The Chrome Web Store no longer accepts Manifest V2 extensions. Please use [Manifest
-V3](/docs/extensions/mv3/intro) when building new extensions. You will find a section on upgrading in the navigation tree at the left, including the [Manifest V2 support timeline](/docs/extensions/mv3/mv2-sunset/).
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
 {% endAside %}

--- a/site/en/docs/extensions/mv2/a11y/index.md
+++ b/site/en/docs/extensions/mv2/a11y/index.md
@@ -8,7 +8,7 @@ description: How to make your Manifest V2 Chrome Extension accessible.
 ---
 
 {% Aside 'warning' %}
-You're looking at the deprecated Manifest V2 version of Accessibility (a11y). For the latest version go to [Manifest V3 - Accessibility (a11y)](docs/extensions/mv3/a11y).
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Accessibility (a11y)](docs/extensions/mv3/a11y) for the MV3 equivalent.
 
 The Chrome Web Store no longer accepts Manifest V2 extensions. See the [Manifest V3 Migration guide](/docs/extensions/migrating) to learn how to migrate to Manifest V3.
 {% endAside %}

--- a/site/en/docs/extensions/mv2/a11y/index.md
+++ b/site/en/docs/extensions/mv2/a11y/index.md
@@ -10,7 +10,7 @@ description: How to make your Manifest V2 Chrome Extension accessible.
 {% Aside 'warning' %}
 You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Accessibility (a11y)](docs/extensions/mv3/a11y) for the MV3 equivalent.
 
-The Chrome Web Store no longer accepts Manifest V2 extensions. See the [Manifest V3 Migration guide](/docs/extensions/migrating) to learn how to migrate to Manifest V3.
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
 {% endAside %}
 
 Extensions empower users to create their ideal browsing experience, tailored to an individual's
@@ -35,7 +35,7 @@ way to create an accessible UI is to use a standard HTML control.
 {% Aside %}
 
 Note: If an extension requires a custom control, it is much easier to make a custom control
-accessible from the beginning than to go back an add accessibility support later.
+accessible from the beginning than to go back and add accessibility support later.
 
 {% endAside %}
 
@@ -196,7 +196,7 @@ As an indicator of flexibility of an extension's UI, apply the [200% test][11]; 
 page zoom is increased 200%, is it still usable?
 
 Avoid baking text into images. Users are unable to modify the size and screen readers are unable to
-interpret images. Insead, opt for styled web font, such as one of the fonts found in the [Google
+interpret images. Instead, opt for styled web font, such as one of the fonts found in the [Google
 Font API][12]. Web fonts can scale to different sizes and can be accessed by people using screen
 readers.
 

--- a/site/en/docs/extensions/mv2/a11y/index.md
+++ b/site/en/docs/extensions/mv2/a11y/index.md
@@ -7,7 +7,11 @@ updated: 2018-07-30
 description: How to make your Manifest V2 Chrome Extension accessible.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're looking at the deprecated Manifest V2 version of Accessibility (a11y). For the latest version go to [Manifest V3 - Accessibility (a11y)](docs/extensions/mv3/a11y).
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. See the [Manifest V3 Migration guide](/docs/extensions/migrating) to learn how to migrate to Manifest V3.
+{% endAside %}
 
 Extensions empower users to create their ideal browsing experience, tailored to an individual's
 abilities and preferences. Extensions should include accessibility components that encourage an

--- a/site/en/docs/extensions/mv2/a11y/index.md
+++ b/site/en/docs/extensions/mv2/a11y/index.md
@@ -8,7 +8,7 @@ description: How to make your Manifest V2 Chrome Extension accessible.
 ---
 
 {% Aside 'warning' %}
-You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Accessibility (a11y)](docs/extensions/mv3/a11y) for the MV3 equivalent.
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Accessibility (a11y)](/docs/extensions/mv3/a11y) for the MV3 equivalent.
 
 The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
 {% endAside %}

--- a/site/en/docs/extensions/mv2/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv2/architecture-overview/index.md
@@ -8,7 +8,7 @@ description: A high-level explanation of the software architecture of Chrome Ext
 ---
 
 {% Aside 'warning' %}
-You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Architecture overview](docs/extensions/mv3/architecture-overview) for the MV3 equivalent.
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Architecture overview](/docs/extensions/mv3/architecture-overview) for the MV3 equivalent.
 
 The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
 {% endAside %}

--- a/site/en/docs/extensions/mv2/architecture-overview/index.md
+++ b/site/en/docs/extensions/mv2/architecture-overview/index.md
@@ -7,7 +7,11 @@ updated: 2018-06-07
 description: A high-level explanation of the software architecture of Chrome Extensions.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Architecture overview](docs/extensions/mv3/architecture-overview) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 Extensions are zipped bundles of HTML, CSS, JavaScript, images, and other files used in the web
 platform, that customize the Google Chrome browsing experience. Extensions are built using web

--- a/site/en/docs/extensions/mv2/background_migration/index.md
+++ b/site/en/docs/extensions/mv2/background_migration/index.md
@@ -9,7 +9,11 @@ description: >
   model to improve the performance of your Chrome Extension.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Migrate to Service Workers](/docs/extensions/migrating/to-service-workers/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 Implementing non-persistent background scripts will greatly reduce the resource cost of your
 extension. Most extension functionality can be supported by an event based background script. Only

--- a/site/en/docs/extensions/mv2/background_pages/index.md
+++ b/site/en/docs/extensions/mv2/background_pages/index.md
@@ -7,7 +7,11 @@ updated: 2018-05-01
 description: How to respond to browser triggers (events) from a Chrome Extension background script.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - About extension service workers](/docs/extensions/mv3/service_workers/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 Extensions are event based programs used to modify or enhance the Chrome browsing experience. Events
 are browser triggers, such as navigating to a new page, removing a bookmark, or closing a tab.

--- a/site/en/docs/extensions/mv2/content_scripts/index.md
+++ b/site/en/docs/extensions/mv2/content_scripts/index.md
@@ -7,7 +7,11 @@ updated: 2019-03-11
 description: An explanation of content scripts and how to use them in your Chrome Extension.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Content scripts](/docs/extensions/mv3/content_scripts/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 Content scripts are files that run in the context of web pages. By using the standard [Document
 Object Model][1] (DOM), they are able to read details of the web pages the browser visits, make

--- a/site/en/docs/extensions/mv2/cross-origin-isolation/index.md
+++ b/site/en/docs/extensions/mv2/cross-origin-isolation/index.md
@@ -7,7 +7,12 @@ updated: 2021-11-10
 description: Overview of cross-origin isolation for extensions
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Cross-origin isolation](/docs/extensions/mv3/cross-origin-isolation/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
+
 
 [Cross-origin isolation][web-coi-guide] enables a web page to use powerful features such as
 [`SharedArrayBuffer`][mdn-sharedarraybuffer]. An extension can opt into cross-origin isolation by

--- a/site/en/docs/extensions/mv2/declare_permissions/index.md
+++ b/site/en/docs/extensions/mv2/declare_permissions/index.md
@@ -7,7 +7,11 @@ updated: 2014-05-21
 description: An overview of the valid values for the permissions property in manifest.json.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Declare permissions](/docs/extensions/mv3/declare_permissions/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 To use most chrome.\* APIs, your extension or app must declare its intent in the "permissions" field
 of the [manifest][1]. Each permission can be either one of a list of known strings (such as

--- a/site/en/docs/extensions/mv2/desktop_notifications/index.md
+++ b/site/en/docs/extensions/mv2/desktop_notifications/index.md
@@ -7,7 +7,11 @@ updated: 2017-01-05
 description: How to implement notifications in your Chrome Extension.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Rich notifications](/docs/extensions/mv3/richNotifications/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 {% Aside 'warning' %}
 **Warning:** `webKitNotifications.createHTMLNotification()` in the [web notifications API][1] has

--- a/site/en/docs/extensions/mv2/devguide/index.md
+++ b/site/en/docs/extensions/mv2/devguide/index.md
@@ -7,7 +7,11 @@ updated: 2018-06-12
 description: An overview of Chrome Extension capabilities and components.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Extension development overview](/docs/extensions/mv3/devguide/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 After reading the [Getting Started][1] tutorial and [Overview][2], use this guide as an outline to
 extension components and abilities. Developers are encouraged to explore and expand extension

--- a/site/en/docs/extensions/mv2/devtools/index.md
+++ b/site/en/docs/extensions/mv2/devtools/index.md
@@ -7,7 +7,11 @@ updated: 2020-08-25
 description: How to create a Chrome Extension that adds functionality to Chrome DevTools.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Extending DevTools](/docs/extensions/mv3/devtools/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 ## Overview {: #overview }
 

--- a/site/en/docs/extensions/mv2/external_extensions/index.md
+++ b/site/en/docs/extensions/mv2/external_extensions/index.md
@@ -7,7 +7,11 @@ updated: 2018-06-12
 description: How to distribute Chrome Extensions outside of the Chrome Web Store.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Alternative extension installation methods](/docs/extensions/mv3/external_extensions/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 All Chrome extensions must be distributed either directly from the Chrome Web Store or by using the
 mechanisms described below. Failure to comply with one of these distribution methods constitutes a

--- a/site/en/docs/extensions/mv2/faq/index.md
+++ b/site/en/docs/extensions/mv2/faq/index.md
@@ -7,7 +7,11 @@ updated: 2020-11-20
 description: Frequently asked questions about Chrome Extensions.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Frequently asked questions](/docs/extensions/mv3/faq/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 If you don't find an answer to your question here, try the [Chrome Web Store FAQ][1], the
 [\[google-chrome-extension\] tag on Stack Overflow][2], the [chromium-extensions group][3], or the

--- a/site/en/docs/extensions/mv2/getstarted/index.md
+++ b/site/en/docs/extensions/mv2/getstarted/index.md
@@ -7,7 +7,11 @@ updated: 2020-11-18
 description: Step-by-step instructions on how to create a Chrome Extension.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Getting started](/docs/extensions/mv3/getstarted/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 Extensions are made of different, but cohesive, components. Components can include [background
 scripts][background], [content scripts][content-scripts], an [options page][options], [UI elements][user-interface] and various logic files.

--- a/site/en/docs/extensions/mv2/hosting/index.md
+++ b/site/en/docs/extensions/mv2/hosting/index.md
@@ -9,7 +9,11 @@ description: >
   that's hosted in the Chrome Web Store.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Extension hosting](/docs/extensions/mv3/hosting/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 Most extensions are hosted in the [Chrome Web Store][1] to best [protect users from malicious
 extensions][2].

--- a/site/en/docs/extensions/mv2/i18n-messages/index.md
+++ b/site/en/docs/extensions/mv2/i18n-messages/index.md
@@ -7,7 +7,11 @@ updated: 2014-05-22
 description: Reference documentation about the format of the messages.json file for Chrome Extensions.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Localization message formats](/docs/extensions/mv3/i18n-messages/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 Each internationalized extension or app has at least one file named `messages.json` that provides
 locale-specific strings. This page describes the format of `messages.json` files. For information on

--- a/site/en/docs/extensions/mv2/linux_hosting/index.md
+++ b/site/en/docs/extensions/mv2/linux_hosting/index.md
@@ -7,7 +7,11 @@ updated: 2018-03-23
 description: How to package, host, and update crx files from a personal server.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Installing extensions on Linux](/docs/extensions/mv3/linux_hosting/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 Extensions hosted outside of the [Chrome Web Store][1] can only be installed by Linux users. This
 article describes how to package, host, and update `.crx` files from a personal server. If

--- a/site/en/docs/extensions/mv2/manifest/activeTab/index.md
+++ b/site/en/docs/extensions/mv2/manifest/activeTab/index.md
@@ -7,7 +7,11 @@ updated: 2018-11-01
 description: How to use the activeTab permission in your Chrome Extension.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - The activeTab permission](/docs/extensions/mv3/manifest/activeTab/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 The `activeTab` permission gives an extension temporary access to the currently active tab when the
 user _invokes_ the extension - for example by clicking its [browser action][1]. Access to the tab

--- a/site/en/docs/extensions/mv2/manifest/cross_origin_embedder_policy/index.md
+++ b/site/en/docs/extensions/mv2/manifest/cross_origin_embedder_policy/index.md
@@ -7,7 +7,11 @@ date: 2021-08-03
 description: Reference documentation for the cross_origin_embedder_policy property of manifest.json.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Manifest Cross-origin embedder policy](/docs/extensions/mv3/manifest/cross_origin_embedder_policy) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 The `cross_origin_embedder_policy` manifest key lets the extension to specify a value for the
 [Cross-Origin-Embedder-Policy][mdn-coep] (COEP) response header for requests to the extension's

--- a/site/en/docs/extensions/mv2/manifest/cross_origin_opener_policy/index.md
+++ b/site/en/docs/extensions/mv2/manifest/cross_origin_opener_policy/index.md
@@ -7,7 +7,11 @@ date: 2021-08-03
 description: Reference documentation for the cross_origin_opener_policy property of manifest.json.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Manifest Cross-origin opener policy](/docs/extensions/mv3/manifest/cross_origin_opener_policy) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 The `cross_origin_opener_policy` manifest key lets extensions specify a value for the
 [Cross-Origin-Opener-Policy][mdn-coop] (COOP) response header for requests to the extension's

--- a/site/en/docs/extensions/mv2/manifest/default_locale/index.md
+++ b/site/en/docs/extensions/mv2/manifest/default_locale/index.md
@@ -7,7 +7,11 @@ updated: 2018-04-26
 description: Reference documentation for the default_locale property of manifest.json.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Manifest Default Locale](/docs/extensions/mv3/manifest/default_locale) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 Specifies the subdirectory of `_locales` that contains the default strings for this extension. This
 field is **required** in extensions that have a `_locales` directory; it **must be absent** in

--- a/site/en/docs/extensions/mv2/manifest/description/index.md
+++ b/site/en/docs/extensions/mv2/manifest/description/index.md
@@ -7,7 +7,11 @@ updated: 2018-04-26
 description: Reference documentation for the description property of manifest.json.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Manifest description](/docs/extensions/mv3/manifest/description) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 A plain text string (no HTML or other formatting; no more than 132 characters) that describes the
 extension. The description should be suitable for both the browser's extension management UI and the

--- a/site/en/docs/extensions/mv2/manifest/externally_connectable/index.md
+++ b/site/en/docs/extensions/mv2/manifest/externally_connectable/index.md
@@ -7,7 +7,11 @@ updated: 2014-10-31
 description: Reference documentation for the externally_connectable property of manifest.json.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Manifest externally_connectable](/docs/extensions/mv3/manifest/externally_connectable) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 The `externally_connectable` manifest property declares which extensions, apps, and web pages can
 connect to your extension via [runtime.connect][1] and [runtime.sendMessage][2].

--- a/site/en/docs/extensions/mv2/manifest/homepage_url/index.md
+++ b/site/en/docs/extensions/mv2/manifest/homepage_url/index.md
@@ -7,7 +7,12 @@ updated: 2018-04-26
 description: Reference documentation for the homepage_url property of manifest.json.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Manifest homepage Url](/docs/extensions/mv3/manifest/homepage_url/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+
+{% endAside %}
 
 The URL of the homepage for this extension. The extensions management page (chrome://extensions)
 will contain a link to this URL. This field is particularly useful if you [host the extension on

--- a/site/en/docs/extensions/mv2/manifest/icons/index.md
+++ b/site/en/docs/extensions/mv2/manifest/icons/index.md
@@ -7,7 +7,11 @@ updated: 2018-04-26
 description: Reference documentation for the icons property of manifest.json.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Manifest icons](/docs/extensions/mv3/manifest/icons) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 One or more icons that represent the extension, app, or theme. You should always provide a 128x128
 icon; it's used during installation and by the Chrome Web Store. Extensions should also provide a

--- a/site/en/docs/extensions/mv2/manifest/incognito/index.md
+++ b/site/en/docs/extensions/mv2/manifest/incognito/index.md
@@ -7,7 +7,11 @@ updated: 2015-09-25
 description: Reference documentation for the incognito property of manifest.json.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Manifest incognito](/docs/extensions/mv3/manifest/incognito) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 Use the `"incognito"` manifest key with either `"spanning"` or `"split"` to specify how this
 extension will behave if allowed to run in incognito mode. Using `"not_allowed"` to prevent this

--- a/site/en/docs/extensions/mv2/manifest/key/index.md
+++ b/site/en/docs/extensions/mv2/manifest/key/index.md
@@ -7,7 +7,11 @@ updated: 2018-04-26
 description: Reference documentation for the key property of manifest.json.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Manifest key](/docs/extensions/mv3/manifest/key) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 This value can be used to control the unique ID of an extension, app, or theme when it is loaded
 during development.

--- a/site/en/docs/extensions/mv2/manifest/minimum_chrome_version/index.md
+++ b/site/en/docs/extensions/mv2/manifest/minimum_chrome_version/index.md
@@ -7,9 +7,13 @@ updated: 2018-04-26
 description: Reference documentation for the minimum_chrome_version property of manifest.json.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Manifest Minimum Chrome Version](/docs/extensions/mv3/manifest/minimum_chrome_version) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 The version of Chrome that your extension, app, or theme requires, if any. The format for this
 string is the same as for the [version][1] field.
 
-[1] /docs/extensions/mv2/tabs#version
+[1] /docs/extensions/mv2/manifest/version

--- a/site/en/docs/extensions/mv2/manifest/name/index.md
+++ b/site/en/docs/extensions/mv2/manifest/name/index.md
@@ -7,7 +7,11 @@ updated: 2018-04-26
 description: Reference documentation for the name and short_name properties of manifest.json.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Manifest name](/docs/extensions/mv3/manifest/name) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 The `name` and `short_name` manifest properties are short, plain text strings that identify the
 extension. You can specify locale-specific strings for both fields; see [Internationalization][1]

--- a/site/en/docs/extensions/mv2/manifest/sandbox/index.md
+++ b/site/en/docs/extensions/mv2/manifest/sandbox/index.md
@@ -7,7 +7,11 @@ updated: 2018-04-26
 description: Reference documentation for the sandbox property of manifest.json.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Manifest Sandbox](/docs/extensions/mv3/manifest/sandbox) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 **_Warning:_** Starting in version 57, Chrome will no longer allow external web content (including
 embedded frames and scripts) inside sandboxed pages. Please use a [webview][1] instead.

--- a/site/en/docs/extensions/mv2/manifest/storage/index.md
+++ b/site/en/docs/extensions/mv2/manifest/storage/index.md
@@ -7,7 +7,11 @@ updated: 2018-05-14
 description: Reference documentation for the storage property of manifest.json.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Manifest storage](/docs/extensions/mv3/manifest/storage) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 Unlike the `local` and `sync` storage areas, the `managed` storage area requires its structure to be
 declared as [JSON Schema][1] and is strictly validated by Chrome. This schema must be stored in a

--- a/site/en/docs/extensions/mv2/manifest/version/index.md
+++ b/site/en/docs/extensions/mv2/manifest/version/index.md
@@ -6,7 +6,11 @@ updated: 2018-04-26
 description: Reference documentation for the version property of manifest.json.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Manifest version](/docs/extensions/mv3/manifest/version) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 One to four dot-separated integers identifying the version of this extension. A couple of rules
 apply to the integers: they must be between 0 and 65535, inclusive, and non-zero integers can't

--- a/site/en/docs/extensions/mv2/manifest/web_accessible_resources/index.md
+++ b/site/en/docs/extensions/mv2/manifest/web_accessible_resources/index.md
@@ -7,7 +7,11 @@ updated: 2018-05-14
 description: Reference documentation for the web_accessible_resources property of manifest.json.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Manifest Web Accessible Resources](/docs/extensions/mv3/manifest/web_accessible_resources) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 An array of strings specifying the paths of packaged resources that are expected to be usable in the
 context of a web page. These paths are relative to the package root, and may contain wildcards. For

--- a/site/en/docs/extensions/mv2/manifestVersion/index.md
+++ b/site/en/docs/extensions/mv2/manifestVersion/index.md
@@ -9,7 +9,11 @@ description: >
   of the manifest specification a Chrome Extension targets.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Manifest_version](/docs/extensions/mv3/manifest/manifest_version) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 Extensions, themes, and applications are simply bundles of resources, wrapped up with a
 [`manifest.json`][1] file that describes the package's contents. The format of this file is

--- a/site/en/docs/extensions/mv2/match_patterns/index.md
+++ b/site/en/docs/extensions/mv2/match_patterns/index.md
@@ -7,7 +7,11 @@ updated: 2017-10-28
 description: How host permission and content script pattern matching works, with examples.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Match patterns](/docs/extensions/mv3/match_patterns/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 [Host permissions][1] and [content script][2] matching are based on a set of URLs defined by match
 patterns. A match pattern is essentially a URL that begins with a permitted scheme (`http`, `https`,

--- a/site/en/docs/extensions/mv2/messaging/index.md
+++ b/site/en/docs/extensions/mv2/messaging/index.md
@@ -7,7 +7,11 @@ updated: 2019-07-17
 description: How to pass messages between extensions and content scripts.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Message passing](/docs/extensions/mv3/messaging/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 Since content scripts run in the context of a web page and not the extension, they often need some
 way of communicating with the rest of the extension. For example, an RSS reader extension might use

--- a/site/en/docs/extensions/mv2/options/index.md
+++ b/site/en/docs/extensions/mv2/options/index.md
@@ -7,7 +7,11 @@ updated: 2018-04-29
 description: How to let users customize your Extension.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Give users options](/docs/extensions/mv3/options/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 Allow users to customise the behavior of an extension by providing an options page. A user can view
 an extension's options by right-clicking the extension icon in the toolbar then selecting options or

--- a/site/en/docs/extensions/mv2/override/index.md
+++ b/site/en/docs/extensions/mv2/override/index.md
@@ -9,7 +9,11 @@ description: >
   pages from your Chrome Extension.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Overriding Chrome pages](/docs/extensions/mv3/override/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 Override pages are a way to substitute an HTML file from your extension for a page that Google
 Chrome normally provides. In addition to HTML, an override page usually has CSS and JavaScript code.

--- a/site/en/docs/extensions/mv2/permission_warnings/index.md
+++ b/site/en/docs/extensions/mv2/permission_warnings/index.md
@@ -8,7 +8,11 @@ description: >
   How to implement permissions to protect your users and your Extension.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Permission Warning guidelines](/docs/extensions/mv3/permission_warnings/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 An extension's ability to access websites and most Chrome APIs is determined by its declared
 [permissions][1]. Permissions should be restricted to only what is needed for its functionality.

--- a/site/en/docs/extensions/mv2/richNotifications/index.md
+++ b/site/en/docs/extensions/mv2/richNotifications/index.md
@@ -7,7 +7,11 @@ updated: 2017-04-27
 description: How to show notifications to your Chrome Extension users.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Rich notifications](/docs/extensions/mv3/richNotifications/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 <div class="aside aside--note"><strong>Platform difference:</strong> In Chrome version 59, notifications appear differently for Mac OS X users. Instead of Chrome's own notifications, users see native Mac OS X notifications. <a href="https://developers.google.com/web/updates/2017/04/native-mac-os-notifications">Learn more in this article</a>.</div>
 

--- a/site/en/docs/extensions/mv2/sandboxingEval/index.md
+++ b/site/en/docs/extensions/mv2/sandboxingEval/index.md
@@ -7,7 +7,11 @@ updated: 2014-05-22
 description: How to use eval() in a Chrome Extension.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Using eval in Chrome extensions](/docs/extensions/mv3/sandboxingEval/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 Chrome's extension system enforces a fairly strict default [**Content Security Policy (CSP)**][1].
 The policy restrictions are straightforward: script must be moved out-of-line into separate

--- a/site/en/docs/extensions/mv2/security/index.md
+++ b/site/en/docs/extensions/mv2/security/index.md
@@ -7,7 +7,11 @@ updated: 2019-07-17
 description: How to keep your Chrome Extension secure.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Stay secure](/docs/extensions/mv3/security/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 Extensions have access to special privileges within the browser, making them an appealing target for
 attackers. If an extension is compromised, _every_ user of that extension becomes vulnerable to

--- a/site/en/docs/extensions/mv2/settings_override/index.md
+++ b/site/en/docs/extensions/mv2/settings_override/index.md
@@ -7,7 +7,11 @@ updated: 2016-11-07
 description: How to override Chrome settings from a Chrome Extension.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Overriding Chrome settings](/docs/extensions/mv3/settings_override/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 Settings overrides are a way for extensions to override selected Chrome settings. The API is
 available on Windows in all current versions of Chrome and is available on Mac in Chrome 56 and

--- a/site/en/docs/extensions/mv2/tut_analytics/index.md
+++ b/site/en/docs/extensions/mv2/tut_analytics/index.md
@@ -8,7 +8,11 @@ description: >
     Step-by-step instructions on how to track usage of your Extension with Google Analytics.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Using Google Analytics 4](/docs/extensions/mv3/tut_analytics/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 This tutorial demonstrates using Google Analytics to track the usage of your extension. If you are
 developing a platform app, see [Analytics for Apps][1] since apps have different restrictions from

--- a/site/en/docs/extensions/mv2/tut_debugging/index.md
+++ b/site/en/docs/extensions/mv2/tut_debugging/index.md
@@ -7,7 +7,11 @@ updated: 2020-07-21
 description: Step-by-step instructions on how to debug Chrome Extensions.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Debugging extensions](/docs/extensions/mv3/tut_debugging/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 Extensions are able to leverage the same debugging benefits [Chrome DevTools][1] provides for web
 pages, but they carry unique behavior properties. Becoming a master extension debugger requires an

--- a/site/en/docs/extensions/mv2/tut_oauth/index.md
+++ b/site/en/docs/extensions/mv2/tut_oauth/index.md
@@ -10,7 +10,11 @@ description: >
   and OAuth2.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - OAuth2: Authenticate users with Google](/docs/extensions/mv3/tut_oauth/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 [OAuth2][1] is the industry-standard protocol for authorization. It provides a mechanism for users
 to grant web and desktop applications access to private information without sharing their username,

--- a/site/en/docs/extensions/mv2/user_interface/index.md
+++ b/site/en/docs/extensions/mv2/user_interface/index.md
@@ -7,7 +7,11 @@ updated: 2018-05-16
 description: UI and design guidelines for Chrome Extensions.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Design the user interface](/docs/extensions/mv3/user_interface/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 The extension user interface should be purposeful and minimal. Just like extensions themselves, the
 UI should customize or enhance the browsing experience without distracting from it.

--- a/site/en/docs/extensions/mv2/user_privacy/index.md
+++ b/site/en/docs/extensions/mv2/user_privacy/index.md
@@ -7,7 +7,11 @@ updated: 2018-04-26
 description: Guidelines for ensuring that your Chrome Extension protects user privacy.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Protect user privacy](/docs/extensions/mv3/user_privacy/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 Users will not install an extension if it compromises their privacy or asks for more permissions
 that it seems to need. Permission requests should make sense to users and be limited to the critical

--- a/site/en/docs/extensions/mv2/xhr/index.md
+++ b/site/en/docs/extensions/mv2/xhr/index.md
@@ -7,7 +7,11 @@ updated: 2020-03-09
 description: How to implement cross-origin XHR in your Chrome Extension.
 ---
 
-{% Partial 'extensions/mv2-legacy-page.md' %}
+{% Aside 'warning' %}
+You're viewing the deprecated Manifest V2 version of this article. See [Manifest V3 - Cross-origin network requests](/docs/extensions/mv3/network-requests/) for the MV3 equivalent.
+
+The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the [Manifest V3 Migration guide](/docs/extensions/migrating) to convert your extension to Manifest V3.
+{% endAside %}
 
 Regular web pages can use the [XMLHttpRequest][1] object to send and receive data from remote
 servers, but they're limited by the [same origin policy][2]. [Content scripts][3] initiate requests

--- a/site/en/docs/extensions/mv3/manifest/background/index.md
+++ b/site/en/docs/extensions/mv3/manifest/background/index.md
@@ -6,7 +6,7 @@ updated:
 description: Reference documentation for the background property of manifest.json.
 ---
 
-An optional manifest key used to specify a javascript file as the extension service worker. A service worker is a background script that acts as the extension's main event handler. For more information, visit the [more comprehensive introduction to service workers](docs/extensions/mv3/service_workers/#manifest).
+An optional manifest key used to specify a javascript file as the extension service worker. A service worker is a background script that acts as the extension's main event handler. For more information, visit the [more comprehensive introduction to service workers](/docs/extensions/mv3/service_workers/#manifest).
 
 ```json
 {


### PR DESCRIPTION
Fixes #https://github.com/GoogleChromeLabs/Extension-Docs/issues/136

Changes proposed in this pull request:

- Adds aside to MV2 articles that links directly to the MV3 equivalent.

PS: It is not a partial, because I wanted developers to be able to go directly to the mv3 equivalent page.