### PR TITLE
Fix syntax error in code examples

### DIFF
--- a/site/en/blog/chrome-119-beta/index.md
+++ b/site/en/blog/chrome-119-beta/index.md
@@ -91,7 +91,7 @@ Make Chrome's handling of URL host punctuation characters compliant with the [UR
 Before:
 
 ```bash
-> const url = new URL("http://exa(mple.com";);
+> const url = new URL("http://exa(mple.com;");
 > url.href
 'http://exa%28mple.com/&apos;
 ```
@@ -101,7 +101,7 @@ Before:
 After:
 
 ```bash
-> const url = new URL("http://exa(mple.com";);
+> const url = new URL("http://exa(mple.com;");
 > => throws TypeError: Invalid URL.
 ```
 


### PR DESCRIPTION
Code examples are supposed to show what would happen with a semi-colon at the end of a URL, but the semi-colon is outside of the actual URL string.

Changes proposed in this pull request:

- Update code examples to fix a typo under [Standard compliant URL host punctuation characters](https://developer.chrome.com/blog/chrome-119-beta/#standard-compliant-url-host-punctuation-characters)