### PR TITLE
Updated Match Patterns

### DIFF
--- a/site/en/docs/extensions/mv3/match_patterns/index.md
+++ b/site/en/docs/extensions/mv3/match_patterns/index.md
@@ -19,14 +19,6 @@ A match pattern is a URL with the following structure, used to specify a group o
 - `https`
 - A wildcard `*`, which matches only `http` or `https`
 - `file`
-- `ftp`
-- `chromeui`
-- `extension`
-- `filesystem`
-- `ws`
-- `wss`
-- `data`
-- `uuid_in_package`
 
 For information on injecting content scripts into unsupported schemes, such as `about:` and `data:`, see [Injecting in related frames][cs-frames].
 


### PR DESCRIPTION
Condensed descriptions and examples. Converted example table to definition list. Integrated the invalid list with the descriptions and examples, to not confuse the reader with a list of things to not do.

Please make sure the special cases and examples are up to date.

Note on the invalid list: It's standard technical writing practice to state instructions positively whenever possible. Readers skimming a document are likely to confuse a list of don'ts with a list of dos and make more mistakes than if the don'ts weren't listed.