### PR TITLE
Updated outdated link to code sample

### DIFF
--- a/site/en/docs/lighthouse/performance/uses-webp-images/index.md
+++ b/site/en/docs/lighthouse/performance/uses-webp-images/index.md
@@ -96,7 +96,7 @@ formats.
 
 ## Resources
 
-- [Source code for **Serve images in modern formats** audit](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/byte-efficiency/modern-image-formats.js)
+- [Source code for **Serve images in modern formats** audit](https://github.com/GoogleChrome/lighthouse/blob/v11.2.0/core/audits/byte-efficiency/modern-image-formats.js)
 - [Use WebP images](https://web.dev/articles/serve-images-webp)
 
 <!-- https://www.reddit.com/r/webdev/comments/gspjwe/serve_images_in_nextgen_formats/ -->


### PR DESCRIPTION
Changes proposed in this pull request:

- I updated the link to properly locate `modern-image-formats.js` as `lighthouse-core` has been renamed to `core`
- I also pinned the link to a fix version (`v11.2.0`) to make sure it will be correct in the future (even when files change on the `main` branch)