### PR TITLE
Clarify when execution of DNR rules is undefined behaviour

### DIFF
--- a/site/en/docs/extensions/reference/declarativeNetRequest/index.md
+++ b/site/en/docs/extensions/reference/declarativeNetRequest/index.md
@@ -167,7 +167,7 @@ Rules are triggered by requests sent from web pages. If multiple rules match a p
 Thinking of matching this way: whatever rule a particular extension prioritizes will then be prioritized against rules from other extensions.
 
 {% Aside 'caution' %}
-Avoid building rulesets that depend on rules with the same priority running in a particular order. Rules with the same priority in the same set (e.g., static rules with priority 1) are executed in an arbitrary order which is not defined and can change between runs or browser versions. This is the case across browsers.
+Avoid writing rules with the same action and priority that must run in a particular order. Rules with the same action and priority (e.g., redirect rules with priority 1) are executed in an arbitrary order which is not defined and can change between runs or browser versions, even when spread between multiple types of ruleset (e.g, a static rule and a session rule). This is the case across browsers.
 {% endAside %}
 
 #### Rule prioritization within an extension {: #rule-prioritization-within-an-extension }


### PR DESCRIPTION
I missed this when reviewing our recent update - the current wording is too strong because it implies there's no ordering whatsoever, when there is ordering between, say, allow and redirect rules (we already have this documented a few lines below!). The key thing to cover is:

- There's no guarantee if two rules of the same action and priority will execute first
  -  This is the case even if one of them came from a static ruleset and another from a session/dynamic one