### PR TITLE
Set up redirect from examples/ to samples/

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -81,6 +81,9 @@ redirects:
 - from: /docs/extensions/mv3/xhr
   to: /docs/extensions/mv3/network-requests
 
+- from: /docs/extensions/examples
+  to: /docs/extensions/samples/
+
 - from: /blog/fedcm-origin-trial
   to: /docs/privacy-sandbox/fedcm
 


### PR DESCRIPTION
`/examples` is one of our top ten URLs according analytics, despite the fact that we don't have such a page. This PR redirects to one we do have.

