### PR TITLE
Fix links in ARA dev guide landing

### DIFF
--- a/site/en/docs/privacy-sandbox/attribution-reporting/developer-guide/index.njk
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/developer-guide/index.njk
@@ -6,10 +6,10 @@ sections:
     - url: /docs/privacy-sandbox/attribution-reporting/getting-started/
       title: Get started with the Attribution Reporting API
       description: Here's where to start, including setup and a quick overview.
-    - url: /docs/privacy-sandbox/attribution-reporting/register-attribution-sources/
+    - url: /docs/privacy-sandbox/attribution-reporting/register-attribution-source/
       title: Register sources
-      description: Learn how to register sources to attribute clicks and views to the appropriate events.
-    - url: /docs/privacy-sandbox/attribution-reporting/register-attribution-triggers/
+      description: Learn how to register triggers to attribute clicks and views to the appropriate events.
+    - url: /docs/privacy-sandbox/attribution-reporting/register-attribution-trigger/
       title: Register triggers
       description: Learn how to register attribution triggers to measure your conversions.
     - url: /docs/privacy-sandbox/attribution-reporting-debugging/

--- a/site/en/docs/privacy-sandbox/attribution-reporting/developer-guide/index.njk
+++ b/site/en/docs/privacy-sandbox/attribution-reporting/developer-guide/index.njk
@@ -8,7 +8,7 @@ sections:
       description: Here's where to start, including setup and a quick overview.
     - url: /docs/privacy-sandbox/attribution-reporting/register-attribution-source/
       title: Register sources
-      description: Learn how to register triggers to attribute clicks and views to the appropriate events.
+      description: Learn how to register sources to attribute clicks and views to the appropriate events.
     - url: /docs/privacy-sandbox/attribution-reporting/register-attribution-trigger/
       title: Register triggers
       description: Learn how to register attribution triggers to measure your conversions.


### PR DESCRIPTION
Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- Fix links to register sources and register triggers. (no ending 's')
- https://pr-7748-static-dot-dcc-staging.uc.r.appspot.com/docs/privacy-sandbox/attribution-reporting/developer-guide/
-