### PR TITLE
Add shared storage walkthrough

### DIFF
--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -40,6 +40,8 @@
         - url: /docs/privacy-sandbox/permissions-policy
           title: i18n.docs.privacy-sandbox.permissions-policy
     - url: /docs/privacy-sandbox/shared-storage
+    - url: https://goo.gle/shared-storage-walkthrough
+      title: i18n.docs.privacy-sandbox.shared-storage-walkthrough
 - title: i18n.docs.privacy-sandbox.tracking-prevention
   sections:
     - url: /docs/privacy-sandbox/ip-protection

--- a/site/_data/i18n/docs/privacy-sandbox.yml
+++ b/site/_data/i18n/docs/privacy-sandbox.yml
@@ -135,3 +135,5 @@ paapi-walkthrough:
   en: 'Protected Audience API walkthrough'
 fedcm-developer-guide:
   en: 'Federated Credential Management API: developer guide'
+shared-storage-walkthrough: 
+  en: 'Shared Storage API walkthrough'


### PR DESCRIPTION
This PR adds the link to the shared storage walkthrough to the sidebar nav. 

Walkthrough link: https://goo.gle/shared-storage-walkthrough
Preview link:  https://pr-6932-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/