### PR TITLE
Fix incorrect API use in index.md

### DIFF
--- a/site/en/blog/fedcm-chrome-120-updates/index.md
+++ b/site/en/blog/fedcm-chrome-120-updates/index.md
@@ -110,7 +110,7 @@ request:
 Set-Login: logged-out
 ```
 
-Alternatively, call the JavaScript API `IdentityProvider.logout()` from the IdP
+Alternatively, call the JavaScript API `navigator.login.setStatus("logged-out")` from the IdP
 origin:
 
 ```js


### PR DESCRIPTION
`IdentityProvider.logout` isn't the right API to call in this case

Changes proposed in this pull request:

- Replace `IdentityProvider.logout` with `navigator.login.setStatus("logged-out")`