### PR TITLE
Update index.md: replace Edge browser version placeholder

### DIFF
--- a/site/en/articles/declarative-shadow-dom/index.md
+++ b/site/en/articles/declarative-shadow-dom/index.md
@@ -342,7 +342,7 @@ in browsers that support Declarative Shadow DOM because the `<template shadowroo
 
 Declarative Shadow DOM has been available since Chrome 90 and Edge 91, but it used an older non-standard attribute called
 `shadowroot` instead of the standardized `shadowrootmode` attribute. The newer `shadowrootmode` attribute and streaming
-behavior is available in Chrome 111 and Edge Xyz.
+behavior is available in Chrome 111 and Edge 111.
 
 As a new web platform API, Declarative Shadow DOM does not yet have widespread support across all browsers. Browser support
 can be detected by checking for the existence of a `shadowRootMode` property on the prototype of `HTMLTemplateElement`:


### PR DESCRIPTION
Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

Update index.md for https://developer.chrome.com/en/articles/declarative-shadow-dom/#feature-detection-and-browser-support: replace Edge browser version placeholder for shadowrootmode support based on the data from https://caniuse.com/mdn-html_elements_template_shadowrootmode