### PR TITLE
chore(footer): fix broken case studies and podcasts links

### DIFF
--- a/site/_includes/partials/footer.njk
+++ b/site/_includes/partials/footer.njk
@@ -45,12 +45,12 @@
             </a>
           </li>
           <li>
-            <a class="footer__link" href="https://web.dev/tags/case-study/">
+            <a class="footer__link" href="https://web.dev/case-studies">
               {{ 'i18n.footer.case_studies' | i18n(locale) }}
             </a>
           </li>
           <li>
-            <a class="footer__link" href="https://web.dev/podcasts/">
+            <a class="footer__link" href="https://web.dev/shows">
               {{ 'i18n.footer.podcasts' | i18n(locale) }}
             </a>
           </li>


### PR DESCRIPTION
Fixes #7574

Changes proposed in this pull request:

- Updated broken links in the site footer:

| Link | :x: | ✔️ |
|------|---|-----|
| Case Studies | https://web.dev/tags/case-study/ | https://web.dev/case-studies |
| Podcasts | https://web.dev/podcasts/ | https://web.dev/shows |

Note: The "Shows" menu includes podcasts and literal "shows"/videos. It may make sense to rename the link in the footer to "Shows" later on.