### PR TITLE
Move single-purpose FAQ to Web Store

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -477,6 +477,9 @@ redirects:
 - from: /docs/webstore/program_policies/
   to: /docs/webstore/program-policies/
 
+- from: /docs/extensions/mv3/quality_guidelines
+  to: /docs/webstore/program-policies/quality-guidelines-faq
+
 - from: /docs/webstore/affiliate-ads-faq
   to: /docs/webstore/program-policies/affiliate-ads-faq
 

--- a/site/_data/docs/extensions/toc.yml
+++ b/site/_data/docs/extensions/toc.yml
@@ -26,7 +26,6 @@
   sections:
     - url: /docs/extensions/mv3/themes
     - url: /docs/extensions/mv3/faq
-    - url: /docs/extensions/mv3/quality_guidelines
 - title: i18n.docs.extensions.migrating
   sections:
     - url: /docs/extensions/migrating/

--- a/site/_data/docs/webstore/toc.yml
+++ b/site/_data/docs/webstore/toc.yml
@@ -39,6 +39,7 @@
   sections:
     - url: /docs/webstore/program-policies/
     - url: /docs/webstore/program-policies/terms/
+    - url: /docs/webstore/program-policies/quality-guidelines-faq
     - url: /docs/webstore/program-policies/affiliate-ads-faq/
     - url: /docs/webstore/program-policies/deceptive-installation-tactics-faq/
     - url: /docs/webstore/program-policies/spam-faq/

--- a/site/en/docs/extensions/mv3/getstarted/extensions-101/index.md
+++ b/site/en/docs/extensions/mv3/getstarted/extensions-101/index.md
@@ -182,7 +182,7 @@ extension and Chrome Web store documentation:
 [doc-popup]: /docs/extensions/mv3/user_interface/#popup
 [doc-reference]: /docs/extensions/reference/
 [doc-service-worker]: /docs/extensions/mv3/service_workers/
-[doc-single-purpose]: /docs/extensions/mv3/quality_guidelines/
+[doc-single-purpose]: /docs/webstore/program-policies/quality-guidelines-faq
 [doc-ui]: /docs/extensions/mv3/user_interface/
 [js-apis]: /docs/extensions/api_other/
 [mdn-dom]: https://developer.mozilla.org/docs/Web/API/Document_Object_Model

--- a/site/en/docs/extensions/mv3/permission_warnings/index.md
+++ b/site/en/docs/extensions/mv3/permission_warnings/index.md
@@ -46,7 +46,7 @@ harder to understand than others. Users are more likely to install extensions th
 guidelines:
 
 Request relevant permissions
