### PR TITLE
Replace Chrome OS with enterprise in description of ephemeral mode

### DIFF
--- a/site/en/docs/extensions/mv3/manifest/minimum_chrome_version/index.md
+++ b/site/en/docs/extensions/mv3/manifest/minimum_chrome_version/index.md
@@ -37,7 +37,7 @@ happens silently so you should exercise caution and consider ways of letting
 existing users know that they are no longer receiving updates.
 
 {% Aside 'note' %}
-Chrome OS users using [ephemeral mode][ephemeral] are treated as new users each time they sign in.
+Enterprise users using [ephemeral mode][ephemeral] are treated as new users each time they sign in.
 This means that if they are using a Chrome version lower than the `minimum_chrome_version`, your
 extension will not be installed.
 {% endAside %}


### PR DESCRIPTION
I added this aside yesterday but just learned this applies to all enterprise users, not just Chrome OS.