### PR TITLE
Protected Audience worklet caching

### DIFF
--- a/site/en/docs/privacy-sandbox/protected-audience-api/index.md
+++ b/site/en/docs/privacy-sandbox/protected-audience-api/index.md
@@ -491,7 +491,7 @@ and membership is removed when users clear their site data.
 ### Are the Protected Audience worklets cached by the browser?
 {% endDetailsSummary %}
 
-The resources that contain the Protected Audience worklets—the buyer bid generation worklet, seller ad scoring worklet, buyer reporting worklet, and seller scoring worklet—are cached by the browser. You can use the `Cache-Control` header to control the caching behavior.
+The resources that contain the Protected Audience worklets—the buyer's bid generation and reporting worklets, and seller's ad scoring and reporting worklets—are cached by the browser. You can use the `Cache-Control` header to control the caching behavior.
 {% endDetails %}
 
 {: #engage}

--- a/site/en/docs/privacy-sandbox/protected-audience-api/index.md
+++ b/site/en/docs/privacy-sandbox/protected-audience-api/index.md
@@ -486,6 +486,14 @@ and membership is removed when users clear their site data.
 
 {% endDetails %}
 
+{% Details %}
+{% DetailsSummary %}
+### Are the Protected Audience worklets cached by the browser?
+{% endDetailsSummary %}
+
+The resources that contain the Protected Audience worklets - the buyer bid generation worklet, seller ad scoring worklet, buyer reporting worklet, and seller scoring worklet - are cached by the browser. You can use the `Cache-Control` header to control the caching behavior.
+{% endDetails %}
+
 {: #engage}
  
 ## Engage and share feedback

--- a/site/en/docs/privacy-sandbox/protected-audience-api/index.md
+++ b/site/en/docs/privacy-sandbox/protected-audience-api/index.md
@@ -491,7 +491,7 @@ and membership is removed when users clear their site data.
 ### Are the Protected Audience worklets cached by the browser?
 {% endDetailsSummary %}
 
-The resources that contain the Protected Audience worklets - the buyer bid generation worklet, seller ad scoring worklet, buyer reporting worklet, and seller scoring worklet - are cached by the browser. You can use the `Cache-Control` header to control the caching behavior.
+The resources that contain the Protected Audience worklets—the buyer bid generation worklet, seller ad scoring worklet, buyer reporting worklet, and seller scoring worklet—are cached by the browser. You can use the `Cache-Control` header to control the caching behavior.
 {% endDetails %}
 
 {: #engage}


### PR DESCRIPTION
This PR adds the Protected Audience worklet caching information

Preview link: https://pr-7392-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/protected-audience-api/#are-the-protected-audience-worklets-cached-by-the-browser