### PR TITLE
Document safe rules in declarativeNetRequest

### DIFF
--- a/site/en/docs/extensions/reference/declarativeNetRequest/index.md
+++ b/site/en/docs/extensions/reference/declarativeNetRequest/index.md
@@ -235,7 +235,8 @@ An extension can have at least 5000 dynamic rules. This is exposed as the
 
 Starting in Chrome 121, there is a larger limit of 30,000 rules available for safe dynamic rules,
 exposed as the [`MAX_NUMBER_OF_DYNAMIC_RULES`](#property-MAX_NUMBER_OF_DYNAMIC_RULES). Safe rules
-are defined as rules with an action of `block`, `allow`, `allowAllRequests` or `upgradeScheme`.
+are defined as rules with an action of `block`, `allow`, `allowAllRequests` or `upgradeScheme`. Any
+unsafe rules added within the limit of 5000 will also count towards this limit.
 
 Before Chrome 120, there was a limit of 5000 combined dynamic and session rules.
 

--- a/site/en/docs/extensions/reference/declarativeNetRequest/index.md
+++ b/site/en/docs/extensions/reference/declarativeNetRequest/index.md
@@ -203,12 +203,6 @@ If only one extension has a rule that matches a request, that rule is applied. B
 
 1. If more than one rule matches, the most recently installed extension gets priority.
 
-### Safe rules {: #safe-rules }
-
-Rules with an action of `block`, `allow`, `allowAllRequests` or `upgradeScheme` are defined as safe
-rules. These rules are deemed to have a lower risk profile and in some cases allow for increased
-limits on the number of rules in a ruleset.
-
 ### Rule limits {: #limits }
 
 There is a performance overhead to loading and evaluating rules in the browser,
@@ -227,20 +221,23 @@ manifest field to limit which Chrome versions can install your extension.
 
 The number of rules available after that depends on how many rules are enabled by all the extensions installed on a user's browser. You can find this number at runtime by calling [`getAvailableStaticRuleCount()`](#method-getAvailableStaticRuleCount). You can see [an example of this](#update-static-rulesets) under [code examples](#code-examples).
 
-#### Dynamic and session rules {: #dynamic-session-rules }
+#### Session rules {: #session-rules }
 
 An extension can have up to 5000 session rules. This is exposed as the
 [`MAX_NUMBER_OF_SESSION_RULES`](#property-MAX_NUMBER_OF_SESSION_RULES).
 
-For dynamic rules, up to 30,000 rules are permitted, exposed as the
-[`MAX_NUMBER_OF_DYNAMIC_RULES`](#property-MAX_NUMBER_OF_DYNAMIC_RULES). Included in this set of
-30,000 rules, up to 5,000 unsafe rules are permitted, called
+Before Chrome 120, there was a limit of 5000 combined dynamic and session rules.
+
+#### Dynamic rules {: #dynamic-rules }
+
+An extension can have at least 5000 dynamic rules. This is exposed as the
 [`MAX_NUMBER_OF_UNSAFE_DYNAMIC_RULES`](#property-MAX_NUMBER_OF_UNSAFE_DYNAMIC_RULES).
 
-{% Aside 'note' %}
-Prior to Chrome 120, the limits for dynamic and session rules were combined, and the total number of
-dynamic and session rules could not exceed 5000.
-{% endAside %}
+Starting in Chrome 121, there is a larger limit of 30,000 rules available for safe dynamic rules,
+exposed as the [`MAX_NUMBER_OF_DYNAMIC_RULES`](#property-MAX_NUMBER_OF_DYNAMIC_RULES). Safe rules
+are defined as rules with an action of `block`, `allow`, `allowAllRequests` or `upgradeScheme`.
+
+Before Chrome 120, there was a limit of 5000 combined dynamic and session rules.
 
 #### Rules that use regex {: #regex-rules }
 

--- a/site/en/docs/extensions/reference/declarativeNetRequest/index.md
+++ b/site/en/docs/extensions/reference/declarativeNetRequest/index.md
@@ -238,7 +238,7 @@ exposed as the [`MAX_NUMBER_OF_DYNAMIC_RULES`](#property-MAX_NUMBER_OF_DYNAMIC_R
 are defined as rules with an action of `block`, `allow`, `allowAllRequests` or `upgradeScheme`. Any
 unsafe rules added within the limit of 5000 will also count towards this limit.
 
-Before Chrome 120, there was a limit of 5000 combined dynamic and session rules.
+Before Chrome 120, there was a 5000 combined dynamic and session rules limit.
 
 #### Rules that use regex {: #regex-rules }
 

--- a/site/en/docs/extensions/reference/declarativeNetRequest/index.md
+++ b/site/en/docs/extensions/reference/declarativeNetRequest/index.md
@@ -203,6 +203,12 @@ If only one extension has a rule that matches a request, that rule is applied. B
 
 1. If more than one rule matches, the most recently installed extension gets priority.
 
+### Safe rules {: #safe-rules }
+
+Rules with an action of `block`, `allow`, `allowAllRequests` or `upgradeScheme` are defined as safe
+rules. These rules are deemed to have a lower risk profile and in some cases allow for increased
+limits on the number of rules in a ruleset.
+
 ### Rule limits {: #limits }
 
 There is a performance overhead to loading and evaluating rules in the browser,
@@ -223,7 +229,18 @@ The number of rules available after that depends on how many rules are enabled b
 
 #### Dynamic and session rules {: #dynamic-session-rules }
 
-The limits applied to dynamic and session rules are simpler than static rules. The total number of both cannot exceed 5000. This is called the [`MAX_NUMBER_OF_DYNAMIC_AND_SESSION_RULES`](#property-MAX_NUMBER_OF_DYNAMIC_AND_SESSION_RULES).
+An extension can have up to 5000 session rules. This is exposed as the
+[`MAX_NUMBER_OF_SESSION_RULES`](#property-MAX_NUMBER_OF_SESSION_RULES).
+
+For dynamic rules, up to 30,000 rules are permitted, exposed as the
+[`MAX_NUMBER_OF_DYNAMIC_RULES`](#property-MAX_NUMBER_OF_DYNAMIC_RULES). Included in this set of
+30,000 rules, up to 5,000 unsafe rules are permitted, called
+[`MAX_NUMBER_OF_UNSAFE_DYNAMIC_RULES`](#property-MAX_NUMBER_OF_UNSAFE_DYNAMIC_RULES).
+
+{% Aside 'note' %}
+Prior to Chrome 120, the limits for dynamic and session rules were combined, and the total number of
+dynamic and session rules could not exceed 5000.
+{% endAside %}
 
 #### Rules that use regex {: #regex-rules }
 


### PR DESCRIPTION
Documents safe rules which were implemented following this proposal: https://docs.google.com/document/d/1srkkCJkl4X2KOOUwnpDd-kvm8AY70eZBAYI4m836bvQ/edit?usp=sharing

As a note, some of the links here are dependent on `nodoc` being removed in the Chromium source to make constants visible in our documentation.

Fixes https://github.com/GoogleChromeLabs/Extension-Docs/issues/218