### PR TITLE
Correct script name in "Communication with the embedding page"

### DIFF
--- a/site/en/docs/extensions/mv3/content_scripts/index.md
+++ b/site/en/docs/extensions/mv3/content_scripts/index.md
@@ -698,7 +698,7 @@ window.addEventListener("message", (event) => {
 }, false);
 ```
 
-{% Label %}content-script.js{% endLabel %}
+{% Label %}example.js{% endLabel %}
 
 ```js
 document.getElementById("theButton").addEventListener("click", () => {


### PR DESCRIPTION
It seems to use the wrong name for the script which should run in example.html. This PR correct the name for it.

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request: 
    - correct the name of the script which runs in example.html for "Communication with the embedding page".

