### PR TITLE
Add hero image to NgOptimizedImage blog post

### DIFF
--- a/site/en/blog/angular_ngoptimizedimage/index.md
+++ b/site/en/blog/angular_ngoptimizedimage/index.md
@@ -9,7 +9,6 @@ authors:
 hero: 'image/m1xBwEK30TUVOPXOaWN8CXVd3Dg1/4lEN9XIan6f86Y2qoAzS.webp'
 alt: >
   The Angular logo
-updated: 2023-11-17
 tags:
   - performance
   - news

--- a/site/en/blog/angular_ngoptimizedimage/index.md
+++ b/site/en/blog/angular_ngoptimizedimage/index.md
@@ -6,6 +6,10 @@ description:
 date: 2023-11-15
 authors:
   - alexcastle
+hero: 'image/m1xBwEK30TUVOPXOaWN8CXVd3Dg1/4lEN9XIan6f86Y2qoAzS.webp'
+alt: >
+  The Angular logo
+updated: 2023-11-17
 tags:
   - performance
   - news


### PR DESCRIPTION
This PR adds a hero image to the blog post published this Wednesday (https://developer.chrome.com/blog/angular_ngoptimizedimage/). The image is just the Angular logo in banner form as recently used by the Angular team in this blog post: https://blog.angular.io/introducing-angular-v17-4d7033312e4b CC: @rachelandrew @kara 