### PR TITLE
Make a heading more accurate.

### DIFF
--- a/site/_data/i18n/docs/extensions.yml
+++ b/site/_data/i18n/docs/extensions.yml
@@ -16,7 +16,7 @@ quality:
 devtools:
   en: 'Extend Chrome DevTools'
 develop:
-  en: 'Develop extensions and themes'
+  en: 'Develop extensions'
 indepth:
   en: 'Development in depth'
 indepth-core:


### PR DESCRIPTION
The whole section this title applies to has one link to information about themes and _nothing else_. It's misleading to include that in its title.