### PR TITLE
Add Sam Richard to authors.

### DIFF
--- a/site/_data/authorsData.json
+++ b/site/_data/authorsData.json
@@ -1865,5 +1865,13 @@
   "hemeryar": {
     "country": "FR",
     "github": "hemeryar"
+  },
+  "samrichard": {
+    "country": "US",
+    "twitter": "snugug",
+    "github": "snugug",
+    "glitch": "snugug",
+    "homepage": "https://snugug.com",
+    "image": "image/admin/5kuER6QRWs54zbYIJ4zS.jpg"
   }
 }

--- a/site/_data/i18n/authors.yaml
+++ b/site/_data/i18n/authors.yaml
@@ -1521,3 +1521,8 @@ hemeryar:
     en: 'Arthur Hemery'
   description:
     en: 'Software Engineer, Google'
+samrichard:
+  title:
+    en: 'Sam Richard'
+  description:
+    en: 'Developer Advocate, Google ChromeOS'


### PR DESCRIPTION
Recently, Sam Richards published [a deprecation announcement](https://chromeos.dev/en/posts/chrome-input-ime-deprecation) for an [extensions API](https://developer.chrome.com/docs/extensions/reference/input_ime/). Because the publication channel is not for extensions, it's not in front of many (most?) of the people who need to see it. Before cross-posting it in extensions content, we need to add Sam Richards to the authors files.