### PR TITLE
fix: chrome-119-beta syntax error in example standard compliant URL

### DIFF
--- a/site/en/blog/chrome-119-beta/index.md
+++ b/site/en/blog/chrome-119-beta/index.md
@@ -91,7 +91,7 @@ Make Chrome's handling of URL host punctuation characters compliant with the [UR
 Before:
 
 ```bash
-> const url = new URL("http://exa(mple.com";);
+> const url = new URL("http://exa(mple.com;");
 > url.href
 'http://exa%28mple.com/&apos;
 ```
@@ -101,7 +101,7 @@ Before:
 After:
 
 ```bash
-> const url = new URL("http://exa(mple.com";);
+> const url = new URL("http://exa(mple.com;");
 > => throws TypeError: Invalid URL.
 ```
 


### PR DESCRIPTION
Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

-
-
-