### PR TITLE
Add isUrlFilterCaseSensitive change to What's New

### DIFF
--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -15,6 +15,20 @@ tags:
 
 Check this page often to learn about changes to Chrome extensions, extensions documentation, or related policy or other changes. You'll find other notices posted on the [Extensions Google Group](https://groups.google.com/a/chromium.org/g/chromium-extensions). The [Extensions News](/tags/extensions-news/) tag lists articles about some of the topics listed here. (It even has [an RSS feed](/feeds/extensions-news.xml).) The [Chrome schedule](https://chromiumdash.appspot.com/schedule) lists stable and beta release dates.
 
+### Chrome 118: isUrlFilterCaseSensitive now defaults to false {: #118-url-filter-case-sensitive }
+
+<p class="color-secondary-text type--caption">Posted on <time>October 10, 2023</time></p>
+
+Starting in Chrome 118, the [isUrlFilterCaseSensitive](/docs/extensions/reference/declarativeNetRequest/#property-RuleCondition-isUrlFilterCaseSensitive)
+property in the [chrome.declarativeNetRequest](/docs/extensions/reference/declarativeNetRequest/)
+API has been changed to default to false.
+
+This follows [discussions](https://github.com/w3c/webextensions/issues/269) in the Web Extensions
+Community Group and a similar change already implemented by Firefox and Safari.
+
+If you wish to keep the old behavior, you can explicitly set isUrlFilterCaseSensitive to true in
+your declarativeNetRequest rules.
+
 ### Extension samples now searchable {: #extension-samples-searchable }
 
 <p class="color-secondary-text type--caption">Posted on <time>September 29, 2023</time></p>

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -19,15 +19,13 @@ Check this page often to learn about changes to Chrome extensions, extensions do
 
 <p class="color-secondary-text type--caption">Posted on <time>October 10, 2023</time></p>
 
-Starting in Chrome 118, the [isUrlFilterCaseSensitive](/docs/extensions/reference/declarativeNetRequest/#property-RuleCondition-isUrlFilterCaseSensitive)
+Starting in Chrome 118, the [`isUrlFilterCaseSensitive`](/docs/extensions/reference/declarativeNetRequest/#property-RuleCondition-isUrlFilterCaseSensitive)
 property in the [chrome.declarativeNetRequest](/docs/extensions/reference/declarativeNetRequest/)
-API has been changed to default to false.
+API has been changed to default to `false`. If you wish to keep the old behavior, you can explicitly set `isUrlFilterCaseSensitive` to `true` in
+your declarativeNetRequest rules.
 
 This follows [discussions](https://github.com/w3c/webextensions/issues/269) in the Web Extensions
-Community Group and a similar change already implemented by Firefox and Safari.
-
-If you wish to keep the old behavior, you can explicitly set isUrlFilterCaseSensitive to true in
-your declarativeNetRequest rules.
+Community Group. Firefox and Safari have already implemented a similar change.
 
 ### Extension samples now searchable {: #extension-samples-searchable }
 

--- a/site/en/docs/extensions/whatsnew/index.md
+++ b/site/en/docs/extensions/whatsnew/index.md
@@ -17,7 +17,7 @@ Check this page often to learn about changes to Chrome extensions, extensions do
 
 ### Chrome 118: isUrlFilterCaseSensitive now defaults to false {: #118-url-filter-case-sensitive }
 
-<p class="color-secondary-text type--caption">Posted on <time>October 10, 2023</time></p>
+<p class="color-secondary-text type--caption">Posted on <time>October 11, 2023</time></p>
 
 Starting in Chrome 118, the [`isUrlFilterCaseSensitive`](/docs/extensions/reference/declarativeNetRequest/#property-RuleCondition-isUrlFilterCaseSensitive)
 property in the [chrome.declarativeNetRequest](/docs/extensions/reference/declarativeNetRequest/)


### PR DESCRIPTION
Adds the change to the default isUrlFilterCaseSensitive value to What's New.

Fixes https://github.com/GoogleChromeLabs/Extension-Docs/issues/137