### PR TITLE
Fix `complext` typo

### DIFF
--- a/site/en/docs/extensions/reference/declarativeNetRequest/index.md
+++ b/site/en/docs/extensions/reference/declarativeNetRequest/index.md
@@ -226,7 +226,7 @@ All types of rules can use regular expressions; however, the total number of reg
 Additionally, each rule must be less than 2KB once compiled. This roughly correlates with the complexity of the rule. If you try to load a rule that exceeds this limit, you will see a warning like the one below and the rule will be ignored.
 
 ```bash
-rules_1.json: Rule with id 1 specified a more complext regex than allowed
+rules_1.json: Rule with id 1 specified a more complex regex than allowed
 as part of the "regexFilter" key.
 ```
 


### PR DESCRIPTION
I noticed a minor typo in the `declarativeNetRequest` documentation, specifically the `regexFilter` section. The error message example regarding the regex complexity rule reads "complext" instead of "complex".

Please see the screenshot below showing the actual error being triggered intentionally by loading an unpacked extension with a `regexFilter` with a complexity that exceeds the maximum rule limit.

![complex-rule-error](https://github.com/GoogleChrome/developer.chrome.com/assets/43578531/73fb6aa8-da6f-41e5-9084-691357bc1ebf)

I have already signed the [Individual CLA](https://cla.developers.google.com/about/google-individual) which is linked to my GitHub username if needed.