### PR TITLE
Update code sample for chrome.alarm

### DIFF
--- a/site/en/blog/chrome-120-beta-whats-new-for-extensions/index.md
+++ b/site/en/blog/chrome-120-beta-whats-new-for-extensions/index.md
@@ -84,7 +84,7 @@ Starting with Chrome 120, you can now either fire an event in:
 
 ```js
 await chrome.alarms.create('demo-default-alarm', {
-   periodInMinutes: 0.45
+   periodInMinutes: 0.75
  });
 ```
 


### PR DESCRIPTION
[Fix code sample issue reported](https://groups.google.com/a/chromium.org/g/chromium-extensions/c/g1RLhieLG-Y/m/ba3Qimo2BAAJ)

> Hi Amy.
> 
> The example code under [Trigger an alarm in 30 seconds](https://developer.chrome.com/blog/chrome-120-beta-whats-new-for-extensions/#trigger-an-alarm-in-30-seconds), with a periodInMinutes of 0.45, contradicts both the text introducing it and the [chrome.alarms.create](https://developer.chrome.com/docs/extensions/reference/alarms/#method-create) documentation, which states that periodInMinutes should not be less than 0.5.
> 
> Regards,
> 
> Jordi