### PR TITLE
Fixed typo in Chrome extension reference article

### DIFF
--- a/site/en/docs/extensions/reference/tabCapture/index.md
+++ b/site/en/docs/extensions/reference/tabCapture/index.md
@@ -56,7 +56,7 @@ returned stream ID can be used:
 
 - If `consumerTabId` is specified, the ID can be used by a `getUserMedia()` call in any frame in the
 given tab which has the same security origin.
-- When this is not specified, begininning in Chrome 116, the ID can be used in any frame with the
+- When this is not specified, beginning in Chrome 116, the ID can be used in any frame with the
 same security origin in the same render process as the caller. This means that a stream ID obtained
 in a service worker can be used in an [offscreen document][offscreen-document].
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Correction of a typographical error in Chrome extension reference article.
-  Here is a link to the article:
- https://developer.chrome.com/docs/extensions/reference/tabCapture/

Fixes #7421 

I have signed the Contributor Licence Agreement form and the username I used is ```mighty-odewumi```.

Please, I would like to have this PR labeled as ```hacktoberfest-accepted``` on merge if this is fine with you as this is my first hacktoberfest contribution. 

Thanks. 