### PR TITLE
Tweak LoAF example to make it more obvious it's two code snippets

### DIFF
--- a/site/en/articles/long-animation-frames/index.md
+++ b/site/en/articles/long-animation-frames/index.md
@@ -305,7 +305,7 @@ const observer = new PerformanceObserver(list => {
       if (entry.duration > REPORTING_THRESHOLD_MS &&
         entry.firstUIEventTimestamp > 0
       ) {
-      // Example here logs to console, but could also report back to analytics
+        // Example here logs to console, but could also report back to analytics
         console.log(entry);
       }
     }

--- a/site/en/articles/long-animation-frames/index.md
+++ b/site/en/articles/long-animation-frames/index.md
@@ -277,9 +277,11 @@ const observer = new PerformanceObserver(list => {
   ).slice(0, MAX_LOAFS_TO_CONSIDER);
 });
 observer.observe({ type: 'long-animation-frame', buffered: true });
+```
 
-// At the appropriate time, beacon back to analytics.
-// Example here logs to console
+At the appropriate time ([ideally on the `visibilitychange` event](/articles/page-lifecycle-api/#:~:text=it%27s%20always%20better%20to%20rely%20on%20the%20visibilitychange%20event%20to%20determine%20when%20a%20session%20ends)) beacon back to analytics. For local testing you can use `console.table` periodically:
+
+```js
 console.table(longestBlockingLoAFs);
 ```
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Tweak LoAF example to make it more obvious it's two code snippets.
- Adds further note about when best to beacon back summary data.