### PR TITLE
[FIX] Changed the deadlink of Airhorner url #7210

### DIFF
--- a/site/en/blog/autoplay/index.md
+++ b/site/en/blog/autoplay/index.md
@@ -290,7 +290,7 @@ on the Chromium site.
 [command line flag]: https://www.chromium.org/developers/how-tos/run-chromium-with-flags
 [customize-install]: https://web.dev/customize-install/
 [do this with flags]: https://www.chromium.org/developers/how-tos/run-chromium-with-flags
-[https://airhorner.com]: https://airhorner.com/progressive-web-apps/
+[https://airhorner.com]: https://airhorner.com/
 [noticed]: https://webkit.org/blog/7734/auto-play-policy-changes-for-macos/
 [permissions policy]: /docs/privacy-sandbox/permissions-policy/
 [permissions policy for autoplay]: https://github.com/WICG/feature-policy/blob/main/features.md


### PR DESCRIPTION
Fixes #7210 

Changes proposed in this pull request:

- Removed the broken link [https://airhorner.com/progressive-web-apps/]
- Added the Correct url of the Airhorner homepage

**Before** 

<img width="960" alt="airhorner-site-before" src="https://github.com/GoogleChrome/developer.chrome.com/assets/57017965/bd9b8707-c592-4726-b0ca-1a8d61f90300">

**After**

<img width="960" alt="airhorner-site-after" src="https://github.com/GoogleChrome/developer.chrome.com/assets/57017965/094bddd3-cf4a-4ba2-9265-4a0f95c7658f">
