### PR TITLE
Add correction to Decision: Batching Strategy section in index.md

### DIFF
--- a/site/en/docs/privacy-sandbox/summary-reports/design-decisions/index.md
+++ b/site/en/docs/privacy-sandbox/summary-reports/design-decisions/index.md
@@ -232,7 +232,7 @@ batching frequency is how often you process aggregatable reports.
 A report that is scheduled for aggregation more frequently (e.g. each hour) will
 have fewer conversion events included than the same report with a less frequent
 aggregation schedule (e.g. each week). As a result, the hourly report will have
-a higher signal-to-noise ratio than the weekly report, all else being equal. **Experiment with reporting requirements at various frequencies, and assess signal-to-noise ratios for each.**
+a lower signal-to-noise ratio than the weekly report, all else being equal. **Experiment with reporting requirements at various frequencies, and assess signal-to-noise ratios for each.**
 
 Learn more in
 [Batching](/docs/privacy-sandbox/summary-reports/#batching)


### PR DESCRIPTION
A more frequent batching strategy implies fewer conversions which implies less signal to noise, a fact that is reiterated in the documents linked at the end of this section.