### PR TITLE
Fix #6922 - Minor Typo in the "Format and style messages in the Console" Page

### DIFF
--- a/site/en/docs/devtools/console/format-style/index.md
+++ b/site/en/docs/devtools/console/format-style/index.md
@@ -301,7 +301,7 @@ Here is a list of styling code supported in DevTools.
     </tr>
     <tr>
       <td>9</td>
-      <td>Add <code>line-through</code> to <code>text-decoration</code> propertyh</td>
+      <td>Add <code>line-through</code> to <code>text-decoration</code> property</td>
     </tr>
     <tr>
       <td>22</td>


### PR DESCRIPTION
Fixes #6922 

Changes proposed in this pull request:

- Changed text from "Add line-through to text-decoration propertyh" to "Add line-through to text-decoration property".