### PR TITLE
Move permissions policy to articles

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -779,6 +779,9 @@ redirects:
 - from: docs/extensions/mv3/single_purpose/
   to: docs/extensions/mv3/quality_guidelines/
 
+- from: /docs/privacy-sandbox/permissions-policy/
+  to: /articles/permissions-policy/
+
 # DO NOT REMOVE. This seems pointless but we rewrite "." to "_" inside our server's code, so if the
 # URL is fine for all but incorrect syntax, we'll fix it up.
 - from: /...

--- a/site/_data/docs/privacy-sandbox/toc.yml
+++ b/site/_data/docs/privacy-sandbox/toc.yml
@@ -41,9 +41,6 @@
         - url: /docs/privacy-sandbox/fedcm-developer-guide
         - url: /docs/privacy-sandbox/fedcm-updates
     - title: i18n.docs.privacy-sandbox.control-browser-features
-      sections:
-        - url: /docs/privacy-sandbox/permissions-policy
-          title: i18n.docs.privacy-sandbox.permissions-policy
     - url: /docs/privacy-sandbox/shared-storage
     - url: https://goo.gle/shared-storage-walkthrough
       title: i18n.docs.privacy-sandbox.shared-storage-walkthrough

--- a/site/en/articles/permissions-policy/index.md
+++ b/site/en/articles/permissions-policy/index.md
@@ -8,6 +8,9 @@ description: >
 date: 2022-04-20
 authors:
   - kevinkiklee
+tags:
+  - monitoring
+  - security
 ---
 
 Permissions Policy, formerly known as Feature Policy, allows the developer to


### PR DESCRIPTION
Permissions policy is a general web platform feature and should exist under /articles instead of in Privacy Sandbox docs.

Preview: https://pr-7523-static-dot-dcc-staging.uc.r.appspot.com/articles/permissions-policy/