### PR TITLE
Fix typo in declarativeNetRequest API

### DIFF
--- a/site/en/docs/extensions/reference/declarativeNetRequest/index.md
+++ b/site/en/docs/extensions/reference/declarativeNetRequest/index.md
@@ -103,7 +103,7 @@ For performance reasons there are also limits to the number of rules and ruleset
 
 ### Build rules {: #build-rules }
 
-Regardless of type, a rule starts with four fields as shown below. While the `"id"` and `"number"` keys take a number, the [`"action"`](#property-Rule-action) and [`"condition"`](#property-Rule-condition) keys may provide several blocking and redirecting conditions. The following rule blocks all script requests originating from `"foo.com"` to any URL with `"abc"` as a substring.
+Regardless of type, a rule starts with four fields as shown below. While the `"id"` and `"priority"` keys take a number, the [`"action"`](#property-Rule-action) and [`"condition"`](#property-Rule-condition) keys may provide several blocking and redirecting conditions. The following rule blocks all script requests originating from `"foo.com"` to any URL with `"abc"` as a substring.
 
 ```json
 {


### PR DESCRIPTION
fixed the typo in the docs of chrome.declarativeNetRequest section.