### PR TITLE
Fix alignment of search icons on extension samples and fugu pages

### DIFF
--- a/site/_scss/blocks/_fugu-showcase.scss
+++ b/site/_scss/blocks/_fugu-showcase.scss
@@ -17,6 +17,10 @@
     }
   }
 
+  .search-box__btn {
+    display: flex;
+  }
+
   .search-box__btn--close {
     justify-self: end;
   }

--- a/site/_scss/layouts/extension-samples.scss
+++ b/site/_scss/layouts/extension-samples.scss
@@ -67,6 +67,10 @@
     }
   }
 
+  .search-box__btn {
+    display: flex;
+  }
+
   .search-box__btn--close {
     justify-self: end;
 


### PR DESCRIPTION
There was a small regression in the alignment of search and clear icons on the extension samples and fugu showcases pages following the work in https://github.com/GoogleChrome/developer.chrome.com/commit/62e3ff47b1780d0c3d279f4e0240e3e8f1b2a7a3.

I've put a quick fix here - it's probably not the best long term fix, but seems like a reasonable option to avoid spending too much time on this right now (and I don't think it adds any significant tech debt).

<img width="300" alt="Screenshot 2023-10-13 at 12 06 38" src="https://github.com/GoogleChrome/developer.chrome.com/assets/6097064/f57f4a3c-82d3-4142-8b2a-45498ded0932">

Fixes #7302