### PR TITLE
Renew Speculation Rules Origin Trial

### DIFF
--- a/site/_includes/layouts/base.njk
+++ b/site/_includes/layouts/base.njk
@@ -9,7 +9,7 @@
 
     {# Dogfood document speculation rules origin trial #}
     <!-- developer.chrome.com origin trial token for speculation rules document rules -->
-    <meta http-equiv="origin-trial" content="AhaT7AdLUbVk3M0VorYLzXSY8Km9PJZlzg3Xkv6KT2QMZ4zyqA5BfdTJLCj1TVnGhryWtQH66HWQEsIbZDUrsAwAAABseyJvcmlnaW4iOiJodHRwczovL2RldmVsb3Blci5jaHJvbWUuY29tOjQ0MyIsImZlYXR1cmUiOiJTcGVjdWxhdGlvblJ1bGVzUHJlZmV0Y2hGdXR1cmUiLCJleHBpcnkiOjE2OTQxMzExOTl9">
+    <meta http-equiv="origin-trial" content="AtXwNtvKLGSNFBuawE0CYB2BnrKRyHz9s9KLZ9LkTTtvcxoK4UIgtNQrwGOD6wQCKsbHAsbYYjdkBdvj3vuk2QAAAABseyJvcmlnaW4iOiJodHRwczovL2RldmVsb3Blci5jaHJvbWUuY29tOjQ0MyIsImZlYXR1cmUiOiJTcGVjdWxhdGlvblJ1bGVzUHJlZmV0Y2hGdXR1cmUiLCJleHBpcnkiOjE3MDk2ODMxOTl9">
 
     {% include 'partials/meta.njk' %}
     {% block feed %}


### PR DESCRIPTION
Changes proposed in this pull request:

- Renews the prerendering speculation rules OT token as it had expired:

<img width="662" alt="image" src="https://github.com/GoogleChrome/developer.chrome.com/assets/10931297/7a2f4033-9b93-4477-b593-941b732f6463">
