### PR TITLE
Add documentation on testing Chrome Extensions

### DIFF
--- a/site/_data/docs/extensions/toc.yml
+++ b/site/_data/docs/extensions/toc.yml
@@ -75,6 +75,8 @@
     - url: /docs/extensions/mv3/nativeMessaging
     - url: /docs/extensions/mv3/screen_capture
     - url: /docs/extensions/mv3/geolocation
+    - url: /docs/extensions/mv3/automated-testing
+    - url: /docs/extensions/mv3/tut_puppeteer-testing
 - title: i18n.docs.extensions.quality
   sections:
     - url: /docs/extensions/mv3/user_privacy

--- a/site/_data/docs/extensions/toc.yml
+++ b/site/_data/docs/extensions/toc.yml
@@ -75,7 +75,8 @@
     - url: /docs/extensions/mv3/nativeMessaging
     - url: /docs/extensions/mv3/screen_capture
     - url: /docs/extensions/mv3/geolocation
-    - url: /docs/extensions/mv3/automated-testing
+    - url: /docs/extensions/mv3/unit-testing
+    - url: /docs/extensions/mv3/end-to-end-testing
     - url: /docs/extensions/mv3/tut_puppeteer-testing
 - title: i18n.docs.extensions.quality
   sections:

--- a/site/en/docs/extensions/mv3/automated-testing/index.md
+++ b/site/en/docs/extensions/mv3/automated-testing/index.md
@@ -7,13 +7,14 @@ description: How to write automated tests for extensions.
 ---
 
 Automated testing tools provide a great way to regularly test a large amount of your extension's
-functionality. This can be useful to ensure key functionality is working and as a way to avoid
-regressions between releases.
+functionality. This can be useful to ensure key functionality is working and avoids regressions
+between releases.
 
-## Unit testing
+## Unit testing Chrome Extensions
 
 [Unit testing][unit-testing] allows small sections of code to be tested in isolation from the rest
-of your extension, and outside of the browser.
+of your extension, and outside of the browser. For example, you could write a unit test to ensure
+that a helper method correctly writes a value to storage when called.
 
 Code written without using extension APIs can be tested as normal, using a framework such as
 [Jest][jest]. To make code easier to test this way, consider using techniques such as
