### PR TITLE
Fix typo `function` is `func`

### DIFF
--- a/site/en/docs/extensions/mv3/manifest/activeTab/index.md
+++ b/site/en/docs/extensions/mv3/manifest/activeTab/index.md
@@ -66,7 +66,7 @@ chrome.action.onClicked.addListener((tab) => {
   if (!tab.url.includes('chrome://')) {
     chrome.scripting.executeScript({
       target: { tabId: tab.id },
-      function: reddenPage
+      func: reddenPage
     });
   }
 });


### PR DESCRIPTION
Changes proposed in this pull request:

- Fix typo `function` is `func`

It can be found from the [chrome extension documentation](https://developer.chrome.com/docs/extensions/reference/scripting/#:~:text=to%20ISOLATED.-,func,-void%C2%A0optional) that there is no parameter named `function`, and the correct parameter is `func`.

![Snipaste_2023-10-13_14-22-18](https://github.com/GoogleChrome/developer.chrome.com/assets/104723527/cfea6a0a-6fc7-4cf1-ac59-031b268abcf4)
![Snipaste_2023-10-13_14-26-07](https://github.com/GoogleChrome/developer.chrome.com/assets/104723527/a96f2dea-093c-41e3-85c7-ee619c1b0938)
