### PR TITLE
Clean up approvers

### DIFF
--- a/.github/chrome-devrel-bot.json
+++ b/.github/chrome-devrel-bot.json
@@ -5,6 +5,7 @@
         "check_name" : "Content team approval",
         "teams" : [],
         "users" : [
+          "PaulKinlan",
           "malchata",
           "rachelandrew",
           "heyawhite",
@@ -13,7 +14,6 @@
           "sofiayem",
           "nancymic2",
           "anusmitaray",
-          "IanStanion-google",
           "AmySteam"
         ],
         "paths" : [
@@ -46,16 +46,18 @@
         "teams" : [],
         "users" : [
           "PaulKinlan",
-          "jeffposnick",
-          "devnook",
           "malchata",
           "rachelandrew",
           "heyawhite",
           "jpmedley",
           "mihajlija",
           "sofiayem",
-          "AaronForinton",
-          "matthiasrohmer"
+          "nancymic2",
+          "anusmitaray",
+          "AmySteam",
+          "matthiasrohmer",
+          "devnook",
+          "tunetheweb"
         ],
         "paths" : [
           "site/_data/**.yml",
@@ -65,9 +67,18 @@
         ]
       },
       {
-        "check_name" : "Content (es) team approval",
+        "check_name" : "Content team or Spanish reader approval",
         "teams" : [],
         "users" : [
+          "malchata",
+          "rachelandrew",
+          "heyawhite",
+          "jpmedley",
+          "mihajlija",
+          "sofiayem",
+          "nancymic2",
+          "anusmitaray",
+          "AmySteam",
           "tropicadri"
         ],
         "paths" : [


### PR DESCRIPTION
This PR aims to reduce the confusion around required approvals. It syncs the list of TW users to the approval group for changes requiring content *or* engineering approval and adds them to the group that can approve Spanish translations.