### PR TITLE
Remove colon from JSON keys

### DIFF
--- a/site/en/docs/webstore/publish/index.md
+++ b/site/en/docs/webstore/publish/index.md
@@ -36,10 +36,10 @@ We'll go into detail about each step below.
 To upload your item, you need to create a ZIP file that contains the
 manifest file located in the **root directory** and the files for your extension. The manifest file must specify at least the following fields:
 
-- `"name":`—This [name][name] appears in the Chrome Web Store and in the Chrome browser
-- `"version":`—The [version][version] of the metadata, incremented
-- `"icons":`—An array specifying the [icons][icons] your item uses
-- `"description":`—A string of no more than 132 characters [describing][description] your extension
+- `"name"`—This [name][name] appears in the Chrome Web Store and in the Chrome browser
+- `"version"`—The [version][version] of the metadata, incremented
+- `"icons"`—An array specifying the [icons][icons] your item uses
+- `"description"`—A string of no more than 132 characters [describing][description] your extension
 
 Your zip file may also include other images and any files that the item requires. The contents of
 the ZIP file and manifest depend on the specifics of your item.


### PR DESCRIPTION
We don't do this anywhere else. Frankly, I think we shouldn't since the colon only seems relevant in discussions of syntax, which this is not.

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

-
-
-