### PR TITLE
feature-policy blog: retitle post

### DIFF
--- a/site/en/blog/feature-policy/index.md
+++ b/site/en/blog/feature-policy/index.md
@@ -1,6 +1,6 @@
 ---
 layout: 'layouts/blog-post.njk'
-title: 'Chacmool: Augmented reality in Chrome Canary'
+title: 'Introduction to Feature Policy'
 authors:
   - ericbidelman
 date: 2018-06-26


### PR DESCRIPTION
Looks like title got mis-pasted up in the migration https://github.com/GoogleChrome/developer.chrome.com/pull/2322