### PR TITLE
fix: typo in Chrome 119 release notes

### DIFF
--- a/site/en/blog/new-in-chrome-119/index.md
+++ b/site/en/blog/new-in-chrome-119/index.md
@@ -52,7 +52,7 @@ Now you can use [`<geometry-box>`](https://developer.mozilla.org/docs/Web/CSS/cl
 
 You can also use the functions [`xywh()`](https://developer.mozilla.org/docs/Web/CSS/basic-shape/xywh) and [`rect()`](https://developer.mozilla.org/docs/Web/CSS/basic-shape/rect) that make it easier to specify rectangular or rounded-rectangular clips.
 
-_Correction: A previous version of this article referred to inprovements for Fenced Frames. These changes are now shipping in Chrome 120._
+_Correction: A previous version of this article referred to improvements for Fenced Frames. These changes are now shipping in Chrome 120._
 
 ## And more! {: #more }
 


### PR DESCRIPTION
<!-- Due to an upcoming migration of this site we are no longer merging pull requests for changes to existing content. Please raise content issues at https://issuetracker.google.com/issues/new?component=1400036&template=1897236 -->

Small typo, noticed it while reading the release notes.