### PR TITLE
docs(cookieMaxAge): fix cookie max-age examples

### DIFF
--- a/site/en/blog/cookie-max-age-expires/index.md
+++ b/site/en/blog/cookie-max-age-expires/index.md
@@ -53,7 +53,7 @@ Jan 1, 2024</td>
     </tr>
     <tr>
       <td> 
-Name=Value; Max-Age=1704085200</td>
+Name=Value; Max-Age=31536000</td>
       <td> 
 Jan 1, 2024</td>
       <td> 
@@ -77,7 +77,7 @@ Feb 5, 2024</td>
     </tr>
     <tr>
       <td> 
-Name=Value; Max-Age=1707109200</td>
+Name=Value; Max-Age=34560000</td>
       <td> 
 Feb 5, 2024</td>
       <td> 
@@ -101,7 +101,7 @@ Feb 5, 2024</td>
     </tr>
     <tr>
       <td> 
-Name=Value; Max-Age=1707195600</td>
+Name=Value; Max-Age=34646400</td>
       <td> 
 Feb 6, 2024</td>
       <td> 
@@ -125,7 +125,7 @@ Feb 5, 2024</td>
     </tr>
     <tr>
       <td> 
-Name=Value; Max-Age=1735707600</td>
+Name=Value; Max-Age=63158400</td>
       <td> 
 Jan 1, 2025</td>
       <td> 


### PR DESCRIPTION
<!-- Due to an upcoming migration of this site we are no longer merging pull requests for changes to existing content. Please raise content issues at https://issuetracker.google.com/issues/new?component=1400036&template=1897236 -->

Fixes #6640, relates to #6639

Changes proposed in this pull request:

- Use correct values for [Cookie Max-Age / Expires](https://developer.chrome.com/blog/cookie-max-age-expires) examples
