### PR TITLE
Document device sleep and persistence behaviour of alarms API

### DIFF
--- a/site/en/docs/extensions/reference/alarms/index.md
+++ b/site/en/docs/extensions/reference/alarms/index.md
@@ -27,9 +27,9 @@ scheduled.
 
 ### Persistence
 
-Alarms generally persist until an extension is updated. However, this is not guarenteed and alarms
+Alarms generally persist until an extension is updated. However, this is not guaranteed, and alarms
 may be cleared when the browser is restarted. Consequently, consider setting a value in storage
-when an alarm is created and then making sure it exists each time your service worker starts up:
+when an alarm is created, and then ensure it exists each time your service worker starts up. For example:
 
 ```js
 const STORAGE_KEY = "user-preference-alarm-enabled";

--- a/site/en/docs/extensions/reference/alarms/index.md
+++ b/site/en/docs/extensions/reference/alarms/index.md
@@ -65,6 +65,15 @@ chrome.alarms.onAlarm.addListener((alarm) => {
 });
 ```
 
+### Device sleep
+
+The behavior of alarms when a device goes to sleep is currently undefined. An alarm will never fire
+early but may fire significantly later than expected if a device went to sleep after an alarm was scheduled.
+
+### Persistence
+
+Alarms generally persist until an extension is updated. However, this is not guarenteed and alarms may be cleared when the browser is restarted. Consequently, consider storing any important alarms in storage and making sure they exist each time your service worker starts up.
+
 [repo-samples]: https://github.com/GoogleChrome/chrome-extensions-samples
 [sample-example]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/alarms
 [action-icon]: /docs/extensions/reference/action/#icon

--- a/site/en/docs/extensions/reference/alarms/index.md
+++ b/site/en/docs/extensions/reference/alarms/index.md
@@ -17,6 +17,20 @@ To use the `chrome.alarms` API, declare the `"alarms"` permission in the [manife
 }
 ```
 
+## Concepts and usage
+
+### Device sleep
+
+The behavior of alarms when a device goes to sleep is currently undefined. An alarm will never fire
+early but may fire significantly later than expected if a device went to sleep after an alarm was
+scheduled.
+
+### Persistence
+
+Alarms generally persist until an extension is updated. However, this is not guarenteed and alarms
+may be cleared when the browser is restarted. Consequently, consider storing any important alarms in
+storage and making sure they exist each time your service worker starts up.
+
 ## Examples
 
 The following examples show how to use and respond to an alarm. To try this API,
@@ -64,15 +78,6 @@ chrome.alarms.onAlarm.addListener((alarm) => {
   });
 });
 ```
-
-### Device sleep
-
-The behavior of alarms when a device goes to sleep is currently undefined. An alarm will never fire
-early but may fire significantly later than expected if a device went to sleep after an alarm was scheduled.
-
-### Persistence
-
-Alarms generally persist until an extension is updated. However, this is not guarenteed and alarms may be cleared when the browser is restarted. Consequently, consider storing any important alarms in storage and making sure they exist each time your service worker starts up.
 
 [repo-samples]: https://github.com/GoogleChrome/chrome-extensions-samples
 [sample-example]: https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/alarms

--- a/site/en/docs/extensions/reference/alarms/index.md
+++ b/site/en/docs/extensions/reference/alarms/index.md
@@ -28,8 +28,27 @@ scheduled.
 ### Persistence
 
 Alarms generally persist until an extension is updated. However, this is not guarenteed and alarms
-may be cleared when the browser is restarted. Consequently, consider storing any important alarms in
-storage and making sure they exist each time your service worker starts up.
+may be cleared when the browser is restarted. Consequently, consider setting a value in storage
+when an alarm is created and then making sure it exists each time your service worker starts up:
+
+```js
+const STORAGE_KEY = "user-preference-alarm-enabled";
+
+async function checkAlarmState() {
+  const { alarmEnabled } = await chrome.storage.get(STORAGE_KEY);
+
+  if (alarmEnabled) {
+    const alarm = await chrome.alarms.get("my-alarm");
+
+    if (!alarm) {
+      await chrome.alarms.create({ periodInMinutes: 1 });
+    }
+  }
+}
+
+checkAlarmState();
+```
+
 
 ## Examples
 


### PR DESCRIPTION
Adds some documentation on more nuanced behaviour in the `chrome.alarms` API.

The wording here is quite vague but unfortunately I think it's the best we can do at the moment. There are several open issues around the behaviour we are close to resolving but which are still open:

- https://github.com/w3c/webextensions/issues/433
- https://github.com/w3c/webextensions/issues/406
- https://bugs.chromium.org/p/chromium/issues/detail?id=1285798

While we could wait for those to be resolved, I think it's important we at least document the current behaviour since this is a heavily used API and the fixes may take time.

Fixes https://github.com/GoogleChromeLabs/Extension-Docs/issues/167
