### PR TITLE
Link old popover blogpost to new one

### DIFF
--- a/site/en/blog/pop-ups-theyre-making-a-resurgence/index.md
+++ b/site/en/blog/pop-ups-theyre-making-a-resurgence/index.md
@@ -10,8 +10,9 @@ tags:
   - css
   - html
 date: 2022-09-13
-last_updated: 2023-01-25
+last_updated: 2023-10-03
 is_outdated: true
+new_available_content_url: /blog/introducing-popover-api/
 ---
 
 {% Aside 'caution' %}


### PR DESCRIPTION
The blog post https://developer.chrome.com/blog/pop-ups-theyre-making-a-resurgence/ is outdated. This PR updates the outdated banner to include a link to the up-to-date blog post located at https://developer.chrome.com/blog/introducing-popover-api/