### PR TITLE
fix: escape HTML tag-like syntax in header

### DIFF
--- a/site/en/blog/chrome-120-beta/index.md
+++ b/site/en/blog/chrome-120-beta/index.md
@@ -24,7 +24,7 @@ This release adds seven new CSS features.
 
 Supports using the` <image>` syntax for custom properties registered with `@property` or `registerProperty()`. The `<image>` syntax can be used to restrict values of the custom property to `url()` values and generated images like gradients.. 
 
-### CSS <transform-function> and <transform-list> syntax for registered custom properties
+### CSS `<transform-function>` and `<transform-list>` syntax for registered custom properties
 
 Supports using the `<transform-function>` and `<transform-list>` syntaxes for custom properties registered with `@property` or `registerProperty()`.
 


### PR DESCRIPTION
Fixes “CSS and syntax”

<img width="1054" alt="Screenshot 2023-11-02 at 09 32 40" src="https://github.com/GoogleChrome/developer.chrome.com/assets/716405/9caca602-c4f9-40a0-a36b-aca2826e7094">
