### PR TITLE
[JA] Fix ja localized content for bounce tracking mitigations doc

### DIFF
--- a/site/ja/_partials/privacy-sandbox/timeline/bounce-tracking.md
+++ b/site/ja/_partials/privacy-sandbox/timeline/bounce-tracking.md
@@ -1,3 +1,3 @@
-- [バウンストラッキング対策の提案](https://github.com/wanderview/bounce-tracking-mitigations/blob/main/explainer.md)の[公開ディスカッション](https://github.com/wanderview/bounce-tracking-mitigations/issues)が開始しました。
+- [バウンストラッキング対策の提案](https://github.com/privacycg/nav-tracking-mitigations/blob/main/bounce-tracking-explainer.md)の[公開ディスカッション](https://github.com/privacycg/nav-tracking-mitigations/issues/)が開始しました。
 - [Chrome プラットフォームのステータス](https://chromestatus.com/feature/5705149616488448?context=myfeatures)。
 - この提案はどのブラウザにも実装されていません。

--- a/site/ja/_partials/privacy-sandbox/timeline/bounce-tracking.md
+++ b/site/ja/_partials/privacy-sandbox/timeline/bounce-tracking.md
@@ -1,3 +1,2 @@
 - [バウンストラッキング対策の提案](https://github.com/privacycg/nav-tracking-mitigations/blob/main/bounce-tracking-explainer.md)の[公開ディスカッション](https://github.com/privacycg/nav-tracking-mitigations/issues/)が開始しました。
 - [Chrome プラットフォームのステータス](https://chromestatus.com/feature/5705149616488448?context=myfeatures)。
-- この提案はどのブラウザにも実装されていません。

--- a/site/ja/docs/privacy-sandbox/bounce-tracking-mitigations/index.md
+++ b/site/ja/docs/privacy-sandbox/bounce-tracking-mitigations/index.md
@@ -14,8 +14,8 @@ authors:
 
 このドキュメントでは、[バウンストラッキング対策に関する新しい提案](https://github.com/wanderview/bounce-tracking-mitigations)の概要を説明します。
 
-- [バウンス トラッキング対策の提案](https://github.com/wanderview/bounce-tracking-mitigations/blob/main/explainer.md)が[公開ディスカッション](https://github.com/wanderview/bounce-tracking-mitigations/issues)に進みました。
-- この提案は[どのブラウザにも実装されていません](https://chromestatus.com/feature/5705149616488448?context=myfeatures)。
+{% Partial 'privacy-sandbox/timeline/bounce-tracking.njk' %}
+
 - [プライバシーサンドボックスのタイムライン](http://privacysandbox.com/timeline)には、バウンストラッキング対策やその他のプライバシーサンドボックスの提案の実装タイミングに関する情報が提供されています。
 
 ## この提案が必要とされる理由 {: #proposal-reason}

--- a/site/ja/docs/privacy-sandbox/bounce-tracking-mitigations/index.md
+++ b/site/ja/docs/privacy-sandbox/bounce-tracking-mitigations/index.md
@@ -12,7 +12,7 @@ authors:
 
 ## 実装ステータス {: #status}
 
-このドキュメントでは、[バウンストラッキング対策に関する新しい提案](https://github.com/wanderview/bounce-tracking-mitigations)の概要を説明します。
+このドキュメントでは、[バウンストラッキング対策に関する新しい提案](https://github.com/privacycg/nav-tracking-mitigations/blob/main/bounce-tracking-explainer.md)の概要を説明します。
 
 {% Partial 'privacy-sandbox/timeline/bounce-tracking.njk' %}
 
@@ -41,7 +41,7 @@ authors:
 
 ### 範囲外のユースケース
 
-範囲外のリダイレクトフローには、ID 連携認証、SSO、および決済が含まれます。これは、こういったフローはバウンストラッキングのシナリオに似ているものの、直接的なユーザー操作を伴うものであるためです。[詳細については、Explainer を参照](https://github.com/wanderview/bounce-tracking-mitigations/blob/main/explainer.md)してください。
+範囲外のリダイレクトフローには、ID 連携認証、SSO、および決済が含まれます。これは、こういったフローはバウンストラッキングのシナリオに似ているものの、直接的なユーザー操作を伴うものであるためです。[詳細については、Explainer を参照](https://github.com/privacycg/nav-tracking-mitigations/blob/main/bounce-tracking-explainer.md)してください。
 
 - **ID 連携認証**: [ID 連携認証](/docs/privacy-sandbox/fedcm/)は、ユーザーがウェブで **ID プロバイダーでログイン**（Facebook、GitHub、Google など）ボタンをクリックすると発生します。
 - **シングル サインオン**: サイトでシングル サインオン（SSO）が使用されている場合、ユーザーは、ID プロバイダーで 1 回ログインしておけば、他のサイトへのすべてのアクセスでも自動的にログインされることを期待しています。
@@ -58,11 +58,11 @@ authors:
 
 これらの定義を明確にすることが、バウンストラッキング対策の取り組みにおいて重要となります。
 
-バウンストラッキング対策の実施については、まだ[議論中](https://github.com/wanderview/bounce-tracking-mitigations/issues)です。
+バウンストラッキング対策の実施については、まだ[議論中](https://github.com/privacycg/nav-tracking-mitigations/issues)です。
 
 ### セキュリティに関する考慮事項
 
-[この提案には、バウンストラッキング対策の Explainer で概説されているセキュリティ上の考慮事項](https://github.com/wanderview/bounce-tracking-mitigations/blob/main/explainer.md#privacy-and-security-considerations)がいくつかあります。
+[この提案には、バウンストラッキング対策の Explainer で概説されているセキュリティ上の考慮事項](https://github.com/privacycg/nav-tracking-mitigations/blob/main/bounce-tracking-explainer.md#privacy-and-security-considerations)がいくつかあります。
 
 ## バウンス トラッキング対策の公開時期 {: #availability}
 
@@ -72,5 +72,5 @@ authors:
 
 バウンストラッキング対策の提案は現在も検討中であるため、今後変更される可能性があります。フィードバックがある場合は、ぜひお聞かせください。
 
-- **GitHub**: [提案](https://github.com/wanderview/bounce-tracking-mitigations)を読み、[質問を投稿したり、ディスカッションに参加](https://github.com/wanderview/bounce-tracking-mitigations/issues)したりできます。
+- **GitHub**: [提案](https://github.com/privacycg/nav-tracking-mitigations/blob/main/bounce-tracking-explainer.md)を読み、[質問を投稿したり、ディスカッションに参加](https://github.com/privacycg/proposals/issues/6)したりできます。
 - **開発者サポート**: [Privacy Sandbox Developer Support リポジトリ](https://github.com/GoogleChromeLabs/privacy-sandbox-dev-support)では、質問したり、ディスカッションに参加したりできます。


### PR DESCRIPTION
Changes proposed in this pull request:

- Fix github link for nav-tracking-mitigations. Seems like repository moved to [privacycg](https://github.com/privacycg/nav-tracking-mitigations) from [wanderview](https://github.com/wanderview/bounce-tracking-mitigations).
- use template for nav-tracking-mitigations's timeline. related to https://github.com/GoogleChrome/developer.chrome.com/pull/6628
- remove `この提案はどのブラウザにも実装されていません。` part in timeline part for JA.  This was removed by the same PR above. https://github.com/GoogleChrome/developer.chrome.com/pull/6628/commits/d8ba424fce85002d3443cd1862373455c5e64a9f