### PR TITLE
Update use cases for ARA debug reports

### DIFF
--- a/site/en/docs/privacy-sandbox/attribution-reporting-debugging/part-1/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting-debugging/part-1/index.md
@@ -4,7 +4,7 @@ title: 'Introduction to debug reports'
 subhead: Part 1 of 3 on debugging Attribution Reporting. Learn why debugging matters and when to use debug reports in testing.
 description: Part 1 of 3 on debugging Attribution Reporting. Learn why debugging matters and when to use debug reports in testing.
 date: 2022-12-13
-updated: 2023-03-02
+updated: 2023-09-11
 authors:
   - maudn
   - alexandrawhite
@@ -172,6 +172,10 @@ You may want to reprocess reports when you're:
 - attempting to debug the Aggregation Service.
 - experimenting with different batching strategies.
 - experimenting with different epsilon values.
+
+### Data recovery
+
+During this testing phase, and before the deprecation of third-party cookies when debug reports will be deprecated, ad techs can enable debug mode to receive debug reports so they can recover their reporting data in the case of Aggregation service disasters such as unavailable or non-responsive services that may cause summary report generation to fail.
 
 ## Up next
 

--- a/site/en/docs/privacy-sandbox/attribution-reporting-debugging/part-1/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting-debugging/part-1/index.md
@@ -175,7 +175,7 @@ You may want to reprocess reports when you're:
 
 ### Data recovery
 
-During this testing phase, and before the deprecation of third-party cookies when debug reports will be deprecated, ad techs can enable debug mode to receive debug reports so they can recover their reporting data in the case of Aggregation service disasters such as unavailable or non-responsive services that may cause summary report generation to fail.
+During this testing phase, and before the deprecation of third-party cookies when debug reports will be deprecated, ad techs can enable debug mode to receive debug reports so they can recover their reporting data. This is useful in cases of Aggregation Service issues such as unavailable or non-responsive services that may cause summary report generation to fail.
 
 ## Up next
 

--- a/site/en/docs/privacy-sandbox/attribution-reporting-debugging/part-1/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting-debugging/part-1/index.md
@@ -175,7 +175,7 @@ You may want to reprocess reports when you're:
 
 ### Data recovery
 
-During this testing phase, and before the deprecation of third-party cookies when debug reports will be deprecated, ad techs can enable debug mode to receive debug reports so they can recover their reporting data. This is useful in cases of Aggregation Service issues such as unavailable or non-responsive services that may cause summary report generation to fail.
+During this testing phase, and before the deprecation of third-party cookies when debug reports will be deprecated, we recommend ad techs enable debug mode to receive debug reports so they can recover their reporting data. This is useful in cases of Aggregation Service issues such as unavailable or non-responsive services that may cause summary report generation to fail.
 
 ## Up next
 

--- a/site/en/docs/privacy-sandbox/attribution-reporting-debugging/part-1/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting-debugging/part-1/index.md
@@ -175,7 +175,7 @@ You may want to reprocess reports when you're:
 
 ### Data recovery
 
-During this testing phase, and before the deprecation of third-party cookies when debug reports will be deprecated, we recommend ad techs enable debug mode to receive debug reports so they can recover their reporting data. This is useful in cases of Aggregation Service issues such as unavailable or non-responsive services that may cause summary report generation to fail.
+We recommend ad techs enable debug mode to receive debug reports so they can recover their reporting data. This is useful in cases of Aggregation Service issues such as unavailable or non-responsive services that may cause summary report generation to fail.
 
 ## Up next
 


### PR DESCRIPTION
Fixes b/295886312

Changes proposed in this pull request:

- Add a use case for data recovery
- https://pr-7276-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/attribution-reporting-debugging/part-1/#data-recovery
-