### PR TITLE
Add Reading List API reference

### DIFF
--- a/site/en/docs/extensions/mv3/permission_warnings/index.md
+++ b/site/en/docs/extensions/mv3/permission_warnings/index.md
@@ -362,6 +362,11 @@ the steps in [Viewing Warnings](#view_warnings).
       <td>Grants access to the <a href="/docs/extensions/reference/proxy">chrome.proxy</a> API.</td>
       <td><strong>Read and change all your data on all websites</strong></td>
     </tr>
+    <tr id="readingList">
+      <td><code>"readingList"</code></td>
+      <td>Grants access to the <a href="/docs/extensions/reference/readingList">chrome.readingList</a> API.</td>
+      <td><strong>Read and change entries in the reading list</strong></td>
+    </tr>
     <tr id="sessionshistory">
       <td><code>"sessions"</code> and <code>"history"</code></td>
       <td>Grants the extension access to the <a href="/docs/extensions/reference/sessions">chrome.sessions</a> API and <a href="/docs/extensions/reference/history">chrome.history</a> API.</td>

--- a/site/en/docs/extensions/reference/readingList/index.md
+++ b/site/en/docs/extensions/reference/readingList/index.md
@@ -1,0 +1,103 @@
+---
+api: readingList
+has_warning: This permission <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">triggers a warning</a>.
+---
+
+Chrome features a reading list which allows users to save web pages to read later or when offline.
+Use the Reading List API to retrieve existing items and to add and remove items from the list.
+
+<figure>
+  {% Img src="image/wVNVUJS8Z8O04i1tJKSdsp6nkRQ2/isx7uJZA6B8YmEGTFmB6.png", alt="Reading list showing a number of articles", width="400", height="371" %}
+  <figcaption>
+    Reading list showing a number of articles
+  </figcaption>
+</figure>
+
+## Manifest {: #manifest }
+
+To use the Reading List API, add the `"readingList"` permission in the extension [manifest][doc-manifest] file:
+
+{% Label %}manifest.json:{% endLabel %}
+
+```json
+{
+  "name": "My reading list extension",
+  ...
+  "permissions": [
+    "readingList"
+  ]
+}
+```
+
+## Concepts and usage {: #concepts }
+
+### Item ordering
+
+Items in the reading list are not in any guarenteed order.
+
+### Item uniqueness
+
+Items are keyed by URL. This includes the hash and query string.
+
+## Use cases {: #use-cases }
+
+The following sections demonstrate some common use cases for the Reading List API. See [Extension samples](#examples) for complete extension examples.
+
+### Add an item {: #add-item }
+
+To add an item to the reading list, use [`chrome.readingList.addEntry`][add-entry]:
+
+```js
+chrome.readingList.addEntry({
+  title: "New to the web platform in September | web.dev",
+  url: "https://developer.chrome.com/",
+  hasBeenRead: false
+});
+```
+
+### Display items {: #display-items }
+
+To display items currently in the reading list, use the [`chrome.readingList.query()`][query]
+method.
+
+```js
+const items = await chrome.readingList.query({});
+
+for (const item of items) {
+  // Do something do display the item
+}
+```
+
+### Mark an item as read {: #mark-item-read }
+
+To mark an item as read, use [`chrome.readingList.updateEntry`][update-entry]:
+
+```js
+chrome.readingList.updateEntry({
+  url: "https://developer.chrome.com/",
+  hasBeenRead: true
+});
+```
+
+### Remove an item {: #remove-item }
+
+To remove an item, use [`chrome.readingList.removeEntry`][remove-entry]:
+
+```js
+chrome.readingList.removeEntry({
+  url: "https://developer.chrome.com/",
+  hasBeenRead: true
+});
+```
+
+## Extension samples {: #examples }
+
+For more Reading List API extensions demos, explore any of the following extensions:
+
+- Coming soon.
+
+[doc-manifest]: /docs/extensions/mv3/manifest/
+[query]: #method-query
+[add-entry]: #method-addEntry
+[update-entry]: #method-updateEntry
+[remove-entry]: #method-removeEntry

--- a/site/en/docs/extensions/reference/readingList/index.md
+++ b/site/en/docs/extensions/reference/readingList/index.md
@@ -3,6 +3,10 @@ api: readingList
 has_warning: This permission <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">triggers a warning</a>.
 ---
 
+{% Aside 'note' %}
+This API is currently available in Chrome 120 [beta][beta].
+{% endAside %}
+
 Chrome features a reading list located on the side panel. It lets users save web pages to read later or when offline.
 Use the Reading List API to retrieve existing items and add or remove items from the list.
 
@@ -99,3 +103,4 @@ For more Reading List API extensions demos, see the [Reading List API sample][sa
 [update-entry]: #method-updateEntry
 [remove-entry]: #method-removeEntry
 [sample]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/readingList
+[beta]: https://www.google.com/chrome/beta/

--- a/site/en/docs/extensions/reference/readingList/index.md
+++ b/site/en/docs/extensions/reference/readingList/index.md
@@ -85,8 +85,7 @@ To remove an item, use [`chrome.readingList.removeEntry`][remove-entry]:
 
 ```js
 chrome.readingList.removeEntry({
-  url: "https://developer.chrome.com/",
-  hasBeenRead: true
+  url: "https://developer.chrome.com/"
 });
 ```
 

--- a/site/en/docs/extensions/reference/readingList/index.md
+++ b/site/en/docs/extensions/reference/readingList/index.md
@@ -3,8 +3,8 @@ api: readingList
 has_warning: This permission <a href="/docs/extensions/mv3/permission_warnings/#permissions_with_warnings">triggers a warning</a>.
 ---
 
-Chrome features a reading list which allows users to save web pages to read later or when offline.
-Use the Reading List API to retrieve existing items and to add and remove items from the list.
+Chrome features a reading list located on the side panel. It lets users save web pages to read later or when offline.
+Use the Reading List API to retrieve existing items and add or remove items from the list.
 
 <figure>
   {% Img src="image/wVNVUJS8Z8O04i1tJKSdsp6nkRQ2/isx7uJZA6B8YmEGTFmB6.png", alt="Reading list showing a number of articles", width="400", height="371" %}
@@ -57,7 +57,7 @@ chrome.readingList.addEntry({
 
 ### Display items {: #display-items }
 
-To display items currently in the reading list, use the [`chrome.readingList.query()`][query]
+To display items from the reading list, use the [`chrome.readingList.query()`][query] method to retrieve them.
 method.
 
 ```js
@@ -70,7 +70,7 @@ for (const item of items) {
 
 ### Mark an item as read {: #mark-item-read }
 
-To mark an item as read, use [`chrome.readingList.updateEntry`][update-entry]:
+You can use [`chrome.readingList.updateEntry`][update-entry] to update the title, URL, and read status. The following code marks an item as read:
 
 ```js
 chrome.readingList.updateEntry({

--- a/site/en/docs/extensions/reference/readingList/index.md
+++ b/site/en/docs/extensions/reference/readingList/index.md
@@ -91,12 +91,11 @@ chrome.readingList.removeEntry({
 
 ## Extension samples {: #examples }
 
-For more Reading List API extensions demos, explore any of the following extensions:
-
-- Coming soon.
+For more Reading List API extensions demos, see the [Reading List API sample][sample].
 
 [doc-manifest]: /docs/extensions/mv3/manifest/
 [query]: #method-query
 [add-entry]: #method-addEntry
 [update-entry]: #method-updateEntry
 [remove-entry]: #method-removeEntry
+[sample]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/readingList


### PR DESCRIPTION
Adds documentation for the new [`chrome.readingList`](https://github.com/w3c/webextensions/blob/main/proposals/reading_list.md) API.

Sample: https://github.com/GoogleChrome/chrome-extensions-samples/pull/1021
Related: https://github.com/GoogleChromeLabs/Extension-Docs/issues/174