### PR TITLE
Add Storage and Cookies doc to What's New

### DIFF
--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -3,7 +3,7 @@ layout: 'layouts/doc-post.njk'
 title: What's new in Chrome extensions
 description: 'Recent changes to the Chrome extensions platform, documentation, and policy'
 date: 2021-02-25
-updated: 2023-09-29
+updated: 2023-10-02
 tags:
   - extensions-news
 
@@ -14,6 +14,14 @@ tags:
 <!--lint disable first-heading-level-->
 
 Check this page often to learn about changes to Chrome extensions, extensions documentation, or related policy or other changes. You'll find other notices posted on the [Extensions Google Group](https://groups.google.com/a/chromium.org/g/chromium-extensions). The [Extensions News](/tags/extensions-news/) tag lists articles about some of the topics listed here. (It even has [an RSS feed](/feeds/extensions-news.xml).) The [Chrome schedule](https://chromiumdash.appspot.com/schedule) lists stable and beta release dates.
+
+### Documentation on cookies and web storage APIs {: #storage-and-cookies-guide }
+
+<p class="color-secondary-text type--caption">Posted on <time>October 2, 2023</time></p>
+
+We published [a new guide](/docs/extensions/mv3/storage-and-cookies/) on how cookies and web storage
+APIs work in Chrome extensions. It includes all you need to know about
+[Privacy Sandbox](/docs/privacy-sandbox/) as an extension developer.
 
 ### Extension samples now searchable {: #extension-samples-searchable }
 

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -19,8 +19,10 @@ Check this page often to learn about changes to Chrome extensions, extensions do
 
 <p class="color-secondary-text type--caption">Posted on <time>October 9, 2023</time></p>
 
-We published a new guide on [how cookies and web storage APIs work](/docs/extensions/mv3/storage-and-cookies/) in Chrome extensions. It includes all you need to know about
-[Privacy Sandbox](/docs/privacy-sandbox/) as an extension developer.
+We published a new guide on [how cookies and web storage APIs work in Chrome extensions](/docs/extensions/mv3/storage-and-cookies/).
+It includes details on how cookie and storage partitioning changes in
+[Privacy Sandbox](/docs/privacy-sandbox/), an ongoing project to deprecate third-party cookies
+through the creation of a series of new APIs, work in extensions.
 
 ### Extension samples now searchable {: #extension-samples-searchable }
 

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -19,8 +19,7 @@ Check this page often to learn about changes to Chrome extensions, extensions do
 
 <p class="color-secondary-text type--caption">Posted on <time>October 2, 2023</time></p>
 
-We published [a new guide](/docs/extensions/mv3/storage-and-cookies/) on how cookies and web storage
-APIs work in Chrome extensions. It includes all you need to know about
+We published a new guide on [how cookies and web storage APIs work](/docs/extensions/mv3/storage-and-cookies/) in Chrome extensions. It includes all you need to know about
 [Privacy Sandbox](/docs/privacy-sandbox/) as an extension developer.
 
 ### Extension samples now searchable {: #extension-samples-searchable }

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -22,7 +22,7 @@ Check this page often to learn about changes to Chrome extensions, extensions do
 We published a new guide on [how cookies and web storage APIs work in Chrome extensions](/docs/extensions/mv3/storage-and-cookies/).
 It includes details on cookie and storage partitioning changes in
 [Privacy Sandbox](/docs/privacy-sandbox/), an ongoing project to deprecate third-party cookies
-through the creation of a series of new APIs, work in extensions.
+through the creation of a series of new web platform APIs, work in extensions.
 
 ### Extension samples now searchable {: #extension-samples-searchable }
 

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -3,7 +3,7 @@ layout: 'layouts/doc-post.njk'
 title: What's new in Chrome extensions
 description: 'Recent changes to the Chrome extensions platform, documentation, and policy'
 date: 2021-02-25
-updated: 2023-10-02
+updated: 2023-10-09
 tags:
   - extensions-news
 

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -22,7 +22,7 @@ Check this page often to learn about changes to Chrome extensions, extensions do
 We published a new guide on [how cookies and web storage APIs work in Chrome extensions](/docs/extensions/mv3/storage-and-cookies/).
 It includes details on cookie and storage partitioning changes in
 [Privacy Sandbox](/docs/privacy-sandbox/), an ongoing project to deprecate third-party cookies
-through the creation of a series of new web platform APIs, work in extensions.
+through the creation of a series of new web platform APIs, and details on how they work in extensions.
 
 ### Extension samples now searchable {: #extension-samples-searchable }
 

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -17,7 +17,7 @@ Check this page often to learn about changes to Chrome extensions, extensions do
 
 ### Documentation on cookies and web storage APIs {: #storage-and-cookies-guide }
 
-<p class="color-secondary-text type--caption">Posted on <time>October 2, 2023</time></p>
+<p class="color-secondary-text type--caption">Posted on <time>October 9, 2023</time></p>
 
 We published a new guide on [how cookies and web storage APIs work](/docs/extensions/mv3/storage-and-cookies/) in Chrome extensions. It includes all you need to know about
 [Privacy Sandbox](/docs/privacy-sandbox/) as an extension developer.

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -20,7 +20,7 @@ Check this page often to learn about changes to Chrome extensions, extensions do
 <p class="color-secondary-text type--caption">Posted on <time>October 9, 2023</time></p>
 
 We published a new guide on [how cookies and web storage APIs work in Chrome extensions](/docs/extensions/mv3/storage-and-cookies/).
-It includes details on how cookie and storage partitioning changes in
+It includes details on cookie and storage partitioning changes in
 [Privacy Sandbox](/docs/privacy-sandbox/), an ongoing project to deprecate third-party cookies
 through the creation of a series of new APIs, work in extensions.
 


### PR DESCRIPTION
Adds the new [Storage and Cookies](https://developer.chrome.com/docs/extensions/mv3/storage-and-cookies/) documentation to [What's New](https://developer.chrome.com/docs/extensions/whatsnew/).