### PR TITLE
Update where available section of PS overview

### DIFF
--- a/site/en/docs/privacy-sandbox/overview/index.md
+++ b/site/en/docs/privacy-sandbox/overview/index.md
@@ -163,7 +163,7 @@ Chrome on MacOS supports the Privacy Sandbox APIs, but Safari on MacOS (which us
 
 [WebView](https://developer.android.com/reference/android/webkit/WebView) allows you to display web content in an app, but lacks some of the features of 
 fully developed browsers. We do not currently include WebView at this stage of third-party 
-cookie deprecation or Privacy Sandbox API rollout and testing, beyond enabling Cross App and Web Attribution Measurement (more on [measurement with WebView](https://developer.android.com/design-for-safety/privacy-sandbox/attribution-app-to-web#register-attribution)). Third-party cookies have been off by default in WebView since Android 5 - Lollipop, but in practice many apps enable them for web content. If we do make announcements in the future, these will be communicated through both Android and Chrome channels.
+cookie deprecation or Privacy Sandbox API rollout and testing, beyond enabling Cross App and Web Attribution Measurement (more on [measurement with WebView](https://developer.android.com/design-for-safety/privacy-sandbox/attribution-app-to-web#register-attribution)). Third-party cookies have been off by default in WebView since Android 5 - Lollipop, but in practice many apps enable them for web content. If we do make announcements in the future, these will be communicated through both Android and Chrome channels. For individual APIs and features, support in WebView will be shown on the feature's Chrome Status entry.
 
 ### Custom Tabs
 

--- a/site/en/docs/privacy-sandbox/overview/index.md
+++ b/site/en/docs/privacy-sandbox/overview/index.md
@@ -162,7 +162,7 @@ Chrome on MacOS supports the Privacy Sandbox APIs, but Safari on MacOS (which us
 ### Android WebView
 
 [WebView](https://developer.android.com/reference/android/webkit/WebView) allows you to display web content in an app, but lacks some of the features of 
-fully developed browsers. We do not currently include WebView at this stage of third-party 
+fully developed browsers. We don't currently include WebView at this stage of third-party 
 cookie deprecation or Privacy Sandbox API rollout and testing, beyond enabling [Cross App and Web Attribution Measurement](https://github.com/WICG/attribution-reporting-api/blob/main/app_to_web.md) (more on [measurement with WebView](https://developer.android.com/design-for-safety/privacy-sandbox/attribution-app-to-web#register-attribution)). Third-party cookies have been off by default in WebView since Android 5 - Lollipop, but in practice many apps enable them for web content. If we do make announcements in the future, these will be communicated through both Android and Chrome channels. For individual APIs and features, support in WebView will be shown on the feature's Chrome Status entry.
 
 ### Custom Tabs

--- a/site/en/docs/privacy-sandbox/overview/index.md
+++ b/site/en/docs/privacy-sandbox/overview/index.md
@@ -163,7 +163,7 @@ Chrome on MacOS supports the Privacy Sandbox APIs, but Safari on MacOS (which us
 
 [WebView](https://developer.android.com/reference/android/webkit/WebView) allows you to display web content in an app, but lacks some of the features of 
 fully developed browsers. We do not currently include WebView at this stage of third-party 
-cookie deprecation or Privacy Sandbox API rollout and testing, beyond enabling Cross App and Web Attribution Measurement (more on [measurement with WebView](https://developer.android.com/design-for-safety/privacy-sandbox/attribution-app-to-web#register-attribution)). Third-party cookies have been off by default in WebView since Android 5 - Lollipop, but in practice many apps enable them for web content. If we do make announcements in the future, these will be communicated through both Android and Chrome channels. For individual APIs and features, support in WebView will be shown on the feature's Chrome Status entry.
+cookie deprecation or Privacy Sandbox API rollout and testing, beyond enabling [Cross App and Web Attribution Measurement](https://github.com/WICG/attribution-reporting-api/blob/main/app_to_web.md) (more on [measurement with WebView](https://developer.android.com/design-for-safety/privacy-sandbox/attribution-app-to-web#register-attribution)). Third-party cookies have been off by default in WebView since Android 5 - Lollipop, but in practice many apps enable them for web content. If we do make announcements in the future, these will be communicated through both Android and Chrome channels. For individual APIs and features, support in WebView will be shown on the feature's Chrome Status entry.
 
 ### Custom Tabs
 

--- a/site/en/docs/privacy-sandbox/overview/index.md
+++ b/site/en/docs/privacy-sandbox/overview/index.md
@@ -163,8 +163,7 @@ Chrome on MacOS supports the Privacy Sandbox APIs, but Safari on MacOS (which us
 
 [WebView](https://developer.android.com/reference/android/webkit/WebView) allows you to display web content in an app, but lacks some of the features of 
 fully developed browsers. We do not currently include WebView at this stage of third-party 
-cookie deprecation or Privacy Sandbox API rollout and testing, beyond enabling Cross App and Web Attribution Measurement. (Third-party cookies have been off by 
-default in WebView since Android 5 - Lollipop, but in practice many apps enable them for web content.) If we do make announcements in the future, these will be communicated through both Android and Chrome channels.
+cookie deprecation or Privacy Sandbox API rollout and testing, beyond enabling Cross App and Web Attribution Measurement (more on [measurement with WebView](https://developer.android.com/design-for-safety/privacy-sandbox/attribution-app-to-web#register-attribution)). Third-party cookies have been off by default in WebView since Android 5 - Lollipop, but in practice many apps enable them for web content. If we do make announcements in the future, these will be communicated through both Android and Chrome channels.
 
 ### Custom Tabs
 

--- a/site/en/docs/privacy-sandbox/overview/index.md
+++ b/site/en/docs/privacy-sandbox/overview/index.md
@@ -145,7 +145,7 @@ as well as [CHIPS](/docs/privacy-sandbox/chips/) and
 are now available for all users for all Chrome channels on Android and desktop. As with all technologies, use feature detection to check for support and availability before accessing a Privacy Sandbox feature.
 
 [Chrome Platform Status](chromestatus.com) details browser and implementation status on desktop, Android, iOS, and Android WebView, for individual APIs:
-* [All features](https://chromestatus.com/features) provide shipping  milestones, standardization signals, relevant [Blink](https://www.youtube.com/watch?v=CVRLeOX-TGI) 
+* [All features](https://chromestatus.com/features) provides shipping  milestones, standardization signals, relevant [Blink](https://www.youtube.com/watch?v=CVRLeOX-TGI) 
   components, and other information for an individual feature. You can star a feature to be notified of  updates,  and view your starred features from [My features](https://chromestatus.com/myfeatures).
 * [HTML & JavaScript usage metrics](https://chromestatus.com/metrics/feature/popularity) 
 shows the percentage of page loads in Chrome that use a feature across all channels and 

--- a/site/en/docs/privacy-sandbox/overview/index.md
+++ b/site/en/docs/privacy-sandbox/overview/index.md
@@ -145,7 +145,7 @@ as well as [CHIPS](/docs/privacy-sandbox/chips/) and
 are now available for all users for all Chrome channels on Android and desktop. As with all technologies, use feature detection to check for support and availability before accessing a Privacy Sandbox feature.
 
 [Chrome Platform Status](chromestatus.com) details browser and implementation status on desktop, Android, iOS, and Android WebView, for individual APIs:
-* [All features](https://chromestatus.com/features) provides shipping  milestones, standardization signals, relevant [Blink](https://www.youtube.com/watch?v=CVRLeOX-TGI) 
+* [All features](https://chromestatus.com/features) provide shipping  milestones, standardization signals, relevant [Blink](https://www.youtube.com/watch?v=CVRLeOX-TGI) 
   components, and other information for an individual feature. You can star a feature to be notified of  updates,  and view your starred features from [My features](https://chromestatus.com/myfeatures).
 * [HTML & JavaScript usage metrics](https://chromestatus.com/metrics/feature/popularity) 
 shows the percentage of page loads in Chrome that use a feature across all channels and 

--- a/site/en/docs/privacy-sandbox/overview/index.md
+++ b/site/en/docs/privacy-sandbox/overview/index.md
@@ -145,7 +145,7 @@ as well as [CHIPS](/docs/privacy-sandbox/chips/) and
 are now available for all users for all Chrome channels on Android and desktop. As with all technologies, use feature detection to check for support and availability before accessing a Privacy Sandbox feature.
 
 [Chrome Platform Status](chromestatus.com) details browser and implementation status on desktop, Android, iOS, and Android WebView, for individual APIs:
-* [All features](https://chromestatus.com/features) provides shipping  milestones, standardization signals, relevant [Blink](https://www.youtube.com/watch?v=CVRLeOX-TGI) 
+* The [All features](https://chromestatus.com/features) section of the Chrome status page provides shipping  milestones, standardization signals, relevant [Blink](https://www.youtube.com/watch?v=CVRLeOX-TGI) 
   components, and other information for an individual feature. You can star a feature to be notified of  updates,  and view your starred features from [My features](https://chromestatus.com/myfeatures).
 * [HTML & JavaScript usage metrics](https://chromestatus.com/metrics/feature/popularity) 
 shows the percentage of page loads in Chrome that use a feature across all channels and 

--- a/site/en/docs/privacy-sandbox/overview/index.md
+++ b/site/en/docs/privacy-sandbox/overview/index.md
@@ -6,7 +6,7 @@ subhead: >
   third-party cookies or other tracking mechanisms.
 description: "What's in it, what's it for, and how to get involved."
 date: 2021-05-18
-updated: 2023-09-18
+updated: 2023-10-11
 authors:
   - samdutton
   - alexandrawhite
@@ -133,18 +133,43 @@ the [Privacy Community Group](https://www.w3.org/community/privacycg/participant
 
 ## Where are the Privacy Sandbox APIs available?
 
-Five API implementations are currently available for testing in Chrome.
+Privacy Sandbox APIs are implemented in [Chromium](https://wikipedia.org/wiki/Chromium_(web_browser)),
+which is the open-source browser used to make Chrome. Code for the Privacy Sandbox APIs 
+can be accessed with [Chromium Code Search](https://source.chromium.org/search). You can 
+[download Chromium](http://chromium.org/getting-involved/download-chromium), then 
+[run it with flags](https://www.chromium.org/developers/how-tos/run-chromium-with-flags) to allow access to APIs that are in the process of implementation.
 
-The APIs are implemented in
-[Chromium](https://en.wikipedia.org/wiki/Chromium_(web_browser)), which
-is the open-source browser used to make Chrome. Code for the Privacy Sandbox
-APIs can be accessed via
-[Chromium Code Search](https://source.chromium.org/search?q=floc).
+Privacy Sandbox technologies, including [relevance and measurement APIs](/blog/shipping-privacy-sandbox/#whats-shipping) 
+as well as [CHIPS](/docs/privacy-sandbox/chips/) and 
+[Related Website Sets](/docs/privacy-sandbox/related-website-sets/), 
+are now available for all users for all Chrome channels on Android and desktop. As with all technologies, use feature detection to check for support and availability before accessing a Privacy Sandbox feature.
 
-You can
-[download Chromium](http://chromium.org/getting-involved/download-chromium),
-then [run it with flags](https://www.chromium.org/developers/how-tos/run-chromium-with-flags)
-to allow access to APIs that are in the process of implementation.
+[Chrome Platform Status](chromestatus.com) details browser and implementation status on desktop, Android, iOS, and Android WebView, for individual APIs:
+* [All features](https://chromestatus.com/features) provides shipping  milestones, standardization signals, relevant [Blink](https://www.youtube.com/watch?v=CVRLeOX-TGI) 
+  components, and other information for an individual feature. You can star a feature to be notified of  updates,  and view your starred features from [My features](https://chromestatus.com/myfeatures).
+* [HTML & JavaScript usage metrics](https://chromestatus.com/metrics/feature/popularity) 
+shows the percentage of page loads in Chrome that use a feature across all channels and 
+platforms. Note: this reflects how often the API is being called from pages, not how many users 
+have a feature enabled on their browser.
+
+Chrome Status metrics charts for Privacy Sandbox ads APIs are collated on [pscs.glitch.me](https://pscs.glitch.me).
+
+### MacOS, iOS and iPadOS
+Chrome on MacOS supports the Privacy Sandbox APIs, but Safari on MacOS (which uses WebKit) does not.
+
+[Apple's App Store rules](https://developer.apple.com/app-store/review/guidelines/#:~:text=2.5.6) mean that Chrome and other browsers on iOS and iPadOS must use the WebKit browser engine, which does not support the Privacy Sandbox APIs. 
+
+### Android WebView
+
+[WebView](https://developer.android.com/reference/android/webkit/WebView) allows you to display web content in an app, but lacks some of the features of 
+fully developed browsers. We do not currently include WebView at this stage of third-party 
+cookie deprecation or Privacy Sandbox API rollout and testing, beyond enabling Cross App and Web Attribution Measurement. (Third-party cookies have been off by 
+default in WebView since Android 5 - Lollipop, but in practice many apps enable them for web content.) If we do make announcements in the future, these will be communicated through both Android and Chrome channels.
+
+### Custom Tabs
+
+[Custom Tabs](/docs/android/custom-tabs/) allow a customized 
+browser experience directly within an Android app. Custom Tabs support all the Privacy Sandbox APIs.
 
 ## When will the APIs be implemented?
 

--- a/site/en/docs/privacy-sandbox/overview/index.md
+++ b/site/en/docs/privacy-sandbox/overview/index.md
@@ -149,7 +149,7 @@ are now available for all users for all Chrome channels on Android and desktop. 
   components, and other information for an individual feature. You can star a feature to be notified of  updates,  and view your starred features from [My features](https://chromestatus.com/myfeatures).
 * [HTML & JavaScript usage metrics](https://chromestatus.com/metrics/feature/popularity) 
 shows the percentage of page loads in Chrome that use a feature across all channels and 
-platforms. Note: this reflects how often the API is being called from pages, not how many users 
+platforms. Note that this reflects how often the API is being called from pages, not how many users 
 have a feature enabled on their browser.
 
 Chrome Status metrics charts for Privacy Sandbox ads APIs are collated on [pscs.glitch.me](https://pscs.glitch.me).


### PR DESCRIPTION
Fixes b/303843333

Changes proposed in this pull request:

- Update where available section of PS overview
- https://pr-7525-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/overview/
-