### PR TITLE
Fix origin trial token on home page

### DIFF
--- a/site/_includes/layouts/devsite.njk
+++ b/site/_includes/layouts/devsite.njk
@@ -47,8 +47,8 @@
     {% endif %}
 
     {# Dogfood document speculation rules origin trial #}
-    <!-- developer.chrome.com origin trial token - valid until 23 Mar 2023 -->
-    <meta http-equiv="origin-trial" content="AhaT7AdLUbVk3M0VorYLzXSY8Km9PJZlzg3Xkv6KT2QMZ4zyqA5BfdTJLCj1TVnGhryWtQH66HWQEsIbZDUrsAwAAABseyJvcmlnaW4iOiJodHRwczovL2RldmVsb3Blci5jaHJvbWUuY29tOjQ0MyIsImZlYXR1cmUiOiJTcGVjdWxhdGlvblJ1bGVzUHJlZmV0Y2hGdXR1cmUiLCJleHBpcnkiOjE2OTQxMzExOTl9">
+    <!-- developer.chrome.com origin trial token for speculation rules document rules -->
+    <meta http-equiv="origin-trial" content="AtXwNtvKLGSNFBuawE0CYB2BnrKRyHz9s9KLZ9LkTTtvcxoK4UIgtNQrwGOD6wQCKsbHAsbYYjdkBdvj3vuk2QAAAABseyJvcmlnaW4iOiJodHRwczovL2RldmVsb3Blci5jaHJvbWUuY29tOjQ0MyIsImZlYXR1cmUiOiJTcGVjdWxhdGlvblJ1bGVzUHJlZmV0Y2hGdXR1cmUiLCJleHBpcnkiOjE3MDk2ODMxOTl9">
     {# Exclude the /articles/ section as a control #}
     <script type="speculationrules">
     {


### PR DESCRIPTION
I fixed this for most pages in #7361 but the home page came after with it's own template so wasn't updated correctly