### PR TITLE
Add missing attribute in New in Chrome 120 post

### DIFF
--- a/site/en/blog/new-in-chrome-120/index.md
+++ b/site/en/blog/new-in-chrome-120/index.md
@@ -44,19 +44,19 @@ Multiple `<details>` elements that have the same `name` form a group. With this 
 Here is an example with a group that shares the name `cookies`:
 
 ```html
-<details>
+<details name="cookies">
   <summary>Chocolate chip</summary>
   Yum yum chocolate chip.
 </details>
-<details>
+<details name="cookies">
   <summary>Snickerdoodle</summary>
    Yum yum snickerdoodle.
 </details>
-<details>
+<details name="cookies">
   <summary>Maicenitas</summary>
    Yum yum maicenitas.
 </details>
-<details>
+<details name="cookies">
   <summary>Sugar cookies</summary>
    Yum yum sugar cookies.
 </details>

--- a/site/es/blog/new-in-chrome-120/index.md
+++ b/site/es/blog/new-in-chrome-120/index.md
@@ -44,19 +44,19 @@ Múltiples elementos `<details>` que tienen el mismo atributo `name`  forman un 
 A continuación se muestra un ejemplo con un grupo que comparte el nombre "cookies":
 
 ```html
-<details>
+<details name="cookies">
   <summary>Chispas de chocolate</summary>
   Yum yum chispas de chocolate.
 </details>
-<details>
+<details name="cookies">
   <summary>Snickerdoodle</summary>
    Yum yum snickerdoodle.
 </details>
-<details>
+<details name="cookies">
   <summary>Maicenitas</summary>
    Yum yum Maicenitas
 </details>
-<details>
+<details name="cookies">
   <summary>Galletas de azúcar</summary>
    Yum yum galletas de azúcar
 </details>


### PR DESCRIPTION
<!-- Due to an upcoming migration of this site we are no longer merging pull requests for changes to existing content. Please raise content issues at https://issuetracker.google.com/issues/new?component=1400036&template=1897236 -->

Fixes omission of `details[name]` attribute from New in Chrome 120 post:

- https://github.com/GoogleChrome/developer.chrome.com/pull/7893/files#r1417039603

cc @tropicadri 