### PR TITLE
fix: change fir to fire

### DIFF
--- a/site/en/blog/chrome-120-beta-whats-new-for-extensions/index.md
+++ b/site/en/blog/chrome-120-beta-whats-new-for-extensions/index.md
@@ -77,7 +77,7 @@ This is a small update, but addresses an important gap in the service worker lif
 
 There’s a catch though. Before Chrome 120, the shortest time span to trigger an alarm was one minute. However, service workers shut down after 30 seconds of inactivity. So there was no straightforward way to schedule an alarm to fire in 45 seconds, because when using [`setTimeout()`](https://developer.mozilla.org//docs/Web/API/setTimeout) to set an event in 45 seconds, the service worker could potentially be shut down before the event fired. 
 
-Starting with Chrome 120, you can now either fir an event in:
+Starting with Chrome 120, you can now either fire an event in:
 
 * less than 30 seconds using [`setTimeout()`](https://developer.mozilla.org//docs/Web/API/setTimeout). 
 * anything longer than or equal to 30 seconds using [`chrome.alarms`](/docs/extensions/reference/alarms/):


### PR DESCRIPTION
Noticed this small typo.

@sebastianbenz Also had a question in general around the need to use `setTimeout` for below 30 seconds & then `chrome.alarms` for more than 30 seconds - this feels like an area that could cause confusion for new developers who might start with the need for a short time (using setTimeout) and then fall into an issue when trying to use this next for a delay of 60 seconds.