### PR TITLE
Speculation rules: match any hash fragment.

### DIFF
--- a/site/_includes/layouts/base.njk
+++ b/site/_includes/layouts/base.njk
@@ -52,11 +52,11 @@
           "where": {
             "and": [
               {
-                "href_matches": "/*\\?*", "relative_to": "document"
+                "href_matches": "/*\\?*#*", "relative_to": "document"
               },
               {
                 "not": {
-                  "href_matches": "/articles/*\\?*",
+                  "href_matches": "/articles/*\\?*#*",
                   "relative_to": "document"
                 }
               }


### PR DESCRIPTION
This expands the scope slightly, but also we're contemplating a change which would make this unnecessary -- but while developer.chrome.com is using this syntax, it's more difficult to tell at a glance how common other uses are.