### PR TITLE
Disable smooth scrolling

### DIFF
--- a/site/_scss/_global.scss
+++ b/site/_scss/_global.scss
@@ -33,7 +33,8 @@
 }
 
 html {
-  scroll-behavior: smooth;
+  // Disabled due to https://github.com/GoogleChrome/developer.chrome.com/issues/7412
+  // scroll-behavior: smooth;
 }
 
 body {


### PR DESCRIPTION
Disables smooth scrolling. This was nice in general, but could be an accessibility issue, and was leading to a bug where anchor links were not reliable.

Fixes https://github.com/GoogleChrome/developer.chrome.com/issues/7412