### PR TITLE
Remove zero width space from URL

### DIFF
--- a/site/en/docs/extensions/mv3/service_workers/service-worker-lifecycle/index.md
+++ b/site/en/docs/extensions/mv3/service_workers/service-worker-lifecycle/index.md
@@ -63,7 +63,7 @@ Any global variables you set will be lost if the service worker shuts down. Inst
 : A low-level API for client-side storage of structured data, including files and blobs. This API provides primitives for creating transactional data storage and retrieval. Although this API is often too complicated for simple use cases, a number of [third-party](https://developer.mozilla.org/docs/Web/API/IndexedDB_API#see_also) storage solutions are built on top of it.
 
 [CacheStorage API](https://developer.mozilla.org/docs/Web/API/CacheStorage)
-: A persistent storage mechanism for Request and Response object pairs. This API was designed specifically for web service workers and is used to retrieve data from an endpoint. There are a variety of ways to use this API depending on whether and how critical it is that users see up-to-date data. For more information, see [The Offline Cookbook](​​https://web.dev/offline-cookbook). Unless you're specifically proxying network requests via the fetch handler, you should use `chrome.storage`.
+: A persistent storage mechanism for Request and Response object pairs. This API was designed specifically for web service workers and is used to retrieve data from an endpoint. There are a variety of ways to use this API depending on whether and how critical it is that users see up-to-date data. For more information, see [The Offline Cookbook](https://web.dev/offline-cookbook). Unless you're specifically proxying network requests via the fetch handler, you should use `chrome.storage`.
 
 ### Choose a minimum Chrome version {: #timeouts }
 


### PR DESCRIPTION
The URL is pointing to the wrong URL since it had zero width space in it

* Before
`https://developer.chrome.com/docs/extensions/mv3/service_workers/service-worker-lifecycle/%E2%80%8B%E2%80%8Bhttps://web.dev/offline-cookbook`

* After
`https://web.dev/offline-cookbook`