### PR TITLE
typo in match pattern 

### DIFF
--- a/site/en/docs/extensions/mv3/match_patterns/index.md
+++ b/site/en/docs/extensions/mv3/match_patterns/index.md
@@ -62,7 +62,7 @@ Top Level domain match patterns
       </tr>
       <tr>
          <td><code>http://*/*</code></td>
-         <td>Matches any URL that uses the <code>https</code> scheme</td>
+         <td>Matches any URL that uses the <code>http</code> scheme</td>
          <td>http://74.125.127.100/search <br>http://example.com/</li></ul></td>
       </tr>
       <tr>


### PR DESCRIPTION
corrected 'https' to 'http'  in valid patterns example of 'http://*/*'