### PR TITLE
Update remaining links from ARA tips doc to DCC docs

### DIFF
--- a/site/en/_partials/privacy-sandbox/ar-engage.md
+++ b/site/en/_partials/privacy-sandbox/ar-engage.md
@@ -3,6 +3,6 @@
 You can [participate and experiment with this API](/docs/privacy-sandbox/attribution-reporting-experiment/).
 
 *  Read the [client-side proposal](https://github.com/WICG/conversion-measurement-api/blob/main/AGGREGATE.md) and [aggregation service proposal](https://github.com/WICG/conversion-measurement-api/blob/main/AGGREGATION_SERVICE_TEE.md), ask questions, and suggest feedback.
-*  Read the [Strategy and tips for summary reports](https://docs.google.com/document/d/1bU0a_njpDcRd9vDR0AJjwJjrf3Or8vAzyfuK8JZDEfo/edit?usp=sharing).
+*  Read the [Attribution reporting guides](/docs/privacy-sandbox/attribution-reporting/).
 * Ask questions and join discussions on the [Privacy
    Sandbox Developer Support repo](https://github.com/GoogleChromeLabs/privacy-sandbox-dev-support).

--- a/site/en/docs/privacy-sandbox/aggregation-service/index.md
+++ b/site/en/docs/privacy-sandbox/aggregation-service/index.md
@@ -135,7 +135,7 @@ data by a scaling factor to reduce the impact of noise.
 
 To understand how noise is added, your controls, and the impact on your
 reports, refer to the
-[Contribution section of the Attribution Reporting strategy guide](https://docs.google.com/document/d/1bU0a_njpDcRd9vDR0AJjwJjrf3Or8vAzyfuK8JZDEfo/edit#heading=h.683u7t2q1xk2). 
+[Contribution budget](/docs/privacy-sandbox/attribution-reporting/contribution-budget/) and [Scale up to contribution budget](/docs/privacy-sandbox/attribution-reporting/working-with-noise/#scale-up-to-contribution-budget) in [Working with noise](/docs/privacy-sandbox/attribution-reporting/working-with-noise/).
 
 ## Generate summary reports
 

--- a/site/en/docs/privacy-sandbox/attribution-reporting-experiment/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting-experiment/index.md
@@ -24,10 +24,10 @@ in the first half of 2023.
      guide](https://docs.google.com/document/d/1NY7SScCYcPc9v5wtf_fVAikFxGQTAFvwldhExN1P03Y/edit#)
      to participate in the latest origin trial.
    * To experiment with the API, follow these guides:
-     * [What you should know about the Attribution Reporting
-       API](https://docs.google.com/document/d/1lvrKd5Vv7SYLMGZb0Fz7bpGNEl0LOx9i1waAHw2sUg8/)
+     * [Getting started with the Attribution Reporting
+       API](/docs/privacy-sandbox/attribution-reporting/getting-started/)
 4. Experiment with [summary
-   reports](/docs/privacy-sandbox/summary-reports).
+   reports](/docs/privacy-sandbox/summary-reports/).
    *  Ad techs can generate summary reports with the [aggregation service](/docs/privacy-sandbox/aggregation-service). Set up
       [local testing](https://github.com/google/trusted-execution-aggregation-service/#set-up-local-testing)
       or [test in production with Amazon Web Services](https://github.com/google/trusted-execution-aggregation-service/#test-on-aws-with-support-for-encrypted-reports) (AWS) :
@@ -37,7 +37,7 @@ in the first half of 2023.
         *  Complete the aggregation service
 	      [onboarding form](https://forms.gle/EHoecersGKhpcLPNA). After you've
 		submitted this form, we'll send a verification email and instructions.
-   *  Refer to the [strategy and tips for summary reports](https://docs.google.com/document/d/1bU0a_njpDcRd9vDR0AJjwJjrf3Or8vAzyfuK8JZDEfo/edit?usp=sharing).
+   *  Refer to the [Getting started guide](/docs/privacy-sandbox/attribution-reporting/getting-started/).
 
 ## Get support
 

--- a/site/en/docs/privacy-sandbox/attribution-reporting/contribution-budget/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/contribution-budget/index.md
@@ -41,7 +41,7 @@ These tips will help you work successfully with the contribution budget.
 - Ensure your values are strictly within the contribution budget to not lose any information, since the budget is a hard cap. 
 - Allocate the contribution budget across metrics. Because the budget is common to all metrics for a given source, if more than one metric is tracked, you should share the budget across these metrics.
 
-- If you're tracking two metrics—for example, the purchase value and the purchase count—you would split the contribution budget across these two metrics. More details can be found [in the example](https://docs.google.com/document/d/1bU0a_njpDcRd9vDR0AJjwJjrf3Or8vAzyfuK8JZDEfo/view#heading=h.i6ovl4dm1npa).
+- If you're tracking two metrics—for example, the purchase value and the purchase count—you would split the contribution budget across these two metrics. More details can be found [in this example](/docs/privacy-sandbox/attribution-reporting/aggregation-keys/#main-example).
 
 - Adjust aggregatable values to minimize the impact of noise. Because the contribution budget impacts noise, adjusting the aggregatable values to this budget will allow you to improve signal-to-noise ratio. Read the details in [Scale up to contribution budget](/docs/privacy-sandbox/attribution-reporting/working-with-noise/#scale-up-to-contribution-budget). <!-- working with noise -->
 

--- a/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/working-with-noise/index.md
@@ -52,7 +52,7 @@ If you have several measurement goals&mdash;for example, purchase count and purc
 
 In this case, your scaling factors will be different for different aggregatable values, depending on the expected maximum of a given aggregatable value.
 
-Read details in the [complete example](https://docs.google.com/document/d/1bU0a_njpDcRd9vDR0AJjwJjrf3Or8vAzyfuK8JZDEfo/view#heading=h.duini3m1xb4y).
+Read details in the [Understanding aggregation keys](/docs/privacy-sandbox/attribution-reporting/aggregation-keys/).
 
 {% Aside %}
 You may decide to allocate the budget equally between two measurement goals, or you can choose to prioritize different measurement goals by allocating more budget to certain goals and less to others.

--- a/site/en/docs/privacy-sandbox/private-aggregation-fundamentals/index.md
+++ b/site/en/docs/privacy-sandbox/private-aggregation-fundamentals/index.md
@@ -12,7 +12,7 @@ authors:
 
 ## Who is this article for?
 
-The [Private Aggregation API]( /docs/privacy-sandbox/private-aggregation) enables aggregate data collection from worklets with access to cross-site data. The concepts shared here are important for developers building reporting functions within Shared Storage and Protected Audience API.
+The [Private Aggregation API](/docs/privacy-sandbox/private-aggregation) enables aggregate data collection from worklets with access to cross-site data. The concepts shared here are important for developers building reporting functions within Shared Storage and Protected Audience API.
 
 *   If you're a **developer** building a reporting system for cross-site measurement. 
 *   If you're a **marketer**, **data scientist**, or other **summary report consumer**, understanding these mechanisms will help you make design decisions to retrieve an optimized summary report.
@@ -44,7 +44,7 @@ When you call the Private Aggregation API with an aggregation key and an aggrega
 A _trusted execution environment_ is a special configuration of computer hardware and software that allows external parties to verify the exact versions of software running on the computer. TEEs allow external parties to verify that the software does exactly what the software manufacturer claims it does—nothing more or less.
 {% endAside %}
 
-The workflow described in this section is similar to the [Attribution Reporting API](https://docs.google.com/document/d/1bU0a_njpDcRd9vDR0AJjwJjrf3Or8vAzyfuK8JZDEfo/edit#). However, Attribution Reporting associates data gathered from an impression event and a conversion event, which happen at different times. Private Aggregation measures a single, cross-site event. 
+The workflow described in this section is similar to the [Attribution Reporting API](/docs/privacy-sandbox/attribution-reporting/). However, Attribution Reporting associates data gathered from an impression event and a conversion event, which happen at different times. Private Aggregation measures a single, cross-site event. 
 
 ## Aggregation key
 
@@ -157,7 +157,7 @@ When you sum all aggregatable values across all aggregation keys, the sum must b
 
 The _contribution budget_ is represented by the parameter `L<sub>1</sub>`, and for the current Privacy Sandbox Origin Trial, the contribution budget has been set to 2<sup>16</sup> = 65,536.  The value of the contribution budget is arbitrary where noise is scaled to it, and you can use this budget to maximize signal-to-noise ratio on the summary values (discussed more below in the [Noise and scaling](#noise-and-scaling) section below). 
 
-To learn more about contribution budgets, see the [explainer](https://github.com/patcg-individual-drafts/private-aggregation-api#contribution-bounding-and-budgeting). Also, refer to the [Contribution Budget section of the Attribution Reporting strategy guide](https://docs.google.com/document/d/1bU0a_njpDcRd9vDR0AJjwJjrf3Or8vAzyfuK8JZDEfo/edit#) for more guidance. 
+To learn more about contribution budgets, see the [explainer](https://github.com/patcg-individual-drafts/private-aggregation-api#contribution-bounding-and-budgeting). Also, refer to [Contribution Budget](/docs/privacy-sandbox/attribution-reporting/contribution-budget/) for more guidance. 
 
 ## Aggregatable reports
 

--- a/site/en/docs/privacy-sandbox/summary-reports/design-decisions/index.md
+++ b/site/en/docs/privacy-sandbox/summary-reports/design-decisions/index.md
@@ -49,17 +49,15 @@ here. Your suggestions, additions, and questions are welcome!
 
 ### Before you start
 
-1. Read [Attribution Reporting: summary reports](/docs/privacy-sandbox/attribution-reporting/summary-reports/) and [What you should know about the Attribution Reporting API](https://docs.google.com/document/d/1lvrKd5Vv7SYLMGZb0Fz7bpGNEl0LOx9i1waAHw2sUg8/edit) for an introduction.
-2. Scan [Strategy and tips for summary reports](https://docs.google.com/document/d/1bU0a_njpDcRd9vDR0AJjwJjrf3Or8vAzyfuK8JZDEfo/edit#heading=h.j8m326urvgnt)⏤in particular the [essential notions](https://docs.google.com/document/d/1bU0a_njpDcRd9vDR0AJjwJjrf3Or8vAzyfuK8JZDEfo/edit#heading=h.kizul7z2av3y) required for you to make best use of this guide.
+1. Read [Attribution Reporting: summary reports](/docs/privacy-sandbox/attribution-reporting/summary-reports/) and [Attribution Reporting full system overview](/docs/privacy-sandbox/attribution-reporting/system-overview/) for an introduction.
+2. Scan [Understanding noise](/docs/privacy-sandbox/attribution-reporting/understanding-noise/) and [Understanding aggregation keys](/docs/privacy-sandbox/attribution-reporting/aggregation-keys/) to make best use of this guide.
 
 ## Design decisions
 
 ### Core design principle {: #core}
 
-There are
-[foundational differences](https://docs.google.com/document/d/1lvrKd5Vv7SYLMGZb0Fz7bpGNEl0LOx9i1waAHw2sUg8/edit#heading=h.ktl1cq7bdlk)
-between how third-party cookies and summary reports operate. One key difference is the
-[noise](/docs/privacy-sandbox/attribution-reporting/understanding-noise/) added to measurement data in summary reports.
+There are foundational differences between how third-party cookies and summary reports operate. One key difference is the
+[noise](/docs/privacy-sandbox/attribution-reporting/understanding-noise/) added to measurement data in summary reports. Another is how reports are [scheduled](/docs/privacy-sandbox/attribution-reporting/report-schedules/).
 
 **To access summary report measurement data with higher signal-to-noise
 ratios, demand-side platforms (DSPs) and ad measurement providers will need to
@@ -176,7 +174,7 @@ are included; you can also modify these.
 
 Another design decision that will impact the number of attributed conversion
 events within a single bucket is the
-[key structures](https://docs.google.com/document/d/1bU0a_njpDcRd9vDR0AJjwJjrf3Or8vAzyfuK8JZDEfo/edit#heading=h.81usg7c4jnsg)
+[key structures](/docs/privacy-sandbox/attribution-reporting/aggregation-keys/#aggregation-keys-in-practice)
 you decide to use. Consider the following examples of aggregation keys:
 
 - One key structure with all dimensions; let's call this Key Strategy A.
@@ -191,7 +189,7 @@ reports may already give you the information you need. This means that Strategy 
 will likely lead to better signal-to-noise ratios than Strategy A. However, the
 noise may already be acceptable with Strategy A, so you may still decide to favor
 Strategy A for simplicity.
-[Learn more in the detailed example outlining these two strategies](https://docs.google.com/document/d/1bU0a_njpDcRd9vDR0AJjwJjrf3Or8vAzyfuK8JZDEfo/edit#heading=h.i6ovl4dm1npa).
+[Learn more in the detailed example outlining these two strategies](/docs/privacy-sandbox/attribution-reporting/aggregation-keys/#translate-goals-into-keys).
 
 Key management is a deep topic. A number of elaborate techniques can be
 considered to improve signal-to-noise ratios. One is described in [Advanced key
@@ -234,12 +232,11 @@ batching frequency is how often you process aggregatable reports.
 A report that is scheduled for aggregation more frequently (e.g. each hour) will
 have fewer conversion events included than the same report with a less frequent
 aggregation schedule (e.g. each week). As a result, the hourly report will have
-a higher signal-to-noise ratio than the weekly report, all else being equal. **Experiment with reporting requirements at various frequencies, and assess
-signal-to-noise ratios for each.**
+a higher signal-to-noise ratio than the weekly report, all else being equal. **Experiment with reporting requirements at various frequencies, and assess signal-to-noise ratios for each.**
 
 Learn more in
-[Batching](https://docs.google.com/document/d/1bU0a_njpDcRd9vDR0AJjwJjrf3Or8vAzyfuK8JZDEfo/edit#heading=h.pef51jskrx06)
-and [Aggregating over longer time periods](https://docs.google.com/document/d/1bU0a_njpDcRd9vDR0AJjwJjrf3Or8vAzyfuK8JZDEfo/edit#heading=h.pef51jskrx06).
+[Batching](/docs/privacy-sandbox/summary-reports/#batching)
+and [Aggregating over longer time periods](/docs/privacy-sandbox/attribution-reporting/working-with-noise/#aggregating-over-longer-time-periods-increases-signal-to-noise-ratio).
 
 ### Decision: Campaign variables that affect attributable conversions {: #campaign-variables}
 


### PR DESCRIPTION
Fixes b/290250177

Changes proposed in this pull request:

- Update remaining links from ARA tips doc to DCC docs
- https://pr-7290-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/aggregation-service/#generate-summary-reports 
- https://pr-7290-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/attribution-reporting-experiment/
- https://pr-7290-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/attribution-reporting/contribution-budget/
- https://pr-7290-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/attribution-reporting/working-with-noise/
- https://pr-7290-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/private-aggregation-fundamentals/
- https://pr-7290-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/summary-reports/design-decisions/