### PR TITLE
Update a blog post to match the release version date

### DIFF
--- a/site/en/blog/migrate-way-from-data-urls-in-svg-use/index.md
+++ b/site/en/blog/migrate-way-from-data-urls-in-svg-use/index.md
@@ -12,7 +12,7 @@ tags:
 
 {% Aside %}
 We expect to [remove support for `data:` URLs in SVG `<use>` element](https://chromestatus.com/feature/5128825141198848)
-in Chrome 119, scheduled to ship in November 2023.
+in Chrome 120, scheduled to ship in December 2023.
 {% endAside %}
 
 The SVG spec was [recently updated](https://github.com/w3c/svgwg/pull/901) to remove support for `data:` URLs in SVG `<use>` element.


### PR DESCRIPTION
Changes proposed in this pull request:

- Update the release version and date for the [deprecation of data: URLs in SVGUseElement](https://chromestatus.com/feature/5128825141198848).