### PR TITLE
Add guidance for Publishing an MV3 extension

### DIFF
--- a/site/_data/docs/extensions/toc.yml
+++ b/site/_data/docs/extensions/toc.yml
@@ -29,6 +29,7 @@
     - url: /docs/extensions/migrating/api-calls
     - url: /docs/extensions/migrating/blocking-web-requests
     - url: /docs/extensions/migrating/improve-security
+    - url: /docs/extensions/migrating/publish-mv3
     - url: /docs/extensions/migrating/mv2-sunset
     - url: /docs/extensions/migrating/known-issues
 - url: /docs/extensions/reference

--- a/site/en/docs/extensions/migrating/checklist/index.md
+++ b/site/en/docs/extensions/migrating/checklist/index.md
@@ -91,3 +91,18 @@ Changes are required to improve the security of extensions. This includes removi
 * [Remove unsupported content security policy values](/docs/extensions/migrating/improve-security/#remove-unsupported-csv)
 
 {% endDetails %}
+
+{% Details  'open' %}
+
+{% DetailsSummary %}
+## Publish your Manifest V3 extension
+{% endDetailsSummary %}
+
+After converting to Manifest Version 3, it's time to release your extension on the Chrome Web Store. Depending on the changes made, consider a step-wise rollout. This approach allows you to ensure your extension works as expected with a limited audience first, before releasing it to the entire user base.
+
+* [Publish a beta testing version](/docs/extensions/migrating/publish-mv3/#publish-beta).
+* [Gradually roll out your release](/docs/extensions/migrating/publish-mv3/#gradual-rollout).
+* [Plan for review times](/docs/extensions/migrating/publish-mv3/#review).
+* [Additional tips](/docs/extensions/migrating/publish-mv3/#tips).
+
+{% endDetails %}

--- a/site/en/docs/extensions/migrating/checklist/index.md
+++ b/site/en/docs/extensions/migrating/checklist/index.md
@@ -98,7 +98,7 @@ Changes are required to improve the security of extensions. This includes removi
 ## Publish your Manifest V3 extension
 {% endDetailsSummary %}
 
-After converting to Manifest Version 3, it's time to release your extension on the Chrome Web Store. Depending on the changes made, consider a step-wise rollout. This approach allows you to ensure your extension works as expected with a limited audience first, before releasing it to the entire user base.
+After converting to Manifest Version 3, it's time to release your extension on the Chrome Web Store. Depending on the changes made, consider a step-wise roll out. This approach allows you to ensure your extension works as expected with a limited audience first, before releasing it to the entire user base.
 
 * [Publish a beta testing version](/docs/extensions/migrating/publish-mv3/#publish-beta).
 * [Gradually roll out your release](/docs/extensions/migrating/publish-mv3/#gradual-rollout).

--- a/site/en/docs/extensions/migrating/index.md
+++ b/site/en/docs/extensions/migrating/index.md
@@ -16,6 +16,8 @@ This section helps you upgrade an extension from Manifest V2 to Manifest V3, the
 * [Update API calls](/docs/extensions/migrating/api-calls)&mdash;Some API calls need to be replaced with more modern equivalents. 
 * [Replace blocking web request listeners](/docs/extensions/migrating/blocking-web-requests)&mdash;Blocking or modifying network requests in Manifest V2 could significantly degrade performance and require excessive access to sensitive user data. The Declarative Net Request API allows extensions to block or modify web content with fewer permissions and without hindering performance.
 * [Improve extension security](/docs/extensions/migrating/improve-security)&mdash;Manifest V3 improves extension security in several ways. Besides an enhanced content security policy, support is removed for remotely hosted code and execution of arbitrary strings.
+* [Publish your extension](/docs/extensions/migrating/publish-mv3/)&mdash;This section describes how to release your Manifest V3 extension to testers and then gradually rollout to the rest of your user base.
+
 
 We also have an [Extension Manifest Converter](https://github.com/GoogleChromeLabs/extension-manifest-converter). It does not do everything for you, but it will get you started. The converter's README describes what the tool changes.
 

--- a/site/en/docs/extensions/migrating/index.md
+++ b/site/en/docs/extensions/migrating/index.md
@@ -19,6 +19,25 @@ This section helps you upgrade an extension from Manifest V2 to Manifest V3, the
 
 We also have an [Extension Manifest Converter](https://github.com/GoogleChromeLabs/extension-manifest-converter). It does not do everything for you, but it will get you started. The converter's README describes what the tool changes.
 
-## New extension features
+## Keep the current set of features {: #keep-features }
+
+To reduce the chances of unexpected issues or bugs, we recommend not adding new functionality when publishing a new release. For instance, adding a feature that requires new permissions may [trigger a permission warning][perm-warn], which may disable your extension until the user enables it.
+
+<figure>
+    {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/tQgKKMKbzmCzwBEAoatX.gif", alt="Example of extension that is disabled until the user accepts new permission.", width="496", height="388" %}
+    <figcaption>
+    Extension disabled until user accepts new permission.
+    </figcaption>
+</figure>
+
+Note that the extension will also be disabled if [`"host_permissions"`][host-perms] are added or modified in the manifest. This includes [`"content_scripts.matches"`][content-manifest], which are also considered host permissions. See [Permissions Best Practices][perm-warn] to learn of other ways to add permission without displaying a warning.
+
+## New extension platform features
 
 Since the release of Manifest V3, we've continued to [add new features](/docs/extensions/whatsnew/), many of which are usable in both Manifest V2 and Manifest V3. You are not required to use them when converting; however, when they replace older features, you should prefer them to the features they replace and expect that the replaced features will eventually be deprecated and removed.
+
+[cws]: https://chrome.google.com/webstore
+[host-perms]: /docs/extensions/mv3/declare_permissions/#host-permissions
+[content-manifest]: /docs/extensions/manifest/content_scripts
+[perm-warn]: /docs/extensions/mv3/permission_warnings/
+

--- a/site/en/docs/extensions/migrating/index.md
+++ b/site/en/docs/extensions/migrating/index.md
@@ -26,9 +26,9 @@ We also have an [Extension Manifest Converter](https://github.com/GoogleChromeLa
 To reduce the chances of unexpected issues or bugs, we recommend not adding new functionality when migrating. For instance, adding a feature that requires new permissions may [trigger a permission warning][perm-warn], which will disable your extension until the user accepts the new permissions.
 
 <figure>
-    {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/tQgKKMKbzmCzwBEAoatX.gif", alt="Example of extension that is disabled until the user accepts new permission.", width="496", height="388" %}
+    {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/tQgKKMKbzmCzwBEAoatX.gif", alt="Example of an extension that is disabled until the user accepts the new permission.", width="496", height="388" %}
     <figcaption>
-    Extension disabled until user accepts new permission.
+    An extension that is disabled until the user accepts the new permission.
     </figcaption>
 </figure>
 

--- a/site/en/docs/extensions/migrating/index.md
+++ b/site/en/docs/extensions/migrating/index.md
@@ -16,7 +16,7 @@ This section helps you upgrade an extension from Manifest V2 to Manifest V3, the
 * [Update API calls](/docs/extensions/migrating/api-calls)&mdash;Some API calls need to be replaced with more modern equivalents. 
 * [Replace blocking web request listeners](/docs/extensions/migrating/blocking-web-requests)&mdash;Blocking or modifying network requests in Manifest V2 could significantly degrade performance and require excessive access to sensitive user data. The Declarative Net Request API allows extensions to block or modify web content with fewer permissions and without hindering performance.
 * [Improve extension security](/docs/extensions/migrating/improve-security)&mdash;Manifest V3 improves extension security in several ways. Besides an enhanced content security policy, support is removed for remotely hosted code and execution of arbitrary strings.
-* [Publish your extension](/docs/extensions/migrating/publish-mv3/)&mdash;This section describes how to perform a step-wise roll out to ensure your MV3 extension works as expected
+* [Publish your extension](/docs/extensions/migrating/publish-mv3/)&mdash;This section describes how to perform a step-wise roll out to ensure your Manifest V3 extension works as expected
 by testing it with a limited audience first.
 
 We also have an [Extension Manifest Converter](https://github.com/GoogleChromeLabs/extension-manifest-converter). It does not do everything for you, but it will get you started. The converter's README describes what the tool changes.

--- a/site/en/docs/extensions/migrating/index.md
+++ b/site/en/docs/extensions/migrating/index.md
@@ -4,7 +4,7 @@ title: Migrate to Manifest V3
 subhead: A guide to converting Manifest V2 extensions to Manifest V3 extensions.
 description: A guide to converting Manifest V2 extensions to Manifest V3 extensions.
 date: 2023-03-09
-updated: 2023-04-14
+updated: 2023-09-14
 ---
 
 {% Partial 'extensions/mv3-support.md' %}
@@ -21,7 +21,7 @@ We also have an [Extension Manifest Converter](https://github.com/GoogleChromeLa
 
 ## Keep the current set of features {: #keep-features }
 
-To reduce the chances of unexpected issues or bugs, we recommend not adding new functionality when publishing a new release. For instance, adding a feature that requires new permissions may [trigger a permission warning][perm-warn], which may disable your extension until the user enables it.
+To reduce the chances of unexpected issues or bugs, we recommend not adding new functionality when migrating. For instance, adding a feature that requires new permissions may [trigger a permission warning][perm-warn], which will disable your extension until the user accepts the new permissions.
 
 <figure>
     {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/tQgKKMKbzmCzwBEAoatX.gif", alt="Example of extension that is disabled until the user accepts new permission.", width="496", height="388" %}
@@ -30,13 +30,12 @@ To reduce the chances of unexpected issues or bugs, we recommend not adding new 
     </figcaption>
 </figure>
 
-Note that the extension will also be disabled if [`"host_permissions"`][host-perms] are added or modified in the manifest. This includes [`"content_scripts.matches"`][content-manifest], which are also considered host permissions. See [Permissions Best Practices][perm-warn] to learn of other ways to add permission without displaying a warning.
+See [Permission Best Practices][perm-warn] to learn of other ways to add permissions without displaying a warning.
 
 ## New extension platform features
 
 Since the release of Manifest V3, we've continued to [add new features](/docs/extensions/whatsnew/), many of which are usable in both Manifest V2 and Manifest V3. You are not required to use them when converting; however, when they replace older features, you should prefer them to the features they replace and expect that the replaced features will eventually be deprecated and removed.
 
-[cws]: https://chrome.google.com/webstore
 [host-perms]: /docs/extensions/mv3/declare_permissions/#host-permissions
 [content-manifest]: /docs/extensions/manifest/content_scripts
 [perm-warn]: /docs/extensions/mv3/permission_warnings/

--- a/site/en/docs/extensions/migrating/index.md
+++ b/site/en/docs/extensions/migrating/index.md
@@ -25,14 +25,7 @@ We also have an [Extension Manifest Converter](https://github.com/GoogleChromeLa
 
 To reduce the chances of unexpected issues or bugs, we recommend not adding new functionality when migrating. For instance, adding a feature that requires new permissions may [trigger a permission warning][perm-warn], which will disable your extension until the user accepts the new permissions.
 
-<figure>
-    {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/tQgKKMKbzmCzwBEAoatX.gif", alt="Example of an extension that is disabled until the user accepts the new permission.", width="496", height="388" %}
-    <figcaption>
-    An extension that is disabled until the user accepts the new permission.
-    </figcaption>
-</figure>
-
-See [Permission Best Practices][perm-warn] to learn of other ways to add permissions without displaying a warning.
+See [Permission warning best practices][perm-warn] to learn of other ways to add permissions without displaying a warning.
 
 ## New extension platform features
 

--- a/site/en/docs/extensions/migrating/index.md
+++ b/site/en/docs/extensions/migrating/index.md
@@ -16,8 +16,8 @@ This section helps you upgrade an extension from Manifest V2 to Manifest V3, the
 * [Update API calls](/docs/extensions/migrating/api-calls)&mdash;Some API calls need to be replaced with more modern equivalents. 
 * [Replace blocking web request listeners](/docs/extensions/migrating/blocking-web-requests)&mdash;Blocking or modifying network requests in Manifest V2 could significantly degrade performance and require excessive access to sensitive user data. The Declarative Net Request API allows extensions to block or modify web content with fewer permissions and without hindering performance.
 * [Improve extension security](/docs/extensions/migrating/improve-security)&mdash;Manifest V3 improves extension security in several ways. Besides an enhanced content security policy, support is removed for remotely hosted code and execution of arbitrary strings.
-* [Publish your extension](/docs/extensions/migrating/publish-mv3/)&mdash;This section describes how to release your Manifest V3 extension to testers and then gradually rollout to the rest of your user base.
-
+* [Publish your extension](/docs/extensions/migrating/publish-mv3/)&mdash;This section describes how to perform a step-wise roll out to ensure your MV3 extension works as expected
+by testing it with a limited audience first.
 
 We also have an [Extension Manifest Converter](https://github.com/GoogleChromeLabs/extension-manifest-converter). It does not do everything for you, but it will get you started. The converter's README describes what the tool changes.
 

--- a/site/en/docs/extensions/migrating/publish-mv3/index.md
+++ b/site/en/docs/extensions/migrating/publish-mv3/index.md
@@ -11,7 +11,7 @@ After following the [MV3 Migration Checklist][migration-checklist] to convert yo
 
 ## Keep the current set of features {: #keep-features }
 
-When publishing your Manifest V3 extension for the first time, we recommend not adding extra functionality. This way, you can minimize the chances of unexpected issues or bugs. If new features require new permissions, it may [trigger a warning][perm-warn], which means your extension may be disabled until the user enables it again.
+When migrating to Manifest V3 extension, we recommend not adding extra functionality. This way, you can minimize the chances of unexpected issues or bugs unrelated to the migration. If new features require new permissions, it may [trigger a warning][perm-warn], which means your extension may be disabled until the user enables it again.
 
 <figure>
     {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/tQgKKMKbzmCzwBEAoatX.gif", alt="ALT_TEXT_HERE", width="496", height="388" %}

--- a/site/en/docs/extensions/migrating/publish-mv3/index.md
+++ b/site/en/docs/extensions/migrating/publish-mv3/index.md
@@ -1,21 +1,26 @@
 ---
 layout: 'layouts/doc-post.njk'
-title: TBD
-seoTitle: Best practices when publishing a converted Manifest V3 extension.
-description: 'TBD'
-date: 2022-09-23
-updated: 2023-05-10
+title: Publish your Manifest V3 extension.
+seoTitle: Publishing a new Manifest V3 Chrome extension.
+description: 'Best practices for publishing a new Manifest V3 extension'
+date: 2023-09-06
+# updated: 2023-05-10
 ---
 
-After following the [MV3 Migration Checklist][migration-checklist] to convert your extension, you are ready to move on to distributing your extension in the Chrome Web Store. This article includes a few helpful recommendations to ensure your extension is released smoothly.
+After following the [MV3 Migration Checklist][migration-checklist] to convert your extension, you are ready to publish your update in the Chrome Web Store. This article includes a few helpful recommendations to ensure your release goes smoothly.
 
 ## Keep the current set of features {: #keep-features }
 
 When publishing your Manifest V3 extension for the first time, we recommend not adding extra functionality. This way, you can minimize the chances of unexpected issues or bugs. If new features require new permissions, it may [trigger a warning][perm-warn], which means your extension may be disabled until the user enables it again.
 
-_Screenshot of disabled extension_
+<figure>
+    {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/tQgKKMKbzmCzwBEAoatX.gif", alt="ALT_TEXT_HERE", width="496", height="388" %}
+    <figcaption>
+    Extension disabled until user accepts new permission.
+    </figcaption>
+</figure>
 
-Note that the extension will also be disabled if `"host_permissions"` are added or modified in the manifest. This includes `"content_scripts.matches"`, which are also considered host permissions. See [Permission warnings][perm-warn] to learn of other ways to add permission without displaying a warning.
+Note that the extension will also be disabled if [`"host_permissions"`][host-perms] are added or modified in the manifest. This includes [`"content_scripts.matches"`][content-manifest], which are also considered host permissions. See [Permissions Best Practices][perm-warn] to learn of other ways to add permission without displaying a warning.
 
 ## Publish a beta testing version {: #publish-beta }
 
@@ -32,7 +37,9 @@ First, you must label this extension as a testing version by following these ste
 1. Add the label “BETA” at the end of the name of your extension.
 2. Add "THIS EXTENSION IS FOR BETA TESTING" to the description.
 
-Note that skipping this step may result in your extension being rejected for [repetitive content][spam-policy]. 
+{% Aside 'caution' %}
+Skipping this step may result in your extension being rejected for [repetitive content][spam-policy]. 
+{% endAside %}
 
 Now that your beta version is clearly labeled, you can either distribute it to specified email addresses, to members of a Google group or share as a direct link.
 
@@ -41,22 +48,18 @@ Now that your beta version is clearly labeled, you can either distribute it to s
 Follow these steps to distribute to a small number of testers:
 
 1. Go to the Account tab of the Developer Dashboard.
-2. Scroll down to Management.
-3. Under Trusted Testers, enter email addresses separated by spaces or commas.
-4. Save changes at the bottom of the page.
-
-<figure>
-    {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/SrVxYFc0lmMgXxtN30gA.png", alt="Screenshot showing trusted tester accounts listed in a Chrome Web Store developer account page", height="395", width="800" %}
-    <figcaption>
-        Trusted tester emails listed in a Chrome Web Store developer Account page.
-    </figcaption>
-</figure>
-
+1. Scroll down to Management.
+1. Under Trusted Testers, enter email addresses separated by spaces or commas.
+    <figure>
+        {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/SrVxYFc0lmMgXxtN30gA.png", alt="Screenshot showing trusted tester accounts listed in a Chrome Web Store developer account page", height="395", width="800", class="screenshot" %}
+        <figcaption>
+            Trusted tester emails listed in a Chrome Web Store developer Account page.
+        </figcaption>
+    </figure>
+1. Save changes at the bottom of the page.
 1. Upload the beta version of your extension
-2. Go to the Distribution tab
-3. Set the Visibility to **Private**. 
-
-_Example Screenshot_
+1. Go to the Distribution tab
+1. Set the Visibility to **Private**. 
 
 ### Distribute to members of a Google group {: #dist-group }
 
@@ -65,7 +68,7 @@ Once you've received enough feedback from your beta testers, you can expand dist
 Go to the Distribution tab, set the Visibility to **Private**, and choose your beta tester Google group from the dropdown menu. 
 
 <figure>
-    {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/VjVunVpPxNsVKpIXKMpr.png", alt="Screenshot of the Private Visibility Setting and Google Group Selection Dropdown", width="800", height="445" %}
+    {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/eW95QyUHVYrQw0eThSNc.png", alt="ALT_TEXT_HERE", width="600", height="445" %}
     <figcaption>
         Distributing to Members of a Google Group
     </figcaption>
@@ -79,41 +82,79 @@ Another alternative is to set the Visibility as **Unlisted**. This way, only use
 
 The Chrome Web Store allows you to roll out a new version gradually. This ensures that any unexpected problems will have minimal impact. This is only available for extensions with more than 10,000 active users. To start rolling out your extension partially, follow these steps:
 
-1. [Upload](/docs/webstore/publish/) your new version.
+1. [Upload][cws-upload] your new version.
 2. Go to the Distribution tab.
 3. Enter a percentage in **Percentage rollout** field.
 
+<figure>
+    {% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/yoMNFt1ht6qSLXzFyrWj.png", alt="Screenshot showing the 'more' menu's defer publish option", width="286", height="184", class='screenshot' %}
+    <figcaption>
+        Setting the initial rollout percentage.
+    </figcaption>
+</figure>
+
 To continue rolling out gradually, navigate to the **Package** tab of your item and increase the percentage located in the **Published** section. Note that the percentage can only be increased, and it doesn't trigger an additional review.
 
-## Understand the review process {: #review }
+<figure>
+    {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/UA8vDp8aG89exqqjzY55.png", alt="Screenshot of the Chrome Web Store update percent rollout field", width="800", height="395", class='screenshot' %}
+    <figcaption>
+        Updating the rollout percentage
+    </figcaption>
+</figure>
 
-We recommend planing enough time for your item to be reviewed. Review times vary based on [different factors](/docs/webstore/review-process/#review-time-factors). You can be more proactive by staging the release and checking the review status to follow up quickly if the version is rejected.
+## Plan for review times {: #review }
+
+We recommend planning enough time for your item to be reviewed as review times may vary based on [different factors][review-factors]. Consider staging your release and regularly checking your item's status to make changes quickly if necessary.
 
 ### Stage your release {: #staged-release }
 
-The Chrome web store offers a way to stage a release by submitting it for review ahead of time. This way, when you are ready, you can officially release it. 
+The Chrome Web Store offers a way to stage a release by submitting it for review ahead of time. This way, when you are ready, you can officially release it. 
 
 You can do this by unchecking the "Publish automatically" checkbox when you submit the item. 
 
+<figure>
+    {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/BiZituXHHZ74SIkwc3q7.png", alt="Screenshot of the Chrome Web Store confirm submission dialog", height="388", width="800" %}
+    <figcaption>
+        Checkbox to stage an extension update.
+    </figcaption>
+</figure>
 
 Or you can do it later by choosing "Defer publish" in the three-dot menu on the top-right.
 
-Aside
+<figure>
+    {% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/yoMNFt1ht6qSLXzFyrWj.png", alt="Screenshot showing the 'more' menu's defer publish option", width="286", height="184", class='screenshot' %}
+    <figcaption>
+      Choosing deferred publishing in menu.
+    </figcaption>
+</figure>
+
+{% Aside %}
 Once your item is approved, you have up to 30 days to publish. After that period expires, the staged submission will revert to a draft, which will have to be reviewed again. You can check when your staged submission will expire under the status of your item.
+{% endAside %}
 
 ### Check your item status {: #check-status }
 
-Most extensions are reviewed within three days. You should receive an email notifying you if your item has passed or if a violation has been found. If you have not received an email in a week or two, you can check your item's status in the Published section of the Status tab. For example:
+Most extensions are reviewed within three days. You should receive an email notifying you if your item has passed or if a violation has been found. If you have not received an email in a week, check your item's status in the Published section of the **Status** tab.
 
-If your extension is pending review for over three weeks, you can [contact developer support][cws-support] to request assistance.
+<figure>
+    {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/C4wpnEeMriI9YeDAMDIr.png", alt="The Chrome Web Store Status Tab", width="700", height="276", class='screenshot' %}
+    <figcaption>
+        Status tab in the Developer Dashboard.
+    </figcaption>
+</figure>
+
+If your extension is pending review for over two weeks, you can [contact developer support][cws-support] to request assistance.
 
 ## Additional tips {: #learn-more }
 
 There are other ways to make your extension more robust as you transition to Manifest Version 3. See [Engineering resilient extensions](TBD) for best practices for building a reliable extension.
 
-
-[perm-warn]: /docs/extensions/mv2/permission_warnings/
+[content-manifest]: /docs/extensions/manifest/content_scripts
 [cws-support]: /docs/webstore/review-process/#support
-[migration-checklist]: /docs/extensions/migrating/checklist/
-[spam-policy]: /docs/webstore/troubleshooting/#spam
+[cws-upload]: /docs/webstore/upload
 [google-group]: https://groups.google.com/my-groups
+[host-perms]: /docs/extensions/mv3/declare_permissions/#host-permissions
+[migration-checklist]: /docs/extensions/migrating/checklist/
+[perm-warn]: /docs/extensions/mv3/permission_warnings/
+[review-factors]: /docs/webstore/review-process/#review-time-factors
+[spam-policy]: /docs/webstore/troubleshooting/#spam

--- a/site/en/docs/extensions/migrating/publish-mv3/index.md
+++ b/site/en/docs/extensions/migrating/publish-mv3/index.md
@@ -8,8 +8,8 @@ date: 2023-09-04
 ---
 
 After [converting your extension][migration-checklist] to Manifest Version 3, the next step is to
-release it on the [Chrome Web Store][cws]. Depending on the extent of the changes you had to make,
-it can be advisable to perform a step-wise roll out to ensure your MV3 extension works as expected
+release it on the [Chrome Web Store][cws]. Depending on the extent of the changes you made,
+it can be advisable to perform a step-wise roll out to ensure your Manifest V3 extension works as expected
 by testing it with a limited audience first. 
 
 This article discusses a few ways to publish your new release in stages. For example, releasing a
@@ -19,7 +19,7 @@ needed.
 
 ## Publish a beta testing version {: #publish-beta }
 
-Publishing a beta release allows you to gather feedback and identify any issues with a group of testers before releasing it to the rest of your user base. Beta releases also go through the [Chrome Web Store review process][cws-review].
+Publishing a beta release allows you to gather feedback and identify any issues with a group of testers before releasing your extension to the rest of your users. Beta releases also go through the [Chrome Web Store review process][cws-review].
 
 ### Label your beta version {: #label-beta }
 
@@ -32,7 +32,7 @@ First, you must label the beta release as a testing version by following these s
 Skipping this step may result in your extension being rejected for [repetitive content][spam-policy]. 
 {% endAside %}
 
-Now that your beta version is clearly labeled, you can either distribute it to specified email addresses, to members of a Google group or share it as a direct link.
+Now that your beta version is clearly labeled, you can either distribute it to specified email addresses, to members of a Google group, or share it as a direct link.
 
 ### Distribute to testers by email {: #dist-email }
 
@@ -63,12 +63,12 @@ Follow these steps to distribute to a small number of testers:
 
 Once you've received enough feedback from your beta testers, you can expand distribution to members of a [Google group][google-group] that you own or manage. 
 
-Go to the Distribution tab, set the Visibility to **Private**, and choose your beta tester Google group from the dropdown menu. 
+Go to the **Distribution** tab, set the **Visibility** to Private, and choose your beta tester Google group from the **dropdown menu**. 
 
 <figure>
     {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/eW95QyUHVYrQw0eThSNc.png", alt="ALT_TEXT_HERE", width="600", height="445" %}
     <figcaption>
-        Distributing to Members of a Google Group
+        Distributing to Members of a Google Group.
     </figcaption>
 </figure>
 
@@ -96,7 +96,7 @@ To continue rolling out gradually, navigate to the **Package** tab of your item 
 <figure>
     {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/UA8vDp8aG89exqqjzY55.png", alt="Screenshot of the Chrome Web Store update percent rollout field", width="800", height="395", class='screenshot' %}
     <figcaption>
-        Updating the rollout percentage
+        Updating the rollout percentage.
     </figcaption>
 </figure>
 
@@ -117,7 +117,7 @@ You can do this by unchecking the "Publish automatically" checkbox when you subm
     </figcaption>
 </figure>
 
-Or you can do it later by choosing "Defer publish" in the three-dot menu on the top right.
+Or you can do it later by choosing **Defer publish** in the three-dot menu on the top right.
 
 <figure>
     {% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/yoMNFt1ht6qSLXzFyrWj.png", alt="Screenshot showing the 'more' menu's defer publish option", width="286", height="184", class='screenshot' %}
@@ -132,7 +132,7 @@ Once your item is approved, you have up to 30 days to publish. After that period
 
 ### Check your item status {: #check-status }
 
-Most extensions are reviewed within three days. When your item has passed or if a violation has been found, you will receive a notification email. If you have not received an email in a week, check your item's status in the Published section of the **Status** tab.
+Most extensions are reviewed within three days. When your item has passed or if a violation has been found, you will receive a notification email. If you have not received an email in a week, check your item's status in the **Published** section of the **Status** tab.
 
 <figure>
     {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/C4wpnEeMriI9YeDAMDIr.png", alt="The Chrome Web Store Status Tab", width="700", height="276", class='screenshot' %}

--- a/site/en/docs/extensions/migrating/publish-mv3/index.md
+++ b/site/en/docs/extensions/migrating/publish-mv3/index.md
@@ -7,21 +7,19 @@ date: 2023-09-04
 # updated: 2023-05-10
 ---
 
-After [converting your extension][migration-checklist] to Manifest Version 3, the next step is to release
-it on the [Chrome Web Store][cws]. Depending on the extent of the changes during conversion, it can be advisable to perform a gradual release to ensure your MV3 extension works as
-expected by testing it with a limited audience first. 
+After [converting your extension][migration-checklist] to Manifest Version 3, the next step is to
+release it on the [Chrome Web Store][cws]. Depending on the extent of the changes you had to make,
+it can be advisable to perform a step-wise roll out to ensure your MV3 extension works as expected
+by testing it with a limited audience first. 
 
-There are a few ways to release your extension gradually. This article explores different approaches such as releasing a beta version and slowly increasing the number of testers, gradually
-rolling out to your user base, and monitoring your extension review status to quickly publish any
-fixes if needed.
+This article discusses a few ways to publish your new release in stages. For example, releasing a
+beta version to testers and gradually rolling out to your user base. We also recommend monitoring
+your extension review status and keeping an eye on user feedback to quickly publish any bug fixes if
+needed.
 
 ## Publish a beta testing version {: #publish-beta }
 
-Publishing a beta release allows you to gather feedback and identify any issues with a select group of testers before releasing it to the rest of your user base. 
-
-{% Aside %}
-Beta releases also go through the [Chrome Web Store review process][cws-review], so make sure you plan for that.
-{% endAside %}
+Publishing a beta release allows you to gather feedback and identify any issues with a group of testers before releasing it to the rest of your user base. Beta releases also go through the [Chrome Web Store review process][cws-review].
 
 ### Label your beta version {: #label-beta }
 
@@ -50,9 +48,16 @@ Follow these steps to distribute to a small number of testers:
         </figcaption>
     </figure>
 1. Save changes at the bottom of the page.
-1. Upload the beta version of your extension
+1. [Upload][cws-upload] the beta version of your extension
 1. Go to the Distribution tab
 1. Set the Visibility to **Private**. 
+
+<figure>
+    {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/EfL45p0rsDFExxbjMp0B.png", alt="Setting the Visibility as Private in the Distribution tab", width="500", height="612", class='screenshot' %}
+    <figcaption>
+    Visibility set to Private in the Distribution tab. 
+    </figcaption>
+</figure>
 
 ### Distribute to members of a Google group {: #dist-group }
 
@@ -69,11 +74,11 @@ Go to the Distribution tab, set the Visibility to **Private**, and choose your b
 
 ### Distribute to testers with a direct link {: #dist-link }
 
-Another alternative is to set the Visibility as **Unlisted**. This way, only users who have the direct link can install the extension.
+Another alternative is to set the visibility to **Unlisted**. This way, only users who have the direct link can install the extension.
 
 ## Gradually roll-out your release {: #gradual-rollout }
 
-The Chrome Web Store allows you to roll out a new version gradually. This ensures that any unexpected problems will have minimal impact. This is only available for extensions with more than 10,000 active users. To start rolling out your extension partially, follow these steps:
+To ensure that any unexpected problems will have minimal impact, you can roll out your update gradually by following these steps. This is only available for extensions with more than 10,000 active users.
 
 1. [Upload][cws-upload] your new version.
 2. Go to the Distribution tab.
@@ -140,9 +145,9 @@ If your extension has been pending review for over two weeks, [contact developer
 
 ## Additional tips {: #learn-more }
 
-There are other ways to make your extension more robust as you transition to Manifest Version 3. See [Engineering resilient extensions](TBD) for best practices for building a reliable extension.
+To stay on top of user feedback you can add a link to a [dedicated support site][support-site] under the Support tab of your extension listing.
 
-Additionally, get user feedback as quickly as possible by adding a link to a [dedicated support site][support-site] under the Support tab of your extension listing.
+There are other ways to make your extension more robust as you transition to Manifest Version 3. See [Engineering resilient extensions](TBD) for best practices for building a reliable extension.
 
 [cws]: https://chrome.google.com/webstore
 [cws-review]: /docs/webstore/review-process/

--- a/site/en/docs/extensions/migrating/publish-mv3/index.md
+++ b/site/en/docs/extensions/migrating/publish-mv3/index.md
@@ -7,158 +7,113 @@ date: 2022-09-23
 updated: 2023-05-10
 ---
 
-After following the [MV3 Migration Checklist](/docs/extensions/migrating/checklist/) and converting your extension to Manifest Version 3, you are ready to move on to distributing your extension in the Chrome Web Store. This article includes a few helpful recommendations to ensure a smooth release.
+After following the [MV3 Migration Checklist][migration-checklist] to convert your extension, you are ready to move on to distributing your extension in the Chrome Web Store. This article includes a few helpful recommendations to ensure your extension is released smoothly.
 
+## Keep the current set of features {: #keep-features }
 
-## Keep the current set of features
-
-When publishing your Manifest Version 3 extension for the first time, we recommend not adding any functionality to minimize the possibility of things going wrong, especially features that require new permissions. Some [permissions trigger warnings](/docs/extensions/mv2/permission_warnings/), which means your extension may be disabled until the user enables it again.
+When publishing your Manifest V3 extension for the first time, we recommend not adding extra functionality. This way, you can minimize the chances of unexpected issues or bugs. If new features require new permissions, it may [trigger a warning][perm-warn], which means your extension may be disabled until the user enables it again.
 
 _Screenshot of disabled extension_
 
-Note that the extension will also be disabled if "host_permissions" are added or modified in the manifest. This includes "content_scripts.matches", which are also considered host permissions. See Onboarding Users to learn how to design a better onboarding user experience.
+Note that the extension will also be disabled if `"host_permissions"` are added or modified in the manifest. This includes `"content_scripts.matches"`, which are also considered host permissions. See [Permission warnings][perm-warn] to learn of other ways to add permission without displaying a warning.
 
-
-## Publish a beta testing version
+## Publish a beta testing version {: #publish-beta }
 
 The Chrome Web Store provides a way to publish to beta testers. This way, a subset of users can report any issues before publishing to the rest of your user base. 
 
-Note that Beta releases will also be subject to the Chrome Web Store review process.
+{% Aside %}
+Beta releases will also be subject to the Chrome Web Store review process.    
+{% endAside %}
 
+### Label your beta version {: #label-beta }
 
-### Label your beta version
-
-First, you must label this extension as a testing version. You can do so by following these steps:
-
-
+First, you must label this extension as a testing version by following these steps:
 
 1. Add the label “BETA” at the end of the name of your extension.
 2. Add "THIS EXTENSION IS FOR BETA TESTING" to the description.
 
-Note that skipping this step may result in your extension being rejected for violating the spam policy. 
+Note that skipping this step may result in your extension being rejected for [repetitive content][spam-policy]. 
 
-Now that your beta version is clearly labeled, you can either distribute it to specified email addresses or to members of a Google group you own or manage.
+Now that your beta version is clearly labeled, you can either distribute it to specified email addresses, to members of a Google group or share as a direct link.
 
-
-### Distribute to testers by email
+### Distribute to testers by email {: #dist-email }
 
 Follow these steps to distribute to a small number of testers:
-
-
 
 1. Go to the Account tab of the Developer Dashboard.
 2. Scroll down to Management.
 3. Under Trusted Testers, enter email addresses separated by spaces or commas.
 4. Save changes at the bottom of the page.
 
-_Example Screenshot_
+<figure>
+    {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/SrVxYFc0lmMgXxtN30gA.png", alt="Screenshot showing trusted tester accounts listed in a Chrome Web Store developer account page", height="395", width="800" %}
+    <figcaption>
+        Trusted tester emails listed in a Chrome Web Store developer Account page.
+    </figcaption>
+</figure>
 
-
-
-1. Upload the beta version of your extension, go to the Distribution tab, and set the Visibility to **Private**. 
-
-_Example Screenshot_
-
-
-### Distribute to testers in a Google group
-
-Once you've received enough feedback from your beta testers, you can expand distribution to members of a [Google group](https://groups.google.com/my-groups) that you own or manage. 
-
-Go to the Distribution tab, set the Visibility to **Private**, and choose your beta tester Google group. 
+1. Upload the beta version of your extension
+2. Go to the Distribution tab
+3. Set the Visibility to **Private**. 
 
 _Example Screenshot_
 
+### Distribute to members of a Google group {: #dist-group }
 
-### 
+Once you've received enough feedback from your beta testers, you can expand distribution to members of a [Google group][google-group] that you own or manage. 
 
-<p id="gdcalert1" ><span style="color: red; font-weight: bold">>>>>>  gd2md-html alert: inline image link here (to images/image1.png). Store image on your image server and adjust path/filename/extension if necessary. </span><br>(<a href="#">Back to top</a>)(<a href="#gdcalert2">Next alert</a>)<br><span style="color: red; font-weight: bold">>>>>> </span></p>
+Go to the Distribution tab, set the Visibility to **Private**, and choose your beta tester Google group from the dropdown menu. 
 
+<figure>
+    {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/VjVunVpPxNsVKpIXKMpr.png", alt="Screenshot of the Private Visibility Setting and Google Group Selection Dropdown", width="800", height="445" %}
+    <figcaption>
+        Distributing to Members of a Google Group
+    </figcaption>
+</figure>
 
-![alt_text](images/image1.png "image_tooltip")
+### Distribute to testers with a direct link {: #dist-link }
 
+Another alternative is to set the Visibility as **Unlisted**. This way, only users who have the direct link can install the extension.
 
+## Gradually roll-out your release {: #gradual-rollout }
 
-### Distribute to testers with a direct link
-
-Another alternative is to set the Visibility as Unlisted. This way, only users who have the direct link can install the extension.
-
-
-## Gradually roll-out your release
-
-The Chrome Web Store allows you to roll out your new version gradually. This helps to ensure that any unexpected problems will have minimal impact. This is only available for extensions with more than 10,000 active users. To start rolling out your extension partially, follow these steps:
-
-
+The Chrome Web Store allows you to roll out a new version gradually. This ensures that any unexpected problems will have minimal impact. This is only available for extensions with more than 10,000 active users. To start rolling out your extension partially, follow these steps:
 
 1. [Upload](/docs/webstore/publish/) your new version.
 2. Go to the Distribution tab.
 3. Enter a percentage in **Percentage rollout** field.
 
- 
+To continue rolling out gradually, navigate to the **Package** tab of your item and increase the percentage located in the **Published** section. Note that the percentage can only be increased, and it doesn't trigger an additional review.
 
-To continue rolling out gradually, navigate to the **Package** tab of your item and increase the percentage located in the **Published** section. Note that the percentage can only be increased and that it will not trigger an additional review.
+## Understand the review process {: #review }
 
+We recommend planing enough time for your item to be reviewed. Review times vary based on [different factors](/docs/webstore/review-process/#review-time-factors). You can be more proactive by staging the release and checking the review status to follow up quickly if the version is rejected.
 
-## 
-
-<p id="gdcalert2" ><span style="color: red; font-weight: bold">>>>>>  gd2md-html alert: inline image link here (to images/image2.png). Store image on your image server and adjust path/filename/extension if necessary. </span><br>(<a href="#">Back to top</a>)(<a href="#gdcalert3">Next alert</a>)<br><span style="color: red; font-weight: bold">>>>>> </span></p>
-
-
-![alt_text](images/image2.png "image_tooltip")
-
-
-
-## Understand the review process
-
-We recommend you plan enough time for your item to be reviewed. Review times vary based on different factors (see [Notable factors that increase review times](/docs/webstore/review-process/#review-time-factors)). One way to plan ahead is to stage your release. We also recommend that you check on the review status of your item to follow-up if needed.
-
-
-### Stage your release
+### Stage your release {: #staged-release }
 
 The Chrome web store offers a way to stage a release by submitting it for review ahead of time. This way, when you are ready, you can officially release it. 
 
 You can do this by unchecking the "Publish automatically" checkbox when you submit the item. 
 
 
-
-<p id="gdcalert3" ><span style="color: red; font-weight: bold">>>>>>  gd2md-html alert: inline image link here (to images/image3.png). Store image on your image server and adjust path/filename/extension if necessary. </span><br>(<a href="#">Back to top</a>)(<a href="#gdcalert4">Next alert</a>)<br><span style="color: red; font-weight: bold">>>>>> </span></p>
-
-
-![alt_text](images/image3.png "image_tooltip")
-
-
 Or you can do it later by choosing "Defer publish" in the three-dot menu on the top-right.
 
-
-
-<p id="gdcalert4" ><span style="color: red; font-weight: bold">>>>>>  gd2md-html alert: inline image link here (to images/image4.png). Store image on your image server and adjust path/filename/extension if necessary. </span><br>(<a href="#">Back to top</a>)(<a href="#gdcalert5">Next alert</a>)<br><span style="color: red; font-weight: bold">>>>>> </span></p>
-
-
-![alt_text](images/image4.png "image_tooltip")
-
-
 Aside
+Once your item is approved, you have up to 30 days to publish. After that period expires, the staged submission will revert to a draft, which will have to be reviewed again. You can check when your staged submission will expire under the status of your item.
 
-Once it is approved, you have up to 30 days to publish. After that period expires, the staged submission will revert to a draft, which will have to be submitted again for review. You can check when your staged submission will expire under the status of your item.
-
-
-
-<p id="gdcalert5" ><span style="color: red; font-weight: bold">>>>>>  gd2md-html alert: inline image link here (to images/image5.png). Store image on your image server and adjust path/filename/extension if necessary. </span><br>(<a href="#">Back to top</a>)(<a href="#gdcalert6">Next alert</a>)<br><span style="color: red; font-weight: bold">>>>>> </span></p>
-
-
-![alt_text](images/image5.png "image_tooltip")
-
-
-
-### Check your item status
+### Check your item status {: #check-status }
 
 Most extensions are reviewed within three days. You should receive an email notifying you if your item has passed or if a violation has been found. If you have not received an email in a week or two, you can check your item's status in the Published section of the Status tab. For example:
 
+If your extension is pending review for over three weeks, you can [contact developer support][cws-support] to request assistance.
 
-
-If your extension is pending review for over three weeks, you can [contact developer support](/docs/webstore/review-process/#support) to request assistance.
-
-
-## Additional tips
+## Additional tips {: #learn-more }
 
 There are other ways to make your extension more robust as you transition to Manifest Version 3. See [Engineering resilient extensions](TBD) for best practices for building a reliable extension.
 
+
+[perm-warn]: /docs/extensions/mv2/permission_warnings/
+[cws-support]: /docs/webstore/review-process/#support
+[migration-checklist]: /docs/extensions/migrating/checklist/
+[spam-policy]: /docs/webstore/troubleshooting/#spam
+[google-group]: https://groups.google.com/my-groups

--- a/site/en/docs/extensions/migrating/publish-mv3/index.md
+++ b/site/en/docs/extensions/migrating/publish-mv3/index.md
@@ -7,21 +7,25 @@ date: 2023-09-04
 # updated: 2023-05-10
 ---
 
-After [converting your extension][migration-checklist] to Manifest Version 3, it's time to release it on the [Chrome Web Store][cws]. Depending on how many adjustments you had to make to your app, it can be advisable to perform a step-wise roll out to make sure that your MV3 extension works as expected by testing it with a smaller audience first. 
+After [converting your extension][migration-checklist] to Manifest Version 3, the next step is to release
+it on the [Chrome Web Store][cws]. Depending on the extent of the changes during conversion, it can be advisable to perform a gradual release to ensure your MV3 extension works as
+expected by testing it with a limited audience first. 
 
-There are a few ways to publish your new release gradually. This article discusses recommended approaches such as releasing a beta version and slowly increasing the number of testers, gradually rolling out to your user base, and monitoring your extension review status to quickly publish any fixes if needed.
+There are a few ways to release your extension gradually. This article explores different approaches such as releasing a beta version and slowly increasing the number of testers, gradually
+rolling out to your user base, and monitoring your extension review status to quickly publish any
+fixes if needed.
 
 ## Publish a beta testing version {: #publish-beta }
 
-The Chrome Web Store provides a way to publish to beta testers. This way, a subset of users can report any issues before publishing to the rest of your user base. 
+Publishing a beta release allows you to gather feedback and identify any issues with a select group of testers before releasing it to the rest of your user base. 
 
 {% Aside %}
-Beta releases will also be subject to the Chrome Web Store review process.    
+Beta releases also go through the [Chrome Web Store review process][cws-review], so make sure you plan for that.
 {% endAside %}
 
 ### Label your beta version {: #label-beta }
 
-First, you must label this extension as a testing version by following these steps:
+First, you must label the beta release as a testing version by following these steps:
 
 1. Add the label “BETA” at the end of the name of your extension.
 2. Add "THIS EXTENSION IS FOR BETA TESTING" to the description.
@@ -30,7 +34,7 @@ First, you must label this extension as a testing version by following these ste
 Skipping this step may result in your extension being rejected for [repetitive content][spam-policy]. 
 {% endAside %}
 
-Now that your beta version is clearly labeled, you can either distribute it to specified email addresses, to members of a Google group or share as a direct link.
+Now that your beta version is clearly labeled, you can either distribute it to specified email addresses, to members of a Google group or share it as a direct link.
 
 ### Distribute to testers by email {: #dist-email }
 
@@ -138,10 +142,14 @@ If your extension has been pending review for over two weeks, [contact developer
 
 There are other ways to make your extension more robust as you transition to Manifest Version 3. See [Engineering resilient extensions](TBD) for best practices for building a reliable extension.
 
+Additionally, get user feedback as quickly as possible by adding a link to a [dedicated support site][support-site] under the Support tab of your extension listing.
+
 [cws]: https://chrome.google.com/webstore
+[cws-review]: /docs/webstore/review-process/
 [cws-support]: /docs/webstore/review-process/#support
 [cws-upload]: /docs/webstore/upload
 [google-group]: https://groups.google.com/my-groups
 [migration-checklist]: /docs/extensions/migrating/checklist/
 [review-factors]: /docs/webstore/review-process/#review-time-factors
 [spam-policy]: /docs/webstore/troubleshooting/#spam
+[support-site]: /docs/webstore/manage/#dedicated-support-site

--- a/site/en/docs/extensions/migrating/publish-mv3/index.md
+++ b/site/en/docs/extensions/migrating/publish-mv3/index.md
@@ -1,0 +1,164 @@
+---
+layout: 'layouts/doc-post.njk'
+title: TBD
+seoTitle: Best practices when publishing a converted Manifest V3 extension.
+description: 'TBD'
+date: 2022-09-23
+updated: 2023-05-10
+---
+
+After following the [MV3 Migration Checklist](/docs/extensions/migrating/checklist/) and converting your extension to Manifest Version 3, you are ready to move on to distributing your extension in the Chrome Web Store. This article includes a few helpful recommendations to ensure a smooth release.
+
+
+## Keep the current set of features
+
+When publishing your Manifest Version 3 extension for the first time, we recommend not adding any functionality to minimize the possibility of things going wrong, especially features that require new permissions. Some [permissions trigger warnings](/docs/extensions/mv2/permission_warnings/), which means your extension may be disabled until the user enables it again.
+
+_Screenshot of disabled extension_
+
+Note that the extension will also be disabled if "host_permissions" are added or modified in the manifest. This includes "content_scripts.matches", which are also considered host permissions. See Onboarding Users to learn how to design a better onboarding user experience.
+
+
+## Publish a beta testing version
+
+The Chrome Web Store provides a way to publish to beta testers. This way, a subset of users can report any issues before publishing to the rest of your user base. 
+
+Note that Beta releases will also be subject to the Chrome Web Store review process.
+
+
+### Label your beta version
+
+First, you must label this extension as a testing version. You can do so by following these steps:
+
+
+
+1. Add the label “BETA” at the end of the name of your extension.
+2. Add "THIS EXTENSION IS FOR BETA TESTING" to the description.
+
+Note that skipping this step may result in your extension being rejected for violating the spam policy. 
+
+Now that your beta version is clearly labeled, you can either distribute it to specified email addresses or to members of a Google group you own or manage.
+
+
+### Distribute to testers by email
+
+Follow these steps to distribute to a small number of testers:
+
+
+
+1. Go to the Account tab of the Developer Dashboard.
+2. Scroll down to Management.
+3. Under Trusted Testers, enter email addresses separated by spaces or commas.
+4. Save changes at the bottom of the page.
+
+_Example Screenshot_
+
+
+
+1. Upload the beta version of your extension, go to the Distribution tab, and set the Visibility to **Private**. 
+
+_Example Screenshot_
+
+
+### Distribute to testers in a Google group
+
+Once you've received enough feedback from your beta testers, you can expand distribution to members of a [Google group](https://groups.google.com/my-groups) that you own or manage. 
+
+Go to the Distribution tab, set the Visibility to **Private**, and choose your beta tester Google group. 
+
+_Example Screenshot_
+
+
+### 
+
+<p id="gdcalert1" ><span style="color: red; font-weight: bold">>>>>>  gd2md-html alert: inline image link here (to images/image1.png). Store image on your image server and adjust path/filename/extension if necessary. </span><br>(<a href="#">Back to top</a>)(<a href="#gdcalert2">Next alert</a>)<br><span style="color: red; font-weight: bold">>>>>> </span></p>
+
+
+![alt_text](images/image1.png "image_tooltip")
+
+
+
+### Distribute to testers with a direct link
+
+Another alternative is to set the Visibility as Unlisted. This way, only users who have the direct link can install the extension.
+
+
+## Gradually roll-out your release
+
+The Chrome Web Store allows you to roll out your new version gradually. This helps to ensure that any unexpected problems will have minimal impact. This is only available for extensions with more than 10,000 active users. To start rolling out your extension partially, follow these steps:
+
+
+
+1. [Upload](/docs/webstore/publish/) your new version.
+2. Go to the Distribution tab.
+3. Enter a percentage in **Percentage rollout** field.
+
+ 
+
+To continue rolling out gradually, navigate to the **Package** tab of your item and increase the percentage located in the **Published** section. Note that the percentage can only be increased and that it will not trigger an additional review.
+
+
+## 
+
+<p id="gdcalert2" ><span style="color: red; font-weight: bold">>>>>>  gd2md-html alert: inline image link here (to images/image2.png). Store image on your image server and adjust path/filename/extension if necessary. </span><br>(<a href="#">Back to top</a>)(<a href="#gdcalert3">Next alert</a>)<br><span style="color: red; font-weight: bold">>>>>> </span></p>
+
+
+![alt_text](images/image2.png "image_tooltip")
+
+
+
+## Understand the review process
+
+We recommend you plan enough time for your item to be reviewed. Review times vary based on different factors (see [Notable factors that increase review times](/docs/webstore/review-process/#review-time-factors)). One way to plan ahead is to stage your release. We also recommend that you check on the review status of your item to follow-up if needed.
+
+
+### Stage your release
+
+The Chrome web store offers a way to stage a release by submitting it for review ahead of time. This way, when you are ready, you can officially release it. 
+
+You can do this by unchecking the "Publish automatically" checkbox when you submit the item. 
+
+
+
+<p id="gdcalert3" ><span style="color: red; font-weight: bold">>>>>>  gd2md-html alert: inline image link here (to images/image3.png). Store image on your image server and adjust path/filename/extension if necessary. </span><br>(<a href="#">Back to top</a>)(<a href="#gdcalert4">Next alert</a>)<br><span style="color: red; font-weight: bold">>>>>> </span></p>
+
+
+![alt_text](images/image3.png "image_tooltip")
+
+
+Or you can do it later by choosing "Defer publish" in the three-dot menu on the top-right.
+
+
+
+<p id="gdcalert4" ><span style="color: red; font-weight: bold">>>>>>  gd2md-html alert: inline image link here (to images/image4.png). Store image on your image server and adjust path/filename/extension if necessary. </span><br>(<a href="#">Back to top</a>)(<a href="#gdcalert5">Next alert</a>)<br><span style="color: red; font-weight: bold">>>>>> </span></p>
+
+
+![alt_text](images/image4.png "image_tooltip")
+
+
+Aside
+
+Once it is approved, you have up to 30 days to publish. After that period expires, the staged submission will revert to a draft, which will have to be submitted again for review. You can check when your staged submission will expire under the status of your item.
+
+
+
+<p id="gdcalert5" ><span style="color: red; font-weight: bold">>>>>>  gd2md-html alert: inline image link here (to images/image5.png). Store image on your image server and adjust path/filename/extension if necessary. </span><br>(<a href="#">Back to top</a>)(<a href="#gdcalert6">Next alert</a>)<br><span style="color: red; font-weight: bold">>>>>> </span></p>
+
+
+![alt_text](images/image5.png "image_tooltip")
+
+
+
+### Check your item status
+
+Most extensions are reviewed within three days. You should receive an email notifying you if your item has passed or if a violation has been found. If you have not received an email in a week or two, you can check your item's status in the Published section of the Status tab. For example:
+
+
+
+If your extension is pending review for over three weeks, you can [contact developer support](/docs/webstore/review-process/#support) to request assistance.
+
+
+## Additional tips
+
+There are other ways to make your extension more robust as you transition to Manifest Version 3. See [Engineering resilient extensions](TBD) for best practices for building a reliable extension.
+

--- a/site/en/docs/extensions/migrating/publish-mv3/index.md
+++ b/site/en/docs/extensions/migrating/publish-mv3/index.md
@@ -23,10 +23,10 @@ Publishing a beta release allows you to gather feedback and identify any issues 
 
 ### Label your beta version {: #label-beta }
 
-First, you must label the beta release as a testing version by following these steps:
+First, you must label the beta release as a testing version by following these steps in the [manifest.json][manifest]:
 
-1. Add the label “BETA” at the end of the name of your extension.
-2. Add "THIS EXTENSION IS FOR BETA TESTING" to the description.
+1. Add the label “BETA” at the end of the [name][manifest-name] of your extension.
+2. Add "THIS EXTENSION IS FOR BETA TESTING" to the [description][manifest-desc].
 
 {% Aside 'caution' %}
 Skipping this step may result in your extension being rejected for [repetitive content][spam-policy]. 
@@ -149,11 +149,14 @@ To stay on top of user feedback you can add a link to a [dedicated support site]
 
 There are other ways to make your extension more robust as you transition to Manifest Version 3. See [Engineering resilient extensions](TBD) for best practices for building a reliable extension.
 
-[cws]: https://chrome.google.com/webstore
 [cws-review]: /docs/webstore/review-process/
 [cws-support]: /docs/webstore/review-process/#support
 [cws-upload]: /docs/webstore/upload
+[cws]: https://chrome.google.com/webstore
 [google-group]: https://groups.google.com/my-groups
+[manifest-desc]: /docs/extensions/mv3/manifest/description/
+[manifest-name]: /docs/extensions/mv3/manifest/name/
+[manifest]: /docs/extensions/mv3/manifest/
 [migration-checklist]: /docs/extensions/migrating/checklist/
 [review-factors]: /docs/webstore/review-process/#review-time-factors
 [spam-policy]: /docs/webstore/troubleshooting/#spam

--- a/site/en/docs/extensions/migrating/publish-mv3/index.md
+++ b/site/en/docs/extensions/migrating/publish-mv3/index.md
@@ -9,7 +9,7 @@ date: 2023-09-04
 
 After [converting your extension][migration-checklist] to Manifest Version 3, the next step is to
 release it on the [Chrome Web Store][cws]. Depending on the extent of the changes you made,
-it can be advisable to perform a step-wise rollout to ensure your Manifest V3 extension works as expected
+it can be advisable to perform a step-wise roll out to ensure your Manifest V3 extension works as expected
 by testing it with a limited audience first. 
 
 This article discusses a few ways to publish your new release in stages. For example, releasing a
@@ -85,7 +85,7 @@ To ensure that any unexpected problems will have minimal impact, you can roll ou
 3. Enter a percentage in **Percentage rollout** field.
 
 <figure>
-    {% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/yoMNFt1ht6qSLXzFyrWj.png", alt="Screenshot showing the 'more' menu's defer publish option", width="286", height="184", class='screenshot' %}
+{% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/oZxWW5oMsh7fUSzwvRNp.png", alt="Screenshot of the Chrome Web Store fractional rollout field", height="488", width="800", class='screenshot' %}
     <figcaption>
         Setting the initial rollout percentage.
     </figcaption>

--- a/site/en/docs/extensions/migrating/publish-mv3/index.md
+++ b/site/en/docs/extensions/migrating/publish-mv3/index.md
@@ -9,7 +9,7 @@ date: 2023-09-04
 
 After [converting your extension][migration-checklist] to Manifest Version 3, the next step is to
 release it on the [Chrome Web Store][cws]. Depending on the extent of the changes you made,
-it can be advisable to perform a step-wise roll out to ensure your Manifest V3 extension works as expected
+it can be advisable to perform a step-wise rollout to ensure your Manifest V3 extension works as expected
 by testing it with a limited audience first. 
 
 This article discusses a few ways to publish your new release in stages. For example, releasing a
@@ -23,7 +23,7 @@ Publishing a beta release allows you to gather feedback and identify any issues 
 
 ### Label your beta version {: #label-beta }
 
-First, you must label the beta release as a testing version by following these steps in the [manifest.json][manifest]:
+First, you must label the beta release as a testing version in the [manifest.json][manifest] by following these steps:
 
 1. Add the label “BETA” at the end of the [name][manifest-name] of your extension.
 2. Add "THIS EXTENSION IS FOR BETA TESTING" to the [description][manifest-desc].
@@ -38,8 +38,8 @@ Now that your beta version is clearly labeled, you can either distribute it to s
 
 Follow these steps to distribute to a small number of testers:
 
-1. Go to the Account tab of the Developer Dashboard.
-1. Scroll down to Management.
+1. Go to the **Account tab** of the Developer Dashboard.
+1. Scroll down to **Management**.
 1. Under Trusted Testers, enter email addresses separated by spaces or commas.
     <figure>
         {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/SrVxYFc0lmMgXxtN30gA.png", alt="Screenshot showing trusted tester accounts listed in a Chrome Web Store developer account page", height="395", width="800", class="screenshot" %}
@@ -49,7 +49,7 @@ Follow these steps to distribute to a small number of testers:
     </figure>
 1. Save changes at the bottom of the page.
 1. [Upload][cws-upload] the beta version of your extension
-1. Go to the Distribution tab
+1. Go to the **Distribution** tab
 1. Set the Visibility to **Private**. 
 
 <figure>
@@ -66,22 +66,22 @@ Once you've received enough feedback from your beta testers, you can expand dist
 Go to the **Distribution** tab, set the **Visibility** to Private, and choose your beta tester Google group from the **dropdown menu**. 
 
 <figure>
-    {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/eW95QyUHVYrQw0eThSNc.png", alt="ALT_TEXT_HERE", width="600", height="445" %}
+    {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/eW95QyUHVYrQw0eThSNc.png", alt="Setting the visibility to private and choosing a google group to distribute the extension to", width="600", height="445" %}
     <figcaption>
-        Distributing to Members of a Google Group.
+        Distributing to members of a Google Group.
     </figcaption>
 </figure>
 
 ### Distribute to testers with a direct link {: #dist-link }
 
-Another alternative is to set the visibility to **Unlisted**. This way, only users who have the direct link can install the extension.
+Another alternative is to set the visibility to **Unlisted**. This way, only users who have the direct link to your store listing item can install the extension.
 
 ## Gradually roll-out your release {: #gradual-rollout }
 
 To ensure that any unexpected problems will have minimal impact, you can roll out your update gradually by following these steps. This is only available for extensions with more than 10,000 active users.
 
 1. [Upload][cws-upload] your new version.
-2. Go to the Distribution tab.
+2. Go to the **Distribution** tab.
 3. Enter a percentage in **Percentage rollout** field.
 
 <figure>
@@ -102,7 +102,7 @@ To continue rolling out gradually, navigate to the **Package** tab of your item 
 
 ## Plan for review times {: #review }
 
-We recommend planning enough time for your item to be reviewed as review times may vary based on [different factors][review-factors]. Consider staging your release and regularly checking your item's status to make changes quickly if necessary.
+We recommend planning enough time for your item to be reviewed as review times may vary based on [different factors][review-factors]. Most extensions are reviewed within three days. Consider staging your release and regularly checking your item's status to make changes quickly if necessary.
 
 ### Stage your release {: #staged-release }
 
@@ -127,12 +127,21 @@ Or you can do it later by choosing **Defer publish** in the three-dot menu on th
 </figure>
 
 {% Aside %}
-Once your item is approved, you have up to 30 days to publish. After that period expires, the staged submission will revert to a draft, which will have to be reviewed again. You can check when your staged submission will expire under the status of your item.
+Once your item is approved, you have up to 30 days to publish. After that period expires, the staged submission will revert to a draft, which will have to be reviewed again. You can check your staged submission expiration in the developer dashboard next to each listed item.
+
+<figure>
+{% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/sYCH3lvreW0bUWznlOsE.png", alt="Staged item
+status in the developer dashboard", width="700", height="84", class='screenshot' %}
+    <figcaption>
+    Staged item status in the developer dashboard
+    </figcaption>
+</figure>
+
 {% endAside %}
 
 ### Check your item status {: #check-status }
 
-Most extensions are reviewed within three days. When your item has passed or if a violation has been found, you will receive a notification email. If you have not received an email in a week, check your item's status in the **Published** section of the **Status** tab.
+When your item has passed or if a violation has been found, you will receive a notification email, usually within 3 days. If you have not received an email in a week, check your item's status in the **Published** section of the **Status** tab.
 
 <figure>
     {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/C4wpnEeMriI9YeDAMDIr.png", alt="The Chrome Web Store Status Tab", width="700", height="276", class='screenshot' %}
@@ -143,7 +152,7 @@ Most extensions are reviewed within three days. When your item has passed or if 
 
 If your extension has been pending review for over two weeks, [contact developer support][cws-support] to request assistance.
 
-## Additional tips {: #learn-more }
+## Additional tips {: #tips }
 
 To stay on top of user feedback you can add a link to a [dedicated support site][support-site] under the Support tab of your extension listing.
 

--- a/site/en/docs/extensions/migrating/publish-mv3/index.md
+++ b/site/en/docs/extensions/migrating/publish-mv3/index.md
@@ -7,7 +7,9 @@ date: 2023-09-04
 # updated: 2023-05-10
 ---
 
-After [converting your extension][migration-checklist] to Manifest Version 3, it's time to release it on the [Chrome Web Store][cws]. There are a few ways to publish your new release gradually. This article discusses releasing a beta version and slowly increasing the number of testers, gradually rolling out to your user base, and monitoring your extension review status to quickly publish any fixes if needed.
+After [converting your extension][migration-checklist] to Manifest Version 3, it's time to release it on the [Chrome Web Store][cws]. Depending on how many adjustments you had to make to your app, it can be advisable to perform a step-wise roll out to make sure that your MV3 extension works as expected by testing it with a smaller audience first. 
+
+There are a few ways to publish your new release gradually. This article discusses recommended approaches such as releasing a beta version and slowly increasing the number of testers, gradually rolling out to your user base, and monitoring your extension review status to quickly publish any fixes if needed.
 
 ## Publish a beta testing version {: #publish-beta }
 

--- a/site/en/docs/extensions/migrating/publish-mv3/index.md
+++ b/site/en/docs/extensions/migrating/publish-mv3/index.md
@@ -156,8 +156,6 @@ If your extension has been pending review for over two weeks, [contact developer
 
 To stay on top of user feedback you can add a link to a [dedicated support site][support-site] under the Support tab of your extension listing.
 
-There are other ways to make your extension more robust as you transition to Manifest Version 3. See [Engineering resilient extensions](TBD) for best practices for building a reliable extension.
-
 [cws-review]: /docs/webstore/review-process/
 [cws-support]: /docs/webstore/review-process/#support
 [cws-upload]: /docs/webstore/upload

--- a/site/en/docs/extensions/migrating/publish-mv3/index.md
+++ b/site/en/docs/extensions/migrating/publish-mv3/index.md
@@ -7,20 +7,7 @@ date: 2023-09-04
 # updated: 2023-05-10
 ---
 
-After following the [MV3 Migration Checklist][migration-checklist] to convert your extension, you are ready to publish your update in the Chrome Web Store. This article includes a few helpful recommendations to ensure your release goes smoothly.
-
-## Keep the current set of features {: #keep-features }
-
-When migrating to Manifest V3 extension, we recommend not adding extra functionality. This way, you can minimize the chances of unexpected issues or bugs unrelated to the migration. If new features require new permissions, it may [trigger a warning][perm-warn], which means your extension may be disabled until the user enables it again.
-
-<figure>
-    {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/tQgKKMKbzmCzwBEAoatX.gif", alt="ALT_TEXT_HERE", width="496", height="388" %}
-    <figcaption>
-    Extension disabled until user accepts new permission.
-    </figcaption>
-</figure>
-
-Note that the extension will also be disabled if [`"host_permissions"`][host-perms] are added or modified in the manifest. This includes [`"content_scripts.matches"`][content-manifest], which are also considered host permissions. See [Permissions Best Practices][perm-warn] to learn of other ways to add permission without displaying a warning.
+After following the [MV3 Migration Checklist][migration-checklist] to convert your extension, you are ready to publish your update in the [Chrome Web Store][cws]. This article includes a few helpful recommendations to ensure your release goes smoothly.
 
 ## Publish a beta testing version {: #publish-beta }
 
@@ -143,18 +130,15 @@ Most extensions are reviewed within three days. You should receive an email noti
     </figcaption>
 </figure>
 
-If your extension is pending review for over two weeks, you can [contact developer support][cws-support] to request assistance.
+If your extension has been pending review for over two weeks, you can [contact developer support][cws-support] to request assistance.
 
 ## Additional tips {: #learn-more }
 
 There are other ways to make your extension more robust as you transition to Manifest Version 3. See [Engineering resilient extensions](TBD) for best practices for building a reliable extension.
 
-[content-manifest]: /docs/extensions/manifest/content_scripts
 [cws-support]: /docs/webstore/review-process/#support
 [cws-upload]: /docs/webstore/upload
 [google-group]: https://groups.google.com/my-groups
-[host-perms]: /docs/extensions/mv3/declare_permissions/#host-permissions
 [migration-checklist]: /docs/extensions/migrating/checklist/
-[perm-warn]: /docs/extensions/mv3/permission_warnings/
 [review-factors]: /docs/webstore/review-process/#review-time-factors
 [spam-policy]: /docs/webstore/troubleshooting/#spam

--- a/site/en/docs/extensions/migrating/publish-mv3/index.md
+++ b/site/en/docs/extensions/migrating/publish-mv3/index.md
@@ -2,7 +2,7 @@
 layout: 'layouts/doc-post.njk'
 title: Publish your Manifest V3 extension.
 seoTitle: Publishing a new Manifest V3 Chrome extension.
-description: 'Best practices for publishing a new Manifest V3 extension'
+description: 'Guidance for publishing a new Manifest V3 extension'
 date: 2023-09-04
 # updated: 2023-05-10
 ---

--- a/site/en/docs/extensions/migrating/publish-mv3/index.md
+++ b/site/en/docs/extensions/migrating/publish-mv3/index.md
@@ -3,7 +3,7 @@ layout: 'layouts/doc-post.njk'
 title: Publish your Manifest V3 extension.
 seoTitle: Publishing a new Manifest V3 Chrome extension.
 description: 'Best practices for publishing a new Manifest V3 extension'
-date: 2023-09-06
+date: 2023-09-04
 # updated: 2023-05-10
 ---
 

--- a/site/en/docs/extensions/migrating/publish-mv3/index.md
+++ b/site/en/docs/extensions/migrating/publish-mv3/index.md
@@ -1,13 +1,13 @@
 ---
 layout: 'layouts/doc-post.njk'
-title: Publish your Manifest V3 extension.
+title: Publish your extension
 seoTitle: Publishing a new Manifest V3 Chrome extension.
 description: 'Guidance for publishing a new Manifest V3 extension'
 date: 2023-09-04
 # updated: 2023-05-10
 ---
 
-After following the [MV3 Migration Checklist][migration-checklist] to convert your extension, you are ready to publish your update in the [Chrome Web Store][cws]. This article includes a few helpful recommendations to ensure your release goes smoothly.
+After [converting your extension][migration-checklist] to Manifest Version 3, it's time to release it on the [Chrome Web Store][cws]. There are a few ways to publish your new release gradually. This article discusses releasing a beta version and slowly increasing the number of testers, gradually rolling out to your user base, and monitoring your extension review status to quickly publish any fixes if needed.
 
 ## Publish a beta testing version {: #publish-beta }
 
@@ -40,7 +40,7 @@ Follow these steps to distribute to a small number of testers:
     <figure>
         {% Img src="image/BrQidfK9jaQyIHwdw91aVpkPiib2/SrVxYFc0lmMgXxtN30gA.png", alt="Screenshot showing trusted tester accounts listed in a Chrome Web Store developer account page", height="395", width="800", class="screenshot" %}
         <figcaption>
-            Trusted tester emails listed in a Chrome Web Store developer Account page.
+            Trusted tester emails in the Chrome Web Store developer Account page.
         </figcaption>
     </figure>
 1. Save changes at the bottom of the page.
@@ -106,7 +106,7 @@ You can do this by unchecking the "Publish automatically" checkbox when you subm
     </figcaption>
 </figure>
 
-Or you can do it later by choosing "Defer publish" in the three-dot menu on the top-right.
+Or you can do it later by choosing "Defer publish" in the three-dot menu on the top right.
 
 <figure>
     {% Img src="image/SHhb2PDKzXTggPGAYpv8JgR81pX2/yoMNFt1ht6qSLXzFyrWj.png", alt="Screenshot showing the 'more' menu's defer publish option", width="286", height="184", class='screenshot' %}
@@ -121,7 +121,7 @@ Once your item is approved, you have up to 30 days to publish. After that period
 
 ### Check your item status {: #check-status }
 
-Most extensions are reviewed within three days. You should receive an email notifying you if your item has passed or if a violation has been found. If you have not received an email in a week, check your item's status in the Published section of the **Status** tab.
+Most extensions are reviewed within three days. When your item has passed or if a violation has been found, you will receive a notification email. If you have not received an email in a week, check your item's status in the Published section of the **Status** tab.
 
 <figure>
     {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/C4wpnEeMriI9YeDAMDIr.png", alt="The Chrome Web Store Status Tab", width="700", height="276", class='screenshot' %}
@@ -130,12 +130,13 @@ Most extensions are reviewed within three days. You should receive an email noti
     </figcaption>
 </figure>
 
-If your extension has been pending review for over two weeks, you can [contact developer support][cws-support] to request assistance.
+If your extension has been pending review for over two weeks, [contact developer support][cws-support] to request assistance.
 
 ## Additional tips {: #learn-more }
 
 There are other ways to make your extension more robust as you transition to Manifest Version 3. See [Engineering resilient extensions](TBD) for best practices for building a reliable extension.
 
+[cws]: https://chrome.google.com/webstore
 [cws-support]: /docs/webstore/review-process/#support
 [cws-upload]: /docs/webstore/upload
 [google-group]: https://groups.google.com/my-groups

--- a/site/en/docs/extensions/mv3/permission_warnings/index.md
+++ b/site/en/docs/extensions/mv3/permission_warnings/index.md
@@ -28,7 +28,16 @@ display a warning. Other permissions trigger a warning that users have to allow.
 
 When a new permission that [triggers a warning](#permissions_with_warnings) is added, the extension
 will be disabled until the user accepts the new permission. See [Updating
-permissions](#update_permissions) to learn how to test this behavior. Some permissions may not display warnings when paired
+permissions](#update_permissions) to learn how to test this behavior. 
+
+<figure>
+    {% Img src="image/BhuKGJaIeLNPW9ehns59NfwqKxF2/tQgKKMKbzmCzwBEAoatX.gif", alt="Example of an extension that is disabled until the user accepts the new permission.", width="396", height="288" %}
+    <figcaption>
+    An extension that is disabled until the user accepts the new permission.
+    </figcaption>
+</figure>
+
+Some permissions may not display warnings when paired
 with other permissions. For example, the `"tabs"` warning will not show if the extension also
 requests `"<all_urls>"`.
 


### PR DESCRIPTION
Fixes #https://github.com/GoogleChromeLabs/Extension-Docs/issues/51

Changes proposed in this pull request:

- Adding Publishing guidance to Migration collection

TODO:
- [x] Add links to the Migration landing page