### PR TITLE
Make it more explicit that `effectiveConnectionType` is not supported

### DIFF
--- a/site/en/docs/crux/history-api/index.md
+++ b/site/en/docs/crux/history-api/index.md
@@ -314,7 +314,7 @@ The URL uses [gRPC Transcoding](https://google.aip.dev/127) syntax.
 
 ### Request body
 
-As the CrUX History API uses the same request bodies, you can reference [the daily CrUX API request body documentation](../api/#request-body) for more details.
+The CrUX History API uses the same request bodies as [the daily CrUX API](../api/#request-body), with the exception of not supporting the `effectiveConnectionType` request field.
 
 For example, to request the desktop Largest Contentful Paint values for the web.dev homepage:
 

--- a/site/en/docs/crux/history-api/index.md
+++ b/site/en/docs/crux/history-api/index.md
@@ -314,7 +314,7 @@ The URL uses [gRPC Transcoding](https://google.aip.dev/127) syntax.
 
 ### Request body
 
-The CrUX History API uses the same request bodies as [the daily CrUX API](../api/#request-body), with the exception of not supporting the `effectiveConnectionType` request field.
+The CrUX History API uses the same request bodies as [the daily CrUX API](/docs/crux/api/#request-body), with the exception of not supporting the `effectiveConnectionType` request field.
 
 For example, to request the desktop Largest Contentful Paint values for the web.dev homepage:
 


### PR DESCRIPTION
This PR documents that the `effectiveConnectionType` field is not supported in CrUX History API requests.

Right now, this is mentioned in one or two places in the article but not in the Schema section, which might be misleading (it misled me a bit 🙂).