### PR TITLE
Update React links

### DIFF
--- a/site/en/docs/lighthouse/performance/server-response-time/index.md
+++ b/site/en/docs/lighthouse/performance/server-response-time/index.md
@@ -55,7 +55,7 @@ Use Magento's [Varnish integration](https://devdocs.magento.com/guides/v2.3/conf
 
 ### React
 
-If you are server-side rendering any React components, consider using [`renderToNodeStream()`](https://reactjs.org/docs/react-dom-server.html#rendertonodestream) or `renderToStaticNodeStream()` to allow the client to receive and hydrate different parts of the markup instead of all at once.
+If you are server-side rendering any React components, consider using [`renderToPipeableStream()`](https://react.dev/reference/react-dom/server/renderToPipeableStream) or [`renderToStaticNodeStream()`](https://react.dev/reference/react-dom/server/renderToStaticNodeStream) to allow the client to receive and hydrate different parts of the markup instead of all at once.
 
 ### WordPress
 


### PR DESCRIPTION
Update links to the new documentation and change the deprecated hook renderToNodeStream to renderToPipeableStream.