### PR TITLE
Add requires policy tag

### DIFF
--- a/external/build/lib/dts-parse.js
+++ b/external/build/lib/dts-parse.js
@@ -767,6 +767,10 @@ class Transform {
             chromeOsOnly = false;
           }
           break;
+        case 'chrome-install-location':
+          if (text === 'policy') {
+            out.requiresPolicyInstall = true;
+          }
       }
     });
 

--- a/site/_includes/macros/render-type.njk
+++ b/site/_includes/macros/render-type.njk
@@ -508,6 +508,12 @@
       </span>
     {% endif %}
 
+    {% if feature.requiresPolicyInstall %}
+      <span class="aside--important tag-pill type--label rounded-lg" title="Only available to policy installed extensions">
+        Requires policy
+      </span>
+    {% endif %}
+
     {% if feature.deprecated %}
       <span class="aside--warning tag-pill type--label rounded-lg">
         Deprecated

--- a/types/site/_data/types.d.ts
+++ b/types/site/_data/types.d.ts
@@ -48,6 +48,7 @@ declare global {
     permissions?: string[];
     manifestKeys?: string[];
     chromeOsOnly?: true;
+    requiresPolicyInstall?: true;
   }
 
   /**


### PR DESCRIPTION
Adds a new tag which shows when an API is only available to policy installed extensions.

Matching chrome-types PR: https://github.com/GoogleChrome/chrome-types/pull/59