### PR TITLE
Fixed typo in workbox-sw/index.md

### DIFF
--- a/site/en/docs/workbox/modules/workbox-sw/index.md
+++ b/site/en/docs/workbox/modules/workbox-sw/index.md
@@ -225,7 +225,7 @@ const {CacheableResponse} = workbox.cacheableResponse;
 registerRoute(
   ({request}) => request.destination === 'image',
   new CacheFirst({
-    plugins: [new CacheableResponsePlugin({statuses: [0, 200]})],
+    plugins: [new CacheableResponse({statuses: [0, 200]})],
   })
 );
 ```


### PR DESCRIPTION
The plugin was import as `CacheableResponse` but it was used as `CacheableResponsePlugin`

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

-
-
-