-: Extensions are required to fulfill a [single purpose](/docs/extensions/mv3/quality_guidelines#single-purpose) and
+: Extensions are required to fulfill a [single purpose](/docs/webstore/program-policies/quality-guidelines-faq) and
 comply with the [Use of permissions](/docs/webstore/program-policies/permissions/) policy. Ensure you only
 request permissions that support the extension's main functionality.
 

--- a/site/en/docs/webstore/program-policies/quality-guidelines-faq/index.md
+++ b/site/en/docs/webstore/program-policies/quality-guidelines-faq/index.md
@@ -100,7 +100,7 @@ your extension modifies one of these functions, it must use the Settings Overrid
 
 Where more than one extension modifies these Chrome settings, the most recently installed extension
 will manage the settings it has modified via the Settings Override API. Extension developers can
-modify the new tab page (and a few other Chrome pages) using the same [override method][9] as
+modify the new tab page (and a few other Chrome pages) using the same [override method][settings-override] as
 before.
 
 In addition, if you want to publish an extension that modifies Chrome settings, you must either
@@ -116,7 +116,7 @@ compliant with the single purpose policy.
 
 The only supported way to change the web search settings using an extension is via the Settings
 Overrides API. Extensions that change the web search experience in any form, without using the
-[Settings Overrides API][16], are subject to removal from the Chrome Web Store.
+[Settings Overrides API][settings-override], are subject to removal from the Chrome Web Store.
 
 ### My extension makes programmatic changes to Chrome user settings, but does not use one of the available APIs. What is the deadline to make changes to my extension? {: #eight }
 
@@ -161,8 +161,7 @@ No. This violates the single purpose policy. However, if injecting ads is the si
 extension and the extension is otherwise compliant with Chrome policies, then it would be
 acceptable. For example, a "related articles" extension that adds sponsored links to articles
 related to a page the user is visiting would be compliant with the single purpose policy because it
-has a single purpose limited to a narrow function of the browser. You also might want to explore the
-other monetization options described [here][10].
+has a single purpose limited to a narrow function of the browser.
 
 ### Are toolbars permitted under this policy? {: #fourteen }
 
@@ -248,11 +247,8 @@ to the narrow subject matter of search.
 [4]: https://security.googleblog.com/2017/03/expanding-protection-for-chrome-users.html
 [5]: http://blog.chromium.org/2013/12/keeping-chrome-extensions-simple.html
 [6]: /docs/webstore/program-policies/quality-guidelines
-[9]: /docs/extensions/mv3/override
-[10]: /docs/webstore/money
+[settings-override]: /docs/extensions/mv3/settings_override/
 [11]: #three
 [12]: /docs/extensions/action
 [13]: http://blog.chromium.org/2014/02/make-sure-to-get-your-extension-in.html
-[16]: /docs/extensions/mv3/settings_override/#others
-
 [crx-group]: https://groups.google.com/a/chromium.org/g/chromium-extensions

--- a/site/en/docs/webstore/program-policies/quality-guidelines-faq/index.md
+++ b/site/en/docs/webstore/program-policies/quality-guidelines-faq/index.md
@@ -247,7 +247,7 @@ to the narrow subject matter of search.
 [3]: http://blog.chromium.org/2014/03/protecting-user-settings-on-windows.html
 [4]: https://security.googleblog.com/2017/03/expanding-protection-for-chrome-users.html
 [5]: http://blog.chromium.org/2013/12/keeping-chrome-extensions-simple.html
-[6]: /docs/webstore/program-policies?csw=1#extensions
+[6]: /docs/webstore/program-policies/quality-guidelines
 [9]: /docs/extensions/mv3/override
 [10]: /docs/webstore/money
 [11]: #three

--- a/site/en/docs/webstore/program-policies/quality-guidelines/index.md
+++ b/site/en/docs/webstore/program-policies/quality-guidelines/index.md
@@ -23,4 +23,4 @@ updated: 2023-05-30
 
 See [this FAQ][faq] for more information.
 
-[faq]: /docs/extensions/mv3/quality_guidelines
+[faq]: /docs/webstore/program-policies/quality-guidelines-faq

--- a/site/en/docs/webstore/troubleshooting/index.md
+++ b/site/en/docs/webstore/troubleshooting/index.md
@@ -1312,7 +1312,7 @@ Store
 [docs-pack-extension]: /docs/extensions/mv3/linux_hosting/#create
 [docs-publish-setup]: /docs/webstore/cws-dashboard-privacy/#set-privacy-policy
 [docs-service-workers]: /docs/extensions/mv3/service_workers/
-[docs-single-purpose-faq]: /docs/extensions/mv3/quality_guidelines#single-purpose
+[docs-single-purpose-faq]: /docs/webstore/program-policies/quality-guidelines-faq
 [lie-fi]: https://web.dev/performance-poor-connectivity/#what-is-lie-fi
 [mature-content]: /docs/webstore/cws-dashboard-listing/#mature-content
 [mdn-cookie-store]: https://developer.mozilla.org/docs/Web/API/Cookie_Store_API


### PR DESCRIPTION
Part of #https://github.com/GoogleChromeLabs/Extension-Docs/issues/228

Changes proposed in this pull request:

- Move single-purpose FAQ to web store docs. 
-
-