### PR TITLE
protected audience demo code links

### DIFF
--- a/site/en/_partials/privacy-sandbox/demos/paapi.md
+++ b/site/en/_partials/privacy-sandbox/demos/paapi.md
@@ -10,7 +10,11 @@ and then initiates an on-device auction to select an ad for display on a publish
 
 [Demo](https://protected-audience-demo.web.app/)
 
+[Demo code](https://github.com/GoogleChromeLabs/protected-audience-demo)
+
 [Docs](/docs/privacy-sandbox/protected-audience-api/)
+
+
 
 {% endColumn %}
 {% Column %}

--- a/site/en/blog/fledge-api/index.md
+++ b/site/en/blog/fledge-api/index.md
@@ -1272,7 +1272,7 @@ to share feedback privately with the Chrome team outside of public forums.
 To ask a question about **your implementation**, about the **demo**, or about the **documentation**:
 * [Open a new issue](https://github.com/GoogleChromeLabs/privacy-sandbox-dev-support/issues/new/choose)
 on the privacy-sandbox-dev-support repository. Make sure to select the issue template for Protected Audience.
-* Raise an issue on the [demo code repo on GitHub](https://github.com/JackJey/fledge-demo).
+* Raise an issue on the [demo code repo on GitHub](https://github.com/GoogleChromeLabs/protected-audience-demo).
 * For more general questions about how to meet your **use cases** with the API,
 [file an issue on the proposal repository](https://github.com/WICG/turtledove/issues/new).
 

--- a/site/en/docs/privacy-sandbox/protected-audience-api/index.md
+++ b/site/en/docs/privacy-sandbox/protected-audience-api/index.md
@@ -550,7 +550,7 @@ documentation:
 *  **GitHub**: Read the
   [proposal](https://github.com/WICG/turtledove/blob/main/FLEDGE.md), 
    [raise questions, and follow  discussion](https://github.com/WICG/turtledove/issues).
-* **Demo**: Raise an issue on the [demo code repository](https://github.com/JackJey/fledge-demo).
+* **Demo**: Raise an issue on the [demo code repository](https://github.com/GoogleChromeLabs/protected-audience-demo).
 *  **Developer support**: Ask questions and join discussions on the
    [Privacy Sandbox Developer Support 
    repo](https://github.com/GoogleChromeLabs/privacy-sandbox-dev-support).

--- a/site/en/docs/privacy-sandbox/protected-audience-experiment/index.md
+++ b/site/en/docs/privacy-sandbox/protected-audience-experiment/index.md
@@ -67,7 +67,7 @@ about **your implementation**, the **demo**, or the **documentation**:
    on the Privacy Sandbox Dev Support repository. Make sure to select the
    Issue template for the Protected Audience API.
 *  Raise an issue on the [demo code repo on
-   GitHub](https://github.com/JackJey/fledge-demo).
+   GitHub](https://github.com/GoogleChromeLabs/protected-audience-demo).
 *  For more general questions about how to meet your **use cases** with the
    API, [file an issue on the proposal repository](https://github.com/WICG/turtledove/issues/new).
 


### PR DESCRIPTION
Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- add and change protected audience demo code links
- https://pr-7260-static-dot-dcc-staging.uc.r.appspot.com/blog/fledge-api/
- https://pr-7260-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/protected-audience-api/
- https://pr-7260-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/protected-audience-experiment/
-