### PR TITLE
Mention that percentage rollout only appears for new drafts

### DIFF
--- a/site/en/docs/webstore/update/index.md
+++ b/site/en/docs/webstore/update/index.md
@@ -93,7 +93,7 @@ minimal impact.
 {% Aside %}
 
 This is only available for new versions of an **already-published** item with over **10,000 seven-day
-active users**
+active users. The section does not appear until a new draft has been uploaded.**
 
 {% endAside %}
 


### PR DESCRIPTION
Small tweak based on a discussion in the mailing list: https://groups.google.com/a/chromium.org/g/chromium-extensions/c/7FXYl4HpkuY/m/MAG1cvCfAgAJ