### PR TITLE
Update Compute Pressure API documentation

### DIFF
--- a/site/en/blog/compute-pressure-origin-trial-2/index.md
+++ b/site/en/blog/compute-pressure-origin-trial-2/index.md
@@ -131,7 +131,7 @@ function callback(records) {
   }
 }
 
-const observer = new PressureObserver(callback, {
+const observer = new PressureObserver(callback,{
   // Sample rate in Hertz.
   sampleRate: 1,
 });

--- a/site/en/docs/web-platform/compute-pressure/index.md
+++ b/site/en/docs/web-platform/compute-pressure/index.md
@@ -138,8 +138,7 @@ updates.
 
 `PressureObserver.takeRecords()`: Returns a sequence of [records](#records), since the last callback invocation.
 
-
-`static PressureObserver.supportedSources()` (read only): Returns supported source types by the hardware.
+`PressureObserver.supportedSources()` (read only): Returns supported source types by the hardware.
 
 ##### Parameters {: #parameters }
 


### PR DESCRIPTION
Fixes #6284 

Changes proposed in this pull request:

- Remove the "static" keyword from the method description.
- Correctly describe the method as a read-only function.
- Reference the relevant specification.