### PR TITLE
Add WebHID/WebUSB information.

### DIFF
--- a/site/_data/docs/extensions/toc.yml
+++ b/site/_data/docs/extensions/toc.yml
@@ -81,6 +81,8 @@
     - url: /docs/extensions/mv3/nativeMessaging
     - url: /docs/extensions/mv3/screen_capture
     - url: /docs/extensions/mv3/geolocation
+    - url: /docs/extensions/mv3/webhid
+    - url: /docs/extensions/mv3/webusb
     - url: /docs/extensions/mv3/file_handling
     - url: /docs/extensions/mv3/unit-testing
     - url: /docs/extensions/mv3/end-to-end-testing

--- a/site/en/docs/extensions/mv3/webhid/index.md
+++ b/site/en/docs/extensions/mv3/webhid/index.md
@@ -1,0 +1,61 @@
+---
+layout: "layouts/doc-post.njk"
+title: "WebHID in extensions"
+seoTitle: "Chrome Extensions: WebHID"
+date: 2023-11-02
+description: The WebHID API, which exposes Human Interface Device (HID) compatible devices to the web, is available in extensions.
+
+---
+
+A Human Interface Device (HID) takes input from or provides output to humans. It also refers to the HID protocol, a standard for bi-directional communication between a host and a device that is designed to simplify the installation procedure.
+
+This page describes aspects of the API that are particular to extensions. Refer to MDN for complete details of the [WebHID API](https://developer.mozilla.org/docs/Web/API/WebHID_API).
+
+You can find a [sample app for WebHID](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples/sample.co2meter) in our samples repo.
+
+## Availability in extensions
+
+Chrome 117 or later.
+
+## Permissions
+
+No manifest file permissions are required; however WebHID triggers the browser's user permission flow.
+
+## Manifest
+
+No manifest keys are needed for this API.
+
+## Supporting contexts
+
+This API may be used in almost any context; The `WebHID.requestDevice()` method cannot be used in extension service workers. See the next section for details.
+
+## Chrome extension differences
+
+Although WebHID is available to extension service workers, [`WebHID.requestDevice()`](https://developer.mozilla.org/docs/Web/API/HID/requestDevice), which returns a promise that resolves with an [HIDDevice](https://developer.mozilla.org/docs/Web/API/HIDDevice) instance, cannot be called in an extension service worker. To get around this, call `requestDevice()` from an extension page other than the extension service worker and send a message to the extension service worker.
+
+The following code follows a typical pattern by calling `requestDevice()` as part of a permissions flow requiring a user gesture. When the device is acquired it sends a message to the service worker, which can then retrieve the device using [`getDevices()`](https://developer.mozilla.org/docs/Web/API/HID/getDevices).
+
+{% Label %}popup.js:{% endLabel %}
+
+```javascript
+myButton.addEventListener("click", async () => {
+  await navigator.hid.requestDevice({
+    filters: [{ vendorId: 0x1234, productId: 0x5678 }],
+  });
+  chrome.runtime.sendMessage("newDevice");
+});
+```
+
+{% Label %}service-worker.js{% endLabel %}
+
+```javascript
+chrome.runtime.onMessage.addListener(async (message) => {
+  if (message === "newDevice") {
+    const devices = await navigator.hid.getDevices();
+    for (const device of devices) {
+      // open device connection.
+      await device.open();
+    }
+  }
+});
+```

--- a/site/en/docs/extensions/mv3/webusb/index.md
+++ b/site/en/docs/extensions/mv3/webusb/index.md
@@ -1,0 +1,56 @@
+---
+layout: "layouts/doc-post.njk"
+title: "WebUSB in extensions"
+seoTitle: "Chrome Extensions: WebUSB"
+date: 2023-11-02
+description: The WebUSB API, which exposes non-standard Universal Serial Bus (USB) compatible devices to the web, is available in extensions.
+---
+
+The WebUSB API exposes non-standard Universal Serial Bus (USB) compatible devices to the web. This page describes aspects of the API that are particular to extensions. Refer to MDN for complete details of the [WebUSB API](https://developer.mozilla.org/docs/Web/API/WebUSB_API).
+
+## Availability in extensions
+
+Chrome 118 or later.
+
+## Permissions
+
+No manifest file permissions are required; however WebUSB triggers the browser's user permission flow.
+
+## Manifest
+
+No manifest keys are needed for this API.
+
+## Supporting contexts
+
+This API may be used in almost any context; The `WebUSB.requestDevice()` method cannot be used in extension service workers. See the next section for details.
+
+## Chrome extension differences
+
+Although WebUSB is available to extension service workers, [`WebUSB.requestDevice()`](https://developer.mozilla.org/docs/Web/API/USB/requestDevice), which returns a promise that resolves with a [USBDevice](https://developer.mozilla.org/docs/Web/API/USBDevice) instance, cannot be called in an extension service worker. To get around this, call `requestDevice()` from an extension page other than the extension service worker and send a message to the extension service worker.
+
+The following code follows a typical pattern by calling `requestDevice()` as part of a permissions flow requiring a user gesture. When the device is acquired it sends a message to the service worker, which can then retrieve the device using [`getDevices()`](https://developer.mozilla.org/docs/Web/API/USB/getDevices).
+
+{% Label %}popup.js:{% endLabel %}
+
+```javascript
+myButton.addEventListener("click", async () => {
+  await navigator.usb.requestDevice({
+    filters: [{ vendorId: 0x1234, productId: 0x5678 }],
+  });
+  chrome.runtime.sendMessage("newDevice");
+});
+```
+
+{% Label %}service-worker.js{% endLabel %}
+
+```javascript
+chrome.runtime.onMessage.addListener(async (message) => {
+  if (message === "newDevice") {
+    const devices = await navigator.usb.getDevices();
+    for (const device of devices) {
+      // open device connection.
+      await device.open();
+    }
+  }
+});
+```


### PR DESCRIPTION
Fixes https://github.com/GoogleChromeLabs/Extension-Docs/issues/31
Replaces #7712, which broke during CI runs.

Before you look at this please glance through these [WebHID](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples/sample.co2meter) and [WebUSB](https://github.com/sowbug/weblight/tree/master) samples. I think these examples show why this is so thin.