### PR TITLE
fix error in metric tracked statement

### DIFF
--- a/site/en/docs/lighthouse/performance/first-contentful-paint/index.md
+++ b/site/en/docs/lighthouse/performance/first-contentful-paint/index.md
@@ -8,7 +8,7 @@ date: 2019-05-02
 updated: 2021-06-04
 ---
 
-First Contentful Paint (FCP) is one of six metrics
+First Contentful Paint (FCP) is one of five metrics
 tracked in the **Performance** section of the Lighthouse report.
 Each metric captures some aspect of page load speed.
 


### PR DESCRIPTION
I'd like to make sure that the text is corrected.

correcting the number of metrics tracked in the Performance section of the lighthouse report


Changes proposed in this pull request:

- The number of metrics tracked changed,