@@ -42,7 +43,7 @@ global.chrome = {
 };
 ```
 
-Then, use jest.spy to mock a return value in a test:
+Then, use `jest.spy` to mock a return value in a test:
 
 ```js
 test("getActiveTabId returns active tab ID", async () => {
@@ -55,7 +56,7 @@ test("getActiveTabId returns active tab ID", async () => {
 });
 ```
 
-## Integration testing
+## Integration testing Chrome Extensions
 
 [Integration testing][integration-testing] involves an extension package being built and loaded into
 a browser. A testing tool communicates with the browser to automate interactions and test the same
@@ -63,7 +64,7 @@ flows that a user would go through.
 
 See [Testing Chrome Extensions with Puppeteer][tutorial] for a tutorial.
 
-### Libraries
+### Using browser testing libraries
 
 Extensions are supported by a range of integration testing libraries.
 
@@ -73,7 +74,7 @@ Extensions are supported by a range of integration testing libraries.
 | Selenium               | Use the [ChromeOptions][selenium-chromeoptions] object to load extensions. More information is available [here][selenium-extensions]. |
 | WebDriverIO            | See [Web Extension Testing][webdriverio-testing].                                                                                     |
 
-### Headless Chrome
+### Running tests in headless Chrome
 
 When running tests as part of an automated workflow, it is often necessary to load your extension on a machine that does not have a screen. Chrome's [new headless][new-headless] mode allows Chrome to be run in an unattended environment like this. Simply start Chrome with the `--headless=new` flag (headless currently defaults to "old", which does not support loading extensions). Depending on the automation tool you choose there may be a setting which adds the flag for you automatically.
 
@@ -109,7 +110,10 @@ async function getActiveTab() {
 
 ### Inspecting extension state
 
-It is generally best practice to avoid accessing internal state in an integration test, and instead you should base your tests on what is visible to the user. However, it can sometimes be desirable to directly access data from the extension. In these cases, consider executing code in the context of an extension page.
+To avoid test failures when you change the internal behavior of your extension, it is generally best
+practice to avoid accessing internal state in an integration test. Instead, you should base your
+tests on what is visible to the user. However, it can sometimes be desirable to directly access data
+from the extension. In these cases, consider executing code in the context of an extension page.
 
 In Puppeteer:
 

--- a/site/en/docs/extensions/mv3/automated-testing/index.md
+++ b/site/en/docs/extensions/mv3/automated-testing/index.md
@@ -1,0 +1,149 @@
+---
+layout: "layouts/doc-post.njk"
+title: "Automated testing for Chrome Extensions"
+seoTitle: "Automated testing for Chrome Extensions"
+date: 2023-10-09
+description: How to write automated tests for extensions.
+---
+
+Automated testing tools provide a great way to regularly test a large amount of your extension's
+functionality. This can be useful to ensure key functionality is working and as a way to avoid
+regressions between releases.
+
+## Unit testing
+
+[Unit testing][unit-testing] allows small sections of code to be tested in isolation from the rest
+of your extension, and outside of the browser.
+
+Code written without using extension APIs can be tested as normal, using a framework such as
+[Jest][jest]. To make code easier to test this way, consider using techniques such as
+[dependency injection][dependency-injection] which can help to remove dependencies on the chrome
+namespace in your lower level implementation.
+
+If you need to test code which includes extension APIs, consider using mocks.
+
+### Example: Using mocks with Jest
+
+Create a `jest.config.js` file, which declares a setup file that will run before all tests:
+
+```js
+module.exports = {
+  setupFiles: ['<rootDir>/mock-extension-apis.js']
+};
+```
+
+In `mock-extension-apis.js`, add implementations for the specific functions you expect to call:
+
+```js
+global.chrome = {
+  tabs: {
+    query: async () => { throw new Error("Unimplemented.") };
+  }
+};
+```
+
+Then, use jest.spy to mock a return value in a test:
+
+```js
+test("getActiveTabId returns active tab ID", async () => {
+  jest.spyOn(chrome.tabs, "query").mockResolvedValue([{
+    id: 3,
+    active: true,
+    currentWindow: true
+  }]);
+  expect(await getActiveTabId()).toBe(3);
+});
+```
+
+## Integration testing
+
+[Integration testing][integration-testing] involves an extension package being built and loaded into
+a browser. A testing tool communicates with the browser to automate interactions and test the same
+flows that a user would go through.
+
+See [Testing Chrome Extensions with Puppeteer][tutorial] for a tutorial.
+
+### Libraries
+
+Extensions are supported by a range of integration testing libraries.
+
+| Library                | Guidance                                                                                                                              |
+|------------------------|:-------------------------------------------------------------------------------------------------------------------------------------:|
+| Puppeteer / Playwright | See Chrome Extensions ([Puppeteer][puppeteer-testing] / [Playwright][playwright-testing]).                                            |
+| Selenium               | Use the [ChromeOptions][selenium-chromeoptions] object to load extensions. More information is available [here][selenium-extensions]. |
+| WebDriverIO            | See [Web Extension Testing][webdriverio-testing].                                                                                     |
+
+### Headless Chrome
+
+When running tests as part of an automated workflow, it is often necessary to load your extension on a machine that does not have a screen. Chrome's [new headless][new-headless] mode allows Chrome to be run in an unattended environment like this. Simply start Chrome with the `--headless=new` flag (headless currently defaults to "old", which does not support loading extensions). Depending on the automation tool you choose there may be a setting which adds the flag for you automatically.
+
+### Setting an extension ID
+
+It is often desirable to have a fixed extension ID in tests. This makes a number of common tasks easier such as allow-listing the extension's origin on a server it needs to communicate with, or opening extension pages within tests. To do this, follow the steps under [Keeping a consistent extension ID][consistent-id].
+
+### Testing extension pages
+
+Extension pages can be accessed using their corresponding URL, e.g `chrome-extension://<id>/index.html`. Use the normal navigation methods available in your automation tool of choice to navigate to these URLs.
+
+### Testing an extension popup
+
+Opening an extension popup in the context of another page is not currently possible. Instead, open the popup's URL in a new tab. If your popup uses the active tab, consider implementing an override where a tab ID can be passed explicitly to your popup. For example:
+
+```js
+const URL_PARAMS  = new URLSearchParams(window.location.search);
+
+async function getActiveTab() {
+  // Open popup.html?tab=5 to use tab ID 5, etc.
+  if (URL_PARAMS.has("tab")) {
+    return parseInt(URL_PARAMS.get("tab"));
+  }
+
+  const tabs = await chrome.tabs.query({
+    active: true,
+    currentWindow: true
+  });
+
+  return tabs[0];
+}
+```
+
+### Inspecting extension state
+
+It is generally best practice to avoid accessing internal state in an integration test, and instead you should base your tests on what is visible to the user. However, it can sometimes be desirable to directly access data from the extension. In these cases, consider executing code in the context of an extension page.
+
+In Puppeteer:
+
+```js
+const workerTarget = await browser.waitForTarget(
+  target => target.type() === 'service_worker'
+);
+const worker = await workerTarget.worker();
+
+const value = await worker.evaluate(() => {
+  chrome.storage.local.get('foo');
+});
+```
+
+In Selenium:
+
+```js
+// Selenium doesn't allow us to access the background page, so we need to open an extension page we can execute the code in
+await driver.get('chrome-extension://<id>/popup.html');
+await driver.executeAsyncScript(
+  'const callback = arguments[arguments.length - 1];' +
+  'chrome.storage.local.get(\'foo\').then(callback);'
+);
+```
+
+[unit-testing]: https://wikipedia.org/wiki/Unit_testing
+[jest]: https://jestjs.io/
+[dependency-injection]: https://wikipedia.org/wiki/Dependency_injection
+[integration-testing]: https://wikipedia.org/wiki/Integration_testing
+[puppeteer-testing]: https://pptr.dev/guides/chrome-extensions
+[playwright-testing]: https://playwright.dev/docs/chrome-extensions
+[selenium-chromeoptions]: https://www.selenium.dev/documentation/webdriver/browsers/chrome/
+[selenium-extensions]: https://chromedriver.chromium.org/extensions
+[webdriverio-testing]: https://webdriver.io/docs/extension-testing/web-extensions/
+[new-headless]: /articles/new-headless/
+[consistent-id]: /docs/extensions/mv3/manifest/key/#keep-consistent-id
+[tutorial]: /docs/extensions/mv3/tut_puppeteer-testing/

--- a/site/en/docs/extensions/mv3/end-to-end-testing/index.md
+++ b/site/en/docs/extensions/mv3/end-to-end-testing/index.md
@@ -13,7 +13,7 @@ controlling the browser, simulating user input and observing the current state o
 
 See [Testing Chrome Extensions with Puppeteer][tutorial] for a tutorial.
 
-## Using browser testing libraries
+## Using browser testing libraries {: #libraries }
 
 Extensions are supported by a range of testing libraries.
 
@@ -23,19 +23,23 @@ Extensions are supported by a range of testing libraries.
 | Selenium               | Use the [ChromeOptions][selenium-chromeoptions] object to load extensions. More information is available [here][selenium-extensions]. |
 | WebDriverIO            | See [Web Extension Testing][webdriverio-testing].                                                                                     |
 
-## Running tests in headless Chrome
+## Running tests in headless Chrome {: #headless }
 
-When running tests as part of an automated workflow, it is often necessary to load your extension on a machine that does not have a screen. Chrome's [new headless][new-headless] mode allows Chrome to be run in an unattended environment like this. Simply start Chrome with the `--headless=new` flag (headless currently defaults to "old", which does not support loading extensions). Depending on the automation tool you choose there may be a setting which adds the flag for you automatically.
+When running tests as part of an automated workflow, it is often necessary to load your extension on
+a machine that does not have a screen. Chrome's [new headless][new-headless] mode allows Chrome to
+be run in an unattended environment like this. Start Chrome using the `--headless=new` flag
+(headless currently defaults to "old", which does not support loading extensions). Depending on the
+automation tool you choose, there may be a setting that adds the flag for you automatically.
 
-## Setting an extension ID
+## Setting an extension ID {: #set-extension-id }
 
-It is often desirable to have a fixed extension ID in tests. This makes a number of common tasks easier such as allow-listing the extension's origin on a server it needs to communicate with, or opening extension pages within tests. To do this, follow the steps under [Keeping a consistent extension ID][consistent-id].
+It is often desirable to have a fixed extension ID in tests. This makes many common tasks easier such as allow-listing the extension's origin on a server it needs to communicate with, or opening extension pages within tests. To do this, follow the steps under [Keeping a consistent extension ID][consistent-id].
 
-## Testing extension pages
+## Testing extension pages {: #extension-pages }
 
 Extension pages can be accessed using their corresponding URL, e.g `chrome-extension://<id>/index.html`. Use the normal navigation methods available in your automation tool of choice to navigate to these URLs.
 
-## Testing an extension popup
+## Testing an extension popup {: #extension-popup }
 
 Opening an extension popup in the context of another page is not currently possible. Instead, open the popup's URL in a new tab. If your popup uses the active tab, consider implementing an override where a tab ID can be passed explicitly to your popup. For example:
 
@@ -57,7 +61,7 @@ async function getActiveTab() {
 }
 ```
 
-## Inspecting extension state
+## Inspecting extension state {: #inspect-state }
 
 To avoid test failures when you change the internal behavior of your extension, it is generally best
 practice to avoid accessing internal state in an integration test. Instead, you should base your
@@ -80,7 +84,7 @@ const value = await worker.evaluate(() => {
 In Selenium:
 
 ```js
-// Selenium doesn't allow us to access the background page, so we need to open an extension page we can execute the code in
+// Selenium doesn't allow us to access the service worker, so we need to open an extension page where we can execute the code
 await driver.get('chrome-extension://<id>/popup.html');
 await driver.executeAsyncScript(
   'const callback = arguments[arguments.length - 1];' +

--- a/site/en/docs/extensions/mv3/end-to-end-testing/index.md
+++ b/site/en/docs/extensions/mv3/end-to-end-testing/index.md
@@ -2,7 +2,7 @@
 layout: "layouts/doc-post.njk"
 title: "End-to-end testing for Chrome Extensions"
 seoTitle: "End-to-end testing Chrome Extensions"
-date: 2023-10-09
+date: 2023-10-12
 description: How to write end-to-end tests for extensions.
 ---
 

--- a/site/en/docs/extensions/mv3/end-to-end-testing/index.md
+++ b/site/en/docs/extensions/mv3/end-to-end-testing/index.md
@@ -8,7 +8,8 @@ description: How to write end-to-end tests for extensions.
 
 End-to-end testing involves an extension package being built and loaded into a browser. A testing
 tool communicates with the browser to automate interactions and test the same flows that a user
-would go through.
+would go through. A library that supports end-to-end testing will generally provide ways of
+controlling the browser, simulating user input and observing the current state of any open pages.
 
 See [Testing Chrome Extensions with Puppeteer][tutorial] for a tutorial.
 

--- a/site/en/docs/extensions/mv3/end-to-end-testing/index.md
+++ b/site/en/docs/extensions/mv3/end-to-end-testing/index.md
@@ -1,72 +1,20 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "Automated testing for Chrome Extensions"
-seoTitle: "Automated testing for Chrome Extensions"
+title: "End-to-end testing Chrome Extensions"
+seoTitle: "End-to-end testing Chrome Extensions"
 date: 2023-10-09
-description: How to write automated tests for extensions.
+description: How to write end-to-end tests for extensions.
 ---
 
-Automated testing tools provide a great way to regularly test a large amount of your extension's
-functionality. This can be useful to ensure key functionality is working and avoids regressions
-between releases.
-
-## Unit testing Chrome Extensions
-
-[Unit testing][unit-testing] allows small sections of code to be tested in isolation from the rest
-of your extension, and outside of the browser. For example, you could write a unit test to ensure
-that a helper method correctly writes a value to storage when called.
-
-Code written without using extension APIs can be tested as normal, using a framework such as
-[Jest][jest]. To make code easier to test this way, consider using techniques such as
-[dependency injection][dependency-injection] which can help to remove dependencies on the chrome
-namespace in your lower level implementation.
-
-If you need to test code which includes extension APIs, consider using mocks.
-
-### Example: Using mocks with Jest
-
-Create a `jest.config.js` file, which declares a setup file that will run before all tests:
-
-```js
-module.exports = {
-  setupFiles: ['<rootDir>/mock-extension-apis.js']
-};
-```
-
-In `mock-extension-apis.js`, add implementations for the specific functions you expect to call:
-
-```js
-global.chrome = {
-  tabs: {
-    query: async () => { throw new Error("Unimplemented.") };
-  }
-};
-```
-
-Then, use `jest.spy` to mock a return value in a test:
-
-```js
-test("getActiveTabId returns active tab ID", async () => {
-  jest.spyOn(chrome.tabs, "query").mockResolvedValue([{
-    id: 3,
-    active: true,
-    currentWindow: true
-  }]);
-  expect(await getActiveTabId()).toBe(3);
-});
-```
-
-## Integration testing Chrome Extensions
-
-[Integration testing][integration-testing] involves an extension package being built and loaded into
-a browser. A testing tool communicates with the browser to automate interactions and test the same
-flows that a user would go through.
+End-to-end testing involves an extension package being built and loaded into a browser. A testing
+tool communicates with the browser to automate interactions and test the same flows that a user
+would go through.
 
 See [Testing Chrome Extensions with Puppeteer][tutorial] for a tutorial.
 
-### Using browser testing libraries
+## Using browser testing libraries
 
-Extensions are supported by a range of integration testing libraries.
+Extensions are supported by a range of testing libraries.
 
 | Library                | Guidance                                                                                                                              |
 |------------------------|:-------------------------------------------------------------------------------------------------------------------------------------:|
@@ -74,19 +22,19 @@ Extensions are supported by a range of integration testing libraries.
 | Selenium               | Use the [ChromeOptions][selenium-chromeoptions] object to load extensions. More information is available [here][selenium-extensions]. |
 | WebDriverIO            | See [Web Extension Testing][webdriverio-testing].                                                                                     |
 
-### Running tests in headless Chrome
+## Running tests in headless Chrome
 
 When running tests as part of an automated workflow, it is often necessary to load your extension on a machine that does not have a screen. Chrome's [new headless][new-headless] mode allows Chrome to be run in an unattended environment like this. Simply start Chrome with the `--headless=new` flag (headless currently defaults to "old", which does not support loading extensions). Depending on the automation tool you choose there may be a setting which adds the flag for you automatically.
 
-### Setting an extension ID
+## Setting an extension ID
 
 It is often desirable to have a fixed extension ID in tests. This makes a number of common tasks easier such as allow-listing the extension's origin on a server it needs to communicate with, or opening extension pages within tests. To do this, follow the steps under [Keeping a consistent extension ID][consistent-id].
 
-### Testing extension pages
+## Testing extension pages
 
 Extension pages can be accessed using their corresponding URL, e.g `chrome-extension://<id>/index.html`. Use the normal navigation methods available in your automation tool of choice to navigate to these URLs.
 
-### Testing an extension popup
+## Testing an extension popup
 
 Opening an extension popup in the context of another page is not currently possible. Instead, open the popup's URL in a new tab. If your popup uses the active tab, consider implementing an override where a tab ID can be passed explicitly to your popup. For example:
 
@@ -108,7 +56,7 @@ async function getActiveTab() {
 }
 ```
 
-### Inspecting extension state
+## Inspecting extension state
 
 To avoid test failures when you change the internal behavior of your extension, it is generally best
 practice to avoid accessing internal state in an integration test. Instead, you should base your
@@ -139,10 +87,6 @@ await driver.executeAsyncScript(
 );
 ```
 
-[unit-testing]: https://wikipedia.org/wiki/Unit_testing
-[jest]: https://jestjs.io/
-[dependency-injection]: https://wikipedia.org/wiki/Dependency_injection
-[integration-testing]: https://wikipedia.org/wiki/Integration_testing
 [puppeteer-testing]: https://pptr.dev/guides/chrome-extensions
 [playwright-testing]: https://playwright.dev/docs/chrome-extensions
 [selenium-chromeoptions]: https://www.selenium.dev/documentation/webdriver/browsers/chrome/

--- a/site/en/docs/extensions/mv3/end-to-end-testing/index.md
+++ b/site/en/docs/extensions/mv3/end-to-end-testing/index.md
@@ -11,14 +11,14 @@ tool communicates with the browser to automate interactions and test the same fl
 would go through. A library that supports end-to-end testing will generally provide ways of
 controlling the browser, simulating user input and observing the current state of any open pages.
 
-See [Testing Chrome Extensions with Puppeteer][tutorial] for a tutorial.
+See [Testing Chrome Extensions with Puppeteer][tutorial] for a tutorial and [Unit testing][unit-testing] for details on writing unit tests for Chrome extensions.
 
 ## Using browser testing libraries {: #libraries }
 
 Extensions are supported by a range of testing libraries.
 
 | Library                | Guidance                                                                                                                              |
-|------------------------|:-------------------------------------------------------------------------------------------------------------------------------------:|
+|------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
 | Puppeteer / Playwright | See Chrome Extensions ([Puppeteer][puppeteer-testing] / [Playwright][playwright-testing]).                                            |
 | Selenium               | Use the [ChromeOptions][selenium-chromeoptions] object to load extensions. More information is available [here][selenium-extensions]. |
 | WebDriverIO            | See [Web Extension Testing][webdriverio-testing].                                                                                     |
@@ -100,3 +100,5 @@ await driver.executeAsyncScript(
 [new-headless]: /articles/new-headless/
 [consistent-id]: /docs/extensions/mv3/manifest/key/#keep-consistent-id
 [tutorial]: /docs/extensions/mv3/tut_puppeteer-testing/
+[unit-testing]: /docs/extensions/mv3/unit-testing
+

--- a/site/en/docs/extensions/mv3/end-to-end-testing/index.md
+++ b/site/en/docs/extensions/mv3/end-to-end-testing/index.md
@@ -1,6 +1,6 @@
 ---
 layout: "layouts/doc-post.njk"
-title: "End-to-end testing Chrome Extensions"
+title: "End-to-end testing for Chrome Extensions"
 seoTitle: "End-to-end testing Chrome Extensions"
 date: 2023-10-09
 description: How to write end-to-end tests for extensions.
@@ -18,7 +18,7 @@ See [Testing Chrome Extensions with Puppeteer][tutorial] for a tutorial and [Uni
 Extensions are supported by a range of testing libraries.
 
 | Library                | Guidance                                                                                                                              |
-|------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
+|:------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
 | Puppeteer / Playwright | See Chrome Extensions ([Puppeteer][puppeteer-testing] / [Playwright][playwright-testing]).                                            |
 | Selenium               | Use the [ChromeOptions][selenium-chromeoptions] object to load extensions. More information is available [here][selenium-extensions]. |
 | WebDriverIO            | See [Web Extension Testing][webdriverio-testing].                                                                                     |

--- a/site/en/docs/extensions/mv3/tut_puppeteer-testing/index.md
+++ b/site/en/docs/extensions/mv3/tut_puppeteer-testing/index.md
@@ -7,7 +7,7 @@ description: How to write an automated test for Chrome Etensions in Puppeteer.
 ---
 
 _For general advice on testing extensions, see
-[Automated testing for Chrome Extensions][automated-testing] and [Unit testing in Chrome Extensions][unit-testing]._
+[End-to-end testing of Chrome Extensions][automated-testing] and [Unit testing in Chrome Extensions][unit-testing]._
 
 [Puppeteer][puppeteer] provides a framework for building automated tests of websites, which also
 includes the ability to test Chrome Extensions. These are high-level end-to-end tests that test the
@@ -173,7 +173,7 @@ After mastering the basics, try building a test suite for your own extension. Th
 [API reference][api-reference] contains more information about what's possible - there are many
 capabilities not described here.
 
-[automated-testing]: /docs/extensions/mv3/automated-testing
+[automated-testing]: /docs/extensions/mv3/end-to-end-testing/
 [puppeteer]: https://github.com/puppeteer/puppeteer
 [samples-repo]: https://github.com/GoogleChrome/chrome-extensions-samples
 [node]: https://nodejs.org/

--- a/site/en/docs/extensions/mv3/tut_puppeteer-testing/index.md
+++ b/site/en/docs/extensions/mv3/tut_puppeteer-testing/index.md
@@ -10,7 +10,7 @@ _For general advice on testing extensions, see
 [Automated testing for Chrome Extensions][automated-testing]._
 
 [Puppeteer][puppeteer] provides a framework for building automated tests of websites, which also
-includes the ability to test Chrome Extensions. These are high-level integration tests that test the
+includes the ability to test Chrome Extensions. These are high-level end-to-end tests that test the
 functionality of a website or extension once it has been built into the final product. In this
 tutorial, we demonstrate how to write a basic test for an extension from our samples repository.
 

--- a/site/en/docs/extensions/mv3/tut_puppeteer-testing/index.md
+++ b/site/en/docs/extensions/mv3/tut_puppeteer-testing/index.md
@@ -37,20 +37,23 @@ following:
 
 Similar to an extension's manifest.json file, this file is required by all Node projects.
 
-### Step 2: Install Puppeteer
+### Step 2: Install Puppeteer and Jest
 
-Run `npm install puppeteer` to add Puppeteer as a dependency. It will be automatically added to your
-`package.json` file.
+Run `npm install puppeteer jest` to add Puppeteer and Jest as dependencies. They will be
+automatically added to your `package.json` file.
+
+It is possible to write standalone Puppeteer tests, but we'll use Jest as a test runner to provide
+some additional structure to our code.
 
 ### Step 3: Create an entry point
 
-{% Aside %}
-In this example, `headless` is set to `false`. This causes the browser window to be visible while
-the tests are running which can be helpful during development. Outside of development, consider
-setting it to `'new'` which uses Chrome's [new headless mode][new-headless].
-{% endAside %}
+In a new file called `index.test.js`, add the following:
 
-In a new file called `index.js`, add the following:
+{% Aside %}
+Jest adds `beforeEach` and `afterEach` to our environment when running the tests, so we do not need
+to import them. However, you may need to configure [ESLint][eslint] or [TypeScript][typescript]
+accordingly.
+{% endAside %}
 
 ```js
 const puppeteer = require('puppeteer');
@@ -58,22 +61,47 @@ const puppeteer = require('puppeteer');
 const EXTENSION_PATH = '../../api-samples/history/showHistory';
 const EXTENSION_ID = 'jkomgjfbbjocikdmilgaehbfpllalmia';
 
-async function run() {
-  const browser = await puppeteer.launch({
+let browser;
+
+beforeEach(async () => {
+  // TODO: Launch the browser.
+});
+
+afterEach(async () => {
+  // TODO: Close the browser.
+});
+```
+
+### Step 4: Launch the browser
+
+{% Aside %}
+In this example, `headless` is set to `false`. This causes the browser window to be visible while
+the tests are running which can be helpful during development. Outside of development, consider
+setting it to `'new'` which uses Chrome's [new headless mode][new-headless].
+{% endAside %}
+
+Update `beforeEach` and `afterEach` to launch and close the browser. When running many tests, you
+may wish to consider using the same browser. However, this is generally discouraged as it reduces
+the isolation between your tests and may cause one test to impact the outcome of another.
+
+```js
+beforeEach(async () => {
+  browser = await puppeteer.launch({
     headless: false,
     args: [
       `--disable-extensions-except=${EXTENSION_PATH}`,
       `--load-extension=${EXTENSION_PATH}`
     ]
   });
-}
+});
 
-run();
+afterEach(async () => {
+  await browser.close();
+  browser = undefined;
+});
 ```
 
-Run `node index.js` and you should see Chrome open with your extension loaded.
-
-### Step 4: Add an alias
+### Step 5: Add an alias
 
 To make running the tests easier, add an alias to your `package.json` file:
 
@@ -85,21 +113,23 @@ To make running the tests easier, add an alias to your `package.json` file:
     "puppeteer": "^21.3.6"
   },
   "scripts": {
-    "start": "node index.js"
+    "start": "jest ."
   }
 }
 ```
 
-You can now use `npm start` to run your test suite.
+This will run all files ending in `.test.js` in the current directory.
 
 ### Step 6: Open the popup
 
-Let's open the popup in a new page. We need to do this because Puppeteer does not support accessing
-an extension popup from the popup window. Add the following code:
+Let's add a basic test that opens the popup in a new page. We need to do this because Puppeteer
+does not support accessing an extension popup from the popup window. Add the following code:
 
 ```js
-const page = await browser.newPage();
-await page.goto(`chrome-extension://${EXTENSION_ID}/popup.html`);
+test('popup renders correctly', async () => {
+  const page = await browser.newPage();
+  await page.goto(`chrome-extension://${EXTENSION_ID}/popup.html`);
+});
 ```
 
 The method `browser.newPage()` actually supports an optional URL parameter, but unfortunately this
@@ -112,38 +142,36 @@ Let's assert something, so that our test can fail if the extension isn't behavin
 know that our popup should show recently visited pages, so let's check that we see one:
 
 ```js
-const list = await page.$('ul');
-const children = await list.$$('li');
+test('popup renders correctly', async () => {
+  const page = await browser.newPage();
+  await page.goto(`chrome-extension://${EXTENSION_ID}/popup.html`);
 
-if (children.length !== 1) {
-  throw new Error('Unexpected number of list elements!');
-}
+  const list = await page.$('ul');
+  const children = await list.$$('li');
+
+  expect(children.length).toBe(1);
+});
 ```
 
-You may want to use an assertion library or test framework for simplifying code like this. Popular
-libraries include [assert][assert] and [mocha][mocha].
+### Step 8: Run your test
 
-### Step 8: Close the browser
-
-When you've finished testing, run the following to close the browser:
-
-```js
-await browser.close();
-```
+To run the test, use `npm start`. You should see output indicating that your test passed.
 
 You can see the [full project][full-project] in our chrome-extensions-samples repository.
 
 ## Next Steps
 
-After mastering the basics, try building a test suite for your own extension. The Puppeteer [API reference][api-reference] contains more information about what's possible - there are many capabilities not described here.
+After mastering the basics, try building a test suite for your own extension. The Puppeteer
+[API reference][api-reference] contains more information about what's possible - there are many
+capabilities not described here.
 
 [automated-testing]: /docs/extensions/mv3/automated-testing
 [puppeteer]: https://github.com/puppeteer/puppeteer
 [samples-repo]: https://github.com/GoogleChrome/chrome-extensions-samples
 [node]: https://nodejs.org/
 [new-headless]: https://developer.chrome.com/articles/new-headless/
-[mocha]: https://www.npmjs.com/package/mocha
-[assert]: https://www.npmjs.com/package/assert
 [full-project]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples/tutorial.puppeteer
 [api-reference]: https://pptr.dev/api
 [consistent-id]: /docs/extensions/mv3/automated-testing/#setting-an-extension-id
+[eslint]: https://www.npmjs.com/package/eslint-plugin-jest
+[typescript]: https://jestjs.io/docs/getting-started#type-definitions

--- a/site/en/docs/extensions/mv3/tut_puppeteer-testing/index.md
+++ b/site/en/docs/extensions/mv3/tut_puppeteer-testing/index.md
@@ -2,8 +2,8 @@
 layout: "layouts/doc-post.njk"
 title: "Tutorial: Testing Chrome Extensions with Puppeteer"
 seoTitle: "Tutorial: Testing Chrome Extensions with Puppeteer"
-date: 2023-10-09
-description: How to write an automated test for Chrome Etensions in Puppeteer.
+date: 2023-10-12
+description: How to write an automated test for Chrome Extensions using Puppeteer.
 ---
 
 _For general advice on testing extensions, see

--- a/site/en/docs/extensions/mv3/tut_puppeteer-testing/index.md
+++ b/site/en/docs/extensions/mv3/tut_puppeteer-testing/index.md
@@ -14,19 +14,21 @@ includes the ability to test Chrome Extensions. These are high-level end-to-end 
 functionality of a website or extension once it has been built into the final product. In this
 tutorial, we demonstrate how to write a basic test for an extension from our samples repository.
 
-## Before you start
+## Before you start {: #prereq }
 
 Clone or download the [chrome-extensions-samples][samples-repo] repository. We'll use the history
 API demo in `api-samples/history/showHistory` as our test extension.
 
 You'll also need to install [Node.JS][node] which is the runtime Puppeteer is built on.
 
-## Writing your test
+## Writing your test {: #write-test }
 
-### Step 1: Start your Node.JS project
+### Step 1: Start your Node.JS project {: #step-1 }
 
 We need to set up a basic Node.JS project. In a new folder, create a `package.json` file with the
 following:
+
+{% Label %}pacakge.json:{% endLabel %}
 
 ```js
 {
@@ -35,9 +37,9 @@ following:
 }
 ```
 
-Similar to an extension's manifest.json file, this file is required by all Node projects.
+Similar to an extension's `manifest.json` file, this file is required by all Node projects.
 
-### Step 2: Install Puppeteer and Jest
+### Step 2: Install Puppeteer and Jest {: #step-2 }
 
 Run `npm install puppeteer jest` to add Puppeteer and Jest as dependencies. They will be
 automatically added to your `package.json` file.
@@ -45,15 +47,17 @@ automatically added to your `package.json` file.
 It is possible to write standalone Puppeteer tests, but we'll use Jest as a test runner to provide
 some additional structure to our code.
 
-### Step 3: Create an entry point
+### Step 3: Create an entry point {: #step-3 }
 
-In a new file called `index.test.js`, add the following:
+Create a new file called `index.test.js` and add the following code:
 
 {% Aside %}
 Jest adds `beforeEach` and `afterEach` to our environment when running the tests, so we do not need
 to import them. However, you may need to configure [ESLint][eslint] or [TypeScript][typescript]
 accordingly.
 {% endAside %}
+
+{% Label %}index.test.js:{% endLabel %}
 
 ```js
 const puppeteer = require('puppeteer');
@@ -72,7 +76,7 @@ afterEach(async () => {
 });
 ```
 
-### Step 4: Launch the browser
+### Step 4: Launch the browser {: #step-4 }
 
 {% Aside %}
 In this example, `headless` is set to `false`. This causes the browser window to be visible while
@@ -83,6 +87,8 @@ setting it to `'new'` which uses Chrome's [new headless mode][new-headless].
 Update `beforeEach` and `afterEach` to launch and close the browser. When running many tests, you
 may wish to consider using the same browser. However, this is generally discouraged as it reduces
 the isolation between your tests and may cause one test to impact the outcome of another.
+
+{% Label %}index.test.js:{% endLabel %}
 
 ```js
 beforeEach(async () => {
@@ -101,9 +107,11 @@ afterEach(async () => {
 });
 ```
 
-### Step 5: Add an alias
+### Step 5: Add an alias {: #step-5 }
 
 To make running the tests easier, add an alias to your `package.json` file:
+
+{% Label %}package.json:{% endLabel %}
 
 ```js
 {
@@ -120,10 +128,12 @@ To make running the tests easier, add an alias to your `package.json` file:
 
 This will run all files ending in `.test.js` in the current directory.
 
-### Step 6: Open the popup
+### Step 6: Open the popup {: #step-6 }
 
 Let's add a basic test that opens the popup in a new page. We need to do this because Puppeteer
 does not support accessing an extension popup from the popup window. Add the following code:
+
+{% Label %}index.test.js:{% endLabel %}
 
 ```js
 test('popup renders correctly', async () => {
@@ -132,14 +142,12 @@ test('popup renders correctly', async () => {
 });
 ```
 
-The method `browser.newPage()` actually supports an optional URL parameter, but unfortunately this
-does not support URLs with the `chrome-extension://` scheme. Consequently, we first open a page and
-then call `page.goto()` to navigate.
-
-### Step 7: Assert the current state
+### Step 7: Assert the current state {: #step-7 }
 
 Let's assert something, so that our test can fail if the extension isn't behaving as expected. We
 know that our popup should show recently visited pages, so let's check that we see one:
+
+{% Label %}index.test.js:{% endLabel %}
 
 ```js
 test('popup renders correctly', async () => {
@@ -153,13 +161,13 @@ test('popup renders correctly', async () => {
 });
 ```
 
-### Step 8: Run your test
+### Step 8: Run your test {: #step-8 }
 
 To run the test, use `npm start`. You should see output indicating that your test passed.
 
 You can see the [full project][full-project] in our chrome-extensions-samples repository.
 
-## Next Steps
+## Next Steps {: #next-steps }
 
 After mastering the basics, try building a test suite for your own extension. The Puppeteer
 [API reference][api-reference] contains more information about what's possible - there are many

--- a/site/en/docs/extensions/mv3/tut_puppeteer-testing/index.md
+++ b/site/en/docs/extensions/mv3/tut_puppeteer-testing/index.md
@@ -7,7 +7,7 @@ description: How to write an automated test for Chrome Etensions in Puppeteer.
 ---
 
 _For general advice on testing extensions, see
-[Automated testing for Chrome Extensions][automated-testing]._
+[Automated testing for Chrome Extensions][automated-testing] and [Unit testing in Chrome Extensions][unit-testing]._
 
 [Puppeteer][puppeteer] provides a framework for building automated tests of websites, which also
 includes the ability to test Chrome Extensions. These are high-level end-to-end tests that test the
@@ -183,3 +183,5 @@ capabilities not described here.
 [consistent-id]: /docs/extensions/mv3/automated-testing/#setting-an-extension-id
 [eslint]: https://www.npmjs.com/package/eslint-plugin-jest
 [typescript]: https://jestjs.io/docs/getting-started#type-definitions
+[unit-testing]: /docs/extensions/mv3/unit-testing
+

--- a/site/en/docs/extensions/mv3/tut_puppeteer-testing/index.md
+++ b/site/en/docs/extensions/mv3/tut_puppeteer-testing/index.md
@@ -11,7 +11,8 @@ _For general advice on testing extensions, see
 
 [Puppeteer][puppeteer] provides a framework for building automated tests of websites, which also
 includes the ability to test Chrome Extensions. These are high-level integration tests that test the
-functionality of a website or extension once it has been built into the final product.
+functionality of a website or extension once it has been built into the final product. In this
+tutorial, we demonstrate how to write a basic test for an extension from our samples repository.
 
 ## Before you start
 
@@ -42,6 +43,12 @@ Run `npm install puppeteer` to add Puppeteer as a dependency. It will be automat
 `package.json` file.
 
 ### Step 3: Create an entry point
+
+{% Aside %}
+In this example, `headless` is set to `false`. This causes the browser window to be visible while
+the tests are running which can be helpful during development. Outside of development, consider
+setting it to `'new'` which uses Chrome's [new headless mode][new-headless].
+{% endAside %}
 
 In a new file called `index.js`, add the following:
 
@@ -134,6 +141,7 @@ After mastering the basics, try building a test suite for your own extension. Th
 [puppeteer]: https://github.com/puppeteer/puppeteer
 [samples-repo]: https://github.com/GoogleChrome/chrome-extensions-samples
 [node]: https://nodejs.org/
+[new-headless]: https://developer.chrome.com/articles/new-headless/
 [mocha]: https://www.npmjs.com/package/mocha
 [assert]: https://www.npmjs.com/package/assert
 [full-project]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples/tutorial.puppeteer

--- a/site/en/docs/extensions/mv3/tut_puppeteer-testing/index.md
+++ b/site/en/docs/extensions/mv3/tut_puppeteer-testing/index.md
@@ -1,0 +1,141 @@
+---
+layout: "layouts/doc-post.njk"
+title: "Tutorial: Testing Chrome Extensions with Puppeteer"
+seoTitle: "Tutorial: Testing Chrome Extensions with Puppeteer"
+date: 2023-10-09
+description: How to write an automated test for Chrome Etensions in Puppeteer.
+---
+
+_For general advice on testing extensions, see
+[Automated testing for Chrome Extensions][automated-testing]._
+
+[Puppeteer][puppeteer] provides a framework for building automated tests of websites, which also
+includes the ability to test Chrome Extensions. These are high-level integration tests that test the
+functionality of a website or extension once it has been built into the final product.
+
+## Before you start
+
+Clone or download the [chrome-extensions-samples][samples-repo] repository. We'll use the history
+API demo in `api-samples/history/showHistory` as our test extension.
+
+You'll also need to install [Node.JS][node] which is the runtime Puppeteer is built on.
+
+## Writing your test
+
+### Step 1: Start your Node.JS project
+
+We need to set up a basic Node.JS project. In a new folder, create a `package.json` file with the
+following:
+
+```js
+{
+  "name": "puppeteer-demo",
+  "version": "1.0"
+}
+```
+
+Similar to an extension's manifest.json file, this file is required by all Node projects.
+
+### Step 2: Install Puppeteer
+
+Run `npm install puppeteer` to add Puppeteer as a dependency. It will be automatically added to your
+`package.json` file.
+
+### Step 3: Create an entry point
+
+In a new file called `index.js`, add the following:
+
+```js
+const puppeteer = require('puppeteer');
+
+const EXTENSION_PATH = '../../api-samples/history/showHistory';
+const EXTENSION_ID = 'jkomgjfbbjocikdmilgaehbfpllalmia';
+
+async function run() {
+  const browser = await puppeteer.launch({
+    headless: false,
+    args: [
+      `--disable-extensions-except=${EXTENSION_PATH}`,
+      `--load-extension=${EXTENSION_PATH}`
+    ]
+  });
+}
+
+run();
+```
+
+Run `node index.js` and you should see Chrome open with your extension loaded.
+
+### Step 4: Add an alias
+
+To make running the tests easier, add an alias to your `package.json` file:
+
+```js
+{
+  "name": "puppeteer-demo",
+  "version": "1.0",
+  "dependencies": {
+    "puppeteer": "^21.3.6"
+  },
+  "scripts": {
+    "start": "node index.js"
+  }
+}
+```
+
+You can now use `npm start` to run your test suite.
+
+### Step 6: Open the popup
+
+Let's open the popup in a new page. We need to do this because Puppeteer does not support accessing
+an extension popup from the popup window. Add the following code:
+
+```js
+const page = await browser.newPage();
+await page.goto(`chrome-extension://${EXTENSION_ID}/popup.html`);
+```
+
+The method `browser.newPage()` actually supports an optional URL parameter, but unfortunately this
+does not support URLs with the `chrome-extension://` scheme. Consequently, we first open a page and
+then call `page.goto()` to navigate.
+
+### Step 7: Assert the current state
+
+Let's assert something, so that our test can fail if the extension isn't behaving as expected. We
+know that our popup should show recently visited pages, so let's check that we see one:
+
+```js
+const list = await page.$('ul');
+const children = await list.$$('li');
+
+if (children.length !== 1) {
+  throw new Error('Unexpected number of list elements!');
+}
+```
+
+You may want to use an assertion library or test framework for simplifying code like this. Popular
+libraries include [assert][assert] and [mocha][mocha].
+
+### Step 8: Close the browser
+
+When you've finished testing, run the following to close the browser:
+
+```js
+await browser.close();
+```
+
+You can see the [full project][full-project] in our chrome-extensions-samples repository.
+
+## Next Steps
+
+After mastering the basics, try building a test suite for your own extension. The Puppeteer [API reference][api-reference] contains more information about what's possible - there are many capabilities not described here.
+
+[automated-testing]: /docs/extensions/mv3/automated-testing
+[puppeteer]: https://github.com/puppeteer/puppeteer
+[samples-repo]: https://github.com/GoogleChrome/chrome-extensions-samples
+[node]: https://nodejs.org/
+[mocha]: https://www.npmjs.com/package/mocha
+[assert]: https://www.npmjs.com/package/assert
+[full-project]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples/tutorial.puppeteer
+[api-reference]: https://pptr.dev/api
+[consistent-id]: /docs/extensions/mv3/automated-testing/#setting-an-extension-id

--- a/site/en/docs/extensions/mv3/unit-testing/index.md
+++ b/site/en/docs/extensions/mv3/unit-testing/index.md
@@ -1,0 +1,55 @@
+---
+layout: "layouts/doc-post.njk"
+title: "Unit testing Chrome Extensions"
+seoTitle: "Unit testing Chrome Extensions"
+date: 2023-10-09
+description: How to write unit tests for extensions.
+---
+
+[Unit testing][unit-testing] allows small sections of code to be tested in isolation from the rest
+of your extension, and outside of the browser. For example, you could write a unit test to ensure
+that a helper method correctly writes a value to storage when called.
+
+Code written without using extension APIs can be tested as normal, using a framework such as
+[Jest][jest]. To make code easier to test this way, consider using techniques such as
+[dependency injection][dependency-injection] which can help to remove dependencies on the chrome
+namespace in your lower level implementation.
+
+If you need to test code which includes extension APIs, consider using mocks.
+
+## Example: Using mocks with Jest
+
+Create a `jest.config.js` file, which declares a setup file that will run before all tests:
+
+```js
+module.exports = {
+  setupFiles: ['<rootDir>/mock-extension-apis.js']
+};
+```
+
+In `mock-extension-apis.js`, add implementations for the specific functions you expect to call:
+
+```js
+global.chrome = {
+  tabs: {
+    query: async () => { throw new Error("Unimplemented.") };
+  }
+};
+```
+
+Then, use `jest.spy` to mock a return value in a test:
+
+```js
+test("getActiveTabId returns active tab ID", async () => {
+  jest.spyOn(chrome.tabs, "query").mockResolvedValue([{
+    id: 3,
+    active: true,
+    currentWindow: true
+  }]);
+  expect(await getActiveTabId()).toBe(3);
+});
+```
+
+[unit-testing]: https://wikipedia.org/wiki/Unit_testing
+[jest]: https://jestjs.io/
+[dependency-injection]: https://wikipedia.org/wiki/Dependency_injection

--- a/site/en/docs/extensions/mv3/unit-testing/index.md
+++ b/site/en/docs/extensions/mv3/unit-testing/index.md
@@ -2,7 +2,7 @@
 layout: "layouts/doc-post.njk"
 title: "Unit testing Chrome Extensions"
 seoTitle: "Unit testing Chrome Extensions"
-date: 2023-10-09
+date: 2023-10-12
 description: How to write unit tests for extensions.
 ---
 

--- a/site/en/docs/extensions/mv3/unit-testing/index.md
+++ b/site/en/docs/extensions/mv3/unit-testing/index.md
@@ -54,6 +54,13 @@ test("getActiveTabId returns active tab ID", async () => {
 });
 ```
 
+## Next steps {: #continue }
+
+To ensure your extension functions as expected, we recommend adding [end-to-end tests][end-to-end]. See [Testing Chrome Extensions with Puppeteer][pupeteer-tutorial] for a complete tutorial.
+
 [unit-testing]: https://wikipedia.org/wiki/Unit_testing
 [jest]: https://jestjs.io/
 [dependency-injection]: https://wikipedia.org/wiki/Dependency_injection
+[pupeteer-tutorial]: /docs/extensions/mv3/tut_puppeteer-testing/
+[end-to-end]: /docs/extensions/mv3/end-to-end-testing/
+

--- a/site/en/docs/extensions/mv3/unit-testing/index.md
+++ b/site/en/docs/extensions/mv3/unit-testing/index.md
@@ -8,7 +8,7 @@ description: How to write unit tests for extensions.
 
 [Unit testing][unit-testing] allows small sections of code to be tested in isolation from the rest
 of your extension, and outside of the browser. For example, you could write a unit test to ensure
-that a helper method correctly writes a value to storage when called.
+that a helper method correctly writes a value to storage.
 
 Code written without using extension APIs can be tested as normal, using a framework such as
 [Jest][jest]. To make code easier to test this way, consider using techniques such as
@@ -17,9 +17,11 @@ namespace in your lower level implementation.
 
 If you need to test code which includes extension APIs, consider using mocks.
 
-## Example: Using mocks with Jest
+## Example: Using mocks with Jest {: #using-mocks }
 
 Create a `jest.config.js` file, which declares a setup file that will run before all tests:
+
+{% Label %}jest.config.js:{% endLabel %}
 
 ```js
 module.exports = {
@@ -28,6 +30,8 @@ module.exports = {
 ```
 
 In `mock-extension-apis.js`, add implementations for the specific functions you expect to call:
+
+{% Label %}mock-extension-apis.js:{% endLabel %}
 
 ```js
 global.chrome = {


### PR DESCRIPTION
Adds two new pages:

- High-level documentation on how to test Chrome Extensions with a variety of libraries
- A tutorial on how to test an extension in Puppeteer

Related sample: https://github.com/GoogleChrome/chrome-extensions-samples/pull/1016

Fixes https://github.com/GoogleChromeLabs/Extension-Docs/issues/42