### PR TITLE
add a use shared storage redirect

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -81,6 +81,9 @@ redirects:
 - from: /docs/privacy-sandbox/status
   to: https://privacysandbox.com/open-web/#the-privacy-sandbox-timeline
 
+- from: /docs/privacy-sandbox/use-shared-storage/
+  to: /docs/privacy-sandbox/shared-storage/
+
 - from: /android
   to: /docs/android
 

--- a/site/en/_partials/privacy-sandbox/glossary-entries/summary-report.md
+++ b/site/en/_partials/privacy-sandbox/glossary-entries/summary-report.md
@@ -1,2 +1,3 @@
 A summary report is an Attribution Reporting API and Private Aggregation API report type. A [summary
-report](/docs/privacy-sandbox/attribution-reporting/summary-reports/) includes aggregated user data and can contain detailed conversion data, with noise added.Summary reports are made up of aggregate reports.
+report](/docs/privacy-sandbox/attribution-reporting/summary-reports/) includes aggregated user data and can contain detailed conversion data, with noise added. 
+Summary reports are made up of aggregate reports.


### PR DESCRIPTION
Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- Page is deleted. this redirects it.
- Also fix a missing space in summary report glossary entry https://pr-7286-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/attribution-reporting/getting-started/#summary-reports 