### PR TITLE
Add bfcache not restored reasons API

### DIFF
--- a/site/_js/analytics.js
+++ b/site/_js/analytics.js
@@ -263,7 +263,7 @@ function getNavigationType() {
  * value returned by the Navigation Timing API (normalized to use kebab case),
  * but in addition to this it also captures pages that were prerendered
  * as well as page that were restored after a discard.
- * @returns {string}
+ * @returns {string|undefined}
  */
 function getBackForwardNotRestoreReasons() {
   const navEntry =
@@ -276,7 +276,7 @@ function getBackForwardNotRestoreReasons() {
       return navEntry.notRestoredReasons.reasons.toString();
     }
   }
-  return '(not set)';
+  return;
 }
 
 /**

--- a/site/_js/analytics.js
+++ b/site/_js/analytics.js
@@ -74,6 +74,9 @@ function sendToGoogleAnalytics({
   };
 
   let overrides;
+  let debug_input_delay;
+  let debug_processing_time;
+  let debug_presentation_delay;
 
   switch (name) {
     case 'CLS':
@@ -100,20 +103,16 @@ function sendToGoogleAnalytics({
       };
       break;
     case 'INP':
-      overrides = {
-        debug_event: attribution.eventType,
-        debug_time: attribution.eventTime,
-        debug_load_state: attribution.loadState,
-        debug_target: attribution.eventTarget || '(not set)',
-        debug_input_delay: Math.round(
+      if (attribution.eventEntry) {
+        debug_input_delay = Math.round(
           attribution.eventEntry.processingStart -
             attribution.eventEntry.startTime
-        ),
-        debug_processing_time: Math.round(
+        );
+        debug_processing_time = Math.round(
           attribution.eventEntry.processingEnd -
             attribution.eventEntry.processingStart
-        ),
-        debug_presentation_delay: Math.round(
+        );
+        debug_presentation_delay = Math.round(
           // RenderTime is an estimate, because duration is rounded, and may get rounded down.
           // In rare cases it can be less than processingEnd and that breaks performance.measure().
           // Lets make sure its at least 4ms in those cases so you can just barely see it.
@@ -121,7 +120,16 @@ function sendToGoogleAnalytics({
             attribution.eventEntry.processingEnd + 4,
             attribution.eventEntry.startTime + attribution.eventEntry.duration
           ) - attribution.eventEntry.processingEnd
-        ),
+        );
+      }
+      overrides = {
+        debug_event: attribution.eventType,
+        debug_time: attribution.eventTime,
+        debug_load_state: attribution.loadState,
+        debug_target: attribution.eventTarget || '(not set)',
+        debug_input_delay: debug_input_delay,
+        debug_processing_time: debug_processing_time,
+        debug_presentation_delay: debug_presentation_delay,
       };
       break;
     case 'LCP':
@@ -251,6 +259,27 @@ function getNavigationType() {
 }
 
 /**
+ * Gets the type of navigation for this page. In most cases this is the
+ * value returned by the Navigation Timing API (normalized to use kebab case),
+ * but in addition to this it also captures pages that were prerendered
+ * as well as page that were restored after a discard.
+ * @returns {string}
+ */
+function getBackForwardNotRestoreReasons() {
+  const navEntry =
+    self.performance &&
+    performance.getEntriesByType &&
+    performance.getEntriesByType('navigation')[0];
+
+  if (navEntry) {
+    if (navEntry.notRestoredReasons) {
+      return navEntry.notRestoredReasons.reasons.toString();
+    }
+  }
+  return '(not set)';
+}
+
+/**
  * Returns a list of any `prerender` speculation rules defined by any
  * `script[type=speculationrules]` elements on the page.
  * @returns {Object}
@@ -328,7 +357,12 @@ export function setConfig() {
     window.dataLayer.push(arguments);
   };
   window.dataLayer.push({measurement_version: version});
-  window.dataLayer.push({navigation_type: getNavigationType()});
+  const navigationType = getNavigationType();
+  window.dataLayer.push({navigation_type: navigationType});
+  if (navigationType === 'back-forward') {
+    const reasons = getBackForwardNotRestoreReasons();
+    window.dataLayer.push({back_forward_not_restore_reasons: reasons});
+  }
   window.dataLayer.push({page_path: location.pathname});
   window.dataLayer.push({page_authors: getMeta('authors')});
   window.dataLayer.push({page_tags: getMeta('tags')});

--- a/types/utils/performance.d.ts
+++ b/types/utils/performance.d.ts
@@ -20,9 +20,19 @@ declare global {
     activationStart: number;
     type: string;
   }
+  export interface NotRestoredReasons {
+    url: string;
+    src: string;
+    id: string;
+    name: string;
+    blocked: boolean;
+    reasons: [string];
+    children: [NotRestoredReasons];
+  }
   export interface PerformanceNavigationTiming {
     deliveryType: string;
     activationStart: number;
+    notRestoredReasons: NotRestoredReasons
   }
   export interface Navigator {
     connection: NetworkInformation;


### PR DESCRIPTION
Changes proposed in this pull request:

- Add no restored reasons API analytics as noticed we have a lot less bfcache usage on desktop than mobile and would like to understand why
- Also found a small bug when `attribution.eventEntry` is not set so included that fix too.

Equivalent change to web.dev is: https://github.com/GoogleChrome/web.dev/pull/10338