### PR TITLE
Update CONTRIBUTING.md: Link to site handbook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,10 @@ Have feedback? We'd love to hear it - please open an
 
 ## Submitting a pull request
 
+### Authoring content ✍️
+
+See the [developer.chrome.com handbook](https://developer.chrome.com/docs/handbook).
+
 ### Contributor License Agreements
 
 We'd love to accept your code patches! However, before we can take them, we


### PR DESCRIPTION
For when people go straight to CONTRIBUTING.md without stopping at README.md.