### PR TITLE
Replace irrelevant :scope documentation link in New in Chrome 118

### DIFF
--- a/site/en/blog/new-in-chrome-118/index.md
+++ b/site/en/blog/new-in-chrome-118/index.md
@@ -159,7 +159,7 @@ Like in the following example, we could apply style to the text and exclude cont
 }
 ```
 
-Checkout the [`@scope` documentation](https://developer.mozilla.org/docs/Web/CSS/:scope) for more information.
+Checkout the article [Limit the reach of your selectors with the CSS @scope at-rule](/articles/at-scope/) for more information.
 
 ## `scripting` and `prefers-reduced-transparency` media features {: #new-media-queries }
 


### PR DESCRIPTION
Changes proposed in this pull request:

- https://developer.mozilla.org/docs/Web/CSS/:scope has nothing to do with `@scope`. Currently `@scope` is not documented on MDN https://github.com/mdn/content/issues/17751, so I've replaced it with a link to this article https://developer.chrome.com/articles/at-scope/. 